### PR TITLE
Feature/eventbridge v2 add cross account test

### DIFF
--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -8,8 +8,10 @@ from typing import Callable, Optional
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.config import TagsList
 from localstack.aws.api.events import (
+    Action,
     Arn,
     Boolean,
+    Condition,
     CreateEventBusResponse,
     DeadLetterConfig,
     DescribeEventBusResponse,
@@ -31,6 +33,8 @@ from localstack.aws.api.events import (
     ListTagsForResourceResponse,
     ListTargetsByRuleResponse,
     NextToken,
+    NonPartnerEventBusName,
+    Principal,
     PutEventsRequestEntry,
     PutEventsRequestEntryList,
     PutEventsResponse,
@@ -50,6 +54,8 @@ from localstack.aws.api.events import (
     RuleResponseList,
     RuleState,
     ScheduleExpression,
+    StatementId,
+    String,
     TagKeyList,
     TagList,
     TagResourceResponse,
@@ -287,6 +293,20 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         if next_token is not None:
             response["NextToken"] = next_token
         return response
+
+    @handler("PutPermission")
+    def put_permission(
+        self,
+        context: RequestContext,
+        event_bus_name: NonPartnerEventBusName = None,
+        action: Action = None,
+        principal: Principal = None,
+        statement_id: StatementId = None,
+        condition: Condition = None,
+        policy: String = None,
+        **kwargs,
+    ) -> None:
+        pass  # TODO align with policy streaming
 
     #######
     # Rules

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -161,6 +161,7 @@ def format_event(event: PutEventsRequestEntry, region: str, account_id: str) -> 
         except json.JSONDecodeError:
             pass
     id = message.get("original_id", str(long_uid()))
+    region = message.get("original_region", region)
     account_id = message.get("original_account", account_id)
 
     formatted_event = {

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -147,9 +147,19 @@ def validate_event(event: PutEventsRequestEntry) -> None | PutEventsResultEntry:
 
 def format_event(event: PutEventsRequestEntry, region: str, account_id: str) -> FormattedEvent:
     # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-events.html
+    trace_header = event.get("TraceHeader")
+    message = {}
+    if trace_header:
+        try:
+            message = json.loads(trace_header)
+        except json.JSONDecodeError:
+            pass
+    id = message.get("original_id", str(long_uid()))
+    account_id = message.get("original_account", account_id)
+
     formatted_event = {
         "version": "0",
-        "id": str(long_uid()),
+        "id": id,
         "detail-type": event.get("DetailType"),
         "source": event.get("Source"),
         "account": account_id,

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -160,13 +160,13 @@ def format_event(event: PutEventsRequestEntry, region: str, account_id: str) -> 
             message = json.loads(trace_header)
         except json.JSONDecodeError:
             pass
-    id = message.get("original_id", str(long_uid()))
+    message_id = message.get("original_id", str(long_uid()))
     region = message.get("original_region", region)
     account_id = message.get("original_account", account_id)
 
     formatted_event = {
         "version": "0",
-        "id": id,
+        "id": message_id,
         "detail-type": event.get("DetailType"),
         "source": event.get("Source"),
         "account": account_id,

--- a/tests/aws/services/events/test_events_cross_account_region.py
+++ b/tests/aws/services/events/test_events_cross_account_region.py
@@ -21,9 +21,9 @@ class TestEventCrossRegion:
     ):
         # overwriting randomized region https://docs.localstack.cloud/contributing/multi-account-region-testing/
         # requires manually adding region replacement for snapshot
-        snapshot.add_transformer(snapshot.transform.regex(region_name, "<region-name>"))
+        snapshot.add_transformer(snapshot.transform.regex(region_name, "<region>"))
         snapshot.add_transformer(
-            snapshot.transform.regex(secondary_region_name, "<region-name-secondary>")
+            snapshot.transform.regex(secondary_region_name, "<region-secondary>")
         )
 
         aws_client_primary = aws_client_factory(region_name=region_name)
@@ -269,4 +269,268 @@ class TestEventCrossRegion:
         aws_client_primary.iam.delete_role(RoleName=role_name_bus_primary_to_bus_secondary)
 
 
-# class TestEventsCrossAccount:
+class TestEventsCrossAccount:
+    @markers.aws.validated
+    @pytest.mark.skipif(is_old_provider(), reason="Not supported in v1 provider")
+    def test_event_bus_to_event_bus_cross_account(
+        self,
+        account_id,
+        secondary_account_id,
+        aws_client,
+        secondary_aws_client,
+        cleanups,
+        snapshot,
+    ):
+        # overwriting randomized region https://docs.localstack.cloud/contributing/multi-account-region-testing/
+        # requires manually adding account replacement for snapshot
+        snapshot.add_transformer(snapshot.transform.regex(account_id, "<account-id>"))
+        snapshot.add_transformer(
+            snapshot.transform.regex(secondary_account_id, "<account-id-secondary>")
+        )
+
+        # Create event buses
+        event_bus_name_primary = f"test-event-bus-primary-{short_uid()}"
+        aws_client.events.create_event_bus(Name=event_bus_name_primary)["EventBusArn"]
+
+        event_bus_name_secondary = f"test-event-bus-secondary-{short_uid()}"
+        event_bus_arn_secondary = secondary_aws_client.events.create_event_bus(
+            Name=event_bus_name_secondary
+        )["EventBusArn"]
+        secondary_aws_client.events.put_permission(
+            StatementId=f"SecondaryEventBusAccessPermission{short_uid()}",
+            EventBusName=event_bus_name_secondary,
+            Action="events:PutEvents",
+            Principal="*",
+        )
+
+        # Create SQS queues
+        queue_name_primary = f"test-queue-primary-{short_uid()}"
+        queue_url_primary = aws_client.sqs.create_queue(QueueName=queue_name_primary)["QueueUrl"]
+        queue_arn_primary = aws_client.sqs.get_queue_attributes(
+            QueueUrl=queue_url_primary, AttributeNames=["QueueArn"]
+        )["Attributes"]["QueueArn"]
+        policy_events_sqs_primary = {
+            "Version": "2012-10-17",
+            "Id": f"sqs-eventbridge-{short_uid()}",
+            "Statement": [
+                {
+                    "Sid": f"SendMessage-{short_uid()}",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "events.amazonaws.com"},
+                    "Action": "sqs:SendMessage",
+                    "Resource": queue_arn_primary,
+                }
+            ],
+        }
+        aws_client.sqs.set_queue_attributes(
+            QueueUrl=queue_url_primary, Attributes={"Policy": json.dumps(policy_events_sqs_primary)}
+        )
+
+        queue_name_secondary = f"test-queue-secondary-{short_uid()}"
+        queue_url_secondary = secondary_aws_client.sqs.create_queue(QueueName=queue_name_secondary)[
+            "QueueUrl"
+        ]
+        queue_arn_secondary = secondary_aws_client.sqs.get_queue_attributes(
+            QueueUrl=queue_url_secondary, AttributeNames=["QueueArn"]
+        )["Attributes"]["QueueArn"]
+        policy_events_sqs_secondary = {
+            "Version": "2012-10-17",
+            "Id": f"sqs-eventbridge-{short_uid()}",
+            "Statement": [
+                {
+                    "Sid": f"SendMessage-{short_uid()}",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "events.amazonaws.com"},
+                    "Action": "sqs:SendMessage",
+                    "Resource": queue_arn_secondary,
+                }
+            ],
+        }
+        secondary_aws_client.sqs.set_queue_attributes(
+            QueueUrl=queue_url_secondary,
+            Attributes={"Policy": json.dumps(policy_events_sqs_secondary)},
+        )
+
+        # Create rule in primary region
+        rule_name = f"test-rule-primary-sqs-{short_uid()}"
+        aws_client.events.put_rule(
+            Name=rule_name,
+            EventPattern=json.dumps({"source": [SOURCE_PRIMARY]}),
+            # EventPattern=json.dumps({"source": [SOURCE_PRIMARY], **TEST_EVENT_PATTERN_NO_SOURCE}),
+            EventBusName=event_bus_name_primary,
+        )
+
+        # Create target in primary region sqs
+        target_id_sqs_primary = f"test-target-primary-sqs-{short_uid()}"
+        aws_client.events.put_targets(
+            Rule=rule_name,
+            EventBusName=event_bus_name_primary,
+            Targets=[
+                {
+                    "Id": target_id_sqs_primary,
+                    "Arn": queue_arn_primary,
+                }
+            ],
+        )
+
+        # Create permission for event bus in primary region to send events to event bus in secondary region
+        role_name_bus_primary_to_bus_secondary = (
+            f"event-bus-primary-to-secondary-role-{short_uid()}"
+        )
+        assume_role_policy_document_bus_primary_to_bus_secondary = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "events.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+
+        role_arn_bus_primary_to_bus_secondary = aws_client.iam.create_role(
+            RoleName=role_name_bus_primary_to_bus_secondary,
+            AssumeRolePolicyDocument=json.dumps(
+                assume_role_policy_document_bus_primary_to_bus_secondary
+            ),
+        )["Role"]["Arn"]
+
+        policy_name_bus_primary_to_bus_secondary = (
+            f"event-bus-primary-to-secondary-policy-{short_uid()}"
+        )
+        policy_document_bus_primary_to_bus_secondary = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "",
+                    "Effect": "Allow",
+                    "Action": "events:PutEvents",
+                    "Resource": "arn:aws:events:*:*:event-bus/*",
+                }
+            ],
+        }
+
+        aws_client.iam.put_role_policy(
+            RoleName=role_name_bus_primary_to_bus_secondary,
+            PolicyName=policy_name_bus_primary_to_bus_secondary,
+            PolicyDocument=json.dumps(policy_document_bus_primary_to_bus_secondary),
+        )
+
+        if is_aws_cloud():
+            time.sleep(10)
+
+        # Create target in primary region event bus secondary region
+        target_id_event_bus_secondary = f"test-target-primary-events-{short_uid()}"
+        aws_client.events.put_targets(
+            Rule=rule_name,
+            EventBusName=event_bus_name_primary,
+            Targets=[
+                {
+                    "Id": target_id_event_bus_secondary,
+                    "Arn": event_bus_arn_secondary,
+                    "RoleArn": role_arn_bus_primary_to_bus_secondary,
+                }
+            ],
+        )
+
+        # Create rule in secondary region
+        rule_name_secondary = f"test-rule-secondary-sqs-{short_uid()}"
+        secondary_aws_client.events.put_rule(
+            Name=rule_name_secondary,
+            EventPattern=json.dumps({"source": [SOURCE_PRIMARY, SOURCE_SECONDARY]}),
+            EventBusName=event_bus_name_secondary,
+        )
+        cleanups.append(lambda: secondary_aws_client.events.delete_rule(Name=rule_name_secondary))
+
+        # Create target in secondary region sqs
+        target_id_sqs_secondary = f"test-target-secondary-{short_uid()}"
+        secondary_aws_client.events.put_targets(
+            Rule=rule_name_secondary,
+            EventBusName=event_bus_name_secondary,
+            Targets=[
+                {
+                    "Id": target_id_sqs_secondary,
+                    "Arn": queue_arn_secondary,
+                }
+            ],
+        )
+
+        ######
+        # Test
+        ######
+
+        # Put events into primary event bus
+        aws_client.events.put_events(
+            Entries=[
+                {
+                    "Source": SOURCE_PRIMARY,
+                    "DetailType": TEST_EVENT_PATTERN_NO_SOURCE["detail-type"][0],
+                    "Detail": json.dumps(EVENT_DETAIL),
+                    "EventBusName": event_bus_name_primary,
+                }
+            ],
+        )
+
+        # Collect messages from primary queue
+        messages_primary = sqs_collect_messages(
+            aws_client, queue_url_primary, min_events=1, wait_time=1, retries=5
+        )
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("ReceiptHandle", reference_replacement=False),
+                snapshot.transform.key_value("MD5OfBody", reference_replacement=False),
+            ],
+        )
+        snapshot.match("messages_primary_queue_from_primary_event_bus", messages_primary)
+
+        # # Collect messages from secondary queue
+        messages_secondary = sqs_collect_messages(
+            secondary_aws_client, queue_url_secondary, min_events=1, wait_time=1, retries=5
+        )
+        snapshot.match("messages_secondary_queue_from_primary_event_bus", messages_secondary)
+
+        # Put events into secondary event bus
+        secondary_aws_client.events.put_events(
+            Entries=[
+                {
+                    "Source": SOURCE_SECONDARY,
+                    "DetailType": TEST_EVENT_PATTERN_NO_SOURCE["detail-type"][0],
+                    "Detail": json.dumps(EVENT_DETAIL),
+                    "EventBusName": event_bus_name_secondary,
+                }
+            ],
+        )
+
+        # Collect messages from secondary queue
+        messages_secondary = sqs_collect_messages(
+            secondary_aws_client, queue_url_secondary, min_events=1, wait_time=1, retries=5
+        )
+        snapshot.match("messages_secondary_queue_from_secondary_event_bus", messages_secondary)
+
+        # Custom cleanup
+        aws_client.events.remove_targets(
+            Rule=rule_name,
+            EventBusName=event_bus_name_primary,
+            Ids=[target_id_sqs_primary, target_id_event_bus_secondary],
+        )
+        aws_client.events.delete_rule(EventBusName=event_bus_name_primary, Name=rule_name)
+        aws_client.events.delete_event_bus(Name=event_bus_name_primary)
+
+        secondary_aws_client.events.remove_targets(
+            Rule=rule_name_secondary,
+            EventBusName=event_bus_name_secondary,
+            Ids=[target_id_sqs_secondary],
+        )
+        secondary_aws_client.events.delete_rule(
+            EventBusName=event_bus_name_secondary, Name=rule_name_secondary
+        )
+        secondary_aws_client.events.delete_event_bus(Name=event_bus_name_secondary)
+
+        aws_client.sqs.delete_queue(QueueUrl=queue_url_primary)
+        secondary_aws_client.sqs.delete_queue(QueueUrl=queue_url_secondary)
+
+        aws_client.iam.delete_role_policy(
+            RoleName=role_name_bus_primary_to_bus_secondary,
+            PolicyName=policy_name_bus_primary_to_bus_secondary,
+        )
+        aws_client.iam.delete_role(RoleName=role_name_bus_primary_to_bus_secondary)

