### PR TITLE
Execute only acceptance tests on pushes to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,7 @@ parameters:
   randomize-aws-credentials:
     type: boolean
     default: false
-  force-only-acceptance-tests:
-    type: boolean
-    default: false
-  is-scheduled:
+  only-acceptance-tests:
     type: boolean
     default: false
 
@@ -34,11 +31,14 @@ commands:
       - run:
           name: Check if only Acceptance Tests should run
           command: |
-            if [[ << pipeline.parameters.force-only-acceptance-tests >> == "true" ]] ; then
+            echo "only-acceptance-tests: << pipeline.parameters.only-acceptance-tests >>"
+            echo "trigger_source: << pipeline.trigger_source >>"
+            echo "CI_PULL_REQUEST: $CI_PULL_REQUEST"
+            if [[ << pipeline.parameters.only-acceptance-tests >> == "true"]] ; then
               echo "export ONLY_ACCEPTANCE_TESTS=true" >> $BASH_ENV
               echo "export DEFAULT_TAG='dev'" >> $BASH_ENV
-              echo "Forcing acceptance tests, the default tag is 'dev'"
-            elif [[ -z "$CI_PULL_REQUEST" ]] && [[ << pipeline.parameters.is-scheduled >> == "false" ]] ; then
+              echo "Only run acceptance tests, the default tag is 'dev'"
+            elif [[ -z "$CI_PULL_REQUEST" ]] && [[ << pipeline.trigger_source >> == "scheduled_pipeline" ]] ; then
               echo "export ONLY_ACCEPTANCE_TESTS=true" >> $BASH_ENV
               echo "export DEFAULT_TAG='dev'" >> $BASH_ENV
               echo "Unscheduled push to non-PR-branch means only acceptance test run, the default tag is 'dev'"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ commands:
               echo "export DEFAULT_TAG='latest'" >> $BASH_ENV
             fi
             source $BASH_ENV
+            echo $ONLY_ACCEPTANCE_TESTS
 
   prepare-testselection:
     steps:
@@ -611,8 +612,10 @@ jobs:
       - run:
           name: Upload test metrics and implemented coverage data to tinybird
           command: |
-            # check if a fork-only env var is set (https://circleci.com/docs/variables/)
-            if [ -z "$CIRCLE_PR_REPONAME" ] || [ $ACCEPTANCE_TEST_ONLY -eq 0 ] ; then
+            if [ $ONLY_ACCEPTANCE_TESTS ]; then
+              echo "Skipping parity reporting to tinybird because only acceptance tests ran"
+            elif [ -z "$CIRCLE_PR_REPONAME" ]  ; then
+              # check if a fork-only env var is set (https://circleci.com/docs/variables/)
               source .venv/bin/activate
               mkdir parity_metrics && mv target/metric_reports/metric-report-raw-data-*amd64*.csv parity_metrics
               METRIC_REPORT_DIR_PATH=parity_metrics \
@@ -620,7 +623,7 @@ jobs:
               SOURCE_TYPE=community \
               python -m scripts.tinybird.upload_raw_test_metrics_and_coverage
             else
-              echo "Skipping parity reporting to tinybird (no credentials, running on fork, acceptance test only)..."
+              echo "Skipping parity reporting to tinybird (no credentials, running on fork)..."
             fi
 
       - run:
@@ -634,12 +637,16 @@ jobs:
           #    2: the changes worsened the overall coverage
           #    3: the changes introduced uncovered statements but the overall coverage is still better than before
           command: |
-            source .venv/bin/activate
-            pip install pycobertura
-            coverage xml --data-file=.coverage -o all.coverage.report.xml --include="localstack-core/localstack/services/*/**" --omit="*/**/__init__.py"
-            coverage xml --data-file=.coverage.acceptance -o acceptance.coverage.report.xml --include="localstack-core/localstack/services/*/**"  --omit="*/**/__init__.py"
-            pycobertura show --format html -s localstack-core/localstack acceptance.coverage.report.xml -o coverage-acceptance.html
-            bash -c "pycobertura diff --format html -s1 localstack-core/localstack/ -s2 localstack-core/localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html; if [[ \$? -eq 1 ]] ; then exit 1 ; else exit 0 ; fi"
+            if [ $ONLY_ACCEPTANCE_TESTS ]; then
+              echo "Skipping coverage diff because only acceptance tests ran"
+            else
+              source .venv/bin/activate
+              pip install pycobertura
+              coverage xml --data-file=.coverage -o all.coverage.report.xml --include="localstack-core/localstack/services/*/**" --omit="*/**/__init__.py"
+              coverage xml --data-file=.coverage.acceptance -o acceptance.coverage.report.xml --include="localstack-core/localstack/services/*/**"  --omit="*/**/__init__.py"
+              pycobertura show --format html -s localstack-core/localstack acceptance.coverage.report.xml -o coverage-acceptance.html
+              bash -c "pycobertura diff --format html -s1 localstack-core/localstack/ -s2 localstack-core/localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html; if [[ \$? -eq 1 ]] ; then exit 1 ; else exit 0 ; fi"
+            fi
       - run:
           name: Create Metric Coverage Diff (API Coverage)
           environment:
@@ -647,9 +654,13 @@ jobs:
             COVERAGE_DIR_ACCEPTANCE: "acceptance_parity_metrics"
             OUTPUT_DIR: "api-coverage"
           command: |
-            source .venv/bin/activate
-            mkdir api-coverage
-            python -m scripts.metrics_coverage.diff_metrics_coverage
+            if [ $ONLY_ACCEPTANCE_TESTS ]; then
+              echo "Skipping metric coverage diff because only acceptance tests ran"
+            else
+              source .venv/bin/activate
+              mkdir api-coverage
+              python -m scripts.metrics_coverage.diff_metrics_coverage
+            fi
       - store_artifacts:
           path: api-coverage/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ parameters:
   randomize-aws-credentials:
     type: boolean
     default: false
+  only-acceptance-test:
+    type: boolean
+    default: false
 
 executors:
   ubuntu-machine-amd64:
@@ -23,6 +26,18 @@ executors:
       image: << pipeline.parameters.ubuntu-amd64-machine-image >>
 
 commands:
+  prepare-acceptance-test:
+    steps:
+      - run:
+          name: Check if only Acceptance Tests should run
+          command: |
+            if [[ $CIRCLE_BRANCH == "master" ]] ; then
+              echo "export ONLY_ACCEPTANCE_TEST=1" >> $BASH_ENV
+            else
+              echo "export ONLY_ACCEPTANCE_TEST=<< pipeline.parameters.only-acceptance-test >>" >> $BASH_ENV
+            fi
+            source $BASH_ENV
+
   prepare-testselection:
     steps:
       - unless:
@@ -169,35 +184,6 @@ jobs:
           paths:
             - repo/target/coverage/
 
-  acceptance-tests:
-    executor: ubuntu-machine-amd64
-    working_directory: /tmp/workspace/repo
-    environment:
-      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - prepare-pytest-tinybird
-      - prepare-account-region-randomization
-      - run:
-          name: Acceptance tests (EXPERIMENTAL)
-          environment:
-            TEST_PATH: "tests/aws/"
-            COVERAGE_ARGS: "-p"
-            LOCALSTACK_INTERNAL_TEST_COLLECT_METRIC: 1
-          command: |
-            COVERAGE_FILE="target/coverage/.coverage.acceptance.${CIRCLE_NODE_INDEX}" \
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 -m acceptance_test --junitxml=target/reports/acceptance_test.xml -o junit_suite_name='acceptance_test'" \
-            make test-coverage
-      - persist_to_workspace:
-          root:
-            /tmp/workspace
-          paths:
-            - repo/target/reports/
-            - repo/target/metric_reports/
-            - repo/target/coverage/
-      - store_test_results:
-          path: target/reports/
 
   itest-sfn-legacy-provider:
     executor: ubuntu-machine-amd64
