### PR TITLE
validate scheduler test and check SWF validation

### DIFF
--- a/tests/aws/services/scheduler/test_scheduler.py
+++ b/tests/aws/services/scheduler/test_scheduler.py
@@ -1,7 +1,7 @@
 from localstack.testing.pytest import markers
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_list_schedules(aws_client):
     # simple smoke test to assert that the provider is available, without creating any schedules
     result = aws_client.scheduler.list_schedules()

--- a/tests/aws/services/scheduler/test_scheduler.validation.json
+++ b/tests/aws/services/scheduler/test_scheduler.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/scheduler/test_scheduler.py::test_list_schedules": {
+    "last_validated_date": "2024-06-11T22:50:50+00:00"
+  }
+}

--- a/tests/aws/services/swf/test_swf.py
+++ b/tests/aws/services/swf/test_swf.py
@@ -6,7 +6,11 @@ SWF_VERSION = "1.0"
 
 
 class TestSwf:
-    @markers.aws.unknown
+    # FIXME: This test does not clean up after itself, and does not use fixtures
+    # It seems you cannot delete an AWS SWF `Domain` after its been registered, only deprecate it
+    # The `Domain` resource will deprecate all `Workflow` and `Activity` it holds, so this might be useful.
+    # You cannot delete `Workflow` and `Activity` if they're not deprecated first.
+    @markers.aws.needs_fixing
     def test_run_workflow(self, aws_client):
         swf_client = aws_client.swf
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As those 2 services were small, I've done PR for 2:
- Scheduler test was easy to validate as it does basically nothing
- SWF is more complex, I've added comments to it but the test does not cleanup, does not use fixtures and will most probably need rework


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add markers

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
