### PR TITLE
[SFN] Normalise Upload Values

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service.py
@@ -120,12 +120,6 @@ class StateTaskService(StateTask, abc.ABC):
                 parameter_value = self._to_boto_request_value(
                     parameter_value, norm_member_bind_shape
                 )
-                #                if isinstance(norm_member_bind_shape, StructureShape):
-                #                    self._to_boto_request(parameter_value, norm_member_bind_shape)
-                #                elif isinstance(norm_member_bind_shape, StringShape) and not isinstance(
-                #                    parameter_value, str
-                #                ):
-                #                    parameter_value = to_json_str(parameter_value)
                 parameters[norm_member_bind_key] = parameter_value
 
     @staticmethod

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service.py
@@ -5,7 +5,7 @@ import copy
 import json
 from typing import Any, Final, Optional, Union
 
-from botocore.model import ListShape, OperationModel, StringShape, StructureShape
+from botocore.model import ListShape, OperationModel, Shape, StringShape, StructureShape
 from botocore.response import StreamingBody
 
 from localstack.aws.api.stepfunctions import (
@@ -39,7 +39,7 @@ from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.eval.event.event_detail import EventDetails
 from localstack.services.stepfunctions.asl.utils.encoding import to_json_str
 from localstack.services.stepfunctions.quotas import is_within_size_quota
-from localstack.utils.strings import camel_to_snake_case, snake_to_camel_case, to_str
+from localstack.utils.strings import camel_to_snake_case, snake_to_camel_case, to_bytes, to_str
 
 
 class StateTaskService(StateTask, abc.ABC):
@@ -91,7 +91,18 @@ class StateTaskService(StateTask, abc.ABC):
         operation_model = service.operation_model(boto_operation_name)
         return operation_model
 
-    def _to_boto_args(self, parameters: dict, structure_shape: StructureShape) -> None:
+    def _to_boto_request_value(self, request_value: Any, value_shape: Shape) -> Any:
+        boto_request_value = request_value
+        if isinstance(value_shape, StructureShape):
+            self._to_boto_request(request_value, value_shape)
+        elif isinstance(value_shape, StringShape) and not isinstance(request_value, str):
+            boto_request_value = to_json_str(request_value)
+        elif value_shape.type_name == "blob":
+            boto_request_value = to_json_str(request_value, separators=(":", ","))
+            boto_request_value = to_bytes(boto_request_value)
+        return boto_request_value
+
+    def _to_boto_request(self, parameters: dict, structure_shape: StructureShape) -> None:
         shape_members = structure_shape.members
         norm_member_binds: dict[str, tuple[str, StructureShape]] = {
             camel_to_snake_case(member_key): (member_key, member_value)
@@ -106,12 +117,15 @@ class StateTaskService(StateTask, abc.ABC):
             if norm_member_bind is not None:
                 norm_member_bind_key, norm_member_bind_shape = norm_member_bind
                 parameter_value = parameters.pop(parameter_key)
-                if isinstance(norm_member_bind_shape, StructureShape):
-                    self._to_boto_args(parameter_value, norm_member_bind_shape)
-                elif isinstance(norm_member_bind_shape, StringShape) and not isinstance(
-                    parameter_value, str
-                ):
-                    parameter_value = to_json_str(parameter_value)
+                parameter_value = self._to_boto_request_value(
+                    parameter_value, norm_member_bind_shape
+                )
+                #                if isinstance(norm_member_bind_shape, StructureShape):
+                #                    self._to_boto_request(parameter_value, norm_member_bind_shape)
+                #                elif isinstance(norm_member_bind_shape, StringShape) and not isinstance(
+                #                    parameter_value, str
+                #                ):
+                #                    parameter_value = to_json_str(parameter_value)
                 parameters[norm_member_bind_key] = parameter_value
 
     @staticmethod
@@ -171,7 +185,7 @@ class StateTaskService(StateTask, abc.ABC):
             boto_service_name=boto_service_name, service_action_name=service_action_name
         ).input_shape
         if input_shape is not None:
-            self._to_boto_args(parameters, input_shape)  # noqa
+            self._to_boto_request(parameters, input_shape)  # noqa
 
     def _normalise_response(
         self,

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service.py
@@ -97,8 +97,9 @@ class StateTaskService(StateTask, abc.ABC):
             self._to_boto_request(request_value, value_shape)
         elif isinstance(value_shape, StringShape) and not isinstance(request_value, str):
             boto_request_value = to_json_str(request_value)
-        elif value_shape.type_name == "blob":
-            boto_request_value = to_json_str(request_value, separators=(":", ","))
+        elif value_shape.type_name == "blob" and not isinstance(boto_request_value, bytes):
+            if not isinstance(boto_request_value, str):
+                boto_request_value = to_json_str(request_value, separators=(":", ","))
             boto_request_value = to_bytes(boto_request_value)
         return boto_request_value
 

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_lambda.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_lambda.py
@@ -79,16 +79,27 @@ class StateTaskServiceLambda(StateTaskServiceCallback):
             ),
         )
 