--- a/tests/aws/services/events/test_events_cross_account_region.py
+++ b/tests/aws/services/events/test_events_cross_account_region.py
@@ -13,282 +13,50 @@ SOURCE_PRIMARY = "source-primary"
 SOURCE_SECONDARY = "source-secondary"
 
 
-class TestEventCrossRegion:
-    @markers.aws.validated
-    @pytest.mark.skipif(is_old_provider(), reason="Not supported in v1 provider")
-    def test_event_bus_to_event_bus_cross_region(
-        self, region_name, secondary_region_name, aws_client_factory, cleanups, snapshot
-    ):
-        # overwriting randomized region https://docs.localstack.cloud/contributing/multi-account-region-testing/
-        # requires manually adding region replacement for snapshot
-        snapshot.add_transformer(snapshot.transform.regex(region_name, "<region>"))
-        snapshot.add_transformer(
-            snapshot.transform.regex(secondary_region_name, "<region-secondary>")
+@markers.aws.validated
+@pytest.mark.skipif(is_old_provider(), reason="Not supported in v1 provider")
+@pytest.mark.parametrize("cross_scenario", ["region", "account", "region_account"])
+@pytest.mark.parametrize("event_bus_name", ["default", "custom"])
+def test_event_bus_to_event_bus_cross_account_region(
+    cross_scenario,
+    event_bus_name,
+    region_name,
+    secondary_region_name,
+    account_id,
+    secondary_account_id,
+    aws_client_factory,
+    secondary_aws_client_factory,
+    cleanups,
+    snapshot,
+):
+    # overwriting randomized region https://docs.localstack.cloud/contributing/multi-account-region-testing/
+    # requires manually adding region replacement for snapshot
+    snapshot.add_transformer(snapshot.transform.regex(region_name, "<region>"))
+    snapshot.add_transformer(snapshot.transform.regex(secondary_region_name, "<region-secondary>"))
+    snapshot.add_transformer(snapshot.transform.regex(account_id, "<account>"))
+    snapshot.add_transformer(snapshot.transform.regex(secondary_account_id, "<account-secondary>"))
+
+    # Create aws clients
+    if cross_scenario == "region":
+        secondary_account_id = account_id
+        aws_client = aws_client_factory(region_name=region_name)
+        secondary_aws_client = aws_client_factory(region_name=secondary_region_name)
+    if cross_scenario == "account":
+        secondary_region_name = region_name
+        aws_client = aws_client_factory(region_name=region_name)
+        secondary_aws_client = secondary_aws_client_factory(region_name=region_name)
+    if cross_scenario == "region_account":
+        aws_client = aws_client_factory(region_name=region_name)
+        secondary_aws_client = secondary_aws_client_factory(region_name=secondary_region_name)
+
+    # Create event buses
+    if event_bus_name == "default":
+        event_bus_name_primary = "default"
+        event_bus_name_secondary = "default"
+        event_bus_arn_secondary = (
+            f"arn:aws:events:{secondary_region_name}:{secondary_account_id}:event-bus/default"
         )
-
-        aws_client_primary = aws_client_factory(region_name=region_name)
-        aws_client_secondary = aws_client_factory(region_name=secondary_region_name)
-
-        # Create event buses
-        event_bus_name_primary = f"test-event-bus-primary-{short_uid()}"
-        aws_client_primary.events.create_event_bus(Name=event_bus_name_primary)["EventBusArn"]
-
-        event_bus_name_secondary = f"test-event-bus-secondary-{short_uid()}"
-        event_bus_arn_secondary = aws_client_secondary.events.create_event_bus(
-            Name=event_bus_name_secondary
-        )["EventBusArn"]
-
-        # Create SQS queues
-        queue_name_primary = f"test-queue-primary-{short_uid()}"
-        queue_url_primary = aws_client_primary.sqs.create_queue(QueueName=queue_name_primary)[
-            "QueueUrl"
-        ]
-        queue_arn_primary = aws_client_primary.sqs.get_queue_attributes(
-            QueueUrl=queue_url_primary, AttributeNames=["QueueArn"]
-        )["Attributes"]["QueueArn"]
-        policy_events_sqs_primary = {
-            "Version": "2012-10-17",
-            "Id": f"sqs-eventbridge-{short_uid()}",
-            "Statement": [
-                {
-                    "Sid": f"SendMessage-{short_uid()}",
-                    "Effect": "Allow",
-                    "Principal": {"Service": "events.amazonaws.com"},
-                    "Action": "sqs:SendMessage",
-                    "Resource": queue_arn_primary,
-                }
-            ],
-        }
-        aws_client_primary.sqs.set_queue_attributes(
-            QueueUrl=queue_url_primary, Attributes={"Policy": json.dumps(policy_events_sqs_primary)}
-        )
-
-        queue_name_secondary = f"test-queue-secondary-{short_uid()}"
-        queue_url_secondary = aws_client_secondary.sqs.create_queue(QueueName=queue_name_secondary)[
-            "QueueUrl"
-        ]
-        queue_arn_secondary = aws_client_secondary.sqs.get_queue_attributes(
-            QueueUrl=queue_url_secondary, AttributeNames=["QueueArn"]
-        )["Attributes"]["QueueArn"]
-        policy_events_sqs_secondary = {
-            "Version": "2012-10-17",
-            "Id": f"sqs-eventbridge-{short_uid()}",
-            "Statement": [
-                {
-                    "Sid": f"SendMessage-{short_uid()}",
-                    "Effect": "Allow",
-                    "Principal": {"Service": "events.amazonaws.com"},
-                    "Action": "sqs:SendMessage",
-                    "Resource": queue_arn_secondary,
-                }
-            ],
-        }
-        aws_client_secondary.sqs.set_queue_attributes(
-            QueueUrl=queue_url_secondary,
-            Attributes={"Policy": json.dumps(policy_events_sqs_secondary)},
-        )
-
-        # Create rule in primary region
-        rule_name = f"test-rule-primary-sqs-{short_uid()}"
-        aws_client_primary.events.put_rule(
-            Name=rule_name,
-            EventPattern=json.dumps({"source": [SOURCE_PRIMARY]}),
-            # EventPattern=json.dumps({"source": [SOURCE_PRIMARY], **TEST_EVENT_PATTERN_NO_SOURCE}),
-            EventBusName=event_bus_name_primary,
-        )
-
-        # Create target in primary region sqs
-        target_id_sqs_primary = f"test-target-primary-sqs-{short_uid()}"
-        aws_client_primary.events.put_targets(
-            Rule=rule_name,
-            EventBusName=event_bus_name_primary,
-            Targets=[
-                {
-                    "Id": target_id_sqs_primary,
-                    "Arn": queue_arn_primary,
-                }
-            ],
-        )
-
-        # Create permission for event bus in primary region to send events to event bus in secondary region
-        role_name_bus_primary_to_bus_secondary = (
-            f"event-bus-primary-to-secondary-role-{short_uid()}"
-        )
-        assume_role_policy_document_bus_primary_to_bus_secondary = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": "events.amazonaws.com"},
-                    "Action": "sts:AssumeRole",
-                }
-            ],
-        }
-
-        role_arn_bus_primary_to_bus_secondary = aws_client_primary.iam.create_role(
-            RoleName=role_name_bus_primary_to_bus_secondary,
-            AssumeRolePolicyDocument=json.dumps(
-                assume_role_policy_document_bus_primary_to_bus_secondary
-            ),
-        )["Role"]["Arn"]
-
-        policy_name_bus_primary_to_bus_secondary = (
-            f"event-bus-primary-to-secondary-policy-{short_uid()}"
-        )
-        policy_document_bus_primary_to_bus_secondary = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Sid": "",
-                    "Effect": "Allow",
-                    "Action": "events:PutEvents",
-                    "Resource": "arn:aws:events:*:*:event-bus/*",
-                }
-            ],
-        }
-
-        aws_client_primary.iam.put_role_policy(
-            RoleName=role_name_bus_primary_to_bus_secondary,
-            PolicyName=policy_name_bus_primary_to_bus_secondary,
-            PolicyDocument=json.dumps(policy_document_bus_primary_to_bus_secondary),
-        )
-
-        if is_aws_cloud():
-            time.sleep(10)
-
-        # Create target in primary region event bus secondary region
-        target_id_event_bus_secondary = f"test-target-primary-events-{short_uid()}"
-        aws_client_primary.events.put_targets(
-            Rule=rule_name,
-            EventBusName=event_bus_name_primary,
-            Targets=[
-                {
-                    "Id": target_id_event_bus_secondary,
-                    "Arn": event_bus_arn_secondary,
-                    "RoleArn": role_arn_bus_primary_to_bus_secondary,
-                }
-            ],
-        )
-
-        # Create rule in secondary region
-        rule_name_secondary = f"test-rule-secondary-sqs-{short_uid()}"
-        aws_client_secondary.events.put_rule(
-            Name=rule_name_secondary,
-            EventPattern=json.dumps({"source": [SOURCE_PRIMARY, SOURCE_SECONDARY]}),
-            EventBusName=event_bus_name_secondary,
-        )
-        cleanups.append(lambda: aws_client_secondary.events.delete_rule(Name=rule_name_secondary))
-
-        # Create target in secondary region sqs
-        target_id_sqs_secondary = f"test-target-secondary-{short_uid()}"
-        aws_client_secondary.events.put_targets(
-            Rule=rule_name_secondary,
-            EventBusName=event_bus_name_secondary,
-            Targets=[
-                {
-                    "Id": target_id_sqs_secondary,
-                    "Arn": queue_arn_secondary,
-                }
-            ],
-        )
-
-        # Put events into primary event bus
-        aws_client_primary.events.put_events(
-            Entries=[
-                {
-                    "Source": SOURCE_PRIMARY,
-                    "DetailType": TEST_EVENT_PATTERN_NO_SOURCE["detail-type"][0],
-                    "Detail": json.dumps(EVENT_DETAIL),
-                    "EventBusName": event_bus_name_primary,
-                }
-            ],
-        )
-
-        # Collect messages from primary queue
-        messages_primary = sqs_collect_messages(
-            aws_client_primary, queue_url_primary, min_events=1, wait_time=1, retries=5
-        )
-        snapshot.add_transformers_list(
-            [
-                snapshot.transform.key_value("ReceiptHandle", reference_replacement=False),
-                snapshot.transform.key_value("MD5OfBody", reference_replacement=False),
-            ],
-        )
-        snapshot.match("messages_primary_queue_from_primary_event_bus", messages_primary)
-
-        # # Collect messages from secondary queue
-        messages_secondary = sqs_collect_messages(
-            aws_client_secondary, queue_url_secondary, min_events=1, wait_time=1, retries=5
-        )
-        snapshot.match("messages_secondary_queue_from_primary_event_bus", messages_secondary)
-
-        # Put events into secondary event bus
-        aws_client_secondary.events.put_events(
-            Entries=[
-                {
-                    "Source": SOURCE_SECONDARY,
-                    "DetailType": TEST_EVENT_PATTERN_NO_SOURCE["detail-type"][0],
-                    "Detail": json.dumps(EVENT_DETAIL),
-                    "EventBusName": event_bus_name_secondary,
-                }
-            ],
-        )
-
-        # Collect messages from secondary queue
-        messages_secondary = sqs_collect_messages(
-            aws_client_secondary, queue_url_secondary, min_events=1, wait_time=1, retries=5
-        )
-        snapshot.match("messages_secondary_queue_from_secondary_event_bus", messages_secondary)
-
-        # Custom cleanup
-        aws_client_primary.events.remove_targets(
-            Rule=rule_name,
-            EventBusName=event_bus_name_primary,
-            Ids=[target_id_sqs_primary, target_id_event_bus_secondary],
-        )
-        aws_client_primary.events.delete_rule(EventBusName=event_bus_name_primary, Name=rule_name)
-        aws_client_primary.events.delete_event_bus(Name=event_bus_name_primary)
-
-        aws_client_secondary.events.remove_targets(
-            Rule=rule_name_secondary,
-            EventBusName=event_bus_name_secondary,
-            Ids=[target_id_sqs_secondary],
-        )
-        aws_client_secondary.events.delete_rule(
-            EventBusName=event_bus_name_secondary, Name=rule_name_secondary
-        )
-        aws_client_secondary.events.delete_event_bus(Name=event_bus_name_secondary)
-
-        aws_client_primary.sqs.delete_queue(QueueUrl=queue_url_primary)
-        aws_client_secondary.sqs.delete_queue(QueueUrl=queue_url_secondary)
-
-        aws_client_primary.iam.delete_role_policy(
-            RoleName=role_name_bus_primary_to_bus_secondary,
-            PolicyName=policy_name_bus_primary_to_bus_secondary,
-        )
-        aws_client_primary.iam.delete_role(RoleName=role_name_bus_primary_to_bus_secondary)
-
-
-class TestEventsCrossAccount:
-    @markers.aws.validated
-    @pytest.mark.skipif(is_old_provider(), reason="Not supported in v1 provider")
-    def test_event_bus_to_event_bus_cross_account(
-        self,
-        account_id,
-        secondary_account_id,
-        aws_client,
-        secondary_aws_client,
-        cleanups,
-        snapshot,
-    ):
-        # overwriting randomized region https://docs.localstack.cloud/contributing/multi-account-region-testing/
-        # requires manually adding account replacement for snapshot
-        snapshot.add_transformer(snapshot.transform.regex(account_id, "<account-id>"))
-        snapshot.add_transformer(
-            snapshot.transform.regex(secondary_account_id, "<account-id-secondary>")
-        )
-
-        # Create event buses
+    if event_bus_name == "custom":
         event_bus_name_primary = f"test-event-bus-primary-{short_uid()}"
         aws_client.events.create_event_bus(Name=event_bus_name_primary)["EventBusArn"]
 
