### PR TITLE
Feature: EventBridge v2: Add test put events limit to 10 messages

### DIFF
--- a/localstack-core/localstack/services/events/event_bus.py
+++ b/localstack-core/localstack/services/events/event_bus.py
@@ -86,6 +86,7 @@ class EventBusService:
                 for statement in policy["Statement"]
                 if statement.get("Sid") != statement_id
             ]
+            self.event_bus.last_modified_time = datetime.now(timezone.utc)
 
     def _pars_statement(self, statement_id, action, principal, resource_arn, condition):
         if condition and principal != "*":

--- a/localstack-core/localstack/services/events/event_bus.py
+++ b/localstack-core/localstack/services/events/event_bus.py
@@ -51,7 +51,6 @@ class EventBusService:
     ):
         if policy and any([action, principal, statement_id, condition]):
             raise ValueError("Combination of policy with other arguments is not allowed")
-        self.event_bus.creation_time = datetime.now(timezone.utc)
         self.event_bus.last_modified_time = datetime.now(timezone.utc)
         if policy:  # policy document replaces all existing permissions
             policy = json.loads(policy)

--- a/localstack-core/localstack/services/events/models.py
+++ b/localstack-core/localstack/services/events/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Literal, Optional, TypeAlias, TypedDict
 
@@ -97,11 +98,13 @@ class EventBus:
     policy: Optional[ResourcePolicy] = None
     rules: RuleDict = field(default_factory=dict)
     arn: Arn = field(init=False)
-    creation_time: Optional[Timestamp] = None
-    last_modified_time: Optional[Timestamp] = None
+    creation_time: Timestamp = field(init=False)
+    last_modified_time: Timestamp = field(init=False)
 
     def __post_init__(self):
         self.arn = f"arn:aws:events:{self.region}:{self.account_id}:event-bus/{self.name}"
+        self.creation_time = datetime.now(timezone.utc)
+        self.last_modified_time = datetime.now(timezone.utc)
         if self.rules is None:
             self.rules = {}
         if self.tags is None:

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -163,6 +163,10 @@ class TestEvents:
 
     @markers.aws.validated
     @pytest.mark.parametrize("bus_name", ["custom", "default"])
+    @pytest.mark.skipif(
+        is_old_provider(),
+        reason="V1 provider does not support this feature",
+    )
     def test_put_events_exceed_limit_ten_entries(
         self, bus_name, events_create_event_bus, aws_client, snapshot
     ):
@@ -612,6 +616,10 @@ class TestEventBus:
         snapshot.match("delete-default-event-bus-error", e)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        is_old_provider(),
+        reason="V1 provider does not support this feature",
+    )
     def test_list_event_buses_with_prefix(self, create_event_bus, aws_client, snapshot):
         events = aws_client.events
         bus_name = f"unique-prefix-1234567890-{short_uid()}"

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -552,7 +552,7 @@ class TestEvents:
 class TestEventBus:
     @markers.aws.validated
     @pytest.mark.skipif(
-        not is_v2_provider() and not is_aws_cloud(),
+        is_old_provider(),
         reason="V1 provider does not support this feature",
     )
     @pytest.mark.parametrize("regions", [["us-east-1"], ["us-east-1", "us-west-1", "eu-central-1"]])
@@ -639,7 +639,7 @@ class TestEventBus:
 
     @markers.aws.validated
     @pytest.mark.skipif(
-        not is_v2_provider() and not is_aws_cloud(),
+        is_old_provider(),
         reason="V1 provider does not support this feature",
     )
     def test_list_event_buses_with_limit(self, create_event_bus, aws_client, snapshot):
@@ -1272,7 +1272,7 @@ class TestEventRule:
 
     @markers.aws.validated
     @pytest.mark.skipif(
-        not is_v2_provider() and not is_aws_cloud(),
+        is_old_provider(),
         reason="V1 provider does not support this feature",
     )
     def test_describe_nonexistent_rule(self, aws_client, snapshot):
