### PR TITLE
make next-gen APIGW provider default

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1128,21 +1128,8 @@ OPENSEARCH_MULTI_CLUSTER = is_env_not_false("OPENSEARCH_MULTI_CLUSTER")
 # Whether to really publish to GCM while using SNS Platform Application (needs credentials)
 LEGACY_SNS_GCM_PUBLISHING = is_env_true("LEGACY_SNS_GCM_PUBLISHING")
 
-# TODO: remove this, replace this by setting the provider as default
-# force enable the use of the new invocation logic for APIGW v1 in community
-if not os.environ.get("PROVIDER_OVERRIDE_APIGATEWAY"):
-    os.environ["PROVIDER_OVERRIDE_APIGATEWAY"] = "next_gen"
-
-# Whether the Next Gen APIGW invocation logic is enabled (handler chain)
-APIGW_NEXT_GEN_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_APIGATEWAY", "") == "next_gen"
-if APIGW_NEXT_GEN_PROVIDER:
-    # in order to not have conflicts with different implementation registering their own router, we need to have all of
-    # them use the same new implementation
-    if not os.environ.get("PROVIDER_OVERRIDE_APIGATEWAYV2"):
-        os.environ["PROVIDER_OVERRIDE_APIGATEWAYV2"] = "next_gen"
-
-    if not os.environ.get("PROVIDER_OVERRIDE_APIGATEWAYMANAGEMENTAPI"):
-        os.environ["PROVIDER_OVERRIDE_APIGATEWAYMANAGEMENTAPI"] = "next_gen"
+# Whether the Next Gen APIGW invocation logic is enabled (on by default)
+APIGW_NEXT_GEN_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_APIGATEWAY", "") in ("next_gen", "")
 
 # Whether the DynamoDBStreams native provider is enabled
 DDB_STREAMS_PROVIDER_V2 = os.environ.get("PROVIDER_OVERRIDE_DYNAMODBSTREAMS", "") == "v2"
@@ -1155,7 +1142,6 @@ if DDB_STREAMS_PROVIDER_V2:
 elif _override_dynamodb_v2 == "v2":
     os.environ["PROVIDER_OVERRIDE_DYNAMODBSTREAMS"] = "v2"
     DDB_STREAMS_PROVIDER_V2 = True
-
 
 # TODO remove fallback to LAMBDA_DOCKER_NETWORK with next minor version
 MAIN_DOCKER_NETWORK = os.environ.get("MAIN_DOCKER_NETWORK", "") or LAMBDA_DOCKER_NETWORK

--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1128,6 +1128,11 @@ OPENSEARCH_MULTI_CLUSTER = is_env_not_false("OPENSEARCH_MULTI_CLUSTER")
 # Whether to really publish to GCM while using SNS Platform Application (needs credentials)
 LEGACY_SNS_GCM_PUBLISHING = is_env_true("LEGACY_SNS_GCM_PUBLISHING")
 
+# TODO: remove this, replace this by setting the provider as default
+# force enable the use of the new invocation logic for APIGW v1 in community
+if not os.environ.get("PROVIDER_OVERRIDE_APIGATEWAY"):
+    os.environ["PROVIDER_OVERRIDE_APIGATEWAY"] = "next_gen"
+
 # Whether the Next Gen APIGW invocation logic is enabled (handler chain)
 APIGW_NEXT_GEN_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_APIGATEWAY", "") == "next_gen"
 if APIGW_NEXT_GEN_PROVIDER:

--- a/localstack-core/localstack/services/providers.py
+++ b/localstack-core/localstack/services/providers.py
@@ -14,12 +14,12 @@ def acm():
     return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
-@aws_provider(api="apigateway")
+@aws_provider()
 def apigateway():
-    from localstack.services.apigateway.legacy.provider import ApigatewayProvider
+    from localstack.services.apigateway.next_gen.provider import ApigatewayNextGenProvider
     from localstack.services.moto import MotoFallbackDispatcher
 
-    provider = ApigatewayProvider()
+    provider = ApigatewayNextGenProvider()
     return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
@@ -29,6 +29,15 @@ def apigateway_next_gen():
     from localstack.services.moto import MotoFallbackDispatcher
 
     provider = ApigatewayNextGenProvider()
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
+
+
+@aws_provider(api="apigateway", name="legacy")
+def apigateway_legacy():
+    from localstack.services.apigateway.legacy.provider import ApigatewayProvider
+    from localstack.services.moto import MotoFallbackDispatcher
+
+    provider = ApigatewayProvider()
     return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR makes the APIGW NextProvider to be the default used. 

This PR also compiles all PRs done related to this work.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- make the NextGen provider default

## NG Provider
- #10982
- #11043
- #11051
- #11057
- #11062
- #11065
- #11085
- #11096
- #11099
- #11107
- #11111
- #11114
- #11121
- #11129
- #11135
- #11138 
- #11140
- #11142
- #11143
- #11144
- #11148
- #11167
- #11183
- #11196
- #11198
- #11199
- #11219 
- #11226
- #11227
- #11234
- #11237 
- #11250
- #11251
- #11256
- #11257
- #11268
- #11317
- #11327
- #11344
- #11349
- #11350
- #11372
- #11401
- #11413
- #11518
- #11569
- #11702

## Follow-up?
- #11633


## TODO

What's left to do:
- [ ] move the code from the `next_gen` module back into default? TBD

Once this PR is merged:
- [ ] remove the NextGen CI step
