### PR TITLE
fix TaggingDirective REPLACE for CopyObject

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -1299,11 +1299,13 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             dest_s3_bucket.objects.set(dest_key, s3_object)
 
         dest_key_id = get_unique_key_id(dest_bucket, dest_key, dest_version_id)
+
         if (request.get("TaggingDirective")) == "REPLACE":
-            store.TAGS.tags[dest_key_id] = tagging
+            store.TAGS.tags[dest_key_id] = tagging or {}
         else:
             src_key_id = get_unique_key_id(src_bucket, src_key, src_version_id)
-            store.TAGS.tags[dest_key_id] = copy.copy(store.TAGS.tags.get(src_key_id, {}))
+            src_tags = store.TAGS.tags.get(src_key_id, {})
+            store.TAGS.tags[dest_key_id] = copy.copy(src_tags)
 
         copy_object_result = CopyObjectResult(
             ETag=s3_object.quoted_etag,

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -1489,6 +1489,20 @@ class TestS3:
         get_object_tags = aws_client.s3.get_object_tagging(Bucket=s3_bucket, Key=object_key_copy)
         snapshot.match("get-copy-object-tag", get_object_tags)
 
+        object_key_copy_tag_empty = f"{object_key}-copy-tag-empty"
+        resp = aws_client.s3.copy_object(
+            Bucket=s3_bucket,
+            CopySource=f"{s3_bucket}/{object_key}",
+            Key=object_key_copy_tag_empty,
+            **kwargs,
+        )
+        snapshot.match("copy-object-tag-empty", resp)
+
+        get_object_tags = aws_client.s3.get_object_tagging(
+            Bucket=s3_bucket, Key=object_key_copy_tag_empty
+        )
+        snapshot.match("get-copy-object-tag-empty", get_object_tags)
+
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         condition=is_v2_provider,

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -8812,7 +8812,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_tagging_directive[COPY]": {
-    "recorded-date": "03-08-2023, 04:15:09",
+    "recorded-date": "19-06-2024, 17:17:01",
     "recorded-content": {
       "put-object": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -8856,11 +8856,34 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "copy-object-tag-empty": {
+        "CopyObjectResult": {
+          "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-copy-object-tag-empty": {
+        "TagSet": [
+          {
+            "Key": "key1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_tagging_directive[REPLACE]": {
-    "recorded-date": "03-08-2023, 04:15:11",
+    "recorded-date": "19-06-2024, 17:17:03",
     "recorded-content": {
       "put-object": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -8904,11 +8927,29 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "copy-object-tag-empty": {
+        "CopyObjectResult": {
+          "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-copy-object-tag-empty": {
+        "TagSet": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_tagging_directive[None]": {
-    "recorded-date": "03-08-2023, 04:15:14",
+    "recorded-date": "19-06-2024, 17:17:06",
     "recorded-content": {
       "put-object": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -8942,6 +8983,29 @@
         }
       },
       "get-copy-object-tag": {
+        "TagSet": [
+          {
+            "Key": "key1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-tag-empty": {
+        "CopyObjectResult": {
+          "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-copy-object-tag-empty": {
         "TagSet": [
           {
             "Key": "key1",

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -321,13 +321,13 @@
     "last_validated_date": "2024-02-27T11:11:22+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_tagging_directive[COPY]": {
-    "last_validated_date": "2023-08-03T02:15:09+00:00"
+    "last_validated_date": "2024-06-19T17:17:01+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_tagging_directive[None]": {
-    "last_validated_date": "2023-08-03T02:15:14+00:00"
+    "last_validated_date": "2024-06-19T17:17:06+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_tagging_directive[REPLACE]": {
-    "last_validated_date": "2023-08-03T02:15:11+00:00"
+    "last_validated_date": "2024-06-19T17:17:03+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_delete_object_with_version_id": {
     "last_validated_date": "2023-08-03T02:23:32+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #11037, we've had an issue with empty `Tagging` when using the `TaggingDirective` `REPLACE` with `CopyObject`. This was because we would set the result of `if tagging := request.get("Tagging"):` to the tags, which would be `None`. The fix would be to conditionally set the data, but in that case we would need to pop the previous value, or add `tagging or {}` which will set a dict if the value is `None`. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a regression test for this particular use case
- add the fix in the provider


_fixes #11037_
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