@@ -514,7 +282,12 @@ class TestEventsCrossAccount:
             Ids=[target_id_sqs_primary, target_id_event_bus_secondary],
         )
         aws_client.events.delete_rule(EventBusName=event_bus_name_primary, Name=rule_name)
-        aws_client.events.delete_event_bus(Name=event_bus_name_primary)
+        try:
+            aws_client.events.delete_event_bus(
+                Name=event_bus_name_primary
+            )  # default bus cannot be deleted
+        except Exception:
+            pass
 
         secondary_aws_client.events.remove_targets(
             Rule=rule_name_secondary,
@@ -524,7 +297,12 @@ class TestEventsCrossAccount:
         secondary_aws_client.events.delete_rule(
             EventBusName=event_bus_name_secondary, Name=rule_name_secondary
         )
-        secondary_aws_client.events.delete_event_bus(Name=event_bus_name_secondary)
+        try:
+            secondary_aws_client.events.delete_event_bus(
+                Name=event_bus_name_secondary
+            )  # default bus cannot be deleted
+        except Exception:
+            pass
 
         aws_client.sqs.delete_queue(QueueUrl=queue_url_primary)
         secondary_aws_client.sqs.delete_queue(QueueUrl=queue_url_secondary)

--- a/tests/aws/services/events/test_events_cross_account_region.snapshot.json
+++ b/tests/aws/services/events/test_events_cross_account_region.snapshot.json
@@ -1,6 +1,18 @@
 {
-  "tests/aws/services/events/test_events_cross_account_region.py::TestEventCrossRegion::test_event_bus_to_event_bus_cross_region": {
-    "recorded-date": "10-06-2024, 10:06:02",
+  "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[default-region]": {
+    "recorded-date": "14-06-2024, 11:12:09",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[default-account]": {
+    "recorded-date": "14-06-2024, 11:12:09",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[default-region_account]": {
+    "recorded-date": "14-06-2024, 11:12:09",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[custom-region]": {
+    "recorded-date": "14-06-2024, 11:13:16",
     "recorded-content": {
       "messages_primary_queue_from_primary_event_bus": [
         {
@@ -12,7 +24,7 @@
             "id": "<uuid:2>",
             "detail-type": "core.update-account-command",
             "source": "source-primary",
-            "account": "111111111111",
+            "account": "<account>",
             "time": "date",
             "region": "<region>",
             "resources": [],
@@ -36,9 +48,9 @@
             "id": "<uuid:4>",
             "detail-type": "core.update-account-command",
             "source": "source-primary",
-            "account": "111111111111",
+            "account": "<account>",
             "time": "date",
-            "region": "<region-secondary>",
+            "region": "<region>",
             "resources": [],
             "detail": {
               "command": "update-account",
@@ -60,7 +72,7 @@
             "id": "<uuid:6>",
             "detail-type": "core.update-account-command",
             "source": "source-secondary",
-            "account": "111111111111",
+            "account": "<account>",
             "time": "date",
             "region": "<region-secondary>",
             "resources": [],
@@ -76,8 +88,8 @@
       ]
     }
   },
-  "tests/aws/services/events/test_events_cross_account_region.py::TestEventsCrossAccount::test_event_bus_to_event_bus_cross_account": {
-    "recorded-date": "12-06-2024, 12:07:46",
+  "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[custom-account]": {
+    "recorded-date": "14-06-2024, 11:13:34",
     "recorded-content": {
       "messages_primary_queue_from_primary_event_bus": [
         {
@@ -89,7 +101,7 @@
             "id": "<uuid:2>",
             "detail-type": "core.update-account-command",
             "source": "source-primary",
-            "account": "<account-id>",
+            "account": "<account>",
             "time": "date",
             "region": "<region>",
             "resources": [],
@@ -113,7 +125,7 @@
             "id": "<uuid:2>",
             "detail-type": "core.update-account-command",
             "source": "source-primary",
-            "account": "<account-id>",
+            "account": "<account>",
             "time": "date",
             "region": "<region>",
             "resources": [],
@@ -137,9 +149,86 @@
             "id": "<uuid:5>",
             "detail-type": "core.update-account-command",
             "source": "source-secondary",
-            "account": "<account-id-secondary>",
+            "account": "<account-secondary>",
             "time": "date",
             "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[custom-region_account]": {
+    "recorded-date": "14-06-2024, 11:20:57",
+    "recorded-content": {
+      "messages_primary_queue_from_primary_event_bus": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:2>",
+            "detail-type": "core.update-account-command",
+            "source": "source-primary",
+            "account": "<account>",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ],
+      "messages_secondary_queue_from_primary_event_bus": [
+        {
+          "MessageId": "<uuid:3>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:4>",
+            "detail-type": "core.update-account-command",
+            "source": "source-primary",
+            "account": "<account>",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ],
+      "messages_secondary_queue_from_secondary_event_bus": [
+        {
+          "MessageId": "<uuid:5>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:6>",
+            "detail-type": "core.update-account-command",
+            "source": "source-secondary",
+            "account": "<account-secondary>",
+            "time": "date",
+            "region": "<region-secondary>",
             "resources": [],
             "detail": {
               "command": "update-account",

--- a/tests/aws/services/events/test_events_cross_account_region.snapshot.json
+++ b/tests/aws/services/events/test_events_cross_account_region.snapshot.json
@@ -1,15 +1,234 @@
 {
   "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[default-region]": {
-    "recorded-date": "14-06-2024, 11:12:09",
-    "recorded-content": {}
+    "recorded-date": "14-06-2024, 11:29:49",
+    "recorded-content": {
+      "messages_primary_queue_from_primary_event_bus": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:2>",
+            "detail-type": "core.update-account-command",
+            "source": "source-primary",
+            "account": "<account>",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ],
+      "messages_secondary_queue_from_primary_event_bus": [
+        {
+          "MessageId": "<uuid:3>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:4>",
+            "detail-type": "core.update-account-command",
+            "source": "source-primary",
+            "account": "<account>",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ],
+      "messages_secondary_queue_from_secondary_event_bus": [
+        {
+          "MessageId": "<uuid:5>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:6>",
+            "detail-type": "core.update-account-command",
+            "source": "source-secondary",
+            "account": "<account>",
+            "time": "date",
+            "region": "<region-secondary>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ]
+    }
   },
   "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[default-account]": {
-    "recorded-date": "14-06-2024, 11:12:09",
-    "recorded-content": {}
+    "recorded-date": "14-06-2024, 11:30:09",
+    "recorded-content": {
+      "messages_primary_queue_from_primary_event_bus": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:2>",
+            "detail-type": "core.update-account-command",
+            "source": "source-primary",
+            "account": "<account>",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ],
+      "messages_secondary_queue_from_primary_event_bus": [
+        {
+          "MessageId": "<uuid:3>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:2>",
+            "detail-type": "core.update-account-command",
+            "source": "source-primary",
+            "account": "<account>",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ],
+      "messages_secondary_queue_from_secondary_event_bus": [
+        {
+          "MessageId": "<uuid:4>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:5>",
+            "detail-type": "core.update-account-command",
+            "source": "source-secondary",
+            "account": "<account-secondary>",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ]
+    }
   },
   "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[default-region_account]": {
-    "recorded-date": "14-06-2024, 11:12:09",
-    "recorded-content": {}
+    "recorded-date": "14-06-2024, 11:31:05",
+    "recorded-content": {
+      "messages_primary_queue_from_primary_event_bus": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:2>",
+            "detail-type": "core.update-account-command",
+            "source": "source-primary",
+            "account": "<account>",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ],
+      "messages_secondary_queue_from_primary_event_bus": [
+        {
+          "MessageId": "<uuid:3>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:4>",
+            "detail-type": "core.update-account-command",
+            "source": "source-primary",
+            "account": "<account>",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ],
+      "messages_secondary_queue_from_secondary_event_bus": [
+        {
+          "MessageId": "<uuid:5>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:6>",
+            "detail-type": "core.update-account-command",
+            "source": "source-secondary",
+            "account": "<account-secondary>",
+            "time": "date",
+            "region": "<region-secondary>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ]
+    }
   },
   "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[custom-region]": {
     "recorded-date": "14-06-2024, 11:13:16",

--- a/tests/aws/services/events/test_events_cross_account_region.snapshot.json
+++ b/tests/aws/services/events/test_events_cross_account_region.snapshot.json
@@ -14,7 +14,7 @@
             "source": "source-primary",
             "account": "111111111111",
             "time": "date",
-            "region": "<region-name>",
+            "region": "<region>",
             "resources": [],
             "detail": {
               "command": "update-account",
@@ -38,7 +38,7 @@
             "source": "source-primary",
             "account": "111111111111",
             "time": "date",
-            "region": "<region-name-secondary>",
+            "region": "<region-secondary>",
             "resources": [],
             "detail": {
               "command": "update-account",
@@ -62,7 +62,84 @@
             "source": "source-secondary",
             "account": "111111111111",
             "time": "date",
-            "region": "<region-name-secondary>",
+            "region": "<region-secondary>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_cross_account_region.py::TestEventsCrossAccount::test_event_bus_to_event_bus_cross_account": {
+    "recorded-date": "12-06-2024, 12:07:46",
+    "recorded-content": {
+      "messages_primary_queue_from_primary_event_bus": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:2>",
+            "detail-type": "core.update-account-command",
+            "source": "source-primary",
+            "account": "<account-id>",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ],
+      "messages_secondary_queue_from_primary_event_bus": [
+        {
+          "MessageId": "<uuid:3>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:2>",
+            "detail-type": "core.update-account-command",
+            "source": "source-primary",
+            "account": "<account-id>",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ],
+      "messages_secondary_queue_from_secondary_event_bus": [
+        {
+          "MessageId": "<uuid:4>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:5>",
+            "detail-type": "core.update-account-command",
+            "source": "source-secondary",
+            "account": "<account-id-secondary>",
+            "time": "date",
+            "region": "<region>",
             "resources": [],
             "detail": {
               "command": "update-account",

--- a/tests/aws/services/events/test_events_cross_account_region.validation.json
+++ b/tests/aws/services/events/test_events_cross_account_region.validation.json
@@ -1,5 +1,8 @@
 {
   "tests/aws/services/events/test_events_cross_account_region.py::TestEventCrossRegion::test_event_bus_to_event_bus_cross_region": {
     "last_validated_date": "2024-06-10T10:06:02+00:00"
+  },
+  "tests/aws/services/events/test_events_cross_account_region.py::TestEventsCrossAccount::test_event_bus_to_event_bus_cross_account": {
+    "last_validated_date": "2024-06-12T12:07:46+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_cross_account_region.validation.json
+++ b/tests/aws/services/events/test_events_cross_account_region.validation.json
@@ -9,12 +9,12 @@
     "last_validated_date": "2024-06-14T11:20:57+00:00"
   },
   "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[default-account]": {
-    "last_validated_date": "2024-06-14T11:12:09+00:00"
+    "last_validated_date": "2024-06-14T11:30:09+00:00"
   },
   "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[default-region]": {
-    "last_validated_date": "2024-06-14T11:12:09+00:00"
+    "last_validated_date": "2024-06-14T11:29:49+00:00"
   },
   "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[default-region_account]": {
-    "last_validated_date": "2024-06-14T11:12:09+00:00"
+    "last_validated_date": "2024-06-14T11:31:05+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_cross_account_region.validation.json
+++ b/tests/aws/services/events/test_events_cross_account_region.validation.json
@@ -1,8 +1,20 @@
 {
-  "tests/aws/services/events/test_events_cross_account_region.py::TestEventCrossRegion::test_event_bus_to_event_bus_cross_region": {
-    "last_validated_date": "2024-06-10T10:06:02+00:00"
+  "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[custom-account]": {
+    "last_validated_date": "2024-06-14T11:13:34+00:00"
   },
-  "tests/aws/services/events/test_events_cross_account_region.py::TestEventsCrossAccount::test_event_bus_to_event_bus_cross_account": {
-    "last_validated_date": "2024-06-12T12:07:46+00:00"
+  "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[custom-region]": {
+    "last_validated_date": "2024-06-14T11:13:16+00:00"
+  },
+  "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[custom-region_account]": {
+    "last_validated_date": "2024-06-14T11:20:57+00:00"
+  },
+  "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[default-account]": {
+    "last_validated_date": "2024-06-14T11:12:09+00:00"
+  },
+  "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[default-region]": {
+    "last_validated_date": "2024-06-14T11:12:09+00:00"
+  },
+  "tests/aws/services/events/test_events_cross_account_region.py::test_event_bus_to_event_bus_cross_account_region[default-region_account]": {
+    "last_validated_date": "2024-06-14T11:12:09+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Event bridge supporters cross-account and cross-region sending of events between event buses. This PR introduces parametrized tests for cross-region and cross-account and cross region+account sending between the default and custom event buses.

AWS preserves message IDs if the event is sent from one account to a nother, but not if it is sent from one region to the other. The respective region and account id from the original event is preserved in case it changes.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
