### PR TITLE
Fix TableV2 construct with streaming enabled

### DIFF
--- a/localstack-core/localstack/services/dynamodb/resource_providers/aws_dynamodb_globaltable.py
+++ b/localstack-core/localstack/services/dynamodb/resource_providers/aws_dynamodb_globaltable.py
@@ -242,7 +242,7 @@ class DynamoDBGlobalTableProvider(ResourceProvider[DynamoDBGlobalTableProperties
             if stream_spec := model.get("StreamSpecification"):
                 create_params["StreamSpecification"] = {
                     "StreamEnabled": True,
-                    **(stream_spec or {}),
+                    **stream_spec,
                 }
 
             creation_response = request.aws_client_factory.dynamodb.create_table(**create_params)

--- a/localstack-core/localstack/services/dynamodb/resource_providers/aws_dynamodb_globaltable.py
+++ b/localstack-core/localstack/services/dynamodb/resource_providers/aws_dynamodb_globaltable.py
@@ -239,6 +239,12 @@ class DynamoDBGlobalTableProvider(ResourceProvider[DynamoDBGlobalTableProperties
                 # rename bool attribute to fit boto call
                 sse_specification["Enabled"] = sse_specification.pop("SSEEnabled")
 
+            if stream_spec := model.get("StreamSpecification"):
+                create_params["StreamSpecification"] = {
+                    "StreamEnabled": True,
+                    **(stream_spec or {}),
+                }
+
             creation_response = request.aws_client_factory.dynamodb.create_table(**create_params)
             model["Arn"] = creation_response["TableDescription"]["TableArn"]
             model["TableId"] = creation_response["TableDescription"]["TableId"]

--- a/localstack-core/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack-core/localstack/testing/snapshots/transformer_utility.py
@@ -283,6 +283,19 @@ class TransformerUtility:
         ]
 
     @staticmethod
+    def dynamodb_streams_api():
+        return [
+            TransformerUtility.key_value("TableName"),
+            TransformerUtility.key_value("TableStatus"),
+            TransformerUtility.key_value("LatestStreamLabel"),
+            TransformerUtility.key_value("StartingSequenceNumber", reference_replacement=False),
+            TransformerUtility.key_value("ShardId"),
+            TransformerUtility.key_value("StreamLabel"),
+            TransformerUtility.key_value("SequenceNumber"),
+            TransformerUtility.key_value("eventID"),
+        ]
+
+    @staticmethod
     def iam_api():
         """
         :return: array with Transformers, for iam api.

--- a/tests/aws/cdk_templates/TestTableV2Stream/TableV2StreamStack.json
+++ b/tests/aws/cdk_templates/TestTableV2Stream/TableV2StreamStack.json
@@ -1,0 +1,41 @@
+{
+  "Resources": {
+    "v2table6C40CC77": {
+      "Type": "AWS::DynamoDB::GlobalTable",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "id",
+            "AttributeType": "S"
+          }
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "id",
+            "KeyType": "HASH"
+          }
+        ],
+        "Replicas": [
+          {
+            "Region": {
+              "Ref": "AWS::Region"
+            }
+          }
+        ],
+        "StreamSpecification": {
+          "StreamViewType": "NEW_AND_OLD_IMAGES"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    }
+  },
+  "Outputs": {
+    "tableName": {
+      "Value": {
+        "Ref": "v2table6C40CC77"
+      }
+    }
+  }
+}

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -41,18 +41,7 @@ def dynamodb_snapshot_transformer(snapshot):
 
 @pytest.fixture
 def dynamodbstreams_snapshot_transformers(snapshot):
-    snapshot.add_transformers_list(
-        [
-            snapshot.transform.key_value("TableName"),
-            snapshot.transform.key_value("TableStatus"),
-            snapshot.transform.key_value("LatestStreamLabel"),
-            snapshot.transform.key_value("StartingSequenceNumber", reference_replacement=False),
-            snapshot.transform.key_value("ShardId"),
-            snapshot.transform.key_value("StreamLabel"),
-            snapshot.transform.key_value("SequenceNumber"),
-            snapshot.transform.key_value("eventID"),
-        ]
-    )
+    snapshot.add_transformer(snapshot.transform.dynamodb_streams_api())
     snapshot.add_transformer(snapshot.transform.key_value("NextShardIterator"), priority=-1)
     snapshot.add_transformer(snapshot.transform.key_value("ShardIterator"), priority=-1)
 

--- a/tests/aws/services/dynamodbstreams/test_dynamodb_streams.snapshot.json
+++ b/tests/aws/services/dynamodbstreams/test_dynamodb_streams.snapshot.json
@@ -33,5 +33,53 @@
         }
       ]
     }
+  },
+  "tests/aws/services/dynamodbstreams/test_dynamodb_streams.py::TestDynamoDBStreams::test_table_v2_stream": {
+    "recorded-date": "12-06-2024, 21:57:48",
+    "recorded-content": {
+      "global-table-v2": {
+        "Table": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id",
+              "AttributeType": "S"
+            }
+          ],
+          "BillingModeSummary": {
+            "BillingMode": "PAY_PER_REQUEST",
+            "LastUpdateToPayPerRequestDateTime": "datetime"
+          },
+          "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "id",
+              "KeyType": "HASH"
+            }
+          ],
+          "LatestStreamArn": "<latest-stream-arn:1>",
+          "LatestStreamLabel": "<latest-stream-label:1>",
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 0,
+            "WriteCapacityUnits": 0
+          },
+          "StreamSpecification": {
+            "StreamEnabled": true,
+            "StreamViewType": "NEW_AND_OLD_IMAGES"
+          },
+          "TableArn": "<table-arn:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<table-name:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "<table-status:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/dynamodbstreams/test_dynamodb_streams.validation.json
+++ b/tests/aws/services/dynamodbstreams/test_dynamodb_streams.validation.json
@@ -1,5 +1,8 @@
 {
   "tests/aws/services/dynamodbstreams/test_dynamodb_streams.py::TestDynamoDBStreams::test_enable_kinesis_streaming_destination": {
     "last_validated_date": "2024-01-30T20:27:32+00:00"
+  },
+  "tests/aws/services/dynamodbstreams/test_dynamodb_streams.py::TestDynamoDBStreams::test_table_v2_stream": {
+    "last_validated_date": "2024-06-12T21:57:48+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
LocalStack is not able to deploy a [TableV2 construct](https://aws.amazon.com/blogs/devops/a-new-and-improved-aws-cdk-construct-for-amazon-dynamodb-tables/) with `StreamSpecification` enabled.
A sample was provided by a user and is reflected in the implemented test.
Specifying the stream view type in the new construct should be enough to enable the stream (while LocalStack was failing with a missing required field).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Improve provider for `AWS::DynamoDB::GlobalTable` to account for `StreamSpecification`;
- Write a validated CDK test.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
