### PR TITLE
Disable CloudFormation template validation

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/validations.py
+++ b/localstack-core/localstack/services/cloudformation/engine/validations.py
@@ -77,6 +77,10 @@ def resources_top_level_keys(template: dict):
 
 
 DEFAULT_TEMPLATE_VALIDATIONS: list[TemplateValidationStep] = [
-    outputs_have_values,
-    resources_top_level_keys,
+    # FIXME: disabled for now due to the template validation not fitting well with the template that we use here.
+    #  We don't have access to a "raw" processed template here and it's questionable if we should have it at all,
+    #  since later transformations can again introduce issues.
+    #   => Reevaluate this when reworking how we mutate the template dict in the provider
+    # outputs_have_values,
+    # resources_top_level_keys,
 ]

--- a/localstack-core/localstack/services/cloudformation/engine/validations.py
+++ b/localstack-core/localstack/services/cloudformation/engine/validations.py
@@ -39,6 +39,7 @@ def outputs_have_values(template: dict):
             raise ValidationError(f"[{key}] 'null' values are not allowed in templates")
 
 
+# TODO: this would need to be split into different validations pre- and post- transform
 def resources_top_level_keys(template: dict):
     """
     Validate that each resource

--- a/localstack-core/localstack/services/cloudformation/provider.py
+++ b/localstack-core/localstack/services/cloudformation/provider.py
@@ -210,10 +210,6 @@ class CloudformationProvider(CloudformationApi):
 
         template = template_preparer.parse_template(request["TemplateBody"])
 
-        # perform basic static analysis on the template
-        for validation_fn in DEFAULT_TEMPLATE_VALIDATIONS:
-            validation_fn(template)
-
         stack_name = template["StackName"] = request.get("StackName")
         if api_utils.validate_stack_name(stack_name) is False:
             raise ValidationError(
@@ -264,6 +260,10 @@ class CloudformationProvider(CloudformationApi):
             stack.set_stack_status("ROLLBACK_COMPLETE")
             state.stacks[stack.stack_id] = stack
             return CreateStackOutput(StackId=stack.stack_id)
+
+        # perform basic static analysis on the template
+        for validation_fn in DEFAULT_TEMPLATE_VALIDATIONS:
+            validation_fn(template)
 
         stack = Stack(context.account_id, context.region, request, template)
 
@@ -334,10 +334,6 @@ class CloudformationProvider(CloudformationApi):
         api_utils.prepare_template_body(request)
         template = template_preparer.parse_template(request["TemplateBody"])
 
-        # perform basic static analysis on the template
-        for validation_fn in DEFAULT_TEMPLATE_VALIDATIONS:
-            validation_fn(template)
-
         if (
             "CAPABILITY_AUTO_EXPAND" not in request.get("Capabilities", [])
             and "Transform" in template.keys()
@@ -391,6 +387,10 @@ class CloudformationProvider(CloudformationApi):
             )
             stack.set_stack_status("ROLLBACK_COMPLETE")
             return CreateStackOutput(StackId=stack.stack_id)
+
+        # perform basic static analysis on the template
+        for validation_fn in DEFAULT_TEMPLATE_VALIDATIONS:
+            validation_fn(template)
 
         # update the template
         stack.template_original = template
@@ -613,10 +613,6 @@ class CloudformationProvider(CloudformationApi):
             ]  # should then have been set by prepare_template_body
         template = template_preparer.parse_template(req_params["TemplateBody"])
 
-        # perform basic static analysis on the template
-        for validation_fn in DEFAULT_TEMPLATE_VALIDATIONS:
-            validation_fn(template)
-
         del req_params["TemplateBody"]  # TODO: stop mutating req_params
         template["StackName"] = stack_name
         # TODO: validate with AWS what this is actually doing?
@@ -714,6 +710,10 @@ class CloudformationProvider(CloudformationApi):
             conditions={},  # TODO: we don't have any resolved conditions yet at this point but we need the conditions because of the samtranslator...
             resolved_parameters=resolved_parameters,
         )
+
+        # perform basic static analysis on the template
+        for validation_fn in DEFAULT_TEMPLATE_VALIDATIONS:
+            validation_fn(template)
 
         # create change set for the stack and apply changes
         change_set = StackChangeSet(

--- a/tests/aws/services/cloudformation/api/test_transformers.validation.json
+++ b/tests/aws/services/cloudformation/api/test_transformers.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/cloudformation/api/test_transformers.py::test_duplicate_resources": {
     "last_validated_date": "2024-04-15T22:51:13+00:00"
   },
+  "tests/aws/services/cloudformation/api/test_transformers.py::test_transformer_individual_resource_level": {
+    "last_validated_date": "2024-06-13T06:43:21+00:00"
+  },
   "tests/aws/services/cloudformation/api/test_transformers.py::test_transformer_property_level": {
     "last_validated_date": "2024-06-06T10:38:33+00:00"
   }

--- a/tests/aws/services/cloudformation/api/test_validations.py
+++ b/tests/aws/services/cloudformation/api/test_validations.py
@@ -4,6 +4,8 @@ import pytest
 
 from localstack.testing.pytest import markers
 
+pytestmark = pytest.mark.skip("Validations are currently disabled")
+
 
 @markers.aws.validated
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation

A regression was reported on [Discuss ](https://discuss.localstack.cloud/t/validation-error-when-creating-stack-with-cloudformation/943) where not having a `Type` field in the Resource section leads to the following validation error now:
```
An error occurred (ValidationError) when calling the CreateChangeSet operation: Template format error: [/Resources/NotificationsTable] Every Resources object must contain a Type member.
```

This is generally correct behavior but not in combination with transformations since we don't know which fields will be available when processed before doing the actual processing/transformation.

Changing the order to validate only after processing happened still had issues since we currently modify the template by e.g. adding a `LogicalResourceId` field which then fails the validations again. Therefore I decided to just disable them for now and introduce them again when the template handling is refactored.

## Changes

 - Template validation is now disabled (no active default rules) until further notice. Will re-evaluate this with @simonrw when he  is back. Left in the regression test and new position for the validations though so we can pick it up from there