### PR TITLE
apigw create python exceptions for gateway response

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
@@ -4,13 +4,13 @@ from localstack.aws.api.apigateway import GatewayResponseType
 class BaseGatewayResponse(Exception):
     """
     Base class for all Gateway exceptions
-    Do not use this class directly. Instead, subclass from a Default4xxError od Default5xxError.
+    Do not use this class directly. Instead, subclass from Default4xxError or Default5xxError.
     """
 
     message: str = "Unimplemented Response"
     status_code: int = 500
     type: GatewayResponseType = GatewayResponseType.DEFAULT_5XX
-    parent_type: GatewayResponseType = GatewayResponseType.DEFAULT_5XX
+    default_type: GatewayResponseType = GatewayResponseType.DEFAULT_5XX
 
     def __init__(self, message: str = None, status_code: int = None):
         if message is not None:
@@ -21,13 +21,13 @@ class BaseGatewayResponse(Exception):
 
 class Default4xxError(BaseGatewayResponse):
     status_code = 400
-    parent_type = GatewayResponseType.DEFAULT_4XX
+    default_type = GatewayResponseType.DEFAULT_4XX
     type: str = GatewayResponseType.DEFAULT_4XX
 
 
 class Default5xxError(BaseGatewayResponse):
     type: GatewayResponseType = GatewayResponseType.DEFAULT_5XX
-    parent_type: GatewayResponseType = GatewayResponseType.DEFAULT_5XX
+    default_type: GatewayResponseType = GatewayResponseType.DEFAULT_5XX
 
 
 class AccessDeniedError(Default4xxError):

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
@@ -1,0 +1,125 @@
+from localstack.aws.api.apigateway import GatewayResponseType
+
+
+class BaseGatewayResponse(Exception):
+    """
+    Base class for all Gateway exceptions
+    Do not use this class directly. Instead, subclass from a Default4xxError od Default5xxError.
+    """
+
+    message: str = "Unimplemented Response"
+    status_code: int = 500
+    type: GatewayResponseType = GatewayResponseType.DEFAULT_5XX
+    parent_type: GatewayResponseType = GatewayResponseType.DEFAULT_5XX
+
+    def __init__(self, message: str = None, status_code: int = None):
+        if message is not None:
+            self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+
+
+class Default4xxError(BaseGatewayResponse):
+    status_code = 400
+    parent_type = GatewayResponseType.DEFAULT_4XX
+    type: str = GatewayResponseType.DEFAULT_4XX
+
+
+class Default5xxError(BaseGatewayResponse):
+    type: GatewayResponseType = GatewayResponseType.DEFAULT_5XX
+    parent_type: GatewayResponseType = GatewayResponseType.DEFAULT_5XX
+
+
+class AccessDeniedError(Default4xxError):
+    status_code = 403
+    type = GatewayResponseType.ACCESS_DENIED
+
+
+class ApiConfigurationError(Default5xxError):
+    status_code = 500
+    type = GatewayResponseType.API_CONFIGURATION_ERROR
+
+
+class AuthorizerConfigurationError(Default5xxError):
+    status_code = 500
+    type = GatewayResponseType.AUTHORIZER_CONFIGURATION_ERROR
+
+
+class AuthorizerFailureError(Default5xxError):
+    status_code = 500
+    type = GatewayResponseType.AUTHORIZER_FAILURE
+
+
+class BadRequestParametersError(Default4xxError):
+    status_code = 400
+    type = GatewayResponseType.BAD_REQUEST_PARAMETERS
+
+
+class BadRequestBodyError(Default4xxError):
+    status_code = 400
+    type = GatewayResponseType.BAD_REQUEST_BODY
+
+
+class ExpiredTokenError(Default4xxError):
+    status_code = 403
+    type = GatewayResponseType.EXPIRED_TOKEN
+
+
+class IntegrationFailureError(Default5xxError):
+    status_code = 504
+    type = GatewayResponseType.INTEGRATION_FAILURE
+
+
+class IntegrationTimeoutError(Default5xxError):
+    status_code = 504
+    type = GatewayResponseType.INTEGRATION_TIMEOUT
+
+
+class InvalidAPIKeyError(Default4xxError):
+    status_code = 403
+    type = GatewayResponseType.INVALID_API_KEY
+
+
+class InvalidSignatureError(Default4xxError):
+    status_code = 403
+    type = GatewayResponseType.INVALID_SIGNATURE
+
+
+class MissingAuthTokenError(Default4xxError):
+    status_code = 403
+    type = GatewayResponseType.MISSING_AUTHENTICATION_TOKEN
+
+
+class QuotaExceededError(Default4xxError):
+    status_code = 429
+    type = GatewayResponseType.QUOTA_EXCEEDED
+
+
+class RequestTooLargeError(Default4xxError):
+    status_code = 413
+    type = GatewayResponseType.REQUEST_TOO_LARGE
+
+
+class ResourceNotFoundError(Default4xxError):
+    status_code = 404
+    type = GatewayResponseType.RESOURCE_NOT_FOUND
+
+
+class ThrottledError(Default4xxError):
+    status_code = 429
+    type = GatewayResponseType.THROTTLED
+
+
+class UnauthorizedError(Default4xxError):
+    status_code = 401
+    type = GatewayResponseType.UNAUTHORIZED
+
+
+class UnsupportedMediaTypeError(Default4xxError):
+    status_code = 415
+    type = GatewayResponseType.UNSUPPORTED_MEDIA_TYPE
+
+
+class WafFilteredError(Default4xxError):
+    status_code = 403
+    type = GatewayResponseType.WAF_FILTERED

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -1303,6 +1303,7 @@ class TestGatewayResponse:
         with pytest.raises(BaseGatewayResponse) as e:
             raise BaseGatewayResponse()
         assert e.value.status_code == 500
+        assert e.value.message == "Unimplemented Response"
 
     def test_subclassed_response(self):
         with pytest.raises(BaseGatewayResponse) as e:
@@ -1310,4 +1311,4 @@ class TestGatewayResponse:
         assert e.value.status_code == 403
         assert e.value.message == "Access Denied"
         assert e.value.type == GatewayResponseType.ACCESS_DENIED
-        assert e.value.parent_type == GatewayResponseType.DEFAULT_4XX
+        assert e.value.default_type == GatewayResponseType.DEFAULT_4XX


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Base python exception to handle gateway integration error.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Each exception is subclassed from one of the Default response. It will allow us to quickly check if `error.default_type` is a configured `GatewayResponse` by the user when building the response in the exception handler

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
