### PR TITLE
Apigw improve s3 integration support

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -63,7 +63,6 @@ from tests.aws.services.apigateway.conftest import (
     APIGATEWAY_DYNAMODB_POLICY,
     APIGATEWAY_KINESIS_POLICY,
     APIGATEWAY_LAMBDA_POLICY,
-    APIGATEWAY_S3_POLICY,
     APIGATEWAY_STEPFUNCTIONS_POLICY,
     STEPFUNCTIONS_ASSUME_ROLE_POLICY,
 )
@@ -1798,51 +1797,6 @@ def test_rest_api_multi_region(
 
 
 class TestIntegrations:
-    @markers.aws.needs_fixing
-    # Attempts to create invalid integration with proxy
-    def test_api_gateway_s3_get_integration(
-        self, create_rest_apigw, aws_client, create_iam_role_with_policy
-    ):
-        s3_client = aws_client.s3
-
-        bucket_name = f"test-bucket-{short_uid()}"
-        apigateway_name = f"test-api-{short_uid()}"
-        object_name = "test.json"
-        object_content = '{ "success": "true" }'
-        object_content_type = "application/json"
-
-        api_id, _, _ = create_rest_apigw(name=apigateway_name)
-
-        try:
-            resource_util.get_or_create_bucket(bucket_name, s3_client=s3_client)
-            s3_client.put_object(
-                Bucket=bucket_name,
-                Key=object_name,
-                Body=object_content,
-                ContentType=object_content_type,
-            )
-
-            role_arn = create_iam_role_with_policy(
-                RoleName=f"role-apigw-s3-{short_uid()}",
-                PolicyName=f"policy-apigw-s3-{short_uid()}",
-                RoleDefinition=APIGATEWAY_ASSUME_ROLE_POLICY,
-                PolicyDefinition=APIGATEWAY_S3_POLICY,
-            )
-
-            self.connect_api_gateway_to_s3(
-                aws_client.apigateway, bucket_name, object_name, api_id, "GET", role_arn
-            )
-
-            aws_client.apigateway.create_deployment(restApiId=api_id, stageName="test")
-            url = path_based_url(api_id, "test", f"/{object_name}")
-            result = requests.get(url)
-            assert 200 == result.status_code
-            assert object_content == result.text
-            assert object_content_type == result.headers["content-type"]
-        finally:
-            s3_client.delete_object(Bucket=bucket_name, Key=object_name)
-            s3_client.delete_bucket(Bucket=bucket_name)
-
     @pytest.mark.parametrize("method", ["GET", "POST"])
     @pytest.mark.parametrize("url_type", [UrlType.PATH_BASED, UrlType.HOST_BASED])
     @pytest.mark.parametrize(
@@ -1972,45 +1926,6 @@ class TestIntegrations:
     # Helper methods
     # TODO: replace with fixtures, to allow passing aws_client and enable snapshot testing
     # ==================
-
-    def connect_api_gateway_to_s3(
-        self,
-        apigw_client,
-        bucket_name: str,
-        file_name: str,
-        api_id: str,
-        method: str,
-        role_arn: str,
-    ):
-        """Connects the root resource of an api gateway to the given object of an s3 bucket."""
-        s3_uri = "arn:aws:apigateway:{}:s3:path/{}/{{proxy}}".format(
-            TEST_AWS_REGION_NAME, bucket_name
-        )
-
-        resources = apigw_client.get_resources(restApiId=api_id)
-        # using the root resource '/' directly for this test
-        root_resource_id = resources["items"][0]["id"]
-        proxy_resource = apigw_client.create_resource(
-            restApiId=api_id, parentId=root_resource_id, pathPart="{proxy+}"
-        )
-        apigw_client.put_method(
-            restApiId=api_id,
-            resourceId=proxy_resource["id"],
-            httpMethod=method,
-            authorizationType="NONE",
-            apiKeyRequired=False,
-            requestParameters={},
-        )
-        apigw_client.put_integration(
-            restApiId=api_id,
-            resourceId=proxy_resource["id"],
-            httpMethod=method,
-            type="AWS",
-            integrationHttpMethod=method,
-            uri=s3_uri,
-            credentials=role_arn,
-            requestParameters={"integration.request.path.proxy": "method.request.path.proxy"},
-        )
 
     def connect_api_gateway_to_kinesis(
         self,

--- a/tests/aws/services/apigateway/test_apigateway_s3.py
+++ b/tests/aws/services/apigateway/test_apigateway_s3.py
@@ -1,0 +1,85 @@
+import json
+
+import requests
+import xmltodict
+
+from localstack.testing.pytest import markers
+from localstack.utils.sync import retry
+from tests.aws.services.apigateway.apigateway_fixtures import api_invoke_url
+from tests.aws.services.apigateway.conftest import APIGATEWAY_ASSUME_ROLE_POLICY
+
+
+@markers.aws.validated
+def test_apigateway_s3(
+    aws_client, create_rest_apigw, s3_create_bucket, region_name, create_role_with_policy, snapshot
+):
+    api_id, api_name, root_id = create_rest_apigw()
+    bucket = s3_create_bucket()
+    stage_name = "test"
+    object_name = "test.json"
+
+    _, role_arn = create_role_with_policy(
+        "Allow", "s3:*", json.dumps(APIGATEWAY_ASSUME_ROLE_POLICY), "*"
+    )
+
+    resource_id = aws_client.apigateway.create_resource(
+        restApiId=api_id, parentId=root_id, pathPart="{object_path+}"
+    )["id"]
+
+    aws_client.apigateway.put_method(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="ANY",
+        authorizationType="NONE",
+        requestParameters={"method.request.path.object_path": True},
+    )
+    aws_client.apigateway.put_method_response(
+        restApiId=api_id, resourceId=resource_id, httpMethod="ANY", statusCode="200"
+    )
+
+    aws_client.apigateway.put_integration(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="ANY",
+        integrationHttpMethod="ANY",
+        type="AWS",
+        uri=f"arn:aws:apigateway:{region_name}:s3:path/{bucket}/{{object_path}}",
+        requestParameters={
+            "integration.request.path.object_path": "method.request.path.object_path"
+        },
+        credentials=role_arn,
+    )
+
+    aws_client.apigateway.put_integration_response(
+        restApiId=api_id, resourceId=resource_id, httpMethod="ANY", statusCode="200"
+    )
+
+    aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
+
+    invoke_url = api_invoke_url(api_id, stage_name, path="/" + object_name)
+
+    def _invoke(url, method="GET", body=None, assert_text_body: bool = False):
+        response = requests.request(url=url, method=method, data=body)
+        assert response.status_code == 200
+        if assert_text_body:
+            assert response.text.startswith("put_id")
+        return response
+
+    # Try to get an object that doesn't exists
+    response = retry(lambda: _invoke(invoke_url), retries=10, sleep=2)
+    snapshot.match("get-object-empty", xmltodict.parse(response.content))
+
+    # Put a new object
+    retry(lambda: _invoke(invoke_url, "PUT", {"put_id": 1}), retries=10, sleep=2)
+    response = retry(lambda: _invoke(invoke_url, assert_text_body=True), retries=10, sleep=2)
+    snapshot.match("get-object-1", response.text)
+
+    # updated an object
+    retry(lambda: _invoke(invoke_url, "PUT", {"put_id": 2}), retries=10, sleep=2)
+    response = retry(lambda: _invoke(invoke_url, assert_text_body=True), retries=10, sleep=2)
+    snapshot.match("get-object-2", response.text)
+
+    # Delete an object
+    retry(lambda: _invoke(invoke_url, "DELETE"), retries=10, sleep=2)
+    response = retry(lambda: _invoke(invoke_url), retries=10, sleep=2)
+    snapshot.match("get-object-deleted", xmltodict.parse(response.content))

--- a/tests/aws/services/apigateway/test_apigateway_s3.py
+++ b/tests/aws/services/apigateway/test_apigateway_s3.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 import requests
 import xmltodict
 
@@ -10,7 +11,7 @@ from tests.aws.services.apigateway.conftest import APIGATEWAY_ASSUME_ROLE_POLICY
 
 
 @markers.aws.validated
-def test_apigateway_s3(
+def test_apigateway_s3_any(
     aws_client, create_rest_apigw, s3_create_bucket, region_name, create_role_with_policy, snapshot
 ):
     api_id, api_name, root_id = create_rest_apigw()
@@ -31,7 +32,10 @@ def test_apigateway_s3(
         resourceId=resource_id,
         httpMethod="ANY",
         authorizationType="NONE",
-        requestParameters={"method.request.path.object_path": True},
+        requestParameters={
+            "method.request.path.object_path": True,
+            "method.request.header.Content-Type": False,
+        },
     )
     aws_client.apigateway.put_method_response(
         restApiId=api_id, resourceId=resource_id, httpMethod="ANY", statusCode="200"
@@ -45,7 +49,8 @@ def test_apigateway_s3(
         type="AWS",
         uri=f"arn:aws:apigateway:{region_name}:s3:path/{bucket}/{{object_path}}",
         requestParameters={
-            "integration.request.path.object_path": "method.request.path.object_path"
+            "integration.request.path.object_path": "method.request.path.object_path",
+            "integration.request.header.Content-Type": "method.request.header.Content-Type",
         },
         credentials=role_arn,
     )
@@ -58,28 +63,162 @@ def test_apigateway_s3(
 
     invoke_url = api_invoke_url(api_id, stage_name, path="/" + object_name)
 
-    def _invoke(url, method="GET", body=None, assert_text_body: bool = False):
-        response = requests.request(url=url, method=method, data=body)
+    def _get_object(assert_json: bool = False):
+        response = requests.get(url=invoke_url)
         assert response.status_code == 200
-        if assert_text_body:
-            assert response.text.startswith("put_id")
+        if assert_json:
+            response.json()
         return response
 
-    # Try to get an object that doesn't exists
-    response = retry(lambda: _invoke(invoke_url), retries=10, sleep=2)
-    snapshot.match("get-object-empty", xmltodict.parse(response.content))
+    def _put_object(data: dict):
+        response = requests.put(
+            url=invoke_url, json=data, headers={"Content-Type": "application/json"}
+        )
+        assert response.status_code == 200
+
+    # # Try to get an object that doesn't exists
+    # TODO AWS sends a 200 with the xml empty bucket response from s3 when no objects are present.
+    # response = retry(lambda: _get_object, retries=10, sleep=2)
+    # snapshot.match("get-object-empty", xmltodict.parse(response.content))
 
     # Put a new object
-    retry(lambda: _invoke(invoke_url, "PUT", {"put_id": 1}), retries=10, sleep=2)
-    response = retry(lambda: _invoke(invoke_url, assert_text_body=True), retries=10, sleep=2)
+    retry(lambda: _put_object({"put_id": 1}), retries=10, sleep=2)
+    response = retry(lambda: _get_object(assert_json=True), retries=10, sleep=2)
     snapshot.match("get-object-1", response.text)
 
     # updated an object
-    retry(lambda: _invoke(invoke_url, "PUT", {"put_id": 2}), retries=10, sleep=2)
-    response = retry(lambda: _invoke(invoke_url, assert_text_body=True), retries=10, sleep=2)
+    retry(lambda: _put_object({"put_id": 2}), retries=10, sleep=2)
+    response = retry(lambda: _get_object(assert_json=True), retries=10, sleep=2)
     snapshot.match("get-object-2", response.text)
 
     # Delete an object
-    retry(lambda: _invoke(invoke_url, "DELETE"), retries=10, sleep=2)
-    response = retry(lambda: _invoke(invoke_url), retries=10, sleep=2)
-    snapshot.match("get-object-deleted", xmltodict.parse(response.content))
+    requests.delete(invoke_url)
+    # TODO AWS sends a 200 with the xml empty bucket response from s3 when no objects are present.
+    # response = retry(lambda: _get_object, retries=10, sleep=2)
+    # snapshot.match("get-object-deleted", xmltodict.parse(response.content))
+
+    # TODO We can remove this part when we get the empty bucket response on parity
+    with pytest.raises(Exception) as exc_info:
+        aws_client.s3.get_object(Bucket=bucket, Key=object_name)
+    snapshot.match("get-object-s3", exc_info.value.response)
+
+    # Make a POST request
+    #  TODO AWS return a 200 with a message from s3 in xml format stating that POST is invalid
+    # response = requests.post(invoke_url, headers={"Content-Type": "application/json"}, json={"put_id": 3})
+    # snapshot.match("post-object", xmltodict.parse(response.content))
+
+
+@pytest.mark.skip(reason="Need to implement a solution for method mapping")
+def test_apigateway_s3_method_mapping(
+    aws_client, create_rest_apigw, s3_create_bucket, region_name, create_role_with_policy, snapshot
+):
+    api_id, api_name, root_id = create_rest_apigw()
+    bucket = s3_create_bucket()
+    stage_name = "test"
+    object_name = "test.json"
+
+    _, role_arn = create_role_with_policy(
+        "Allow", "s3:*", json.dumps(APIGATEWAY_ASSUME_ROLE_POLICY), "*"
+    )
+
+    get_resource_id = aws_client.apigateway.create_resource(
+        restApiId=api_id, parentId=root_id, pathPart="get"
+    )["id"]
+    put_resource_id = aws_client.apigateway.create_resource(
+        restApiId=api_id, parentId=root_id, pathPart="put"
+    )["id"]
+    delete_resource_id = aws_client.apigateway.create_resource(
+        restApiId=api_id, parentId=root_id, pathPart="delete"
+    )["id"]
+
+    aws_client.apigateway.put_method(
+        restApiId=api_id,
+        resourceId=get_resource_id,
+        httpMethod="GET",
+        authorizationType="NONE",
+    )
+    aws_client.apigateway.put_method(
+        restApiId=api_id,
+        resourceId=put_resource_id,
+        httpMethod="GET",
+        authorizationType="NONE",
+    )
+    aws_client.apigateway.put_method(
+        restApiId=api_id,
+        resourceId=delete_resource_id,
+        httpMethod="GET",
+        authorizationType="NONE",
+    )
+
+    aws_client.apigateway.put_method_response(
+        restApiId=api_id, resourceId=delete_resource_id, httpMethod="GET", statusCode="200"
+    )
+    aws_client.apigateway.put_method_response(
+        restApiId=api_id, resourceId=put_resource_id, httpMethod="GET", statusCode="200"
+    )
+    aws_client.apigateway.put_method_response(
+        restApiId=api_id, resourceId=get_resource_id, httpMethod="GET", statusCode="200"
+    )
+
+    aws_client.apigateway.put_integration(
+        restApiId=api_id,
+        resourceId=get_resource_id,
+        httpMethod="GET",
+        integrationHttpMethod="GET",
+        type="AWS",
+        uri=f"arn:aws:apigateway:{region_name}:s3:path/{bucket}/{object_name}",
+        credentials=role_arn,
+    )
+    aws_client.apigateway.put_integration(
+        restApiId=api_id,
+        resourceId=put_resource_id,
+        httpMethod="GET",
+        integrationHttpMethod="PUT",
+        type="AWS",
+        uri=f"arn:aws:apigateway:{region_name}:s3:path/{bucket}/{object_name}",
+        requestParameters={
+            "integration.request.header.Content-Type": "'application/json'",
+        },
+        requestTemplates={"application/json": '{"message": "great success!"}'},
+        credentials=role_arn,
+    )
+    aws_client.apigateway.put_integration(
+        restApiId=api_id,
+        resourceId=delete_resource_id,
+        httpMethod="GET",
+        integrationHttpMethod="DELETE",
+        type="AWS",
+        uri=f"arn:aws:apigateway:{region_name}:s3:path/{bucket}/{object_name}",
+        credentials=role_arn,
+    )
+
+    aws_client.apigateway.put_integration_response(
+        restApiId=api_id, resourceId=get_resource_id, httpMethod="GET", statusCode="200"
+    )
+    aws_client.apigateway.put_integration_response(
+        restApiId=api_id, resourceId=put_resource_id, httpMethod="GET", statusCode="200"
+    )
+    aws_client.apigateway.put_integration_response(
+        restApiId=api_id, resourceId=delete_resource_id, httpMethod="GET", statusCode="200"
+    )
+
+    aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
+
+    get_invoke_url = api_invoke_url(api_id, stage_name, path="/get")
+    put_invoke_url = api_invoke_url(api_id, stage_name, path="/put")
+    delete_invoke_url = api_invoke_url(api_id, stage_name, path="/delete")
+
+    def _invoke(url, json_response: bool = False):
+        response = requests.get(url=url)
+        assert response.status_code == 200
+        if json_response:
+            return response.json()
+        return response
+
+    retry(lambda: _invoke(put_invoke_url), retries=10, sleep=2)
+    get_object = retry(lambda: _invoke(get_invoke_url, json_response=True), retries=10, sleep=3)
+    snapshot.match("get-object", get_object)
+    _invoke(delete_invoke_url)
+
+    get_object = retry(lambda: _invoke(get_invoke_url), retries=10, sleep=2)
+    snapshot.match("get-deleted-object", xmltodict.parse(get_object.content))

--- a/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
@@ -1,26 +1,4 @@
 {
-  "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3": {
-    "recorded-date": "13-06-2024, 22:24:32",
-    "recorded-content": {
-      "get-object-1": {
-        "put_id": 1
-      },
-      "get-object-2": {
-        "put_id": 2
-      },
-      "get-object-s3": {
-        "Error": {
-          "Code": "NoSuchKey",
-          "Key": "test.json",
-          "Message": "The specified key does not exist."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_any": {
     "recorded-date": "13-06-2024, 23:10:19",
     "recorded-content": {

--- a/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
@@ -1,27 +1,55 @@
 {
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3": {
-    "recorded-date": "11-06-2024, 23:37:02",
+    "recorded-date": "13-06-2024, 22:24:32",
     "recorded-content": {
-      "get-object-empty": {
-        "Error": {
-          "Code": "NoSuchKey",
-          "HostId": "GtejUaU/e0/NITH+fgql01ETYjpFvSclLmVTfP7hp1Wso/stsFt0Y1gRW5u/5iY5ludWnt/MC9w=",
-          "Key": "test.json",
-          "Message": "The specified key does not exist.",
-          "RequestId": "8Z2HJSFVMQ7EWXQR"
-        }
+      "get-object-1": {
+        "put_id": 1
       },
-      "get-object-1": "put_id=1",
-      "get-object-2": "put_id=2",
-      "get-object-deleted": {
+      "get-object-2": {
+        "put_id": 2
+      },
+      "get-object-s3": {
         "Error": {
           "Code": "NoSuchKey",
-          "HostId": "+SvuCQfKi2SsSuYmIfP3wpMveUmE0PsNUx8oW5BnAa205aFRAi6vSoVFrhOkJ/9XPTX287W8Zv8=",
           "Key": "test.json",
-          "Message": "The specified key does not exist.",
-          "RequestId": "BN3QPY0E8AAXHC4V"
+          "Message": "The specified key does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
         }
       }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_any": {
+    "recorded-date": "13-06-2024, 23:10:19",
+    "recorded-content": {
+      "get-object-1": {
+        "put_id": 1
+      },
+      "get-object-2": {
+        "put_id": 2
+      },
+      "get-object-s3": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "Key": "test.json",
+          "Message": "The specified key does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_method_mapping": {
+    "recorded-date": "13-06-2024, 23:48:59",
+    "recorded-content": {
+      "get-object": {
+        "message": "great success!"
+      },
+      "get-deleted-object": "b'<?xml version=\"1.0\" encoding=\"UTF-8\"?>\\n<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>test.json</Key><RequestId>EENKG69QCT1EWSC1</RequestId><HostId>1zYps0DF5XgqCBb3dPp6/LwXpEojpUQD/nRdFvt/x63I/AYnhQ1l5QKHFU6mwkMlBDcWkBQ1ucM=</HostId></Error>'"
     }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
@@ -1,0 +1,27 @@
+{
+  "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3": {
+    "recorded-date": "11-06-2024, 23:37:02",
+    "recorded-content": {
+      "get-object-empty": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "HostId": "GtejUaU/e0/NITH+fgql01ETYjpFvSclLmVTfP7hp1Wso/stsFt0Y1gRW5u/5iY5ludWnt/MC9w=",
+          "Key": "test.json",
+          "Message": "The specified key does not exist.",
+          "RequestId": "8Z2HJSFVMQ7EWXQR"
+        }
+      },
+      "get-object-1": "put_id=1",
+      "get-object-2": "put_id=2",
+      "get-object-deleted": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "HostId": "+SvuCQfKi2SsSuYmIfP3wpMveUmE0PsNUx8oW5BnAa205aFRAi6vSoVFrhOkJ/9XPTX287W8Zv8=",
+          "Key": "test.json",
+          "Message": "The specified key does not exist.",
+          "RequestId": "BN3QPY0E8AAXHC4V"
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
@@ -44,12 +44,20 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_method_mapping": {
-    "recorded-date": "13-06-2024, 23:48:59",
+    "recorded-date": "14-06-2024, 16:12:27",
     "recorded-content": {
       "get-object": {
         "message": "great success!"
       },
-      "get-deleted-object": "b'<?xml version=\"1.0\" encoding=\"UTF-8\"?>\\n<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>test.json</Key><RequestId>EENKG69QCT1EWSC1</RequestId><HostId>1zYps0DF5XgqCBb3dPp6/LwXpEojpUQD/nRdFvt/x63I/AYnhQ1l5QKHFU6mwkMlBDcWkBQ1ucM=</HostId></Error>'"
+      "get-deleted-object": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "HostId": "<host-id:1>",
+          "Key": "test.json",
+          "Message": "The specified key does not exist.",
+          "RequestId": "<request-id:1>"
+        }
+      }
     }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_s3.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3": {
+    "last_validated_date": "2024-06-11T23:37:02+00:00"
+  }
+}

--- a/tests/aws/services/apigateway/test_apigateway_s3.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.validation.json
@@ -6,6 +6,6 @@
     "last_validated_date": "2024-06-13T23:10:19+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_method_mapping": {
-    "last_validated_date": "2024-06-13T23:48:59+00:00"
+    "last_validated_date": "2024-06-14T16:12:27+00:00"
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_s3.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.validation.json
@@ -1,7 +1,4 @@
 {
-  "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3": {
-    "last_validated_date": "2024-06-13T22:24:32+00:00"
-  },
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_any": {
     "last_validated_date": "2024-06-13T23:10:19+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_s3.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.validation.json
@@ -1,5 +1,11 @@
 {
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3": {
-    "last_validated_date": "2024-06-11T23:37:02+00:00"
+    "last_validated_date": "2024-06-13T22:24:32+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_any": {
+    "last_validated_date": "2024-06-13T23:10:19+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_method_mapping": {
+    "last_validated_date": "2024-06-13T23:48:59+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

fixes #10886 

Basic implementation of PUT and DELETE actions for apigw s3 integration.

## Changes

controls GET, PUT and DELETE operation over s3 objects

A more transparent solution where we could mostly proxy the requests would be better and allow for all actions, but we can tackle that as part of the rewrite which should make the implementation along with the s3 xml  response passthrough  easier.

## Out of scope

- We are still returning errors instead of the XML object when performing POST or attempting to get a non-existent object
- We are not mapping method from `HttpMethod` to `IntegrationHttpMethod`. It appears we were also not doing it for http integration. The rewrite should allow us to toggle the extra added test when we get there!


<!-- What changes does this PR make? How does LocalStack behave differently now? -->



<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