@@ -323,7 +309,7 @@ jobs:
         type: string
       machine_image:
         description: "CircleCI machine type to run at"
-        default: "ubuntu-2004:202107-02"
+        default: << pipeline.parameters.ubuntu-amd64-machine-image >>
         type: string
       resource_class:
         description: "CircleCI machine type to run at"
@@ -351,6 +337,58 @@ jobs:
             /tmp/workspace
           paths:
             - repo/target/
+
+  acceptance-test:
+    parameters:
+      platform:
+        description: "Platform to run on"
+        default: "amd64"
+        type: string
+      resource_class:
+        description: "CircleCI machine type to run at"
+        default: "medium"
+        type: string
+      machine_image:
+        description: "CircleCI machine type to run at"
+        default: << pipeline.parameters.ubuntu-amd64-machine-image >>
+        type: string
+    machine:
+      image: << parameters.machine_image >>
+    resource_class: << parameters.resource_class >>
+    working_directory: /tmp/workspace/repo
+    environment:
+      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
+      IMAGE_NAME: "localstack/localstack"
+      PLATFORM: "<< parameters.platform >>"
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Load docker image
+          working_directory: target
+          command: ../bin/docker-helper.sh load
+      - prepare-pytest-tinybird
+      - prepare-account-region-randomization
+      - run:
+          name: Acceptance tests
+          environment:
+            TEST_PATH: "tests/aws/"
+            COVERAGE_ARGS: "-p"
+            COVERAGE_FILE: "target/coverage/.coverage.acceptance.<< parameters.platform >>"
+            PYTEST_ARGS: "${TINYBIRD_PYTEST_ARGS}--reruns 3 -m acceptance_test --junitxml=target/reports/acceptance-test-report-<< parameters.platform >>-${CIRCLE_NODE_INDEX}.xml -o junit_suite_name='acceptance_test'"
+            LOCALSTACK_INTERNAL_TEST_COLLECT_METRIC: 1
+            DEBUG: 1
+          command: |
+            make docker-run-tests
+      - store_test_results:
+          path: target/reports/
+      - persist_to_workspace:
+          root:
+            /tmp/workspace
+          paths:
+            - repo/target/reports/
+            - repo/target/metric_reports/
+            - repo/target/coverage/
 
   docker-test:
     parameters:
@@ -718,9 +756,6 @@ workflows:
       - test-selection:
           requires:
             - install
-      - acceptance-tests:
-          requires:
-            - preflight
       - itest-sfn-legacy-provider:
           requires:
             - preflight
@@ -756,6 +791,20 @@ workflows:
           resource_class: arm.medium
           requires:
             - preflight
+      - acceptance-test:
+          name: acceptance-test-arm64
+          platform: arm64
+          resource_class: arm.medium
+          machine_image: << pipeline.parameters.ubuntu-arm64-machine-image >>
+          requires:
+            - docker-build-arm64
+      - acceptance-test:
+          name: acceptance-test-amd64
+          platform: amd64
+          machine_image: << pipeline.parameters.ubuntu-amd64-machine-image >>
+          resource_class: medium
+          requires:
+            - docker-build-amd64
       - docker-test:
           name: docker-test-arm64
           platform: arm64
@@ -785,7 +834,8 @@ workflows:
             - itest-s3-v2-legacy-provider
             - itest-cloudwatch-v2-provider
             - itest-events-v2-provider
-            - acceptance-tests
+            - acceptance-test-amd64
+            - acceptance-test-arm64
             - docker-test-amd64
             - docker-test-arm64
             - collect-not-implemented
@@ -799,7 +849,8 @@ workflows:
             - itest-s3-v2-legacy-provider
             - itest-cloudwatch-v2-provider
             - itest-events-v2-provider
-            - acceptance-tests
+            - acceptance-test-amd64
+            - acceptance-test-arm64
             - docker-test-amd64
             - docker-test-arm64
             - unit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,6 @@ commands:
             fi
             source $BASH_ENV
 
-
   prepare-testselection:
     steps:
       - unless:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,6 +419,13 @@ jobs:
       IMAGE_NAME: "localstack/localstack"
       PLATFORM: "<< parameters.platform >>"
     steps:
+      - run:
+          name: "Check for acceptance test or default branch"
+          command: |
+            if [ "<< pipeline.parameters.only-acceptance-tests >>" == "true" ] || [ "<< pipeline.parameters.default-branch >>" == "$CIRCLE_BRANCH" ]; then
+              echo "Skipping integration tests because only-acceptance-test is set or running on default branch."
+              circleci-agent step halt
+            fi
       - attach_workspace:
           at: /tmp/workspace
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -642,12 +642,15 @@ jobs:
       - prepare-acceptance-tests
       - attach_workspace:
           at: /tmp/workspace
-      # store (uncombined) coverage from acceptance tests
       - run:
-          name: Fetch isolated acceptance coverage
-          # might need to combine coverage files in future
+          name: Collect isolated acceptance coverage
           command: |
-            cp target/coverage/.coverage.acceptance.* .coverage.acceptance
+            source .venv/bin/activate
+            mkdir target/coverage/acceptance
+            cp target/coverage/.coverage.acceptance.* target/coverage/acceptance
+            cd target/coverage/acceptance
+            coverage combine
+            mv .coverage ../../../.coverage.acceptance
       - store_artifacts:
           path: .coverage.acceptance
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ commands:
              trigger_source="<< pipeline.trigger_source >>"
              git_branch="<< pipeline.git.branch >>"
              echo "only-acceptance-tests: $only_acceptance_tests"
+             # GitHub event: webhook, Scheduled run: scheduled_pipeline, Manual run: api
              echo "trigger_source: $trigger_source"
              echo "git branch: $git_branch"
 
@@ -47,8 +48,8 @@ commands:
 
              if [[ "$only_acceptance_tests" == "true" ]]; then
                  set_env_vars "true" "dev" "Only acceptance tests run, the default tag is 'dev'"
-             elif [[ "$git_branch" == "master" ]] && [[ "$trigger_source" != "scheduled_pipeline" ]]; then
-                 set_env_vars "true" "dev" "Unscheduled push to master means only acceptance test run, the default tag is 'dev'"
+             elif [[ "$git_branch" == "master" ]] && [[ "$trigger_source" == "webhook" ]]; then
+                 set_env_vars "true" "dev" "Regular push run to master means only acceptance test run, the default tag is 'dev'"
              else
                  set_env_vars "false" "latest" "All tests run, the default tag is 'latest'"
              fi
@@ -816,15 +817,14 @@ jobs:
 workflows:
   acceptance-only-run:
     # this workflow only runs when only-acceptance-tests is explicitly set
-    # or when the pipeline is running on the master branch but is not scheduled
+    # or when the pipeline is running on the master branch but is neither scheduled nor a manual run
     # (basically the opposite of the full-run workflow)
     when:
       or:
         - << pipeline.parameters.only-acceptance-tests >>
         - and:
           - equal: [ master,  << pipeline.git.branch>> ]
-          - not:
-              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+          - equal: [ webhook, << pipeline.trigger_source >> ]
     jobs:
       - push-to-tinybird:
           filters:
@@ -882,15 +882,14 @@ workflows:
             - unit-tests
   full-run:
     # this workflow only runs when only-acceptance-tests is not explicitly set (the default)
-    # or when the pipeline is running on the master branch because of a schedule
+    # or when the pipeline is running on the master branch because of a Github event (webhook)
     # (basically the opposite of the acceptance-only-run workflow)
     unless:
       or:
         - << pipeline.parameters.only-acceptance-tests >>
         - and:
           - equal: [ master,  << pipeline.git.branch>> ]
-          - not:
-              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+          - equal: [ webhook, << pipeline.trigger_source >> ]
     jobs:
       - push-to-tinybird:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,25 +29,36 @@ commands:
   prepare-acceptance-tests:
     steps:
       - run:
-          name: Check if only Acceptance Tests should run
+          name: Check if only Acceptance Tests are running
           command: |
-            echo "only-acceptance-tests: << pipeline.parameters.only-acceptance-tests >>"
-            echo "trigger_source: << pipeline.trigger_source >>"
-            echo "CI_PULL_REQUEST: $CI_PULL_REQUEST"
-            if [[ << pipeline.parameters.only-acceptance-tests >> == "true"]] ; then
-              echo "export ONLY_ACCEPTANCE_TESTS=true" >> $BASH_ENV
-              echo "export DEFAULT_TAG='dev'" >> $BASH_ENV
-              echo "Only run acceptance tests, the default tag is 'dev'"
-            elif [[ -z "$CI_PULL_REQUEST" ]] && [[ << pipeline.trigger_source >> == "scheduled_pipeline" ]] ; then
-              echo "export ONLY_ACCEPTANCE_TESTS=true" >> $BASH_ENV
-              echo "export DEFAULT_TAG='dev'" >> $BASH_ENV
-              echo "Unscheduled push to non-PR-branch means only acceptance test run, the default tag is 'dev'"
-            else
-              echo "export ONLY_ACCEPTANCE_TESTS=false" >> $BASH_ENV
-              echo "export DEFAULT_TAG='latest'" >> $BASH_ENV
-              echo "All tests will run, the default tag is 'latest'"
-            fi
-            source $BASH_ENV
+             # Extract pipeline parameters into variables
+             only_acceptance_tests="<< pipeline.parameters.only-acceptance-tests >>"
+             trigger_source="<< pipeline.trigger_source >>"
+             git_branch="<< pipeline.git.branch >>"
+             
+             # Log the extracted parameters
+             echo "only-acceptance-tests: $only_acceptance_tests"
+             echo "trigger_source: $trigger_source"
+             echo "git branch: $git_branch"
+             
+             # Function to set environment variables
+             set_env_vars() {
+                 echo "export ONLY_ACCEPTANCE_TESTS=$1" >> $BASH_ENV
+                 echo "export DEFAULT_TAG='$2'" >> $BASH_ENV
+                 echo "$3"
+             }
+             
+             # Conditional logic to set environment variables based on pipeline parameters
+             if [[ "$only_acceptance_tests" == "true" ]]; then
+                 set_env_vars "true" "dev" "Only run acceptance tests, the default tag is 'dev'"
+             elif [[ "$git_branch" == "master" ]] && [[ "$trigger_source" != "scheduled_pipeline" ]]; then
+                 set_env_vars "true" "dev" "Unscheduled push to master means only acceptance test run, the default tag is 'dev'"
+             else
+                 set_env_vars "false" "latest" "All tests will run, the default tag is 'latest'"
+             fi
+             
+             # Source the environment variables
+             source $BASH_ENV
 
   prepare-testselection:
     steps:
@@ -323,13 +334,6 @@ jobs:
       PLATFORM: "<< parameters.platform >>"
     steps:
       - prepare-acceptance-tests
-      - run:
-          name: "Skip if only acceptance test"
-          command: |
-            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
-              echo "Skipping integration tests because only-acceptance-test is set or running unscheduled on default branch."
-              circleci-agent step halt
-            fi
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -392,13 +396,6 @@ jobs:
       PLATFORM: "amd64"
     steps:
       - prepare-acceptance-tests
-      - run:
-          name: "Skip if only acceptance test"
-          command: |
-            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
-              echo "Skipping bootstrap tests because only-acceptance-test is set or running unscheduled on default branch."
-              circleci-agent step halt
-            fi
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -436,13 +433,6 @@ jobs:
       PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
     steps:
       - prepare-acceptance-tests
-      - run:
-          name: "Skip if only acceptance test"
-          command: |
-            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
-              echo "Skipping integration tests because only-acceptance-test is set or running unscheduled on default branch."
-              circleci-agent step halt
-            fi
       - attach_workspace:
           at: /tmp/workspace
       - prepare-testselection
@@ -473,13 +463,6 @@ jobs:
       PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
     steps:
       - prepare-acceptance-tests
-      - run:
-          name: "Skip if only acceptance test"
-          command: |
-            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
-              echo "Skipping integration tests because only-acceptance-test is set or running unscheduled on default branch."
-              circleci-agent step halt
-            fi
       - attach_workspace:
           at: /tmp/workspace
       - prepare-testselection
@@ -510,13 +493,6 @@ jobs:
       PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
     steps:
       - prepare-acceptance-tests
-      - run:
-          name: "Skip if only acceptance test"
-          command: |
-            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
-              echo "Skipping integration tests because only-acceptance-test is set or running unscheduled on default branch."
-              circleci-agent step halt
-            fi
       - attach_workspace:
           at: /tmp/workspace
       - prepare-testselection
@@ -547,13 +523,6 @@ jobs:
       PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
     steps:
       - prepare-acceptance-tests
-      - run:
-          name: "Skip if only acceptance test"
-          command: |
-            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
-              echo "Skipping integration tests because only-acceptance-test is set or running unscheduled on default branch."
-              circleci-agent step halt
-            fi
       - attach_workspace:
           at: /tmp/workspace
       - prepare-testselection
@@ -589,13 +558,6 @@ jobs:
       PLATFORM: "amd64"
     steps:
       - prepare-acceptance-tests
-      - run:
-          name: "Check for acceptance test or default branch"
-          command: |
-            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
-              echo "Skipping coverage reporting because only-acceptance-test is set or running on default branch."
-              circleci-agent step halt
-            fi
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -857,7 +819,77 @@ jobs:
 ## Workflow setup ##
 ####################
 workflows:
-  main:
+  acceptance-only-run:
+    when:
+      or:
+        - << pipeline.parameters.only-acceptance-tests >>
+        - and:
+          - equal: [ master,  << pipeline.git.branch>> ]
+          - not:
+              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
+      - push-to-tinybird:
+          filters:
+            branches:
+              only: master
+      - install
+      - preflight:
+          requires:
+            - install
+      - unit-tests:
+          requires:
+            - preflight
+      - docker-build:
+          name: docker-build-amd64
+          platform: amd64
+          machine_image: << pipeline.parameters.ubuntu-amd64-machine-image >>
+          resource_class: medium
+          requires:
+            - preflight
+      - docker-build:
+          name: docker-build-arm64
+          platform: arm64
+          # The latest version of ubuntu is not yet supported for ARM:
+          # https://circleci.com/docs/2.0/arm-resources/
+          machine_image: << pipeline.parameters.ubuntu-arm64-machine-image >>
+          resource_class: arm.medium
+          requires:
+            - preflight
+      - acceptance-tests:
+          name: acceptance-tests-arm64
+          platform: arm64
+          resource_class: arm.medium
+          machine_image: << pipeline.parameters.ubuntu-arm64-machine-image >>
+          requires:
+            - docker-build-arm64
+      - acceptance-tests:
+          name: acceptance-tests-amd64
+          platform: amd64
+          machine_image: << pipeline.parameters.ubuntu-amd64-machine-image >>
+          resource_class: medium
+          requires:
+            - docker-build-amd64
+      - report:
+          requires:
+            - acceptance-tests-amd64
+            - acceptance-tests-arm64
+            - unit-tests
+      - push:
+          filters:
+            branches:
+              only: master
+          requires:
+            - acceptance-tests-amd64
+            - acceptance-tests-arm64
+            - unit-tests
+  full-run:
+    unless:
+      or:
+        - << pipeline.parameters.only-acceptance-tests >>
+        - and:
+          - equal: [ master,  << pipeline.git.branch>> ]
+          - not:
+              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - push-to-tinybird:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,12 @@ parameters:
   randomize-aws-credentials:
     type: boolean
     default: false