+    def _normalise_parameters(
+        self,
+        parameters: dict,
+        boto_service_name: Optional[str] = None,
+        service_action_name: Optional[str] = None,
+    ) -> None:
+        # Run Payload value casting before normalisation.
+        if "Payload" in parameters:
+            parameters["Payload"] = lambda_eval_utils.to_payload_type(parameters["Payload"])
+        super()._normalise_parameters(
+            parameters=parameters,
+            boto_service_name=boto_service_name,
+            service_action_name=service_action_name,
+        )
+
     def _eval_service_task(
         self,
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
     ):
-        if "Payload" in normalised_parameters:
-            normalised_parameters["Payload"] = lambda_eval_utils.to_payload_type(
-                normalised_parameters["Payload"]
-            )
         lambda_eval_utils.exec_lambda_function(
             env=env,
             parameters=normalised_parameters,

--- a/tests/aws/services/stepfunctions/templates/services/services_templates.py
+++ b/tests/aws/services/stepfunctions/templates/services/services_templates.py
@@ -35,6 +35,9 @@ class ServicesTemplates(TemplateLoader):
     AWS_SDK_S3_GET_OBJECT: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/aws_sdk_s3_get_object.json5"
     )
+    AWS_SDK_S3_PUT_OBJECT: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/aws_sdk_s3_put_object.json5"
+    )
     API_GATEWAY_INVOKE_BASE: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/api_gateway_invoke_base.json5"
     )

