### PR TITLE
Add *_DOCKER_FLAGS option to support docker compose-style environment files

### DIFF
--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -270,6 +270,41 @@ class TestArgumentParsing:
             "TEST3": "VAL3_OVERRIDE",
         }
 
+    def test_compose_env_files(self, tmp_path):
+        env_file_1 = tmp_path / "env1"
+        env_file_2 = tmp_path / "env2"
+        env_vars_1 = textwrap.dedent("""
+            # Some comment
+            TEST1=VAL1
+            TEST2=VAL2
+            TEST3=${TEST2}
+            TEST4="VAL4"
+            """)
+        env_vars_2 = textwrap.dedent("""
+            # Some comment
+            TEST3=VAL3_OVERRIDE
+            """)
+        env_file_1.write_text(env_vars_1)
+        env_file_2.write_text(env_vars_2)
+
+        argument_string = f"--compose-env-file {env_file_1}"
+        flags = Util.parse_additional_flags(argument_string)
+        assert flags.env_vars == {
+            "TEST1": "VAL1",
+            "TEST2": "VAL2",
+            "TEST3": "VAL2",
+            "TEST4": "VAL4",
+        }
+
+        argument_string = f"-e TEST2=VAL2_OVERRIDE --compose-env-file {env_file_1} --compose-env-file {env_file_2}"
+        flags = Util.parse_additional_flags(argument_string)
+        assert flags.env_vars == {
+            "TEST1": "VAL1",
+            "TEST2": "VAL2_OVERRIDE",
+            "TEST3": "VAL3_OVERRIDE",
+            "TEST4": "VAL4",
+        }
+
 
 def list_in(a, b):
     return len(a) <= len(b) and any((b[x : x + len(a)] == a for x in range(len(b) - len(a) + 1)))


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Per request, we want to support environment files as supported in docker-compose as well as env-files for the docker cli.

They have a quite different feature set, as docker compose allows stripping quotes, end of line comments, and support referencing other variables in a bash-expansion style syntax.

This PR will add, at least to the docker SDK client used within the container, a flag called `--compose-env-file`, which will support these environment files.
It uses the python `dotenv` library for this usecase.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Support for `--compose-env-file`, which will parse the env file similar to docker compose (which uses `godotenv`)

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