-  only-acceptance-tests:
+  force-only-acceptance-tests:
     type: boolean
     default: false
-  default-branch:
-    type: string
-    default: switch-to-acceptance-tests-only
+  is-scheduled:
+    type: boolean
+    default: false
 
 executors:
   ubuntu-machine-amd64:
@@ -34,15 +34,21 @@ commands:
       - run:
           name: Check if only Acceptance Tests should run
           command: |
-            if [[ $CIRCLE_BRANCH == << pipeline.parameters.default-branch >> ]] ; then
-              echo "export ONLY_ACCEPTANCE_TESTS=1" >> $BASH_ENV
+            if [[ << pipeline.parameters.force-only-acceptance-tests >> == "true" ]] ; then
+              echo "export ONLY_ACCEPTANCE_TESTS=true" >> $BASH_ENV
               echo "export DEFAULT_TAG='dev'" >> $BASH_ENV
+              echo "Forcing acceptance tests, the default tag is 'dev'"
+            elif [[ -z "$CI_PULL_REQUEST" ]] && [[ << pipeline.parameters.is-scheduled >> == "false" ]] ; then
+              echo "export ONLY_ACCEPTANCE_TESTS=true" >> $BASH_ENV
+              echo "export DEFAULT_TAG='dev'" >> $BASH_ENV
+              echo "Unscheduled push to non-PR-branch means only acceptance test run, the default tag is 'dev'"
             else
-              echo "export ONLY_ACCEPTANCE_TESTS=<< pipeline.parameters.only-acceptance-tests >>" >> $BASH_ENV
+              echo "export ONLY_ACCEPTANCE_TESTS=false" >> $BASH_ENV
               echo "export DEFAULT_TAG='latest'" >> $BASH_ENV
+              echo "All tests will run, the default tag is 'latest'"
             fi
             source $BASH_ENV
-            echo $ONLY_ACCEPTANCE_TESTS
+
 
   prepare-testselection:
     steps:
@@ -66,7 +72,7 @@ commands:
             fi
             if << pipeline.parameters.randomize-aws-credentials >> ; then
               echo "export TINYBIRD_DATASOURCE=community_tests_circleci_ma_mr" >> $BASH_ENV
-            elif $ONLY_ACCEPTANCE_TESTS ; then
+            elif [[ $ONLY_ACCEPTANCE_TESTS == "true" ]] ; then
               echo "export TINYBIRD_DATASOURCE=community_tests_circleci_acceptance" >> $BASH_ENV
             else
               echo "export TINYBIRD_DATASOURCE=community_tests_circleci" >> $BASH_ENV
@@ -428,7 +434,7 @@ jobs:
       - run:
           name: "Check for acceptance test or default branch"
           command: |
-            if [ $ONLY_ACCEPTANCE_TESTS ]; then
+            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
               echo "Skipping integration tests because only-acceptance-test is set or running on default branch."
               circleci-agent step halt
             fi
@@ -530,7 +536,7 @@ jobs:
       - run:
           name: "Check for acceptance test or default branch"
           command: |
-            if [ $ONLY_ACCEPTANCE_TESTS ]; then
+            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
               echo "Skipping coverage reporting because only-acceptance-test is set or running on default branch."
               circleci-agent step halt
             fi
@@ -612,7 +618,7 @@ jobs:
       - run:
           name: Upload test metrics and implemented coverage data to tinybird
           command: |
-            if [ $ONLY_ACCEPTANCE_TESTS ]; then
+            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
               echo "Skipping parity reporting to tinybird because only acceptance tests ran"
             elif [ -z "$CIRCLE_PR_REPONAME" ]  ; then
               # check if a fork-only env var is set (https://circleci.com/docs/variables/)
@@ -637,7 +643,7 @@ jobs:
           #    2: the changes worsened the overall coverage
           #    3: the changes introduced uncovered statements but the overall coverage is still better than before
           command: |
-            if [ $ONLY_ACCEPTANCE_TESTS ]; then
+            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
               echo "Skipping coverage diff because only acceptance tests ran"
             else
               source .venv/bin/activate
@@ -654,7 +660,7 @@ jobs:
             COVERAGE_DIR_ACCEPTANCE: "acceptance_parity_metrics"
             OUTPUT_DIR: "api-coverage"
           command: |
-            if [ $ONLY_ACCEPTANCE_TESTS ]; then
+            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
               echo "Skipping metric coverage diff because only acceptance tests ran"
             else
               source .venv/bin/activate
@@ -768,7 +774,7 @@ jobs:
 
             if << pipeline.parameters.randomize-aws-credentials >> ; then
               TINYBIRD_WORKFLOW=tests_circleci_ma_mr
-            elif $ONLY_ACCEPTANCE_TESTS ; then
+            elif [[ $ONLY_ACCEPTANCE_TESTS == "true" ]] ; then
               TINYBIRD_WORKFLOW=tests_circleci_acceptance
             else
               TINYBIRD_WORKFLOW=tests_circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,8 @@ commands:
             fi
             if << pipeline.parameters.randomize-aws-credentials >> ; then
               echo "export TINYBIRD_DATASOURCE=community_tests_circleci_ma_mr" >> $BASH_ENV
+            elif $ONLY_ACCEPTANCE_TESTS ; then
+              echo "export TINYBIRD_DATASOURCE=community_tests_circleci_acceptance" >> $BASH_ENV
             else
               echo "export TINYBIRD_DATASOURCE=community_tests_circleci" >> $BASH_ENV
             fi
@@ -328,6 +330,7 @@ jobs:
       IMAGE_NAME: "localstack/localstack"
       PLATFORM: "<< parameters.platform >>"
     steps:
+      - prepare-acceptance-tests
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -366,6 +369,7 @@ jobs:
       IMAGE_NAME: "localstack/localstack"
       PLATFORM: "<< parameters.platform >>"
     steps:
+      - prepare-acceptance-tests
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -419,10 +423,11 @@ jobs:
       IMAGE_NAME: "localstack/localstack"
       PLATFORM: "<< parameters.platform >>"
     steps:
+      - prepare-acceptance-tests
       - run:
           name: "Check for acceptance test or default branch"
           command: |
-            if [ "<< pipeline.parameters.only-acceptance-tests >>" == "true" ] || [ "<< pipeline.parameters.default-branch >>" == "$CIRCLE_BRANCH" ]; then
+            if [ $ONLY_ACCEPTANCE_TESTS ]; then
               echo "Skipping integration tests because only-acceptance-test is set or running on default branch."
               circleci-agent step halt
             fi
