### PR TITLE
Fix payload not being shown in trace logging

### DIFF
--- a/localstack-core/localstack/logging/format.py
+++ b/localstack-core/localstack/logging/format.py
@@ -125,6 +125,7 @@ class TraceLoggingFormatter(logging.Formatter):
         """
         if isinstance(input, bytes) and len(input) > self.bytes_length_display_threshold:
             return f"Bytes({format_bytes(len(input))})"
+        return input
 
     def format(self, record: logging.LogRecord) -> str:
         record.input = self._replace_large_payloads(record.input)

--- a/tests/unit/logging_/test_format.py
+++ b/tests/unit/logging_/test_format.py
@@ -1,4 +1,12 @@
-from localstack.logging.format import compress_logger_name
+import logging
+
+import pytest
+
+from localstack.logging.format import (
+    AddFormattedAttributes,
+    AwsTraceLoggingFormatter,
+    compress_logger_name,
+)
 
 
 def test_compress_logger_name():
@@ -12,3 +20,92 @@ def test_compress_logger_name():
     assert compress_logger_name("my.very.long.logger.name", 16) == "m.v.l.l.name"
     assert compress_logger_name("my.very.long.logger.name", 17) == "m.v.l.logger.name"
     assert compress_logger_name("my.very.long.logger.name", 24) == "my.very.long.logger.name"
+
+
+class TestHandler(logging.Handler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.messages = []
+
+    def emit(self, record):
+        self.messages.append(self.format(record))
+
+
+class TestTraceLoggingFormatter:
+    @pytest.fixture
+    def handler(self):
+        handler = TestHandler()
+
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(AwsTraceLoggingFormatter())
+        handler.addFilter(AddFormattedAttributes())
+        return handler
+
+    @pytest.fixture
+    def logger(self, handler):
+        logger = logging.getLogger("test.logger")
+
+        # avoid propagation to parent loggers
+        logger.propagate = False
+        logger.addHandler(handler)
+        return logger
+
+    def test_aws_trace_logging_contains_payload(self, handler, logger):
+        logger.info(
+            "AWS %s.%s => %s",
+            "TestService",
+            "Operation",
+            "201",
+            extra={
+                # context
+                "account_id": "123123123123",
+                "region": "invalid-region",
+                # request
+                "input_type": "RequestShape",
+                "input": {"test": "request"},
+                "request_headers": {"request": "header"},
+                # response
+                "output_type": "OutputShape",
+                "output": {"test": "response"},
+                "response_headers": {"response": "header"},
+            },
+        )
+        log_message = handler.messages[0]
+        assert "TestService" in log_message
+        assert "RequestShape" in log_message
+        assert "OutputShape" in log_message
+        assert "{'test': 'request'}" in log_message
+        assert "{'test': 'response'}" in log_message
+
+        assert "{'request': 'header'}" in log_message
+        assert "{'response': 'header'}" in log_message
+
+    def test_aws_trace_logging_replaces_bigger_blobs(self, handler, logger):
+        logger.info(
+            "AWS %s.%s => %s",
+            "TestService",
+            "Operation",
+            "201",
+            extra={
+                # context
+                "account_id": "123123123123",
+                "region": "invalid-region",
+                # request
+                "input_type": "RequestShape",
+                "input": {"request": b"a" * 1024},
+                "request_headers": {"request": "header"},
+                # response
+                "output_type": "OutputShape",
+                "output": {"response": b"a" * 1025},
+                "response_headers": {"response": "header"},
+            },
+        )
+        log_message = handler.messages[0]
+        assert "TestService" in log_message
+        assert "RequestShape" in log_message
+        assert "OutputShape" in log_message
+        assert "{'request': 'Bytes(1.024KB)'}" in log_message
+        assert "{'response': 'Bytes(1.025KB)'}" in log_message
+
+        assert "{'request': 'header'}" in log_message
+        assert "{'response': 'header'}" in log_message


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With #10858, I introduced a replacement for large binary payloads when logging HTTP request which do not directly access a service (e.g. while proxying to a backend), to avoid performance degradations when pushing big ECR blobs.

However, I made a mistake by avoiding to LOG the input altogether if the payload is not `bytes`, by not passing the request input shape to the logging formatter at all.
So, all request payloads (other than bytes across a threshold) are currently logged as `None`.

Broken request logging:

```
2024-06-19T17:23:04.469  INFO --- [et.reactor-0] localstack.request.aws     : AWS lambda.ListFunctions => 200; 000000000000/us-east-1; ListFunctionsRequest(None, headers={'Host': 'localhost:4566', ... stripped for readability}); ListFunctionsResponse(None, headers={'Content-Type': 'text/plain; charset=utf-8', ... stripped for readability})
```

Fixed request logging, with this PR applied:

```
2024-06-19T17:24:36.891  INFO --- [et.reactor-0] localstack.request.aws     : AWS lambda.ListFunctions => 200; 000000000000/us-east-1; ListFunctionsRequest({}, headers={'Host': 'localhost:4566', ... stripped for readability}); ListFunctionsResponse({'Functions': [], 'NextMarker': None}, headers={'Content-Type': 'text/plain; charset=utf-8', ... stripped for readability})
```


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Trace logging of requests in LocalStack now correctly prints the input/output payloads again.
* Add test to avoid future regressions

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
