### PR TITLE
Push latest image tag with version tags, regardless of default tag

### DIFF
--- a/.github/workflows/tests-bin.yml
+++ b/.github/workflows/tests-bin.yml
@@ -4,12 +4,16 @@ on:
   pull_request:
     paths:
       - 'bin/docker-helper.sh'
+      - '.github/workflows/tests-bin.yml'
+      - 'tests/bin/*.bats'
     branches:
       - master
       - release/*
   push:
     paths:
       - 'bin/docker-helper.sh'
+      - '.github/workflows/tests-bin.yml'
+      - 'tests/bin/*.bats'
     branches:
       - master
       - release/*

--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -168,6 +168,9 @@ function cmd-push() {
       # create explicitly set image tag (via $IMAGE_TAG)
       docker tag $TARGET_IMAGE_NAME:$DEFAULT_TAG-$PLATFORM $TARGET_IMAGE_NAME:$IMAGE_TAG-$PLATFORM
 
+      # always create "latest" tag on version push
+      docker tag $TARGET_IMAGE_NAME:$DEFAULT_TAG-$PLATFORM $TARGET_IMAGE_NAME:latest-$PLATFORM
+
       # create "stable" tag
       docker tag $TARGET_IMAGE_NAME:$DEFAULT_TAG-$PLATFORM $TARGET_IMAGE_NAME:stable-$PLATFORM
 
@@ -182,6 +185,7 @@ function cmd-push() {
 
       # push all the created tags
       docker push $TARGET_IMAGE_NAME:stable-$PLATFORM
+      docker push $TARGET_IMAGE_NAME:latest-$PLATFORM
       docker push $TARGET_IMAGE_NAME:$IMAGE_TAG-$PLATFORM
       docker push $TARGET_IMAGE_NAME:$MAJOR_VERSION-$PLATFORM
       docker push $TARGET_IMAGE_NAME:$MAJOR_VERSION.$MINOR_VERSION-$PLATFORM
@@ -222,6 +226,11 @@ function cmd-push-manifests() {
       docker manifest create $IMAGE_NAME:$IMAGE_TAG \
         --amend $IMAGE_NAME:$IMAGE_TAG-amd64 \
         --amend $IMAGE_NAME:$IMAGE_TAG-arm64
+
+      # always create "latest" tag on version push
+      docker manifest create $IMAGE_NAME:latest \
+        --amend $IMAGE_NAME:latest-amd64 \
+        --amend $IMAGE_NAME:latest-arm64
 
       # create "stable" tag
       docker manifest create $IMAGE_NAME:stable \

--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -246,6 +246,7 @@ function cmd-push-manifests() {
       # push all the created tags
       docker manifest push $IMAGE_NAME:$IMAGE_TAG
       docker manifest push $IMAGE_NAME:stable
+      docker manifest push $IMAGE_NAME:latest
       docker manifest push $IMAGE_NAME:$MAJOR_VERSION
       docker manifest push $IMAGE_NAME:$MAJOR_VERSION.$MINOR_VERSION
       docker manifest push $IMAGE_NAME:$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION

--- a/tests/bin/README.md
+++ b/tests/bin/README.md
@@ -50,3 +50,9 @@ You can also run all `.bats` files in a directory:
 ```bash
 bats tests/bin
 ```
+
+To run with some debug information, you can use this:
+
+```bash
+bats --trace --verbose-run --print-output-on-failure -r tests/bin/
+```

--- a/tests/bin/README.md
+++ b/tests/bin/README.md
@@ -2,3 +2,51 @@
 
 The tests in this folder are not regular Pytest tests.
 They are implemented with [BATS](https://github.com/bats-core/bats-core) to test scripts in the `bin` folder of this repo.
+
+## Prerequisites
+
+**Install BATS**: If you don't have BATS installed, you need to install it first. On a Unix-like system, you can usually install it using a package manager.
+
+For Debian-based systems (e.g., Ubuntu):
+```bash
+sudo apt-get update
+sudo apt-get install bats
+```
+
+For macOS using Homebrew:
+```bash
+brew install bats-core
+```
+
+Alternatively, you can install BATS manually by cloning the repository and adding the `bin` folder to your `PATH` environment variable.
+```bash
+git clone https://github.com/bats-core/bats-core.git
+cd bats-core
+sudo ./install.sh /usr/local
+```
+
+## Writing tests
+
+Create a file with a `.bats` extension, for example, `test_example.bats`. Here’s a simple test file:
+
+```bash
+#!/usr/bin/env bats
+@test "test description" {
+  run echo "hello"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello" ]
+}
+```
+
+## Running Tests
+To run the tests, simply execute the bats command followed by the test file or directory containing test files:
+
+```bash
+bats test_example.bats
+```
+
+You can also run all `.bats` files in a directory:
+
+```bash
+bats tests/bin
+```

--- a/tests/bin/test.docker-helper.bats
+++ b/tests/bin/test.docker-helper.bats
@@ -144,6 +144,7 @@ setup_file() {
   run bin/docker-helper.sh push
   [ "$status" -eq 0 ]
   [[ "$output" =~ "docker push $IMAGE_NAME:custom-default-tag-$PLATFORM" ]]
+  [[ "$output" =~ "docker push $IMAGE_NAME:latest-$PLATFORM" ]]
   [[ "$output" =~ "docker push $IMAGE_NAME:1-$PLATFORM" ]]
   [[ "$output" =~ "docker push $IMAGE_NAME:1.2-$PLATFORM" ]]
   [[ "$output" =~ "docker push $IMAGE_NAME:1.2.3-$PLATFORM" ]]
@@ -211,6 +212,7 @@ setup_file() {
   [[ "$output" =~ "docker manifest create $IMAGE_NAME:custom-default-tag --amend $IMAGE_NAME:custom-default-tag-amd64 --amend $IMAGE_NAME:custom-default-tag-arm64" ]]
   [[ "$output" =~ "docker manifest push $IMAGE_NAME:$IMAGE_TAG" ]]
   [[ "$output" =~ "docker manifest push $IMAGE_NAME:custom-default-tag" ]]
+  [[ "$output" =~ "docker manifest push $IMAGE_NAME:latest" ]]
   [[ "$output" =~ "docker manifest push $IMAGE_NAME:1" ]]
   [[ "$output" =~ "docker manifest push $IMAGE_NAME:1.2" ]]
   [[ "$output" =~ "docker manifest push $IMAGE_NAME:1.2.3" ]]
@@ -219,7 +221,7 @@ setup_file() {
 
 @test "push-manifests always pushes latest tag w versions" {
   export IMAGE_NAME="localstack/test"
-  export MAIN_BRANCH="$(git branch --show-current)"
+  export MAIN_BRANCH="`git branch --show-current`"
   export DOCKER_USERNAME=test
   export DOCKER_PASSWORD=test
   export VERSION_FILE="$BATS_TEST_DIRNAME/files/VERSION"

--- a/tests/bin/test.docker-helper.bats
+++ b/tests/bin/test.docker-helper.bats
@@ -230,7 +230,7 @@ setup_file() {
   [[ "$output" =~ "docker manifest push $IMAGE_NAME:stable" ]]
   [[ "$output" =~ "docker manifest push $IMAGE_NAME:latest" ]]
   [[ "$output" =~ "docker manifest push $IMAGE_NAME:dev" ]]
-  [[ "$output" =~ "docker manifest push $IMAGE_NAME:1" ]]
-  [[ "$output" =~ "docker manifest push $IMAGE_NAME:1.2" ]]
-  [[ "$output" =~ "docker manifest push $IMAGE_NAME:1.2.3" ]]
+  [[ "$output" =~ "docker manifest push $IMAGE_NAME:0" ]]
+  [[ "$output" =~ "docker manifest push $IMAGE_NAME:0.0" ]]
+  [[ "$output" =~ "docker manifest push $IMAGE_NAME:0.0.1" ]]
 }

--- a/tests/bin/test.docker-helper.bats
+++ b/tests/bin/test.docker-helper.bats
@@ -216,3 +216,21 @@ setup_file() {
   [[ "$output" =~ "docker manifest push $IMAGE_NAME:1.2.3" ]]
   [[ "$output" =~ "docker manifest push $IMAGE_NAME:stable" ]]
 }
+
+@test "push-manifests always pushes latest tag w versions" {
+  export IMAGE_NAME="localstack/test"
+  export MAIN_BRANCH="$(git branch --show-current)"
+  export DOCKER_USERNAME=test
+  export DOCKER_PASSWORD=test
+  export VERSION_FILE="$BATS_TEST_DIRNAME/files/VERSION"
+  export DEFAULT_TAG="dev"
+  export FORCE_VERSION_TAG_PUSH=1
+  run bin/docker-helper.sh push-manifests
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "docker manifest push $IMAGE_NAME:stable" ]]
+  [[ "$output" =~ "docker manifest push $IMAGE_NAME:latest" ]]
+  [[ "$output" =~ "docker manifest push $IMAGE_NAME:dev" ]]
+  [[ "$output" =~ "docker manifest push $IMAGE_NAME:1" ]]
+  [[ "$output" =~ "docker manifest push $IMAGE_NAME:1.2" ]]
+  [[ "$output" =~ "docker manifest push $IMAGE_NAME:1.2.3" ]]
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When switching to the acceptance tests only in the future, the default tag for pushing a new release will be `dev`, which means that releasing a new version won't also upgrade the latest tag. However, there is an implicit expectation that the latest tag at the point of releasing a new version should be the same as the new version. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

This PR forces a push of the latest tag when a new version is pushed, regardless of what the default tag is. 

It also adds instructions on how to use BATS since not everyone might be familiar with it.

It also switches on the Helper tests for changes in the helper test workflow file and changes in the tests themselves. This enables test-driven development, where the tests are changed before the helper script.

## Testing

The newly added BATS test checks whether a latest tag was pushed when the version file changes.

Check the [Helper Tests](https://github.com/localstack/localstack/actions/runs/9562325075/job/26358465713?pr=11046) run to see it work vs the [previous run](https://github.com/localstack/localstack/actions/runs/9562279776/job/26358326523) where it didn't

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