@@ -520,6 +525,14 @@ jobs:
       IMAGE_NAME: "localstack/localstack"
       PLATFORM: "amd64"
     steps:
+      - prepare-acceptance-tests
+      - run:
+          name: "Check for acceptance test or default branch"
+          command: |
+            if [ $ONLY_ACCEPTANCE_TESTS ]; then
+              echo "Skipping coverage reporting because only-acceptance-test is set or running on default branch."
+              circleci-agent step halt
+            fi
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -566,6 +579,7 @@ jobs:
           name: fetch isolated acceptance coverage
           # might need to combine coverage files in future
           command: |
+            mkdir .coverage.acceptance
             cp target/coverage/.coverage.acceptance.* .coverage.acceptance
       - store_artifacts:
           path: .coverage.acceptance
@@ -661,6 +675,7 @@ jobs:
     environment:
       IMAGE_NAME: "localstack/localstack"
     steps:
+      - prepare-acceptance-tests
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -714,6 +729,7 @@ jobs:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
+      - prepare-acceptance-tests
       - run:
           name: Wait for the workflow to complete
           command: |
@@ -740,6 +756,8 @@ jobs:
 
             if << pipeline.parameters.randomize-aws-credentials >> ; then
               TINYBIRD_WORKFLOW=tests_circleci_ma_mr
+            elif $ONLY_ACCEPTANCE_TESTS ; then
+              TINYBIRD_WORKFLOW=tests_circleci_acceptance
             else
               TINYBIRD_WORKFLOW=tests_circleci
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,12 @@ parameters:
   randomize-aws-credentials:
     type: boolean
     default: false
-  only-acceptance-test:
+  only-acceptance-tests:
     type: boolean
     default: false
+  default-branch:
+    type: string
+    default: switch-to-acceptance-tests-only
 
 executors:
   ubuntu-machine-amd64:
@@ -26,15 +29,17 @@ executors:
       image: << pipeline.parameters.ubuntu-amd64-machine-image >>
 
 commands:
-  prepare-acceptance-test:
+  prepare-acceptance-tests:
     steps:
       - run:
           name: Check if only Acceptance Tests should run
           command: |
-            if [[ $CIRCLE_BRANCH == "master" ]] ; then
-              echo "export ONLY_ACCEPTANCE_TEST=1" >> $BASH_ENV
+            if [[ $CIRCLE_BRANCH == << pipeline.parameters.default-branch >> ]] ; then
+              echo "export ONLY_ACCEPTANCE_TESTS=1" >> $BASH_ENV
+              echo "export DEFAULT_TAG='dev'" >> $BASH_ENV
             else
-              echo "export ONLY_ACCEPTANCE_TEST=<< pipeline.parameters.only-acceptance-test >>" >> $BASH_ENV
+              echo "export ONLY_ACCEPTANCE_TESTS=<< pipeline.parameters.only-acceptance-tests >>" >> $BASH_ENV
+              echo "export DEFAULT_TAG='latest'" >> $BASH_ENV
             fi
             source $BASH_ENV
 
@@ -338,7 +343,7 @@ jobs:
           paths:
             - repo/target/
 
-  acceptance-test:
+  acceptance-tests:
     parameters:
       platform:
         description: "Platform to run on"
@@ -390,7 +395,7 @@ jobs:
             - repo/target/metric_reports/
             - repo/target/coverage/
 
-  docker-test:
+  integration-tests:
     parameters:
       platform:
         description: "Platform to build for"
@@ -791,30 +796,30 @@ workflows:
           resource_class: arm.medium
           requires:
             - preflight
-      - acceptance-test:
-          name: acceptance-test-arm64
+      - acceptance-tests:
+          name: acceptance-tests-arm64
           platform: arm64
           resource_class: arm.medium
           machine_image: << pipeline.parameters.ubuntu-arm64-machine-image >>
           requires:
             - docker-build-arm64
-      - acceptance-test:
-          name: acceptance-test-amd64
+      - acceptance-tests:
+          name: acceptance-tests-amd64
           platform: amd64
           machine_image: << pipeline.parameters.ubuntu-amd64-machine-image >>
           resource_class: medium
           requires:
             - docker-build-amd64
-      - docker-test:
-          name: docker-test-arm64
+      - integration-tests:
+          name: integration-tests-arm64
           platform: arm64
           resource_class: arm.medium
           machine_image: << pipeline.parameters.ubuntu-arm64-machine-image >>
           requires:
             - docker-build-arm64
             - test-selection
-      - docker-test:
-          name: docker-test-amd64
+      - integration-tests:
+          name: integration-tests-amd64
           platform: amd64
           resource_class: medium
           machine_image: << pipeline.parameters.ubuntu-amd64-machine-image >>
@@ -834,10 +839,10 @@ workflows:
             - itest-s3-v2-legacy-provider
             - itest-cloudwatch-v2-provider
             - itest-events-v2-provider
-            - acceptance-test-amd64
-            - acceptance-test-arm64
-            - docker-test-amd64
-            - docker-test-arm64
+            - acceptance-tests-amd64
+            - acceptance-tests-arm64
+            - integration-tests-amd64
+            - integration-tests-arm64
             - collect-not-implemented
             - unit-tests
       - push:
@@ -849,8 +854,8 @@ workflows:
             - itest-s3-v2-legacy-provider
             - itest-cloudwatch-v2-provider
             - itest-events-v2-provider
-            - acceptance-test-amd64
-            - acceptance-test-arm64
-            - docker-test-amd64
-            - docker-test-arm64
+            - acceptance-tests-amd64
+            - acceptance-tests-arm64
+            - integration-tests-amd64
+            - integration-tests-arm64
             - unit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -774,6 +774,19 @@ jobs:
             # Record the time this step started
             START_TIME=$(date +%s)
 
+            # Determine if reporting the workflow even is necessary and what the workflow variant is
+            if [[ << pipeline.parameters.randomize-aws-credentials >> == "true" ]] && [[ $ONLY_ACCEPTANCE_TESTS == "true" ]] ; then
+              echo "Don't report only-acceptance-test workflows with randomized aws credentials
+              circleci-agent step halt
+            elif [[ << pipeline.parameters.randomize-aws-credentials >> == "true" ]] ; then
+              TINYBIRD_WORKFLOW=tests_circleci_ma_mr
+            elif [[ $ONLY_ACCEPTANCE_TESTS == "true" ]] ; then
+              TINYBIRD_WORKFLOW=tests_circleci_acceptance
+            else
+              TINYBIRD_WORKFLOW=tests_circleci
+            fi
+
+
             # wait for the workflow to be done
             while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"| jq -r '.items[]|select(.name != "push-to-tinybird" and .name != "push" and .name != "report")|.status' | grep -c "running") -gt 0 ]]; do
               sleep 10
@@ -791,14 +804,6 @@ jobs:
 
             # Record the time this step is done
             END_TIME=$(date +%s)
-
-            if << pipeline.parameters.randomize-aws-credentials >> ; then
-              TINYBIRD_WORKFLOW=tests_circleci_ma_mr
-            elif [[ $ONLY_ACCEPTANCE_TESTS == "true" ]] ; then
-              TINYBIRD_WORKFLOW=tests_circleci_acceptance
-            else
-              TINYBIRD_WORKFLOW=tests_circleci
-            fi
 
             # Build the payload
             echo '{"workflow": "'$TINYBIRD_WORKFLOW'", "attempt": 1, "run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'", "outcome": "'$OUTCOME'", "workflow_url": "'$CIRCLE_BUILD_URL'"}' > stats.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,47 @@ commands:
 
 
 jobs:
