### PR TITLE
fixed error handling in GetSecretValue in secretsmanager

### DIFF
--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -238,7 +238,7 @@ class SecretsmanagerProvider(SecretsmanagerApi):
     ) -> GetSecretValueResponse:
         secret_id = request.get("SecretId")
         version_id = request.get("VersionId")
-        version_stage = request.get("VersionStage", "AWSCURRENT")
+        version_stage = request.get("VersionStage")
         self._raise_if_invalid_secret_id(secret_id)
         backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
         self._raise_if_default_kms_key(secret_id, context, backend)

--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -239,6 +239,8 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         secret_id = request.get("SecretId")
         version_id = request.get("VersionId")
         version_stage = request.get("VersionStage")
+        if not version_id and not version_stage:
+            version_stage = "AWSCURRENT"
         self._raise_if_invalid_secret_id(secret_id)
         backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
         self._raise_if_default_kms_key(secret_id, context, backend)

--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -238,7 +238,7 @@ class SecretsmanagerProvider(SecretsmanagerApi):
     ) -> GetSecretValueResponse:
         secret_id = request.get("SecretId")
         version_id = request.get("VersionId")
-        version_stage = request.get("VersionStage")
+        version_stage = request.get("VersionStage", "AWSCURRENT")
         self._raise_if_invalid_secret_id(secret_id)
         backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
         self._raise_if_default_kms_key(secret_id, context, backend)
@@ -247,6 +247,13 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         except moto_exception.SecretNotFoundException:
             raise ResourceNotFoundException(
                 f"Secrets Manager can't find the specified secret value for staging label: {version_stage}"
+            )
+        except moto_exception.ResourceNotFoundException:
+            error_message = (
+                f"VersionId: {version_id}" if version_id else f"staging label: {version_stage}"
+            )
+            raise ResourceNotFoundException(
+                f"Secrets Manager can't find the specified secret value for {error_message}"
             )
         except moto_exception.SecretStageVersionMismatchException:
             raise InvalidRequestException(

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4501,5 +4501,13 @@
         }
       }
     }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_version_not_found": {
+    "recorded-date": "13-06-2024, 08:04:35",
+    "recorded-content": {
+      "get_secret_value_no_version_ex": "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret value for staging label: AWSCURRENT",
+      "get_secret_value_version_not_found_ex": "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret value for VersionId: <version-id>",
+      "get_secret_value_stage_not_found_ex": "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret value for staging label: AWSPENDING"
+    }
   }
 }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -119,6 +119,9 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_tags": {
     "last_validated_date": "2024-04-01T13:21:01+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_version_not_found": {
+    "last_validated_date": "2024-06-13T08:04:35+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_description": {
     "last_validated_date": "2024-03-15T08:12:49+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR aims to fix issue described in https://github.com/localstack/localstack/issues/10621. As per the current implementation, localstack was not catching `ResourceNotFound` exception from moto.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Adds exception handling for `GetSecretValue`

## Testing
- Added AWS validated test cases


<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
