### PR TITLE
Add new option to manually expose the DNS port to the host, remove binding by default

### DIFF
--- a/localstack-core/localstack/cli/localstack.py
+++ b/localstack-core/localstack/cli/localstack.py
@@ -457,6 +457,13 @@ def _print_service_table(services: Dict[str, str]) -> None:
     multiple=True,
     required=False,
 )
+@click.option(
+    "--host-dns",
+    help="Expose the LocalStack DNS server to the host using port bindings.",
+    required=False,
+    is_flag=True,
+    default=False,
+)
 @publish_invocation
 def cmd_start(
     docker: bool,
@@ -467,6 +474,7 @@ def cmd_start(
     env: Tuple = (),
     publish: Tuple = (),
     volume: Tuple = (),
+    host_dns: bool = False,
 ) -> None:
     """
     Start the LocalStack runtime.

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -31,10 +31,10 @@ from localstack.utils.container_utils.container_client import (
     VolumeMappings,
 )
 from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
-from localstack.utils.docker_utils import DOCKER_CLIENT, container_ports_can_be_bound
+from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.files import cache_dir, mkdir
 from localstack.utils.functions import call_safe
-from localstack.utils.net import Port, get_free_tcp_port, get_free_tcp_port_range
+from localstack.utils.net import get_free_tcp_port, get_free_tcp_port_range
 from localstack.utils.run import is_command_available, run, to_str
 from localstack.utils.serving import Server
 from localstack.utils.strings import short_uid
@@ -549,28 +549,6 @@ class ContainerConfigurators:
         return _cfg
 
     @staticmethod
-    def publish_dns_ports(cfg: ContainerConfiguration):
-        dns_ports = [
-            Port(config.DNS_PORT, protocol="udp"),
-            Port(config.DNS_PORT, protocol="tcp"),
-        ]
-        if container_ports_can_be_bound(dns_ports, address=config.DNS_ADDRESS):
-            # expose the DNS server to the host
-            # TODO: update ContainerConfiguration to support multiple PortMappings objects with different bind addresses
-            docker_flags = []
-            for port in dns_ports:
-                docker_flags.extend(
-                    [
-                        "-p",
-                        f"{config.DNS_ADDRESS}:{port.port}:{port.port}/{port.protocol}",
-                    ]
-                )
-            if cfg.additional_flags is None:
-                cfg.additional_flags = " ".join(docker_flags)
-            else:
-                cfg.additional_flags += " " + " ".join(docker_flags)
-
-    @staticmethod
     def container_name(name: str):
         def _cfg(cfg: ContainerConfiguration):
             cfg.name = name
@@ -692,6 +670,10 @@ class ContainerConfigurators:
         def _cfg(cfg: ContainerConfiguration):
             if params.get("network"):
                 cfg.network = params.get("network")
+
+            if params.get("host_dns"):
+                cfg.ports.add(config.DNS_PORT, config.DNS_PORT, "udp")
+                cfg.ports.add(config.DNS_PORT, config.DNS_PORT, "tcp")
 
             # processed parsed -e, -p, and -v flags
             ContainerConfigurators.env_cli_params(params.get("env"))(cfg)
@@ -1186,7 +1168,6 @@ def configure_container(container: Container):
             ContainerConfigurators.service_port_range,
             ContainerConfigurators.mount_localstack_volume(config.VOLUME_DIR),
             ContainerConfigurators.mount_docker_socket,
-            ContainerConfigurators.publish_dns_ports,
             # overwrites any env vars set in the config that were previously set by configurators
             ContainerConfigurators.config_env_vars,
             # ensure that GATEWAY_LISTEN is taken from the config and not


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With recent Docker Desktop changes, port 53 is not exposable on the host from docker any more, as the port is already taken. Due to the specific error circumstances, our check whether or not we can expose it does not work any more.

As a fix, this PR will remove the automatic binding of the DNS port to the host, as this a rarely used feature (presumably), since it requires additional configuration to make proper use of it (like setting `DNS_SERVER` to avoid loops in the resolution).

This PR introduces a new flag `--host-dns` instead, which will expose the port to the host.

The flag has two shortcomings we should discuss:

1. Per default, we bind the host port to the same address as the `GATEWAY_LISTEN` sets, so per default 127.0.0.1. It will not be seperately configureable, you can only change it for both the gateway and dns together.
2. The port usability detection, which was broken in the docker desktop case, is removed now. This means if a user with port 53 already taken tries to set the flag, the docker exception explaining the failure to bind the port will be returned.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* LocalStack CLI does not bind port 53 on the host anymore when starting LS
* New CLI flag `--host-dns` to force binding port 53 (or whatever the `DNS_PORT` config variable is set to) on the host

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