+  ################
+  ## Build Jobs ##
+  ################
+  docker-build:
+    parameters:
+      platform:
+        description: "Platform to build for"
+        default: "amd64"
+        type: string
+      machine_image:
+        description: "CircleCI machine type to run at"
+        default: << pipeline.parameters.ubuntu-amd64-machine-image >>
+        type: string
+      resource_class:
+        description: "CircleCI machine type to run at"
+        default: "medium"
+        type: string
+    machine:
+      image: << parameters.machine_image >>
+    resource_class: << parameters.resource_class >>
+    working_directory: /tmp/workspace/repo
+    environment:
+      IMAGE_NAME: "localstack/localstack"
+      PLATFORM: "<< parameters.platform >>"
+    steps:
+      - prepare-acceptance-tests
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Build community docker image
+          command: ./bin/docker-helper.sh build
+      - run:
+          name: Save docker image
+          working_directory: target
+          command: ../bin/docker-helper.sh save
+      - persist_to_workspace:
+          root:
+            /tmp/workspace
+          paths:
+            - repo/target/
+
   install:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -130,6 +171,10 @@ jobs:
           paths:
             - repo
 
+
+  ##########################
+  ## Acceptance Test Jobs ##
+  ##########################
   preflight:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -142,7 +187,6 @@ jobs:
       - run:
           name: Checking AWS compatibility markers
           command: make check-aws-markers
-
 
   # can't completely skip it since we need the dependency from other tasks => conditional in run step
   test-selection:
@@ -198,161 +242,6 @@ jobs:
           paths:
             - repo/target/coverage/
 
-
-  itest-sfn-legacy-provider:
-    executor: ubuntu-machine-amd64
-    working_directory: /tmp/workspace/repo
-    environment:
-      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - prepare-testselection
-      - prepare-pytest-tinybird
-      - prepare-account-region-randomization
-      - run:
-          name: Test SFN Legacy provider
-          environment:
-            PROVIDER_OVERRIDE_STEPFUNCTIONS: "legacy"
-            TEST_PATH: "tests/aws/services/stepfunctions/legacy/"
-            COVERAGE_ARGS: "-p"
-          command: |
-            COVERAGE_FILE="target/coverage/.coverage.sfnlegacy.${CIRCLE_NODE_INDEX}" \
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/sfn_legacy.xml -o junit_suite_name='sfn_legacy'" \
-            make test-coverage
-      - persist_to_workspace:
-          root:
-            /tmp/workspace
-          paths:
-            - repo/target/coverage/
-      - store_test_results:
-          path: target/reports/
-
-  itest-s3-v2-legacy-provider:
-    executor: ubuntu-machine-amd64
-    working_directory: /tmp/workspace/repo
-    environment:
-      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - prepare-testselection
-      - prepare-pytest-tinybird
-      - prepare-account-region-randomization
-      - run:
-          name: Test S3 v2 legacy provider
-          environment:
-            PROVIDER_OVERRIDE_S3: "legacy_v2"
-            TEST_PATH: "tests/aws/services/s3/"
-            COVERAGE_ARGS: "-p"
-          command: |
-            COVERAGE_FILE="target/coverage/.coverage.s3legacy.${CIRCLE_NODE_INDEX}" \
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/s3_legacy.xml -o junit_suite_name='s3_legacy'" \
-            make test-coverage
-      - persist_to_workspace:
-          root:
-            /tmp/workspace
-          paths:
-            - repo/target/coverage/
-      - store_test_results:
-          path: target/reports/
-
-  itest-cloudwatch-v2-provider:
-    executor: ubuntu-machine-amd64
-    working_directory: /tmp/workspace/repo
-    environment:
-      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - prepare-testselection
-      - prepare-pytest-tinybird
-      - prepare-account-region-randomization
-      - run:
-          name: Test CloudWatch v2 provider
-          environment:
-            PROVIDER_OVERRIDE_CLOUDWATCH: "v2"
-            TEST_PATH: "tests/aws/services/cloudwatch/"
-            COVERAGE_ARGS: "-p"
-          command: |
-            COVERAGE_FILE="target/coverage/.coverage.cloudwatchV2.${CIRCLE_NODE_INDEX}" \
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/cloudwatch_v2.xml -o junit_suite_name='cloudwatch_v2'" \
-            make test-coverage
-      - persist_to_workspace:
-          root:
-            /tmp/workspace
-          paths:
-            - repo/target/coverage/
-      - store_test_results:
-          path: target/reports/
-
-  itest-events-v2-provider:
-    executor: ubuntu-machine-amd64
-    working_directory: /tmp/workspace/repo
-    environment:
-      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - prepare-testselection
-      - prepare-pytest-tinybird
-      - prepare-account-region-randomization
-      - run:
-          name: Test EventBridge v2 provider
-          environment:
-            PROVIDER_OVERRIDE_EVENTS: "v2"
-            TEST_PATH: "tests/aws/services/events/"
-            COVERAGE_ARGS: "-p"
-          command: |
-            COVERAGE_FILE="target/coverage/.coverage.eventsV2.${CIRCLE_NODE_INDEX}" \
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/events_v2.xml -o junit_suite_name='events_v2'" \
-            make test-coverage
-      - persist_to_workspace:
-          root:
-            /tmp/workspace
-          paths:
-            - repo/target/coverage/
-      - store_test_results:
-          path: target/reports/
-
-  docker-build:
-    parameters:
-      platform:
-        description: "Platform to build for"
-        default: "amd64"
-        type: string
-      machine_image:
-        description: "CircleCI machine type to run at"
-        default: << pipeline.parameters.ubuntu-amd64-machine-image >>
-        type: string
-      resource_class:
-        description: "CircleCI machine type to run at"
-        default: "medium"
-        type: string
-    machine:
-      image: << parameters.machine_image >>
-    resource_class: << parameters.resource_class >>
-    working_directory: /tmp/workspace/repo
-    environment:
-      IMAGE_NAME: "localstack/localstack"
-      PLATFORM: "<< parameters.platform >>"
-    steps:
-      - prepare-acceptance-tests
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: Build community docker image
-          command: ./bin/docker-helper.sh build
-      - run:
-          name: Save docker image
-          working_directory: target
-          command: ../bin/docker-helper.sh save
-      - persist_to_workspace:
-          root:
-            /tmp/workspace
-          paths:
-            - repo/target/
-
   acceptance-tests:
     parameters:
       platform:
@@ -406,6 +295,10 @@ jobs:
             - repo/target/metric_reports/
             - repo/target/coverage/
 
+
+  ###########################
+  ## Integration Test Jobs ##
+  ###########################
   integration-tests:
     parameters:
       platform:
@@ -432,10 +325,10 @@ jobs:
     steps:
       - prepare-acceptance-tests
       - run:
-          name: "Check for acceptance test or default branch"
+          name: "Skip if only acceptance test"
           command: |
             if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
-              echo "Skipping integration tests because only-acceptance-test is set or running on default branch."
+              echo "Skipping integration tests because only-acceptance-test is set or running unscheduled on default branch."
               circleci-agent step halt
             fi
       - attach_workspace:
@@ -499,6 +392,14 @@ jobs:
       IMAGE_NAME: "localstack/localstack"
       PLATFORM: "amd64"
     steps:
+      - prepare-acceptance-tests
+      - run:
+          name: "Skip if only acceptance test"
+          command: |
+            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
+              echo "Skipping bootstrap tests because only-acceptance-test is set or running unscheduled on default branch."
+              circleci-agent step halt
+            fi
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -525,6 +426,162 @@ jobs:
           paths:
             - repo/target/coverage/
 
