### PR TITLE
Feature/eventbridge v2 add put permission

### DIFF
--- a/localstack-core/localstack/services/events/event_bus.py
+++ b/localstack-core/localstack/services/events/event_bus.py
@@ -8,6 +8,7 @@ from localstack.aws.api.events import (
     Condition,
     EventBusName,
     Principal,
+    ResourceNotFoundException,
     StatementId,
     String,
     TagList,
@@ -74,7 +75,12 @@ class EventBusService:
                 self.event_bus.policy = parsed_policy
 
     def revoke_put_events_permission(self, statement_id: str):
-        if policy := self.event_bus.policy:
+        policy = self.event_bus.policy
+        if not policy or not any(
+            statement.get("Sid") == statement_id for statement in policy["Statement"]
+        ):
+            raise ResourceNotFoundException("Statement with the provided id does not exist.")
+        if policy:
             policy["Statement"] = [
                 statement
                 for statement in policy["Statement"]

--- a/localstack-core/localstack/services/events/event_bus.py
+++ b/localstack-core/localstack/services/events/event_bus.py
@@ -1,7 +1,18 @@
+import json
+from datetime import datetime, timezone
 from typing import Optional
 
-from localstack.aws.api.events import Arn, EventBusName, TagList
-from localstack.services.events.models import EventBus, RuleDict
+from localstack.aws.api.events import (
+    Action,
+    Arn,
+    Condition,
+    EventBusName,
+    Principal,
+    StatementId,
+    String,
+    TagList,
+)
+from localstack.services.events.models import EventBus, ResourcePolicy, RuleDict, Statement
 
 
 class EventBusService:
@@ -28,6 +39,45 @@ class EventBusService:
     @property
     def arn(self):
         return self.event_bus.arn
+
+    def put_permission(
+        self,
+        action: Action,
+        principal: Principal,
+        statement_id: StatementId,
+        condition: Condition,
+        policy: String,
+    ):
+        if policy and any([action, principal, statement_id, condition]):
+            raise ValueError("Combination of policy with other arguments is not allowed")
+        if policy:
+            policy = json.loads(policy)
+            parsed_policy = ResourcePolicy(**policy)
+        else:
+            permission_statement = self._pars_statement(
+                statement_id, action, principal, self.arn, condition
+            )
+            parsed_policy = ResourcePolicy(Version="2012-10-17", Statement=[permission_statement])
+
+        self.event_bus.policy = parsed_policy
+        self.event_bus.creation_time = datetime.now(timezone.utc)
+        self.event_bus.last_modified_time = datetime.now(timezone.utc)
+
+    def revoke_put_events_permission(self, account_id: str):
+        self.event_bus.policy = None
+
+    def _pars_statement(self, statement_id, action, principal, resource_arn, condition):
+        if condition and principal != "*":
+            raise ValueError("Condition can only be set when principal is '*'")
+        statement = Statement(
+            Sid=statement_id,
+            Effect="Allow",
+            Principal=principal,
+            Action=action,
+            Resource=resource_arn,
+            Condition=condition,
+        )
+        return statement
 
 
 EventBusServiceDict = dict[Arn, EventBusService]

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -89,6 +89,7 @@ from localstack.services.events.models import (
 from localstack.services.events.rule import RuleService, RuleServiceDict
 from localstack.services.events.scheduler import JobScheduler
 from localstack.services.events.target import TargetSender, TargetSenderDict, TargetSenderFactory
+from localstack.services.events.utils import recursive_remove_none_values_from_dict
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.common import truncate
@@ -752,8 +753,12 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             "Name": event_bus.name,
             "Arn": event_bus.arn,
         }
+        if event_bus.creation_time:
+            event_bus_api_type["CreationTime"] = event_bus.creation_time
+        if event_bus.last_modified_time:
+            event_bus_api_type["LastModifiedTime"] = event_bus.last_modified_time
         if event_bus.policy:
-            event_bus_api_type["Policy"] = event_bus.policy
+            event_bus_api_type["Policy"] = recursive_remove_none_values_from_dict(event_bus.policy)
 
         return event_bus_api_type
 

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -307,7 +307,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         policy: String = None,
         **kwargs,
     ) -> None:
-        pass  # TODO align with policy streaming
+        store = self.get_store(context)
+        event_bus = self.get_event_bus(event_bus_name, store)
+        event_bus_service = self._event_bus_services_store[event_bus.arn]
+        event_bus_service.put_permission(action, principal, statement_id, condition, policy)
 
     #######
     # Rules

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -313,6 +313,25 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         event_bus_service = self._event_bus_services_store[event_bus.arn]
         event_bus_service.put_permission(action, principal, statement_id, condition, policy)
 
+    @handler("RemovePermission")
+    def remove_permission(
+        self,
+        context: RequestContext,
+        statement_id: StatementId = None,
+        remove_all_permissions: Boolean = None,
+        event_bus_name: NonPartnerEventBusName = None,
+        **kwargs,
+    ) -> None:
+        store = self.get_store(context)
+        event_bus = self.get_event_bus(event_bus_name, store)
+        event_bus_service = self._event_bus_services_store[event_bus.arn]
+        if remove_all_permissions:
+            event_bus_service.event_bus.policy = None
+            return
+        if not statement_id:
+            raise ValidationException("Parameter StatementId is required.")
+        event_bus_service.revoke_put_events_permission(statement_id)
+
     #######
     # Rules
     #######

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -1,0 +1,26 @@
+from typing import Any, Dict
+
+
+def recursive_remove_none_values_from_dict(d: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Recursively removes keys with non values from a dictionary.
+    """
+    if not isinstance(d, dict):
+        return d
+
+    clean_dict = {}
+    for key, value in d.items():
+        if value is None:
+            continue
+        if isinstance(value, list):
+            nested_list = [recursive_remove_none_values_from_dict(item) for item in value]
+            nested_list = [item for item in nested_list if item]
+            if nested_list:
+                clean_dict[key] = nested_list
+        elif isinstance(value, dict):
+            nested_dict = recursive_remove_none_values_from_dict(value)
+            if nested_dict:
+                clean_dict[key] = nested_dict
+        else:
+            clean_dict[key] = value
+    return clean_dict

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -840,8 +840,9 @@ class TestEventBus:
         reason="V1 provider does not support this feature",
     )
     @pytest.mark.parametrize("bus_name", ["custom", "default"])
+    @pytest.mark.parametrize("policy_exists", [True, False])
     def test_remove_permission_non_existing_sid(
-        self, aws_client, bus_name, events_create_event_bus, snapshot
+        self, aws_client, bus_name, policy_exists, events_create_event_bus, account_id, snapshot
     ):
         if bus_name == "custom":
             bus_name = f"test-bus-{short_uid()}"
@@ -853,6 +854,14 @@ class TestEventBus:
                 )  # error if no permission is present
             except Exception:
                 pass
+
+        if policy_exists:
+            aws_client.events.put_permission(
+                EventBusName=bus_name,
+                Action="events:PutEvents",
+                Principal=account_id,
+                StatementId=f"statement-{short_uid()}",
+            )
 
         with pytest.raises(ClientError) as e:
             aws_client.events.remove_permission(

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -666,6 +666,14 @@ class TestEventBus:
         )
         snapshot.match("put-permission", response)
 
+        statement_id_primary = f"statement-{short_uid()}"
+        aws_client.events.put_permission(
+            EventBusName=bus_name,
+            Action="events:PutEvents",
+            Principal=account_id,
+            StatementId=statement_id_primary,
+        )
+
         statement_id_secondary = f"statement-{short_uid()}"
         aws_client.events.put_permission(
             EventBusName=bus_name,

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -10,6 +10,7 @@ import uuid
 
 import pytest
 from botocore.exceptions import ClientError
+from localstack_snapshot.snapshots.transformer import SortingTransformer
 from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
@@ -653,11 +654,12 @@ class TestEventBus:
                 snapshot.transform.regex(bus_name, "<bus-name>"),
                 snapshot.transform.regex(account_id, "<account-id>"),
                 snapshot.transform.regex(secondary_account_id, "<secondary-account-id>"),
-                snapshot.transform.key_value("Sid", reference_replacement=False),
+                SortingTransformer("Statement", lambda o: o["Sid"]),
+                snapshot.transform.key_value("Sid"),
             ]
         )
 
-        statement_id_primary = f"statement-{short_uid()}"
+        statement_id_primary = f"statement-1-{short_uid()}"
         response = aws_client.events.put_permission(
             EventBusName=bus_name,
             Action="events:PutEvents",
@@ -666,7 +668,7 @@ class TestEventBus:
         )
         snapshot.match("put-permission", response)
 
-        statement_id_primary = f"statement-{short_uid()}"
+        statement_id_primary = f"statement-2-{short_uid()}"
         aws_client.events.put_permission(
             EventBusName=bus_name,
             Action="events:PutEvents",
@@ -674,7 +676,7 @@ class TestEventBus:
             StatementId=statement_id_primary,
         )
 
-        statement_id_secondary = f"statement-{short_uid()}"
+        statement_id_secondary = f"statement-3-{short_uid()}"
         aws_client.events.put_permission(
             EventBusName=bus_name,
             Action="events:PutEvents",
@@ -686,7 +688,7 @@ class TestEventBus:
         snapshot.match("describe-event-bus-put-permission-multiple-principals", response)
 
         # allow all principals to put events
-        statement_id = f"statement-{short_uid()}"
+        statement_id = f"statement-4-{short_uid()}"
         # only events:PutEvents is allowed for actions
         # only a single access policy is allowed per event bus
         aws_client.events.put_permission(
@@ -713,7 +715,7 @@ class TestEventBus:
             "Version": "2012-10-17",
             "Statement": [
                 {
-                    "Sid": f"test-{short_uid()}",
+                    "Sid": f"statement-5-{short_uid()}",
                     "Effect": "Allow",
                     "Principal": {"Service": "events.amazonaws.com"},
                     "Action": "events:ListRules",
@@ -760,11 +762,12 @@ class TestEventBus:
                 snapshot.transform.regex(bus_name, "<bus-name>"),
                 snapshot.transform.regex(account_id, "<account-id>"),
                 snapshot.transform.regex(secondary_account_id, "<secondary-account-id>"),
-                snapshot.transform.key_value("Sid", reference_replacement=False),
+                SortingTransformer("Statement", lambda o: o["Sid"]),
+                snapshot.transform.key_value("Sid"),
             ]
         )
 
-        statement_id_primary = f"statement-{short_uid()}"
+        statement_id_primary = f"statement-1-{short_uid()}"
         aws_client.events.put_permission(
             EventBusName=bus_name,
             Action="events:PutEvents",
@@ -772,7 +775,7 @@ class TestEventBus:
             StatementId=statement_id_primary,
         )
 
-        statement_id_secondary = f"statement-{short_uid()}"
+        statement_id_secondary = f"statement-2-{short_uid()}"
         aws_client.events.put_permission(
             EventBusName=bus_name,
             Action="events:PutEvents",

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -748,6 +748,24 @@ class TestEventBus:
         is_old_provider(),
         reason="V1 provider does not support this feature",
     )
+    def test_put_permission_non_existing_event_bus(self, aws_client, snapshot):
+        non_exist_bus_name = f"non-existing-bus-{short_uid()}"
+        snapshot.add_transformer(snapshot.transform.regex(non_exist_bus_name, "<bus-name>"))
+
+        with pytest.raises(ClientError) as e:
+            aws_client.events.put_permission(
+                EventBusName=non_exist_bus_name,
+                Action="events:PutEvents",
+                Principal="*",
+                StatementId="statement-id",
+            )
+        snapshot.match("remove-permission-non-existing-sid-error", e)
+
+    @markers.aws.validated
+    @pytest.mark.skipif(
+        is_old_provider(),
+        reason="V1 provider does not support this feature",
+    )
     @pytest.mark.parametrize("bus_name", ["custom", "default"])
     def test_remove_permission(
         self,

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1586,5 +1586,11 @@
     "recorded-content": {
       "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission_non_existing_event_bus": {
+    "recorded-date": "17-06-2024, 10:50:49",
+    "recorded-content": {
+      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the PutPermission operation: Event bus <bus-name> does not exist.') tblen=3>"
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1210,7 +1210,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[custom]": {
-    "recorded-date": "17-06-2024, 09:37:16",
+    "recorded-date": "17-06-2024, 10:32:30",
     "recorded-content": {
       "put-permission": {
         "ResponseMetadata": {
@@ -1227,28 +1227,28 @@
           "Version": "2012-10-17",
           "Statement": [
             {
-              "Sid": "sid",
+              "Sid": "<sid:1>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:2>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:3>",
               "Effect": "Allow",
               "Principal": {
                 "AWS": "arn:aws:iam::<secondary-account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "sid",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "sid",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
               },
               "Action": "events:PutEvents",
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
@@ -1269,14 +1269,25 @@
           "Version": "2012-10-17",
           "Statement": [
             {
-              "Sid": "sid",
+              "Sid": "<sid:1>",
               "Effect": "Allow",
-              "Principal": "*",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
               "Action": "events:PutEvents",
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
             },
             {
-              "Sid": "sid",
+              "Sid": "<sid:2>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:3>",
               "Effect": "Allow",
               "Principal": {
                 "AWS": "arn:aws:iam::<secondary-account-id>:root"
@@ -1285,20 +1296,9 @@
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
             },
             {
-              "Sid": "sid",
+              "Sid": "<sid:4>",
               "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "sid",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
-              },
+              "Principal": "*",
               "Action": "events:PutEvents",
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
             }
@@ -1324,7 +1324,7 @@
           "Version": "2012-10-17",
           "Statement": [
             {
-              "Sid": "sid",
+              "Sid": "<sid:5>",
               "Effect": "Allow",
               "Principal": {
                 "Service": "events.amazonaws.com"
@@ -1342,7 +1342,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
-    "recorded-date": "17-06-2024, 09:37:18",
+    "recorded-date": "17-06-2024, 10:32:33",
     "recorded-content": {
       "put-permission": {
         "ResponseMetadata": {
@@ -1359,7 +1359,7 @@
           "Version": "2012-10-17",
           "Statement": [
             {
-              "Sid": "sid",
+              "Sid": "<sid:1>",
               "Effect": "Allow",
               "Principal": {
                 "AWS": "arn:aws:iam::<account-id>:root"
@@ -1368,19 +1368,19 @@
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
             },
             {
-              "Sid": "sid",
+              "Sid": "<sid:2>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:3>",
               "Effect": "Allow",
               "Principal": {
                 "AWS": "arn:aws:iam::<secondary-account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "sid",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
               },
               "Action": "events:PutEvents",
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
@@ -1401,7 +1401,7 @@
           "Version": "2012-10-17",
           "Statement": [
             {
-              "Sid": "sid",
+              "Sid": "<sid:1>",
               "Effect": "Allow",
               "Principal": {
                 "AWS": "arn:aws:iam::<account-id>:root"
@@ -1410,14 +1410,16 @@
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
             },
             {
-              "Sid": "sid",
+              "Sid": "<sid:2>",
               "Effect": "Allow",
-              "Principal": "*",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
               "Action": "events:PutEvents",
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
             },
             {
-              "Sid": "sid",
+              "Sid": "<sid:3>",
               "Effect": "Allow",
               "Principal": {
                 "AWS": "arn:aws:iam::<secondary-account-id>:root"
@@ -1426,11 +1428,9 @@
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
             },
             {
-              "Sid": "sid",
+              "Sid": "<sid:4>",
               "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
-              },
+              "Principal": "*",
               "Action": "events:PutEvents",
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
             }
@@ -1456,7 +1456,7 @@
           "Version": "2012-10-17",
           "Statement": [
             {
-              "Sid": "sid",
+              "Sid": "<sid:5>",
               "Effect": "Allow",
               "Principal": {
                 "Service": "events.amazonaws.com"
@@ -1474,7 +1474,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[custom]": {
-    "recorded-date": "17-06-2024, 09:26:01",
+    "recorded-date": "17-06-2024, 10:34:04",
     "recorded-content": {
       "remove-permission": {
         "ResponseMetadata": {
@@ -1491,7 +1491,7 @@
           "Version": "2012-10-17",
           "Statement": [
             {
-              "Sid": "sid",
+              "Sid": "<sid:1>",
               "Effect": "Allow",
               "Principal": {
                 "AWS": "arn:aws:iam::<secondary-account-id>:root"
@@ -1525,7 +1525,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[default]": {
-    "recorded-date": "17-06-2024, 09:26:03",
+    "recorded-date": "17-06-2024, 10:34:06",
     "recorded-content": {
       "remove-permission": {
         "ResponseMetadata": {
@@ -1542,7 +1542,7 @@
           "Version": "2012-10-17",
           "Statement": [
             {
-              "Sid": "sid",
+              "Sid": "<sid:1>",
               "Effect": "Allow",
               "Principal": {
                 "AWS": "arn:aws:iam::<secondary-account-id>:root"

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1210,7 +1210,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[custom]": {
-    "recorded-date": "14-06-2024, 12:51:52",
+    "recorded-date": "17-06-2024, 09:32:22",
     "recorded-content": {
       "put-permission": {
         "ResponseMetadata": {
@@ -1218,8 +1218,41 @@
           "HTTPStatusCode": 200
         }
       },
+      "describe-event-bus-put-permission-multiple-principals": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "describe-event-bus-put-permission": {
-        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
         "CreationTime": "datetime",
         "LastModifiedTime": "datetime",
         "Name": "<bus-name>",
@@ -1231,7 +1264,25 @@
               "Effect": "Allow",
               "Principal": "*",
               "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>"
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
             }
           ]
         },
@@ -1247,7 +1298,7 @@
         }
       },
       "describe-event-bus-put-permission-policy": {
-        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
         "CreationTime": "datetime",
         "LastModifiedTime": "datetime",
         "Name": "<bus-name>",
@@ -1273,7 +1324,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
-    "recorded-date": "14-06-2024, 12:51:53",
+    "recorded-date": "17-06-2024, 09:32:25",
     "recorded-content": {
       "put-permission": {
         "ResponseMetadata": {
@@ -1281,8 +1332,41 @@
           "HTTPStatusCode": 200
         }
       },
+      "describe-event-bus-put-permission-multiple-principals": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "describe-event-bus-put-permission": {
-        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
         "CreationTime": "datetime",
         "LastModifiedTime": "datetime",
         "Name": "<bus-name>",
@@ -1294,7 +1378,25 @@
               "Effect": "Allow",
               "Principal": "*",
               "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>"
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
             }
           ]
         },
@@ -1310,7 +1412,7 @@
         }
       },
       "describe-event-bus-put-permission-policy": {
-        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
         "CreationTime": "datetime",
         "LastModifiedTime": "datetime",
         "Name": "<bus-name>",

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1592,5 +1592,29 @@
     "recorded-content": {
       "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the PutPermission operation: Event bus <bus-name> does not exist.') tblen=3>"
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-custom]": {
+    "recorded-date": "17-06-2024, 11:01:19",
+    "recorded-content": {
+      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-default]": {
+    "recorded-date": "17-06-2024, 11:01:20",
+    "recorded-content": {
+      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-custom]": {
+    "recorded-date": "17-06-2024, 11:01:21",
+    "recorded-content": {
+      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-default]": {
+    "recorded-date": "17-06-2024, 11:01:23",
+    "recorded-content": {
+      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1208,5 +1208,131 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[custom]": {
+    "recorded-date": "14-06-2024, 12:51:52",
+    "recorded-content": {
+      "put-permission": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-put-permission": {
+        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-permission-policy": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-put-permission-policy": {
+        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com"
+              },
+              "Action": "events:ListRules",
+              "Resource": "*"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
+    "recorded-date": "14-06-2024, 12:51:53",
+    "recorded-content": {
+      "put-permission": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-put-permission": {
+        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-permission-policy": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-put-permission-policy": {
+        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com"
+              },
+              "Action": "events:ListRules",
+              "Resource": "*"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1210,7 +1210,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[custom]": {
-    "recorded-date": "17-06-2024, 09:32:22",
+    "recorded-date": "17-06-2024, 09:37:16",
     "recorded-content": {
       "put-permission": {
         "ResponseMetadata": {
@@ -1230,6 +1230,15 @@
               "Sid": "sid",
               "Effect": "Allow",
               "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
                 "AWS": "arn:aws:iam::<account-id>:root"
               },
               "Action": "events:PutEvents",
@@ -1239,7 +1248,7 @@
               "Sid": "sid",
               "Effect": "Allow",
               "Principal": {
-                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+                "AWS": "arn:aws:iam::<account-id>:root"
               },
               "Action": "events:PutEvents",
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
@@ -1270,6 +1279,15 @@
               "Sid": "sid",
               "Effect": "Allow",
               "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
                 "AWS": "arn:aws:iam::<account-id>:root"
               },
               "Action": "events:PutEvents",
@@ -1279,7 +1297,7 @@
               "Sid": "sid",
               "Effect": "Allow",
               "Principal": {
-                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+                "AWS": "arn:aws:iam::<account-id>:root"
               },
               "Action": "events:PutEvents",
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
@@ -1324,7 +1342,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
-    "recorded-date": "17-06-2024, 09:32:25",
+    "recorded-date": "17-06-2024, 09:37:18",
     "recorded-content": {
       "put-permission": {
         "ResponseMetadata": {
@@ -1357,6 +1375,15 @@
               },
               "Action": "events:PutEvents",
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
             }
           ]
         },
@@ -1376,13 +1403,6 @@
             {
               "Sid": "sid",
               "Effect": "Allow",
-              "Principal": "*",
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "sid",
-              "Effect": "Allow",
               "Principal": {
                 "AWS": "arn:aws:iam::<account-id>:root"
               },
@@ -1392,8 +1412,24 @@
             {
               "Sid": "sid",
               "Effect": "Allow",
+              "Principal": "*",
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
               "Principal": {
                 "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
               },
               "Action": "events:PutEvents",
               "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1334,5 +1334,107 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[custom]": {
+    "recorded-date": "17-06-2024, 09:26:01",
+    "recorded-content": {
+      "remove-permission": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-remove-permission": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove-permission-all": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-remove-permission-all": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[default]": {
+    "recorded-date": "17-06-2024, 09:26:03",
+    "recorded-content": {
+      "remove-permission": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-remove-permission": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove-permission-all": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-remove-permission-all": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1574,5 +1574,17 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[custom]": {
+    "recorded-date": "17-06-2024, 10:47:29",
+    "recorded-content": {
+      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[default]": {
+    "recorded-date": "17-06-2024, 10:47:30",
+    "recorded-content": {
+      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+    }
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -32,6 +32,12 @@
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
     "last_validated_date": "2024-06-14T12:51:53+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[custom]": {
+    "last_validated_date": "2024-06-17T09:26:01+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[default]": {
+    "last_validated_date": "2024-06-17T09:26:03+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_nested": {
     "last_validated_date": "2024-04-29T13:17:16+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -27,10 +27,10 @@
     "last_validated_date": "2024-04-29T13:16:20+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[custom]": {
-    "last_validated_date": "2024-06-17T09:32:22+00:00"
+    "last_validated_date": "2024-06-17T09:37:16+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
-    "last_validated_date": "2024-06-17T09:32:25+00:00"
+    "last_validated_date": "2024-06-17T09:37:18+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[custom]": {
     "last_validated_date": "2024-06-17T09:26:01+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -27,16 +27,16 @@
     "last_validated_date": "2024-04-29T13:16:20+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[custom]": {
-    "last_validated_date": "2024-06-17T09:37:16+00:00"
+    "last_validated_date": "2024-06-17T10:32:30+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
-    "last_validated_date": "2024-06-17T09:37:18+00:00"
+    "last_validated_date": "2024-06-17T10:32:33+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[custom]": {
-    "last_validated_date": "2024-06-17T09:26:01+00:00"
+    "last_validated_date": "2024-06-17T10:34:04+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[default]": {
-    "last_validated_date": "2024-06-17T09:26:03+00:00"
+    "last_validated_date": "2024-06-17T10:34:06+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_nested": {
     "last_validated_date": "2024-04-29T13:17:16+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -41,6 +41,18 @@
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[default]": {
     "last_validated_date": "2024-06-17T10:34:06+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-custom]": {
+    "last_validated_date": "2024-06-17T11:01:21+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-default]": {
+    "last_validated_date": "2024-06-17T11:01:23+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-custom]": {
+    "last_validated_date": "2024-06-17T11:01:19+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-default]": {
+    "last_validated_date": "2024-06-17T11:01:20+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[custom]": {
     "last_validated_date": "2024-06-17T10:47:29+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -27,10 +27,10 @@
     "last_validated_date": "2024-04-29T13:16:20+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[custom]": {
-    "last_validated_date": "2024-06-14T12:51:52+00:00"
+    "last_validated_date": "2024-06-17T09:32:22+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
-    "last_validated_date": "2024-06-14T12:51:53+00:00"
+    "last_validated_date": "2024-06-17T09:32:25+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[custom]": {
     "last_validated_date": "2024-06-17T09:26:01+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -38,6 +38,12 @@
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[default]": {
     "last_validated_date": "2024-06-17T10:34:06+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[custom]": {
+    "last_validated_date": "2024-06-17T10:47:29+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[default]": {
+    "last_validated_date": "2024-06-17T10:47:30+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_nested": {
     "last_validated_date": "2024-04-29T13:17:16+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -26,6 +26,12 @@
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
     "last_validated_date": "2024-04-29T13:16:20+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[custom]": {
+    "last_validated_date": "2024-06-14T12:51:52+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
+    "last_validated_date": "2024-06-14T12:51:53+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_nested": {
     "last_validated_date": "2024-04-29T13:17:16+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -32,6 +32,9 @@
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
     "last_validated_date": "2024-06-17T10:32:33+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission_non_existing_event_bus": {
+    "last_validated_date": "2024-06-17T10:50:49+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[custom]": {
     "last_validated_date": "2024-06-17T10:34:04+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
EventBridge bus allows for `put_permission` (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/events/client/put_permission.html) and `remove_permission` (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/events/client/remove_permission.html) to controll who has access to write events to the particular event bus.
`put_permission` allows for adding access either by specifying an principal (AWS service or account id) and an action or by directly adding a policy document. Multiple accounts can have permission and additional `put_permission` just extends the attached policy. It is also possible to add a wildcard to give everyone access to the bus.

`remove_permission` allows for removing either all attached permissions or specific statements via their sid.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Add permissions via `put_permission` and pars them to the correct policy
- Only add one statement with a wildcard principal
- Remove permission via `remove_permission` 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