@@ -1524,7 +1524,7 @@ class TestEventTarget:
 
     @markers.aws.validated
     @pytest.mark.skipif(
-        not is_v2_provider() and not is_aws_cloud(),
+        is_old_provider(),
         reason="V1 provider does not support this feature",
     )
     def test_add_exceed_fife_targets_per_rule(
@@ -1549,7 +1549,7 @@ class TestEventTarget:
 
     @markers.aws.validated
     @pytest.mark.skipif(
-        not is_v2_provider() and not is_aws_cloud(),
+        is_old_provider(),
         reason="V1 provider does not support this feature",
     )
     def test_list_target_by_rule_limit(

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_without_source": {
-    "recorded-date": "29-04-2024, 13:15:31",
+    "recorded-date": "19-06-2024, 10:40:50",
     "recorded-content": {
       "put-events": {
         "Entries": [
@@ -18,7 +18,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_event_without_detail": {
-    "recorded-date": "29-04-2024, 13:15:31",
+    "recorded-date": "19-06-2024, 10:40:51",
     "recorded-content": {
       "put-events": {
         "Entries": [
@@ -36,7 +36,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_time": {
-    "recorded-date": "29-04-2024, 13:15:34",
+    "recorded-date": "19-06-2024, 10:40:53",
     "recorded-content": {
       "messages": [
         {
@@ -96,8 +96,38 @@
       ]
     }
   },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_exceed_limit_ten_entries[custom]": {
+    "recorded-date": "19-06-2024, 10:40:54",
+    "recorded-content": {
+      "put-events-exceed-limit-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '[PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null)]' at 'entries' failed to satisfy constraint: Member must have length less than or equal to 10"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_exceed_limit_ten_entries[default]": {
+    "recorded-date": "19-06-2024, 10:40:55",
+    "recorded-content": {
+      "put-events-exceed-limit-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '[PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null), PutEventsRequestEntry(time=null, source=core.update-account-command, resources=null, detailType=core.update-account-command, detail={\"command\": \"update-account\", \"payload\": {\"acc_id\": \"0a787ecb-4015\", \"sf_id\": \"baz\"}}, eventBusName=<bus-name>, traceHeader=null, kmsKeyIdentifier=null, internalMetadata=null)]' at 'entries' failed to satisfy constraint: Member must have length less than or equal to 10"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
-    "recorded-date": "29-04-2024, 13:15:44",
+    "recorded-date": "19-06-2024, 10:54:07",
     "recorded-content": {
       "create-custom-event-bus-us-east-1": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
@@ -110,6 +140,8 @@
         "EventBuses": [
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "CreationTime": "datetime",
+            "LastModifiedTime": "datetime",
             "Name": "<bus-name>"
           }
         ],
@@ -120,6 +152,8 @@
       },
       "describe-custom-event-bus-us-east-1": {
         "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
         "Name": "<bus-name>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -142,7 +176,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
-    "recorded-date": "29-04-2024, 13:15:47",
+    "recorded-date": "19-06-2024, 10:54:09",
     "recorded-content": {
       "create-custom-event-bus-us-east-1": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
@@ -155,6 +189,8 @@
         "EventBuses": [
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "CreationTime": "datetime",
+            "LastModifiedTime": "datetime",
             "Name": "<bus-name>"
           }
         ],
@@ -165,6 +201,8 @@
       },
       "describe-custom-event-bus-us-east-1": {
         "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
         "Name": "<bus-name>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -182,6 +220,8 @@
         "EventBuses": [
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "CreationTime": "datetime",
+            "LastModifiedTime": "datetime",
             "Name": "<bus-name>"
           }
         ],
@@ -192,6 +232,8 @@
       },
       "describe-custom-event-bus-us-west-1": {
         "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
         "Name": "<bus-name>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -209,6 +251,8 @@
         "EventBuses": [
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "CreationTime": "datetime",
+            "LastModifiedTime": "datetime",
             "Name": "<bus-name>"
           }
         ],
@@ -219,6 +263,8 @@
       },
       "describe-custom-event-bus-eu-central-1": {
         "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
         "Name": "<bus-name>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -267,31 +313,33 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
-    "recorded-date": "29-04-2024, 13:15:47",
+    "recorded-date": "19-06-2024, 10:41:05",
     "recorded-content": {
       "create-multiple-event-buses-same-name": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateEventBus operation: Event bus <bus-name> already exists.') tblen=4>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
-    "recorded-date": "29-04-2024, 13:15:49",
+    "recorded-date": "19-06-2024, 10:41:07",
     "recorded-content": {
       "describe-not-existing-event-bus-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>",
       "delete-not-existing-event-bus": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
-    "recorded-date": "29-04-2024, 13:15:49",
+    "recorded-date": "19-06-2024, 10:41:07",
     "recorded-content": {
       "delete-default-event-bus-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the DeleteEventBus operation: Cannot delete event bus default.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_prefix": {
-    "recorded-date": "29-04-2024, 13:15:50",
+    "recorded-date": "19-06-2024, 10:49:27",
     "recorded-content": {
       "list-event-buses-prefix-complete-name": {
         "EventBuses": [
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "CreationTime": "datetime",
+            "LastModifiedTime": "datetime",
             "Name": "<bus-name>"
           }
         ],
@@ -304,6 +352,8 @@
         "EventBuses": [
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "CreationTime": "datetime",
+            "LastModifiedTime": "datetime",
             "Name": "<bus-name>"
           }
         ],
@@ -315,20 +365,26 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_limit": {
-    "recorded-date": "29-04-2024, 13:15:52",
+    "recorded-date": "19-06-2024, 10:50:45",
     "recorded-content": {
       "list-event-buses-limit": {
         "EventBuses": [
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-0",
+            "CreationTime": "datetime",
+            "LastModifiedTime": "datetime",
             "Name": "<bus-name-prefix>-0"
           },
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-1",
+            "CreationTime": "datetime",
+            "LastModifiedTime": "datetime",
             "Name": "<bus-name-prefix>-1"
           },
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-2",
+            "CreationTime": "datetime",
+            "LastModifiedTime": "datetime",
             "Name": "<bus-name-prefix>-2"
           }
         ],
@@ -342,14 +398,20 @@
         "EventBuses": [
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-3",
+            "CreationTime": "datetime",
+            "LastModifiedTime": "datetime",
             "Name": "<bus-name-prefix>-3"
           },
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-4",
+            "CreationTime": "datetime",
+            "LastModifiedTime": "datetime",
             "Name": "<bus-name-prefix>-4"
           },
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-5",
+            "CreationTime": "datetime",
+            "LastModifiedTime": "datetime",
             "Name": "<bus-name-prefix>-5"
           }
         ],
@@ -360,8 +422,404 @@
       }
     }
   },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[custom]": {
+    "recorded-date": "19-06-2024, 10:41:14",
+    "recorded-content": {
+      "put-permission": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-put-permission-multiple-principals": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "<sid:1>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:2>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:3>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-put-permission": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "<sid:1>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:2>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:3>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:4>",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-permission-policy": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-put-permission-policy": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "<sid:5>",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com"
+              },
+              "Action": "events:ListRules",
+              "Resource": "*"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
+    "recorded-date": "19-06-2024, 10:41:15",
+    "recorded-content": {
+      "put-permission": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-put-permission-multiple-principals": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "<sid:1>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:2>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:3>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-put-permission": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "<sid:1>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:2>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:3>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            },
+            {
+              "Sid": "<sid:4>",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-permission-policy": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-put-permission-policy": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "<sid:5>",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com"
+              },
+              "Action": "events:ListRules",
+              "Resource": "*"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission_non_existing_event_bus": {
+    "recorded-date": "19-06-2024, 10:41:15",
+    "recorded-content": {
+      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the PutPermission operation: Event bus <bus-name> does not exist.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[custom]": {
+    "recorded-date": "19-06-2024, 10:41:17",
+    "recorded-content": {
+      "remove-permission": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-remove-permission": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "<sid:1>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove-permission-all": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-remove-permission-all": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[default]": {
+    "recorded-date": "19-06-2024, 10:41:18",
+    "recorded-content": {
+      "remove-permission": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-remove-permission": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "<sid:1>",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::<secondary-account-id>:root"
+              },
+              "Action": "events:PutEvents",
+              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove-permission-all": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-event-bus-remove-permission-all": {
+        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-custom]": {
+    "recorded-date": "19-06-2024, 10:41:18",
+    "recorded-content": {
+      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-default]": {
+    "recorded-date": "19-06-2024, 10:41:19",
+    "recorded-content": {
+      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-custom]": {
+    "recorded-date": "19-06-2024, 10:41:20",
+    "recorded-content": {
+      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-default]": {
+    "recorded-date": "19-06-2024, 10:41:21",
+    "recorded-content": {
+      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+    }
+  },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
-    "recorded-date": "29-04-2024, 13:16:20",
+    "recorded-date": "19-06-2024, 10:41:47",
     "recorded-content": {
       "create-custom-event-bus": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<resource:1>",
@@ -440,7 +898,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_nonexistent_event_bus": {
-    "recorded-date": "29-04-2024, 13:18:57",
+    "recorded-date": "19-06-2024, 10:45:41",
     "recorded-content": {
       "put-events": {
         "Entries": [
@@ -490,7 +948,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[custom]": {
-    "recorded-date": "29-04-2024, 13:16:41",
+    "recorded-date": "19-06-2024, 10:42:07",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
@@ -566,7 +1024,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[default]": {
-    "recorded-date": "29-04-2024, 13:16:43",
+    "recorded-date": "19-06-2024, 10:42:08",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
@@ -642,7 +1100,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_multiple_rules_with_same_name": {
-    "recorded-date": "29-04-2024, 13:16:44",
+    "recorded-date": "19-06-2024, 10:42:09",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
@@ -688,7 +1146,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_with_limit": {
-    "recorded-date": "29-04-2024, 13:16:47",
+    "recorded-date": "19-06-2024, 10:42:12",
     "recorded-content": {
       "list-rules-limit": {
         "NextToken": "<next_token:1>",
@@ -824,13 +1282,13 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
-    "recorded-date": "29-04-2024, 13:16:49",
+    "recorded-date": "19-06-2024, 10:42:14",
     "recorded-content": {
       "describe-not-existing-rule-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeRule operation: Rule <rule-name> does not exist on EventBus default.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[custom]": {
-    "recorded-date": "29-04-2024, 13:16:50",
+    "recorded-date": "19-06-2024, 10:42:15",
     "recorded-content": {
       "disable-rule": {
         "ResponseMetadata": {
@@ -895,7 +1353,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[default]": {
-    "recorded-date": "29-04-2024, 13:16:52",
+    "recorded-date": "19-06-2024, 10:42:17",
     "recorded-content": {
       "disable-rule": {
         "ResponseMetadata": {
@@ -960,13 +1418,13 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
-    "recorded-date": "29-04-2024, 13:16:53",
+    "recorded-date": "19-06-2024, 10:42:18",
     "recorded-content": {
       "delete-rule-with-targets-error": "<ExceptionInfo ClientError(\"An error occurred (ValidationException) when calling the DeleteRule operation: Rule can't be deleted since it has targets.\") tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_update_rule_with_targets": {
-    "recorded-date": "29-04-2024, 13:16:55",
+    "recorded-date": "19-06-2024, 10:42:20",
     "recorded-content": {
       "list-targets": {
         "Targets": [
@@ -1002,7 +1460,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_with_values_in_array": {
-    "recorded-date": "29-04-2024, 13:17:04",
+    "recorded-date": "19-06-2024, 10:42:28",
     "recorded-content": {
       "messages": [
         {
@@ -1038,7 +1496,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_nested": {
-    "recorded-date": "29-04-2024, 13:17:16",
+    "recorded-date": "19-06-2024, 10:42:40",
     "recorded-content": {
       "messages": [
         {
@@ -1057,7 +1515,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[custom]": {
-    "recorded-date": "29-04-2024, 13:17:18",
+    "recorded-date": "19-06-2024, 10:42:42",
     "recorded-content": {
       "put-target": {
         "FailedEntries": [],
@@ -1097,7 +1555,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[default]": {
-    "recorded-date": "29-04-2024, 13:17:20",
+    "recorded-date": "19-06-2024, 10:42:44",
     "recorded-content": {
       "put-target": {
         "FailedEntries": [],
@@ -1137,13 +1595,13 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
-    "recorded-date": "29-04-2024, 13:17:21",
+    "recorded-date": "19-06-2024, 10:42:45",
     "recorded-content": {
       "put-targets-client-error": "<ExceptionInfo LimitExceededException('An error occurred (LimitExceededException) when calling the PutTargets operation: The requested resource exceeds the maximum number allowed.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_list_target_by_rule_limit": {
-    "recorded-date": "29-04-2024, 13:17:23",
+    "recorded-date": "19-06-2024, 10:42:47",
     "recorded-content": {
       "list-targets-limit": {
         "NextToken": "<next_token:1>",
@@ -1185,7 +1643,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_target_id_validation": {
-    "recorded-date": "29-04-2024, 13:17:26",
+    "recorded-date": "19-06-2024, 10:42:49",
     "recorded-content": {
       "put-targets-invalid-id-error": {
         "Error": {
@@ -1207,414 +1665,6 @@
           "HTTPStatusCode": 400
         }
       }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[custom]": {
-    "recorded-date": "17-06-2024, 10:32:30",
-    "recorded-content": {
-      "put-permission": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-event-bus-put-permission-multiple-principals": {
-        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
-        "CreationTime": "datetime",
-        "LastModifiedTime": "datetime",
-        "Name": "<bus-name>",
-        "Policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "<sid:1>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "<sid:2>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "<sid:3>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<secondary-account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            }
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-event-bus-put-permission": {
-        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
-        "CreationTime": "datetime",
-        "LastModifiedTime": "datetime",
-        "Name": "<bus-name>",
-        "Policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "<sid:1>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "<sid:2>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "<sid:3>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<secondary-account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "<sid:4>",
-              "Effect": "Allow",
-              "Principal": "*",
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            }
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-permission-policy": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-event-bus-put-permission-policy": {
-        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
-        "CreationTime": "datetime",
-        "LastModifiedTime": "datetime",
-        "Name": "<bus-name>",
-        "Policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "<sid:5>",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "events.amazonaws.com"
-              },
-              "Action": "events:ListRules",
-              "Resource": "*"
-            }
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
-    "recorded-date": "17-06-2024, 10:32:33",
-    "recorded-content": {
-      "put-permission": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-event-bus-put-permission-multiple-principals": {
-        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
-        "CreationTime": "datetime",
-        "LastModifiedTime": "datetime",
-        "Name": "<bus-name>",
-        "Policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "<sid:1>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "<sid:2>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "<sid:3>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<secondary-account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            }
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-event-bus-put-permission": {
-        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
-        "CreationTime": "datetime",
-        "LastModifiedTime": "datetime",
-        "Name": "<bus-name>",
-        "Policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "<sid:1>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "<sid:2>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "<sid:3>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<secondary-account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            },
-            {
-              "Sid": "<sid:4>",
-              "Effect": "Allow",
-              "Principal": "*",
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            }
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-permission-policy": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-event-bus-put-permission-policy": {
-        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
-        "CreationTime": "datetime",
-        "LastModifiedTime": "datetime",
-        "Name": "<bus-name>",
-        "Policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "<sid:5>",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "events.amazonaws.com"
-              },
-              "Action": "events:ListRules",
-              "Resource": "*"
-            }
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[custom]": {
-    "recorded-date": "17-06-2024, 10:34:04",
-    "recorded-content": {
-      "remove-permission": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-event-bus-remove-permission": {
-        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
-        "CreationTime": "datetime",
-        "LastModifiedTime": "datetime",
-        "Name": "<bus-name>",
-        "Policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "<sid:1>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<secondary-account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            }
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "remove-permission-all": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-event-bus-remove-permission-all": {
-        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
-        "CreationTime": "datetime",
-        "LastModifiedTime": "datetime",
-        "Name": "<bus-name>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[default]": {
-    "recorded-date": "17-06-2024, 10:34:06",
-    "recorded-content": {
-      "remove-permission": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-event-bus-remove-permission": {
-        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
-        "CreationTime": "datetime",
-        "LastModifiedTime": "datetime",
-        "Name": "<bus-name>",
-        "Policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "<sid:1>",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::<secondary-account-id>:root"
-              },
-              "Action": "events:PutEvents",
-              "Resource": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>"
-            }
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "remove-permission-all": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-event-bus-remove-permission-all": {
-        "Arn": "arn:aws:events:<region>:<account-id>:event-bus/<bus-name>",
-        "CreationTime": "datetime",
-        "LastModifiedTime": "datetime",
-        "Name": "<bus-name>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[custom]": {
-    "recorded-date": "17-06-2024, 10:47:29",
-    "recorded-content": {
-      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[default]": {
-    "recorded-date": "17-06-2024, 10:47:30",
-    "recorded-content": {
-      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission_non_existing_event_bus": {
-    "recorded-date": "17-06-2024, 10:50:49",
-    "recorded-content": {
-      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the PutPermission operation: Event bus <bus-name> does not exist.') tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-custom]": {
-    "recorded-date": "17-06-2024, 11:01:19",
-    "recorded-content": {
-      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-default]": {
-    "recorded-date": "17-06-2024, 11:01:20",
-    "recorded-content": {
-      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-custom]": {
-    "recorded-date": "17-06-2024, 11:01:21",
-    "recorded-content": {
-      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-default]": {
-    "recorded-date": "17-06-2024, 11:01:23",
-    "recorded-content": {
-      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
     }
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -116,6 +116,12 @@
   "tests/aws/services/events/test_events.py::TestEvents::test_put_event_without_detail": {
     "last_validated_date": "2024-04-29T13:15:31+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_exceed_limit_ten_entries[custom]": {
+    "last_validated_date": "2024-06-18T11:22:00+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_exceed_limit_ten_entries[default]": {
+    "last_validated_date": "2024-06-18T11:22:01+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_time": {
     "last_validated_date": "2024-04-29T13:15:34+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,131 +1,122 @@
 {
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
-    "last_validated_date": "2024-04-29T13:15:44+00:00"
+    "last_validated_date": "2024-06-19T10:54:07+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
-    "last_validated_date": "2024-04-29T13:15:47+00:00"
+    "last_validated_date": "2024-06-19T10:54:09+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
-    "last_validated_date": "2024-04-29T13:15:47+00:00"
+    "last_validated_date": "2024-06-19T10:41:05+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
-    "last_validated_date": "2024-04-29T13:15:49+00:00"
+    "last_validated_date": "2024-06-19T10:41:07+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
-    "last_validated_date": "2024-04-29T13:15:49+00:00"
+    "last_validated_date": "2024-06-19T10:41:07+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_limit": {
-    "last_validated_date": "2024-04-29T13:15:52+00:00"
+    "last_validated_date": "2024-06-19T10:50:45+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_prefix": {
-    "last_validated_date": "2024-04-29T13:15:50+00:00"
+    "last_validated_date": "2024-06-19T10:49:27+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_nonexistent_event_bus": {
-    "last_validated_date": "2024-04-29T13:18:57+00:00"
+    "last_validated_date": "2024-06-19T10:45:41+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
-    "last_validated_date": "2024-04-29T13:16:20+00:00"
+    "last_validated_date": "2024-06-19T10:41:47+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[custom]": {
-    "last_validated_date": "2024-06-17T10:32:30+00:00"
+    "last_validated_date": "2024-06-19T10:41:14+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission[default]": {
-    "last_validated_date": "2024-06-17T10:32:33+00:00"
+    "last_validated_date": "2024-06-19T10:41:15+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission_non_existing_event_bus": {
-    "last_validated_date": "2024-06-17T10:50:49+00:00"
+    "last_validated_date": "2024-06-19T10:41:15+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[custom]": {
-    "last_validated_date": "2024-06-17T10:34:04+00:00"
+    "last_validated_date": "2024-06-19T10:41:17+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[default]": {
-    "last_validated_date": "2024-06-17T10:34:06+00:00"
+    "last_validated_date": "2024-06-19T10:41:18+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-custom]": {
-    "last_validated_date": "2024-06-17T11:01:21+00:00"
+    "last_validated_date": "2024-06-19T10:41:20+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-default]": {
-    "last_validated_date": "2024-06-17T11:01:23+00:00"
+    "last_validated_date": "2024-06-19T10:41:21+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-custom]": {
-    "last_validated_date": "2024-06-17T11:01:19+00:00"
+    "last_validated_date": "2024-06-19T10:41:18+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-default]": {
-    "last_validated_date": "2024-06-17T11:01:20+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[custom]": {
-    "last_validated_date": "2024-06-17T10:47:29+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[default]": {
-    "last_validated_date": "2024-06-17T10:47:30+00:00"
+    "last_validated_date": "2024-06-19T10:41:19+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_nested": {
-    "last_validated_date": "2024-04-29T13:17:16+00:00"
+    "last_validated_date": "2024-06-19T10:42:40+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_with_values_in_array": {
-    "last_validated_date": "2024-04-29T13:17:04+00:00"
+    "last_validated_date": "2024-06-19T10:42:28+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
-    "last_validated_date": "2024-04-29T13:16:53+00:00"
+    "last_validated_date": "2024-06-19T10:42:18+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
-    "last_validated_date": "2024-04-29T13:16:49+00:00"
+    "last_validated_date": "2024-06-19T10:42:14+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[custom]": {
-    "last_validated_date": "2024-04-29T13:16:50+00:00"
+    "last_validated_date": "2024-06-19T10:42:15+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[default]": {
-    "last_validated_date": "2024-04-29T13:16:52+00:00"
+    "last_validated_date": "2024-06-19T10:42:17+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_with_limit": {
-    "last_validated_date": "2024-04-29T13:16:47+00:00"
+    "last_validated_date": "2024-06-19T10:42:12+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[custom]": {
-    "last_validated_date": "2024-04-29T13:16:41+00:00"
+    "last_validated_date": "2024-06-19T10:42:07+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[default]": {
-    "last_validated_date": "2024-04-29T13:16:43+00:00"
+    "last_validated_date": "2024-06-19T10:42:08+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_multiple_rules_with_same_name": {
-    "last_validated_date": "2024-04-29T13:16:44+00:00"
+    "last_validated_date": "2024-06-19T10:42:09+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_update_rule_with_targets": {
-    "last_validated_date": "2024-04-29T13:16:55+00:00"
+    "last_validated_date": "2024-06-19T10:42:20+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
-    "last_validated_date": "2024-04-29T13:17:21+00:00"
+    "last_validated_date": "2024-06-19T10:42:45+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_list_target_by_rule_limit": {
-    "last_validated_date": "2024-04-29T13:17:23+00:00"
+    "last_validated_date": "2024-06-19T10:42:47+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[custom]": {
-    "last_validated_date": "2024-04-29T13:17:18+00:00"
+    "last_validated_date": "2024-06-19T10:42:42+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[default]": {
-    "last_validated_date": "2024-04-29T13:17:20+00:00"
+    "last_validated_date": "2024-06-19T10:42:44+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_target_id_validation": {
-    "last_validated_date": "2024-04-29T13:17:26+00:00"
+    "last_validated_date": "2024-06-19T10:42:49+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_create_connection_validations": {
-    "last_validated_date": "2024-04-29T13:15:43+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEvents::test_list_tags_for_resource": {
-    "last_validated_date": "2024-04-29T13:15:38+00:00"
+    "last_validated_date": "2024-06-19T10:41:01+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_event_without_detail": {
-    "last_validated_date": "2024-04-29T13:15:31+00:00"
+    "last_validated_date": "2024-06-19T10:40:51+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_exceed_limit_ten_entries[custom]": {
-    "last_validated_date": "2024-06-18T11:22:00+00:00"
+    "last_validated_date": "2024-06-19T10:40:54+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_exceed_limit_ten_entries[default]": {
-    "last_validated_date": "2024-06-18T11:22:01+00:00"
+    "last_validated_date": "2024-06-19T10:40:55+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_time": {
-    "last_validated_date": "2024-04-29T13:15:34+00:00"
+    "last_validated_date": "2024-06-19T10:40:53+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_without_source": {
-    "last_validated_date": "2024-04-29T13:15:31+00:00"
+    "last_validated_date": "2024-06-19T10:40:50+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
`put_events` is the main method to directly put events to an event bus, it takes as input argument a list of events containing `source` `detail-type` `detail` and `bus-name` but it is limited to a maximum of 10 events at a time.

In addition, AWS introduced some changes to default parameters for event buses, in particular creation time and update time, these changes are also incorporated here to get updated snapshot tests passing.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Add error handling for `put_events` number of entries exceeding 10
Pars entries and return correctly parsed events

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