+
+  ######################
+  ## Custom Test Jobs ##
+  ######################
+  itest-sfn-legacy-provider:
+    executor: ubuntu-machine-amd64
+    working_directory: /tmp/workspace/repo
+    environment:
+      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
+    steps:
+      - prepare-acceptance-tests
+      - run:
+          name: "Skip if only acceptance test"
+          command: |
+            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
+              echo "Skipping integration tests because only-acceptance-test is set or running unscheduled on default branch."
+              circleci-agent step halt
+            fi
+      - attach_workspace:
+          at: /tmp/workspace
+      - prepare-testselection
+      - prepare-pytest-tinybird
+      - prepare-account-region-randomization
+      - run:
+          name: Test SFN Legacy provider
+          environment:
+            PROVIDER_OVERRIDE_STEPFUNCTIONS: "legacy"
+            TEST_PATH: "tests/aws/services/stepfunctions/legacy/"
+            COVERAGE_ARGS: "-p"
+          command: |
+            COVERAGE_FILE="target/coverage/.coverage.sfnlegacy.${CIRCLE_NODE_INDEX}" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/sfn_legacy.xml -o junit_suite_name='sfn_legacy'" \
+            make test-coverage
+      - persist_to_workspace:
+          root:
+            /tmp/workspace
+          paths:
+            - repo/target/coverage/
+      - store_test_results:
+          path: target/reports/
+
+  itest-s3-v2-legacy-provider:
+    executor: ubuntu-machine-amd64
+    working_directory: /tmp/workspace/repo
+    environment:
+      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
+    steps:
+      - prepare-acceptance-tests
+      - run:
+          name: "Skip if only acceptance test"
+          command: |
+            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
+              echo "Skipping integration tests because only-acceptance-test is set or running unscheduled on default branch."
+              circleci-agent step halt
+            fi
+      - attach_workspace:
+          at: /tmp/workspace
+      - prepare-testselection
+      - prepare-pytest-tinybird
+      - prepare-account-region-randomization
+      - run:
+          name: Test S3 v2 legacy provider
+          environment:
+            PROVIDER_OVERRIDE_S3: "legacy_v2"
+            TEST_PATH: "tests/aws/services/s3/"
+            COVERAGE_ARGS: "-p"
+          command: |
+            COVERAGE_FILE="target/coverage/.coverage.s3legacy.${CIRCLE_NODE_INDEX}" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/s3_legacy.xml -o junit_suite_name='s3_legacy'" \
+            make test-coverage
+      - persist_to_workspace:
+          root:
+            /tmp/workspace
+          paths:
+            - repo/target/coverage/
+      - store_test_results:
+          path: target/reports/
+
+  itest-cloudwatch-v2-provider:
+    executor: ubuntu-machine-amd64
+    working_directory: /tmp/workspace/repo
+    environment:
+      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
+    steps:
+      - prepare-acceptance-tests
+      - run:
+          name: "Skip if only acceptance test"
+          command: |
+            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
+              echo "Skipping integration tests because only-acceptance-test is set or running unscheduled on default branch."
+              circleci-agent step halt
+            fi
+      - attach_workspace:
+          at: /tmp/workspace
+      - prepare-testselection
+      - prepare-pytest-tinybird
+      - prepare-account-region-randomization
+      - run:
+          name: Test CloudWatch v2 provider
+          environment:
+            PROVIDER_OVERRIDE_CLOUDWATCH: "v2"
+            TEST_PATH: "tests/aws/services/cloudwatch/"
+            COVERAGE_ARGS: "-p"
+          command: |
+            COVERAGE_FILE="target/coverage/.coverage.cloudwatchV2.${CIRCLE_NODE_INDEX}" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/cloudwatch_v2.xml -o junit_suite_name='cloudwatch_v2'" \
+            make test-coverage
+      - persist_to_workspace:
+          root:
+            /tmp/workspace
+          paths:
+            - repo/target/coverage/
+      - store_test_results:
+          path: target/reports/
+
+  itest-events-v2-provider:
+    executor: ubuntu-machine-amd64
+    working_directory: /tmp/workspace/repo
+    environment:
+      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
+    steps:
+      - prepare-acceptance-tests
+      - run:
+          name: "Skip if only acceptance test"
+          command: |
+            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
+              echo "Skipping integration tests because only-acceptance-test is set or running unscheduled on default branch."
+              circleci-agent step halt
+            fi
+      - attach_workspace:
+          at: /tmp/workspace
+      - prepare-testselection
+      - prepare-pytest-tinybird
+      - prepare-account-region-randomization
+      - run:
+          name: Test EventBridge v2 provider
+          environment:
+            PROVIDER_OVERRIDE_EVENTS: "v2"
+            TEST_PATH: "tests/aws/services/events/"
+            COVERAGE_ARGS: "-p"
+          command: |
+            COVERAGE_FILE="target/coverage/.coverage.eventsV2.${CIRCLE_NODE_INDEX}" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/events_v2.xml -o junit_suite_name='events_v2'" \
+            make test-coverage
+      - persist_to_workspace:
+          root:
+            /tmp/workspace
+          paths:
+            - repo/target/coverage/
+      - store_test_results:
+          path: target/reports/
+
+
+  #########################
+  ## Parity Metrics Jobs ##
+  #########################
   capture-not-implemented:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -575,6 +632,10 @@ jobs:
             - repo/scripts/implementation_coverage_aggregated.csv
             - repo/scripts/implementation_coverage_full.csv
 
+
+  ############################
+  ## Result Publishing Jobs ##
+  ############################
   report:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -686,7 +747,6 @@ jobs:
       - store_artifacts:
           path: .coverage
 
-
   push:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -743,6 +803,7 @@ jobs:
             source .venv/bin/activate
             bin/release-helper.sh set-ver $(bin/release-helper.sh next-dev-ver)
             make publish
+
   push-to-tinybird:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -790,6 +851,10 @@ jobs:
             # Fail this step depending on the success to trigger a rerun of this step together with others in case of a "rerun failed"
             [[ $OUTCOME = "success" ]] && exit 0 || exit 1
 
+
+####################
+## Workflow setup ##
+####################
 workflows:
   main:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -572,6 +572,7 @@ jobs:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
+      - prepare-acceptance-tests
       - attach_workspace:
           at: /tmp/workspace
       # store (uncombined) coverage from acceptance tests
@@ -611,7 +612,7 @@ jobs:
           name: Upload test metrics and implemented coverage data to tinybird
           command: |
             # check if a fork-only env var is set (https://circleci.com/docs/variables/)
-            if [ -z "$CIRCLE_PR_REPONAME" ]; then
+            if [ -z "$CIRCLE_PR_REPONAME" ] || [ $ACCEPTANCE_TEST_ONLY -eq 0 ] ; then
               source .venv/bin/activate
               mkdir parity_metrics && mv target/metric_reports/metric-report-raw-data-*amd64*.csv parity_metrics
               METRIC_REPORT_DIR_PATH=parity_metrics \
@@ -619,7 +620,7 @@ jobs:
               SOURCE_TYPE=community \
               python -m scripts.tinybird.upload_raw_test_metrics_and_coverage
             else
-              echo "Skipping parity reporting to tinybird (no credentials, running on fork)..."
+              echo "Skipping parity reporting to tinybird (no credentials, running on fork, acceptance test only)..."
             fi
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -644,10 +644,9 @@ jobs:
           at: /tmp/workspace
       # store (uncombined) coverage from acceptance tests
       - run:
