### PR TITLE
update rolo and fix lambda url form parsing

### DIFF
--- a/localstack-core/localstack/services/lambda_/urlrouter.py
+++ b/localstack-core/localstack/services/lambda_/urlrouter.py
@@ -138,7 +138,6 @@ def event_for_lambda_url(api_id: str, path: str, data, headers, method: str) -> 
 
     is_base64_encoded = not (data.isascii() and content_type_is_text) if data else False
     body = base64.b64encode(data).decode() if is_base64_encoded else data
-    print(f"{body=}")
     if isinstance(body, bytes):
         body = to_str(body)
 

--- a/localstack-core/localstack/services/lambda_/urlrouter.py
+++ b/localstack-core/localstack/services/lambda_/urlrouter.py
@@ -7,6 +7,8 @@ import urllib
 from datetime import datetime
 from http import HTTPStatus
 
+from rolo.request import restore_payload
+
 from localstack.aws.api.lambda_ import InvocationType
 from localstack.aws.protocol.serializer import gen_amzn_requestid
 from localstack.http import Request, Response, Router
@@ -77,7 +79,7 @@ class FunctionUrlRouter:
             return response
 
         event = event_for_lambda_url(
-            api_id, request.full_path, request.data, request.headers, request.method
+            api_id, request.full_path, restore_payload(request), request.headers, request.method
         )
 
         match = FULL_FN_ARN_PATTERN.search(lambda_url_config.function_arn).groupdict()
@@ -136,6 +138,7 @@ def event_for_lambda_url(api_id: str, path: str, data, headers, method: str) -> 
 
     is_base64_encoded = not (data.isascii() and content_type_is_text) if data else False
     body = base64.b64encode(data).decode() if is_base64_encoded else data
+    print(f"{body=}")
     if isinstance(body, bytes):
         body = to_str(body)
 

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -132,7 +132,7 @@ requests-aws4auth==1.2.3
     # via localstack-core (pyproject.toml)
 rich==13.7.1
     # via localstack-core (pyproject.toml)
-rolo==0.5.0
+rolo==0.5.1
     # via localstack-core (pyproject.toml)
 s3transfer==0.10.1
     # via boto3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -423,7 +423,7 @@ rich==13.7.1
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
-rolo==0.5.0
+rolo==0.5.1
     # via localstack-core
 rpds-py==0.18.1
     # via

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -312,7 +312,7 @@ rich==13.7.1
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
-rolo==0.5.0
+rolo==0.5.1
     # via localstack-core
 rpds-py==0.18.1
     # via

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -390,7 +390,7 @@ rich==13.7.1
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
-rolo==0.5.0
+rolo==0.5.1
     # via localstack-core
 rpds-py==0.18.1
     # via

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -619,7 +619,7 @@ rich==13.7.1
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
-rolo==0.5.0
+rolo==0.5.1
     # via localstack-core
 rpds-py==0.18.1
     # via

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4301,5 +4301,26 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_form_payload": {
+    "recorded-date": "13-06-2024, 21:01:16",
+    "recorded-content": {
+      "url_response": {
+        "args": {},
+        "data": "DQotLTRlZmQxNTllYWUwYzRmNGUxMjVhNWE1MDllMDczZDg1DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImZvcm1maWVsZCINCg0Kbm90IGEgZmlsZSwganVzdCBhIGZpZWxkDQotLTRlZmQxNTllYWUwYzRmNGUxMjVhNWE1MDllMDczZDg1DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImZvbyI7IGZpbGVuYW1lPSJmb28iDQpDb250ZW50LVR5cGU6IHRleHQvcGxhaW47DQoNCmJhcg0KDQotLTRlZmQxNTllYWUwYzRmNGUxMjVhNWE1MDllMDczZDg1LS0NCg==",
+        "domain": "<domain:1>",
+        "headers": {
+          "accept": "*/*",
+          "accept-encoding": "gzip, deflate",
+          "content-length": "286",
+          "content-type": "multipart/form-data; boundary=4efd159eae0c4f4e125a5a509e073d85",
+          "host": "<domain:1>",
+          "user-agent": "python/test-request"
+        },
+        "method": "POST",
+        "origin": "<origin:1>",
+        "path": "/test/value"
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -170,6 +170,9 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_echo_invoke[RESPONSE_STREAM]": {
     "last_validated_date": "2024-04-08T16:57:09+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_form_payload": {
+    "last_validated_date": "2024-06-13T21:01:15+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_headers_and_status": {
     "last_validated_date": "2024-04-08T16:57:13+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR updates to rolo to include https://github.com/localstack/rolo/pull/13

While writing a test for APIGW upstream, I've realized Lambda URL were parsing the form and just forwarding an empty body instead of the raw body containing the form data, so I've fixed it as well, as it feels logical to fix in the same PR where we update rolo to include a fix for form parsing

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update rolo to `0.5.1`
- add a fix for lambda URL, calling `restore_payload` to restore the form/multipart part of the request
- add an AWS validate test for it

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
