### PR TITLE
fix for ApiGW resource provider

### DIFF
--- a/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_deployment.py
+++ b/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_deployment.py
@@ -1,6 +1,7 @@
 # LocalStack Resource Provider Scaffolding v2
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Optional, TypedDict
 
@@ -120,7 +121,7 @@ class ApiGatewayDeploymentProvider(ResourceProvider[ApiGatewayDeploymentProperti
             params["stageName"] = model["StageName"]
 
         if model.get("StageDescription"):
-            params["stageDescription"] = model["StageDescription"]
+            params["stageDescription"] = json.dumps(model["StageDescription"])
 
         if model.get("Description"):
             params["description"] = model["Description"]

--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -107,7 +107,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "recorded-date": "15-04-2024, 22:59:18",
+    "recorded-date": "17-06-2024, 21:54:27",
     "recorded-content": {
       "rest-api": {
         "apiKeySource": "HEADER",

--- a/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
@@ -6,7 +6,7 @@
     "last_validated_date": "2024-04-15T22:59:53+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "last_validated_date": "2024-04-15T22:59:17+00:00"
+    "last_validated_date": "2024-06-17T21:54:26+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_integration": {
     "last_validated_date": "2024-02-21T12:54:34+00:00"

--- a/tests/aws/templates/apigateway-url-output.yaml
+++ b/tests/aws/templates/apigateway-url-output.yaml
@@ -34,10 +34,6 @@ Resources:
       RestApiId:
         Ref: apiC8550315
       Description: Automatically created by the RestApi construct
-      StageDescription:
-        TracingEnabled: true
-        LoggingLevel: ERROR
-        DataTraceEnabled: true
     DependsOn:
       - apiGETECF0BD67
   apiDeploymentStageprod896C8101:

--- a/tests/aws/templates/apigateway-url-output.yaml
+++ b/tests/aws/templates/apigateway-url-output.yaml
@@ -34,6 +34,10 @@ Resources:
       RestApiId:
         Ref: apiC8550315
       Description: Automatically created by the RestApi construct
+      StageDescription:
+        TracingEnabled: true
+        LoggingLevel: ERROR
+        DataTraceEnabled: true
     DependsOn:
       - apiGETECF0BD67
   apiDeploymentStageprod896C8101:

--- a/tests/aws/templates/apigateway_integration_from_s3.yml
+++ b/tests/aws/templates/apigateway_integration_from_s3.yml
@@ -31,6 +31,10 @@ Resources:
       RestApiId:
         Ref: ApiGatewayRestApi
       StageName: local
+      StageDescription:
+        TracingEnabled: true
+        LoggingLevel: ERROR
+        DataTraceEnabled: true
 
   ApiGWStage:
     Type: AWS::ApiGateway::Stage


### PR DESCRIPTION
## Motivation
The resource provider for AWS::ApiGateway::Deployment fails to deploy when the StageDescription attribute is define due to a missing conversion. Evidence shown in in #11019

## Changes
- Add conversion from dict to a json string of the attribute in the Create method for the resource.

## Testing
- extended existing deployment test
