### PR TITLE
Skip flaky OpenSearch CloudFormation test

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_opensearch.py
+++ b/tests/aws/services/cloudformation/resources/test_opensearch.py
@@ -1,9 +1,12 @@
 import os
 from operator import itemgetter
 
+import pytest
+
 from localstack.testing.pytest import markers
 
 
+@pytest.skip("flaky")
 @markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(
     paths=[


### PR DESCRIPTION
## Motivation

Recently flaky a couple of times. Latest flake run:
* https://github.com/localstack/localstack-ext/actions/runs/9496248333/attempts/1


## Changes

Skip test