### PR TITLE
Add Nix and Flox to installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,34 @@ The `localstack-cli` installation enables you to run the Docker image containing
 
 > **Important**: Do not use `sudo` or run as `root` user. LocalStack must be installed and started entirely under a local non-root user. If you have problems with permissions in macOS High Sierra, install with `pip install --user localstack`
 
+### Nix (MacOS, Linux)
+
+LocalStack can be installed using the Nix package manager, using `nix profile`.
+
+```bash
+nix profile install nixpkgs#localstack
+```
+
+Or `nix-env`.
+
+```bash
+nix-env --install localstack
+```
+
+It's also possible to get a temporary shell with localstack installed in it.
+
+```bash
+nix-shell -p localstack
+```
+
+### Flox (MacOS, Linux)
+
+LocalStack is available for installation within in a Flox environment.
+
+```bash
+flox install localstack
+```
+
 ## Quickstart
 
 Start LocalStack inside a Docker container by running:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

LocalStack is available in Nix and Flox, and it seems to be working well with those 2 packages managers.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Just README changes, no functionality has changed.

<!-- Optional section: How to test these changes? -->
## Testing

### Nix

1. Install the [Nix package manager](https://nixos.org/download/) and follow the steps in the README.
2a. For Nix installations that have the `nix-command` and `flakes` experimental features enabled, one can use `nix profile install`.
2b. In the case those experimental features aren't enabled, use either `nix-shell` or `nix-env`.

### Flox

1. Install the [Flox CLI](https://flox.dev/docs/install-flox/).
2. Create a Flox environment in the current working directory with `flox init`
3. Install `localstack` with `flox install localstack`
4. Activate the environment with `flox activate`

After that, localstack will be available to the user as long as the environment is activated.

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
