### PR TITLE
Allow secondary client fixtures to take credentials from an aws profile

### DIFF
--- a/localstack-core/localstack/testing/aws/util.py
+++ b/localstack-core/localstack/testing/aws/util.py
@@ -28,6 +28,7 @@ from localstack.testing.config import (
     SECONDARY_TEST_AWS_SECRET_ACCESS_KEY,
     SECONDARY_TEST_AWS_SESSION_TOKEN,
     TEST_AWS_ACCESS_KEY_ID,
+    TEST_AWS_REGION_NAME,
     TEST_AWS_SECRET_ACCESS_KEY,
 )
 from localstack.utils.aws.request_context import get_account_id_from_request
@@ -215,7 +216,7 @@ def secondary_aws_session() -> boto3.Session:
     return session
 
 
-def base_aws_client_factory(session: boto3.Session, region: str) -> ClientFactory:
+def base_aws_client_factory(session: boto3.Session) -> ClientFactory:
     config = None
     if is_env_true("TEST_DISABLE_RETRIES_AND_TIMEOUTS"):
         config = botocore.config.Config(
@@ -231,7 +232,7 @@ def base_aws_client_factory(session: boto3.Session, region: str) -> ClientFactor
             config = botocore.config.Config()
 
         # Prevent this fixture from using the region configured in system config
-        config = config.merge(botocore.config.Config(region_name=region))
+        config = config.merge(botocore.config.Config(region_name=TEST_AWS_REGION_NAME))
         return ExternalClientFactory(session=session, config=config)
 
 

--- a/localstack-core/localstack/testing/config.py
+++ b/localstack-core/localstack/testing/config.py
@@ -10,6 +10,8 @@ TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
 TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
 TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION_NAME") or "us-east-1"
 
+# Secondary test AWS profile - only used for testing against AWS
+SECONDARY_TEST_AWS_PROFILE = os.getenv("SECONDARY_TEST_AWS_PROFILE")
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"
 SECONDARY_TEST_AWS_ACCESS_KEY_ID = os.getenv("SECONDARY_TEST_AWS_ACCESS_KEY_ID") or "000000000002"

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -144,7 +144,7 @@
     "last_validated_date": "2024-03-15T08:12:50+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManagerMultiAccounts::test_cross_account_access": {
-    "last_validated_date": "2024-03-18T05:54:28+00:00"
+    "last_validated_date": "2024-06-12T12:04:52+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManagerMultiAccounts::test_cross_account_access_non_default_key": {
     "last_validated_date": "2024-03-21T10:28:06+00:00"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,16 @@ def aws_session():
 
 
 @pytest.fixture(scope="session")
+def secondary_aws_session():
+    """
+    This fixture returns the Boto Session instance for testing a secondary account.
+    """
+    from localstack.testing.aws.util import secondary_aws_session
+
+    return secondary_aws_session()
+
+
+@pytest.fixture(scope="session")
 def aws_client_factory(aws_session):
     """
     This fixture returns a client factory for testing.
@@ -68,8 +78,22 @@ def aws_client_factory(aws_session):
     Use this fixture if you need to use custom endpoint or Boto config.
     """
     from localstack.testing.aws.util import base_aws_client_factory
+    from localstack.testing.config import TEST_AWS_REGION_NAME
 
-    return base_aws_client_factory(aws_session)
+    return base_aws_client_factory(aws_session, TEST_AWS_REGION_NAME)
+
+
+@pytest.fixture(scope="session")
+def secondary_aws_client_factory(secondary_aws_session):
+    """
+    This fixture returns a client factory for testing a secondary account.
+
+    Use this fixture if you need to use custom endpoint or Boto config.
+    """
+    from localstack.testing.aws.util import base_aws_client_factory
+    from localstack.testing.config import SECONDARY_TEST_AWS_REGION_NAME
+
+    return base_aws_client_factory(secondary_aws_session, SECONDARY_TEST_AWS_REGION_NAME)
 
 
 @pytest.fixture(scope="session")
@@ -79,19 +103,19 @@ def aws_client(aws_client_factory):
 
     The clients are configured with the primary testing credentials.
     """
-    from localstack.testing.aws.util import primary_testing_aws_client
+    from localstack.testing.aws.util import base_testing_aws_client
 
-    return primary_testing_aws_client(aws_client_factory)
+    return base_testing_aws_client(aws_client_factory)
 
 
 @pytest.fixture(scope="session")
-def secondary_aws_client(aws_client_factory):
+def secondary_aws_client(secondary_aws_client_factory):
     """
-    This fixture can be used to obtain Boto clients for testing.
+    This fixture can be used to obtain Boto clients for testing a secondary account.
 
     The clients are configured with the secondary testing credentials.
     The region is not overridden.
     """
-    from localstack.testing.aws.util import secondary_testing_aws_client
+    from localstack.testing.aws.util import base_testing_aws_client
 
-    return secondary_testing_aws_client(aws_client_factory)
+    return base_testing_aws_client(secondary_aws_client_factory)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,9 +78,8 @@ def aws_client_factory(aws_session):
     Use this fixture if you need to use custom endpoint or Boto config.
     """
     from localstack.testing.aws.util import base_aws_client_factory
-    from localstack.testing.config import TEST_AWS_REGION_NAME
 
-    return base_aws_client_factory(aws_session, TEST_AWS_REGION_NAME)
+    return base_aws_client_factory(aws_session)
 
 
 @pytest.fixture(scope="session")
@@ -91,9 +90,8 @@ def secondary_aws_client_factory(secondary_aws_session):
     Use this fixture if you need to use custom endpoint or Boto config.
     """
     from localstack.testing.aws.util import base_aws_client_factory
-    from localstack.testing.config import SECONDARY_TEST_AWS_REGION_NAME
 
-    return base_aws_client_factory(secondary_aws_session, SECONDARY_TEST_AWS_REGION_NAME)
+    return base_aws_client_factory(secondary_aws_session)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, we only allow setting credentials for the secondary account test fixtures using the `SECONDARY_TEST_AWS_ACCESS_KEY_ID` variables and so forth.

This can be quite cumbersome, especially when you want to take advantage of temporary credentials using the AWS IAM Identity Center.

To mitigate this, I refactored our client fixtures a tad, so we can now use `SECONDARY_TEST_AWS_PROFILE` to set an aws profile, if the tests are run against AWS. If it runs against LS, nothing changes to the current behavior, only that credentials are now set on the session, and not on the clients anymore.

Also, the secondary clients now use a different session, but the impact of that should be negligable.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* You can now use `SECONDARY_TEST_AWS_PROFILE` to set the profile used for your secondary aws account for cross region tests. If set, the other `SECONDARY_TEST_*` variables will be ignored.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