--- a/tests/aws/services/stepfunctions/templates/services/statemachines/aws_sdk_s3_put_object.json5
+++ b/tests/aws/services/stepfunctions/templates/services/statemachines/aws_sdk_s3_put_object.json5
@@ -1,0 +1,16 @@
+{
+  "Comment": "AWS_SDK_S3_PUT_OBJECT",
+  "StartAt": "S3PutObject",
+  "States": {
+    "S3PutObject": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:putObject",
+      "Parameters": {
+        "Bucket.$": "$.Bucket",
+        "Key.$": "$.Key",
+        "Body.$": "$.Body"
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py
@@ -286,3 +286,42 @@ class TestTaskServiceAwsSdk:
             definition,
             exec_input,
         )
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            # The serialisation of json values cannot currently lead to an output that can match the ETag obtainable
+            # from through AWS SFN uploading to s3. This is true regardless of sorting or separator settings. Further
+            # investigation into AWS's behaviour is needed.
+            "$..ETag"
+        ]
+    )
+    @pytest.mark.parametrize(
+        "body",
+        ["text data", {"Dict": "Value"}, ["List", "Data"], False, 0],
+        ids=["str", "dict", "list", "bool", "num"],
+    )
+    def test_s3_put_object(
+        self,
+        aws_client,
+        s3_create_bucket,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+        body,
+    ):
+        bucket_name = s3_create_bucket()
+        sfn_snapshot.add_transformer(RegexTransformer(bucket_name, "bucket-name"))
+
+        template = ST.load_sfn_template(ST.AWS_SDK_S3_PUT_OBJECT)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"Bucket": bucket_name, "Key": "file-key", "Body": body})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.snapshot.json
@@ -2346,5 +2346,625 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[str]": {
+    "recorded-date": "11-06-2024, 07:42:53",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file-key",
+                "Body": "text data"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file-key",
+                "Body": "text data"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "S3PutObject"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Bucket": "bucket-name",
+                "Body": "text data",
+                "Key": "file-key"
+              },
+              "region": "<region>",
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSucceededEventDetails": {
+              "output": {
+                "ETag": "\"2b5df3712557f503a9977a8ea893b2c9\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "S3PutObject",
+              "output": {
+                "ETag": "\"2b5df3712557f503a9977a8ea893b2c9\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "ETag": "\"2b5df3712557f503a9977a8ea893b2c9\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[dict]": {
+    "recorded-date": "11-06-2024, 07:43:09",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file-key",
+                "Body": {
+                  "Dict": "Value"
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file-key",
+                "Body": {
+                  "Dict": "Value"
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "S3PutObject"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Bucket": "bucket-name",
+                "Body": {
+                  "Dict": "Value"
+                },
+                "Key": "file-key"
+              },
+              "region": "<region>",
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSucceededEventDetails": {
+              "output": {
+                "ETag": "\"49e31cee5aec8faf3345893addb14346\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "S3PutObject",
+              "output": {
+                "ETag": "\"49e31cee5aec8faf3345893addb14346\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "ETag": "\"49e31cee5aec8faf3345893addb14346\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[list]": {
+    "recorded-date": "11-06-2024, 07:43:26",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file-key",
+                "Body": [
+                  "List",
+                  "Data"
+                ]
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file-key",
+                "Body": [
+                  "List",
+                  "Data"
+                ]
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "S3PutObject"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Bucket": "bucket-name",
+                "Body": [
+                  "List",
+                  "Data"
+                ],
+                "Key": "file-key"
+              },
+              "region": "<region>",
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSucceededEventDetails": {
+              "output": {
+                "ETag": "\"6b23860357f6e63a0272b7f1143a663a\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "S3PutObject",
+              "output": {
+                "ETag": "\"6b23860357f6e63a0272b7f1143a663a\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "ETag": "\"6b23860357f6e63a0272b7f1143a663a\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[bool]": {
+    "recorded-date": "11-06-2024, 07:43:42",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file-key",
+                "Body": false
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file-key",
+                "Body": false
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "S3PutObject"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Bucket": "bucket-name",
+                "Body": false,
+                "Key": "file-key"
+              },
+              "region": "<region>",
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSucceededEventDetails": {
+              "output": {
+                "ETag": "\"68934a3e9455fa72420237eb05902327\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "S3PutObject",
+              "output": {
+                "ETag": "\"68934a3e9455fa72420237eb05902327\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "ETag": "\"68934a3e9455fa72420237eb05902327\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[num]": {
+    "recorded-date": "11-06-2024, 07:43:58",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file-key",
+                "Body": 0
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file-key",
+                "Body": 0
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "S3PutObject"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Bucket": "bucket-name",
+                "Body": 0,
+                "Key": "file-key"
+              },
+              "region": "<region>",
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSucceededEventDetails": {
+              "output": {
+                "ETag": "\"cfcd208495d565ef66e7dff9f98764da\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "putObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "S3PutObject",
+              "output": {
+                "ETag": "\"cfcd208495d565ef66e7dff9f98764da\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "ETag": "\"cfcd208495d565ef66e7dff9f98764da\"",
+                "ServerSideEncryption": "AES256"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.validation.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.validation.json
@@ -26,6 +26,21 @@
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_get_object[str]": {
     "last_validated_date": "2024-05-23T19:11:47+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[bool]": {
+    "last_validated_date": "2024-06-11T07:43:42+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[dict]": {
+    "last_validated_date": "2024-06-11T07:43:09+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[list]": {
+    "last_validated_date": "2024-06-11T07:43:26+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[num]": {
+    "last_validated_date": "2024-06-11T07:43:58+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[str]": {
+    "last_validated_date": "2024-06-11T07:42:53+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_outcome_with_no_such_token[state_machine_template0]": {
     "last_validated_date": "2024-04-10T18:55:26+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The SFN interpreter sometimes fails to implicitly normalise `Parameter` values to match the request shape of the target api action. This lead to errors when performing `putObject` requests to `s3` for which the body was not of string type. This PR addresses such issue by normalising blob target shapes. This issue was highlighted in a [followup report](https://github.com/localstack/localstack/issues/10787#issuecomment-2134740148) in issue https://github.com/localstack/localstack/issues/10787.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Extracted upload value normalisation logic
- Added normalisation of `blob` Shapes
- Added related snapshot tests

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
