### PR TITLE
extend bootstrap lifecycle test to include restarts

### DIFF
--- a/tests/bootstrap/test_localstack_container_server.py
+++ b/tests/bootstrap/test_localstack_container_server.py
@@ -4,6 +4,7 @@ import requests
 from localstack import config
 from localstack.config import in_docker
 from localstack.utils.bootstrap import LocalstackContainerServer
+from localstack.utils.sync import poll_condition
 
 
 @pytest.mark.skipif(condition=in_docker(), reason="cannot run bootstrap tests in docker")
@@ -17,8 +18,38 @@ class TestLocalstackContainerServer:
             server.start()
             assert server.wait_is_up(60)
 
-            response = requests.get("http://localhost:4566/_localstack/health")
-            assert response.ok, "expected health check to return OK: %s" % response.text
+            health_response = requests.get("http://localhost:4566/_localstack/health")
+            assert health_response.ok, (
+                "expected health check to return OK: %s" % health_response.text
+            )
+
+            restart_response = requests.post(
+                "http://localhost:4566/_localstack/health", json={"action": "restart"}
+            )
+            assert restart_response.ok, (
+                "expected restart command via health endpoint to return OK: %s"
+                % restart_response.text
+            )
+
+            def check_restart_successful():
+                logs = server.container.get_logs()
+                if logs.count("Ready.") < 2:
+                    # second ready marker still missing
+                    return False
+
+                health_response_after_retry = requests.get(
+                    "http://localhost:4566/_localstack/health"
+                )
+                if not health_response_after_retry.ok:
+                    # health endpoint not yet ready again
+                    return False
+
+                # second restart marker found and health endpoint returned with 200!
+                return True
+
+            assert poll_condition(
+                check_restart_successful, 45, 1
+            ), "expected two Ready markers in the logs after triggering restart via health endpoint"
         finally:
             server.shutdown()
 


### PR DESCRIPTION
## Motivation
With the latest refactoring of the runtime (https://github.com/localstack/localstack/pull/10942) we had some issues with the restart handling (which can be triggered via the health endpoint).
This issue was fixed in https://github.com/localstack/localstack/pull/11018.
This PR aims at extending an existing bootstrap lifecycle test to also include the restart.

## Changes
- Extends `tests.bootstrap.test_localstack_container_server.TestLocalstackContainerServer.test_lifecycle` to send a restart command and check if the restart in the container is working correctly.