-          name: fetch isolated acceptance coverage
+          name: Fetch isolated acceptance coverage
           # might need to combine coverage files in future
           command: |
-            mkdir .coverage.acceptance
             cp target/coverage/.coverage.acceptance.* .coverage.acceptance
       - store_artifacts:
           path: .coverage.acceptance
@@ -671,7 +670,7 @@ jobs:
               echo "Skipping coverage reporting for pull request."
             fi
       - run:
-          name: store acceptance parity metrics
+          name: Store acceptance parity metrics
           command: |
             mkdir acceptance_parity_metrics
             mv target/metric_reports/metric-report*acceptance* acceptance_parity_metrics/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,33 +31,28 @@ commands:
       - run:
           name: Check if only Acceptance Tests are running
           command: |
-             # Extract pipeline parameters into variables
              only_acceptance_tests="<< pipeline.parameters.only-acceptance-tests >>"
              trigger_source="<< pipeline.trigger_source >>"
              git_branch="<< pipeline.git.branch >>"
-             
-             # Log the extracted parameters
              echo "only-acceptance-tests: $only_acceptance_tests"
              echo "trigger_source: $trigger_source"
              echo "git branch: $git_branch"
-             
+
              # Function to set environment variables
              set_env_vars() {
                  echo "export ONLY_ACCEPTANCE_TESTS=$1" >> $BASH_ENV
                  echo "export DEFAULT_TAG='$2'" >> $BASH_ENV
                  echo "$3"
              }
-             
-             # Conditional logic to set environment variables based on pipeline parameters
+
              if [[ "$only_acceptance_tests" == "true" ]]; then
-                 set_env_vars "true" "dev" "Only run acceptance tests, the default tag is 'dev'"
+                 set_env_vars "true" "dev" "Only acceptance tests run, the default tag is 'dev'"
              elif [[ "$git_branch" == "master" ]] && [[ "$trigger_source" != "scheduled_pipeline" ]]; then
                  set_env_vars "true" "dev" "Unscheduled push to master means only acceptance test run, the default tag is 'dev'"
              else
-                 set_env_vars "false" "latest" "All tests will run, the default tag is 'latest'"
+                 set_env_vars "false" "latest" "All tests run, the default tag is 'latest'"
              fi
-             
-             # Source the environment variables
+
              source $BASH_ENV
 
   prepare-testselection:
@@ -820,6 +815,9 @@ jobs:
 ####################
 workflows:
   acceptance-only-run:
+    # this workflow only runs when only-acceptance-tests is explicitly set
+    # or when the pipeline is running on the master branch but is not scheduled
+    # (basically the opposite of the full-run workflow)
     when:
       or:
         - << pipeline.parameters.only-acceptance-tests >>
@@ -883,6 +881,9 @@ workflows:
             - acceptance-tests-arm64
             - unit-tests
   full-run:
+    # this workflow only runs when only-acceptance-tests is not explicitly set (the default)
+    # or when the pipeline is running on the master branch because of a schedule
+    # (basically the opposite of the acceptance-only-run workflow)
     unless:
       or:
         - << pipeline.parameters.only-acceptance-tests >>

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -65,7 +65,7 @@ on:
       - 'v[0-9]+'
       - release/*
   schedule:
-    - cron: '0 4 * * *'  # run once a day at 4 AM UTC
+    - cron: '15 4 * * *'  # run once a day at 4:15 AM UTC
   push:
     paths:
       - '**'


### PR DESCRIPTION
# Motivation

This PR is a follow up to #9045, which introduced acceptance tests to LocalStack! 

# Changes

This PR changes our integration testing strategy such that:
- On (merge) pushes to `master` we do not run the whole integration test suite anymore.
- We really only run the preflight checks (including unit tests) and our fine, small, super-stable set of acceptance tests for both architectures against the soon-to-be-pushed product (tests against a separately started LocalStack container).
  - If this is successful, we "accept" the state of the product and push the image.
  - As **an intermediary step** we initially push these images to a newly introduced tag called `dev`, i.e. `localstack/localstack:dev`.
  - However, this is just a precautionary, intermediary solution to avoid any issues for our customers which rely on the stability of the `latest` tag.
- On a regular schedule ("every day in the morning") we do run the full test suite (unit tests, acceptance tests, integration tests, ...).
  - On a successful run we push the `latest` tag.

- The CircleCI config is rearranged and organized to more closely match the structure of GitHub pipelines from other repositories
- The acceptance tests now run against the built container and for both ARM and AMD platforms

## Testing

We have the following cases for when the pipeline runs:

- In a PR all tests should run, see the pipeline result from this PR (e.g., [this one](https://app.circleci.com/pipelines/gh/localstack/localstack/26161/workflows/a4a711d4-3b8f-47e1-8b22-114c627f2204))
- On `master` after a push only acceptance tests should run, which we can test by just changing the check from `master` to this branch: [see here](https://app.circleci.com/pipelines/gh/localstack/localstack/26168/workflows/0b391333-4c93-49c3-bebd-7ddaf333ca37)
- On a schedule on master: All tests should run, which is covered by the same logic as the basic PR run
- When manually running it with `only-acceptance-test==true`, only acceptance tests should run: [see here](https://app.circleci.com/pipelines/github/localstack/localstack/26204/workflows/c4c55451-e253-49ab-b685-83c4f4d3fa52)
- When manually running it with `only-acceptance-test==false`, all tests should run: [see here](https://app.circleci.com/pipelines/gh/localstack/localstack/26172/workflows/3e7f780a-4168-49c2-a014-d1184aae7dd9) (Note: the tests are failing, also in the re-runs, but this is due to a currently known instability in some of the tests. The intended behavior, i.e., running all tests and selecting the correct tag works however)

Moreover, on `master`, if only acceptance tests ran, we should use the tag `dev` for now and if all tests ran we should use `latest`. We can see that this happens in this output of the command determining acceptance test status, which also runs before pushing and building the images. (`DEFAULT_TAG = 'dev'` or `'latest'` respectively)
- dev: https://app.circleci.com/pipelines/gh/localstack/localstack/26156/workflows/2c02b600-7652-42f0-bb28-c6ba5631e461/jobs/221602/parallel-runs/0/steps/0-101
- latest: https://app.circleci.com/pipelines/gh/localstack/localstack/26161/workflows/a4a711d4-3b8f-47e1-8b22-114c627f2204/jobs/221676/parallel-runs/0/steps/0-101

The outputs are from calling the command in the build job. However, the command is also called in the job that publishes the image, so the same environment variables will also be set there.

## TODO

What's left to do:

- [ ] Actually create the scheduled run like this: https://circleci.com/docs/migrate-scheduled-workflows-to-scheduled-pipelines/#create-the-new-schedule (sufficient permissions might be required /cc @alexrashed)
    - use this command:
```
curl --location --request POST "https://circleci.com/api/v2/project/localstack/schedule" \
  --header "Circle-Token: <PERSONAL_API_KEY>" \
  --header "Content-Type: application/json" \
  --data-raw '{
      "name": "Scheduled Integration Tests",
      "description": "Full pipeline run on master, which gets executed every morning",
      "attribution-actor": "system",
      "parameters": {
        "branch": "master",
      },
      "timetable": {
          "per-hour": 1,
          "hours-of-day": 4,
          "days-of-week": ["MON", "TUE", "WED", "THU", "FRI"]
      }
  }'
  ```
- [x] Merge https://github.com/localstack/localstack/pull/11076 after this PR (already merged as to not hold up progress)