### PR TITLE
validate route53 integration tests against AWS

### DIFF
--- a/tests/aws/services/route53/test_route53.py
+++ b/tests/aws/services/route53/test_route53.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import pytest
 
 from localstack.testing.pytest import markers
@@ -22,17 +24,25 @@ class TestRoute53:
         response = aws_client.route53.get_hosted_zone(Id=zone_id)
         snapshot.match("get_hosted_zone", response)
 
-    @markers.aws.unknown
-    def test_crud_health_check(self, aws_client):
+    @markers.aws.validated
+    def test_crud_health_check(self, echo_http_server_post, echo_http_server, aws_client):
+        parsed_url = urlparse(echo_http_server_post)
+        protocol = parsed_url.scheme.upper()
+        host, _, port = parsed_url.netloc.partition(":")
+        port = port or (443 if protocol == "HTTPS" else 80)
+        path = (
+            f"{parsed_url.path}health"
+            if parsed_url.path.endswith("/")
+            else f"{parsed_url.path}/health"
+        )
+
         response = aws_client.route53.create_health_check(
-            CallerReference="test123",
+            CallerReference=short_uid(),
             HealthCheckConfig={
-                "IPAddress": "10.0.0.25",
-                "Port": 80,
-                "Type": "HTTP",
-                "ResourcePath": "/",
-                "FullyQualifiedDomainName": "example.com",
-                "SearchString": "a good response",
+                "FullyQualifiedDomainName": host,
+                "Port": int(port),
+                "ResourcePath": path,
+                "Type": protocol,
                 "RequestInterval": 10,
                 "FailureThreshold": 2,
             },
@@ -89,18 +99,10 @@ class TestRoute53:
         zones = [zone for zone in response["HostedZones"] if name in zone["Name"]]
         snapshot.match("list_hosted_zones", zones)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_associate_vpc_with_hosted_zone(
         self, cleanups, hosted_zone, aws_client, account_id, region_name
     ):
-        name = "zone123"
-        response = hosted_zone(
-            Name=name,
-            HostedZoneConfig={"PrivateZone": True, "Comment": "test"},
-        )
-        zone_id = response["HostedZone"]["Id"]
-        zone_id = zone_id.replace("/hostedzone/", "")
-
         # create VPCs
         vpc1 = aws_client.ec2.create_vpc(CidrBlock="10.113.0.0/24")
         cleanups.append(lambda: aws_client.ec2.delete_vpc(VpcId=vpc1["Vpc"]["VpcId"]))
@@ -109,9 +111,21 @@ class TestRoute53:
         cleanups.append(lambda: aws_client.ec2.delete_vpc(VpcId=vpc2["Vpc"]["VpcId"]))
         vpc2_id = vpc2["Vpc"]["VpcId"]
 
+        name = "zone123"
+        response = hosted_zone(
+            Name=name,
+            HostedZoneConfig={
+                "PrivateZone": True,
+                "Comment": "test",
+            },
+            VPC={"VPCId": vpc1_id, "VPCRegion": region_name},
+        )
+        zone_id = response["HostedZone"]["Id"]
+        zone_id = zone_id.replace("/hostedzone/", "")
+
         # associate zone with VPC
         vpc_region = region_name
-        for vpc_id in [vpc1_id, vpc2_id]:
+        for vpc_id in [vpc2_id]:
             result = aws_client.route53.associate_vpc_with_hosted_zone(
                 HostedZoneId=zone_id,
                 VPC={"VPCRegion": vpc_region, "VPCId": vpc_id},
@@ -173,7 +187,7 @@ class TestRoute53:
 
         snapshot.match("failure-response", exc_info.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_reusable_delegation_sets(self, aws_client):
         client = aws_client.route53
 

--- a/tests/aws/services/route53/test_route53.validation.json
+++ b/tests/aws/services/route53/test_route53.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/route53/test_route53.py::TestRoute53::test_associate_vpc_with_hosted_zone": {
+    "last_validated_date": "2024-06-13T07:40:39+00:00"
+  },
   "tests/aws/services/route53/test_route53.py::TestRoute53::test_create_hosted_zone": {
     "last_validated_date": "2023-11-02T11:59:59+00:00"
   },
@@ -7,5 +10,11 @@
   },
   "tests/aws/services/route53/test_route53.py::TestRoute53::test_create_private_hosted_zone": {
     "last_validated_date": "2024-04-11T14:03:14+00:00"
+  },
+  "tests/aws/services/route53/test_route53.py::TestRoute53::test_crud_health_check": {
+    "last_validated_date": "2024-06-13T08:05:47+00:00"
+  },
+  "tests/aws/services/route53/test_route53.py::TestRoute53::test_reusable_delegation_sets": {
+    "last_validated_date": "2024-06-13T07:43:08+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As an initiative to validate tests and remove all `markers.aws.unknown` markers, this PR handles the ones concerning the route53 integration tests. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This PR adds changes for the tests to work against AWS and thereby update the marker to `validated` for: 
- `tests/aws/services/route53/test_route53.py::TestRoute53::test_crud_health_check`
- `tests/aws/services/route53/test_route53.py::TestRoute53::test_associate_vpc_with_hosted_zone`
- `tests/aws/services/route53/test_route53.py::TestRoute53::test_reusable_delegation_sets`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
