### PR TITLE
Fix version.py file glob for release commit

### DIFF
--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -3,7 +3,7 @@
 set -e
 
 VERSION_FILE=${VERSION_FILE-VERSION}
-VERSION_PY=${VERSION_PY-*/version.py}
+VERSION_PY=${VERSION_PY-"**/version.py"}
 DEPENDENCY_FILE=${DEPENDENCY_FILE-pyproject.toml}
 
 function usage() {
@@ -193,7 +193,7 @@ function cmd-git-commit-release() {
     echo $1 || verify_valid_version
 
     for file in ${VERSION_FILE} ${VERSION_PY} ${DEPENDENCY_FILE}; do
-            [ -e "$file" ] && git add "$file"
+            git add "$file" || echo "did not add file '$file' to commit"
     done
     git commit -m "release version ${1}"
     git tag -a "v${1}" -m "Release version ${1}"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In the release commit, which is created by `bin/release-helper.sh git-commit-release <version>`, the glob used to find `version.py` in this and dependent repositories, does not work anymore with the new source layout introduced in #10800. See the [release commit for 3.5.0](https://github.com/localstack/localstack/commit/54edb407df341515a6348e751fa20f4c41732b7d) for the result of this error

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Since everything is now a level deeper, we need to change the glob `*/version.py` to something else. `**/version.py` will be the more robust way going forward. This requires a small change in the way that we add files to the commit. Instead of checking if a file exists and then staging it, we stage it immediately now and print an error if it does not exist. This is because `[ -e **/version.py ]` evaluates to false, even though a file matching the glob exists.



## Testing

Follow these steps (similar to release procedure):

```bash
bin/release-helper.sh set-ver 3.6.0
pip install -e .
# VERSION and localstack-core/localstack/version.py file should both be 3.6.0 now
bin/release-helper.sh git-commit-release 3.6.0
# before: only VERSION committed, now both files committed
```

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
