### PR TITLE
check AWS Support validation status

### DIFF
--- a/tests/aws/services/support/test_support.py
+++ b/tests/aws/services/support/test_support.py
@@ -4,7 +4,7 @@ from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.testing.pytest import markers
 
 TEST_SUPPORT_CASE = {
-    "subject": "Urgent - DynamoDB is down",
+    "subject": "TEST CASE-Please ignore",
     "serviceCode": "general-info",
     "categoryCode": "Service is down",
     "ccEmailAddresses": ["my-email-address@example.com"],
@@ -13,14 +13,45 @@ TEST_SUPPORT_CASE = {
 
 
 class TestConfigService:
+    """
+    https://docs.aws.amazon.com/awssupport/latest/user/about-support-api.html
+    > Important
+    If you call the CreateCase operation to create test support cases, we recommend that you include a subject line,
+    such as TEST CASE-Please ignore. After you're done with your test support case, call the ResolveCase operation
+    to resolve it.
+    To call the AWS Trusted Advisor operations in the AWS Support API, you must use the US East (N. Virginia) endpoint.
+    Currently, the US West (Oregon) and Europe (Ireland) endpoints don't support the Trusted Advisor operations.
+    """
+
     @pytest.fixture
     def support_client(self, aws_client_factory):
         # support is only available in us-east-1
         return aws_client_factory(region_name=AWS_REGION_US_EAST_1).support
 
     @pytest.fixture
-    def case_id_test(self, support_client) -> str:
-        response = support_client.create_case(
+    def create_case(self, support_client):
+        cases = []
+
+        def _create_case(**kwargs):
+            response = support_client.create_case(**kwargs)
+            cases.append(response["caseId"])
+            return response
+
+        yield _create_case
+
+        # DescribeCases does not include resolved cases by default
+        describe_cases = support_client.describe_cases()
+        open_cases_id = [case["caseId"] for case in describe_cases["cases"]]
+        for case_id in cases:
+            if case_id in open_cases_id:
+                support_client.resolve_case(caseId=case_id)
+
+    @markers.aws.only_localstack
+    # we cannot use APIs from AWS Support due to the following:
+    # An error occurred (SubscriptionRequiredException) when calling the DescribeCases/CreateCase operation:
+    # Amazon Web Services Premium Support Subscription is required to use this service.
+    def test_support_case_lifecycle(self, support_client, create_case):
+        create_case = create_case(
             subject=TEST_SUPPORT_CASE["subject"],
             serviceCode=TEST_SUPPORT_CASE["serviceCode"],
             severityCode="low",
@@ -30,17 +61,14 @@ class TestConfigService:
             language=TEST_SUPPORT_CASE["language"],
             issueType="technical",
         )
-        return response["caseId"]
+        case_id = create_case["caseId"]
 
-    @markers.aws.unknown
-    def test_create_support_case(self, support_client, case_id_test):
-        support_cases = support_client.describe_cases()["cases"]
-        assert len(support_cases) == 1
-        assert support_cases[0]["caseId"] == case_id_test
+        # DescribeCases does not include resolved cases by default
+        describe_cases = support_client.describe_cases()
+        cases = describe_cases["cases"]
+        assert cases[0]["caseId"] == case_id
         for key in TEST_SUPPORT_CASE.keys():
-            assert support_cases[0][key] == TEST_SUPPORT_CASE[key]
+            assert cases[0][key] == TEST_SUPPORT_CASE[key]
 
-    @markers.aws.unknown
-    def test_resolve_case(self, support_client, case_id_test):
-        response = support_client.resolve_case(caseId=case_id_test)
+        response = support_client.resolve_case(caseId=case_id)
         assert response["finalCaseStatus"] == "resolved"

--- a/tests/aws/services/support/test_support.py
+++ b/tests/aws/services/support/test_support.py
@@ -46,7 +46,7 @@ class TestConfigService:
             if case_id in open_cases_id:
                 support_client.resolve_case(caseId=case_id)
 
-    @markers.aws.only_localstack
+    @markers.aws.needs_fixing
     # we cannot use APIs from AWS Support due to the following:
     # An error occurred (SubscriptionRequiredException) when calling the DescribeCases/CreateCase operation:
     # Amazon Web Services Premium Support Subscription is required to use this service.


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As part of the effort to validate tests, I've tried to run the AWS Support test against AWS.
It seems you need a Premium account to use the Support API. I had rewritten the test to be easily snapshot-able. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- mark the test a `needs_fixing` as you cannot run them against AWS without a premium plan. Debatable if this is `needs_fixing` or `only_localstack` though, technically it's not by design, but also needs something specific. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
