### PR TITLE
migrating NG APIGW routing to Werkzeug routing

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/__init__.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/__init__.py
@@ -6,7 +6,8 @@ from .integration_response import IntegrationResponseHandler
 from .legacy import LegacyHandler
 from .method_request import MethodRequestHandler
 from .method_response import MethodResponseHandler
-from .parse import InvocationRequestParser, InvocationRequestRouter
+from .parse import InvocationRequestParser
+from .resource_router import InvocationRequestRouter
 
 legacy_handler = LegacyHandler()
 parse_request = InvocationRequestParser()

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -1,19 +1,14 @@
 import logging
-import re
 from collections import defaultdict
-from typing import Optional
 from urllib.parse import urlparse
 
 from rolo.request import Request, restore_payload
 from werkzeug.datastructures import Headers, MultiDict
 
-from localstack.aws.api.apigateway import Resource
 from localstack.http import Response
-from localstack.utils.json import json_safe
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import InvocationRequest, RestApiInvocationContext
-from ..helpers import get_resources_from_deployment
 
 LOG = logging.getLogger(__name__)
 
@@ -104,146 +99,3 @@ class InvocationRequestParser(RestApiGatewayHandler):
             multi_values[key] = headers.getlist(key)
 
         return single_values, multi_values
-
-
-class InvocationRequestRouter(RestApiGatewayHandler):
-    def __call__(
-        self,
-        chain: RestApiGatewayHandlerChain,
-        context: RestApiInvocationContext,
-        response: Response,
-    ):
-        # TODO: replace all the logic in this class by a `url_map` similar to the ServiceRequestRouter
-        # we could create and cache the url_map when creating the deployment
-        # this would allow to more easily extract the path parameters as well
-        # it currently works this way, so we can keep it for now, as it's pretty contained in this handler
-        self.route_and_enrich(context)
-
-    def route_and_enrich(self, context: RestApiInvocationContext):
-        rest_apis_resource_map = self.get_rest_api_paths(context)
-        path_with_no_trailing_slash = context.invocation_request["path"].rstrip("/")
-        request_method = context.request.method
-
-        matched_path, resource = self.get_resource_for_path(
-            path=path_with_no_trailing_slash,
-            method=request_method,
-            path_map=rest_apis_resource_map,
-        )
-        if not matched_path:
-            # TODO: use Gateway Exceptions
-            raise Exception("Not found")
-
-        path_parameters = self.extract_path_params(
-            request_path=path_with_no_trailing_slash,
-            resource_path=matched_path,
-        )
-        context.invocation_request["path_parameters"] = path_parameters
-        context.resource = resource
-
-        method = (
-            resource["resourceMethods"].get(request_method) or resource["resourceMethods"]["ANY"]
-        )
-        context.resource_method = method
-
-    @staticmethod
-    def get_rest_api_paths(context: RestApiInvocationContext) -> dict[str, Resource]:
-        resources = get_resources_from_deployment(context.deployment)
-
-        return {resource["path"]: resource for resource in resources}
-
-    def get_resource_for_path(
-        self, path: str, method: str, path_map: dict[str, Resource]
-    ) -> tuple[
-        Optional[str],
-        Optional[Resource],
-    ]:
-        matches = []
-        # creates a regex from the input path if there are parameters, e.g /foo/{bar}/baz -> /foo/[
-        # ^\]+/baz, otherwise is a direct match.
-        for resource_path, resource in path_map.items():
-            api_path_regex = re.sub(r"{[^+]+\+}", r"[^\?#]+", resource_path)
-            api_path_regex = re.sub(r"{[^}]+}", r"[^/]+", api_path_regex)
-            if re.match(r"^%s$" % api_path_regex, path):
-                matches.append((resource_path, resource))
-
-        # if there are no matches, it's not worth to proceed, bail here!
-        if not matches:
-            LOG.debug(f"No match found for path: '{path}' and method: '{method}'")
-            return None, None
-
-        # /{proxy+} and /api/{proxy+} for inputs like /api/foo/bar
-        # /foo/{param1}/baz and /foo/{param1}/{param2} for inputs like /for/bar/baz
-        param_matches = []
-        proxy_matches = []
-        for resource_path, resource in matches:
-            match_methods = set(resource.get("resourceMethods", {}).keys())
-            # only look for path matches if the request method is in the resource
-            if method.upper() in match_methods or "ANY" in match_methods:
-                # check if we have an exact match (exact matches take precedence) if the method is the same
-                if resource_path == path:
-                    return resource_path, resource
-
-                elif self.path_matches_pattern(path, resource_path):
-                    # parameters can fit in
-                    param_matches.append((resource_path, resource))
-                    continue
-
-                proxy_matches.append((resource_path, resource))
-
-        if param_matches:
-            # count the amount of parameters, return the one with the least which is the most precise
-            sorted_matches = sorted(param_matches, key=lambda x: x[0].count("{"))
-            LOG.debug(f"Match found for path: '{path}' and method: '{method}'")
-            return sorted_matches[0]
-
-        if proxy_matches:
-            # at this stage, we still have more than one match, but we have an eager example like
-            # /{proxy+} or /api/{proxy+}, so we pick the best match by sorting by length, only if they have a method
-            # that could match
-            sorted_matches = sorted(proxy_matches, key=lambda x: len(x[0]), reverse=True)
-            LOG.debug(f"Match found for path: '{path}' and method: '{method}'")
-            return sorted_matches[0]
-
-        # if there are no matches with a method that would match, return
-        LOG.debug(f"No match found for method: '{method}' for matched path: {path}")
-        return None, None
-
-    @staticmethod
-    def tokenize_path(path):
-        return path.lstrip("/").split("/")
-
-    @staticmethod
-    def path_matches_pattern(path: str, api_path: str) -> bool:
-        api_paths = api_path.split("/")
-        paths = path.split("/")
-        reg_check = re.compile(r"{(.*)}")
-        if len(api_paths) != len(paths):
-            return False
-        results = [
-            part == paths[indx]
-            for indx, part in enumerate(api_paths)
-            if reg_check.match(part) is None and part
-        ]
-
-        return len(results) > 0 and all(results)
-
-    def extract_path_params(self, request_path: str, resource_path: str) -> dict[str, str]:
-        tokenized_extracted_path = self.tokenize_path(resource_path)
-        # Looks for '{' in the tokenized extracted path
-        path_params_list = [(i, v) for i, v in enumerate(tokenized_extracted_path) if "{" in v]
-        tokenized_path = self.tokenize_path(request_path)
-        path_params = {}
-        for param in path_params_list:
-            path_param_name = param[1][1:-1]
-            path_param_position = param[0]
-            # if this is a greedy path (aka proxy)
-            if path_param_name.endswith("+"):
-                path_params[path_param_name.rstrip("+")] = "/".join(
-                    tokenized_path[path_param_position:]
-                )
-            else:
-                path_params[path_param_name] = tokenized_path[path_param_position]
-
-        # TODO: maybe move `json_safe` call at the end
-        path_params = json_safe(path_params)
-        return path_params

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
@@ -1,7 +1,7 @@
 import logging
 from functools import cache
 
-from werkzeug.exceptions import MethodNotAllowed
+from werkzeug.exceptions import MethodNotAllowed, NotFound
 from werkzeug.routing import Map, MapAdapter
 
 from localstack.aws.api.apigateway import ListOfResource, Resource
@@ -55,9 +55,9 @@ class RestAPIResourceRouter:
             path = context.invocation_request["path"].rstrip("/")
 
             rule, args = matcher.match(path, method=request.method, return_rule=True)
-        except MethodNotAllowed as e:
+        except (MethodNotAllowed, NotFound) as e:
             # MethodNotAllowed (405) exception is raised if a path is matching, but the method does not.
-            # Our router handles this as a 404.
+            # Our router might handle this as a 404, validate with AWS.
             # TODO: raise proper Gateway exception
             raise Exception("Not found") from e
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
@@ -1,0 +1,127 @@
+import logging
+from functools import cache
+
+from werkzeug.exceptions import MethodNotAllowed
+from werkzeug.routing import Map, MapAdapter
+
+from localstack.aws.api.apigateway import ListOfResource, Resource
+from localstack.aws.protocol.op_router import (
+    GreedyPathConverter,
+    # TODO: all under are private, not sure exactly how we should proceed for them to be re-usable
+    _path_param_regex,
+    _post_process_arg_name,
+    _StrictMethodRule,
+    _transform_path_params_to_rule_vars,
+)
+from localstack.http import Response
+from localstack.services.apigateway.models import RestApiDeployment
+
+from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
+from ..context import RestApiInvocationContext
+from ..helpers import get_resources_from_deployment
+
+LOG = logging.getLogger(__name__)
+
+
+class RestAPIResourceRouter:
+    """
+    A router implementation which abstracts the routing of incoming REST API Context to a specific
+    resource of the Deployment.
+    """
+
+    _map: Map
+
+    def __init__(self, deployment: RestApiDeployment):
+        resources = get_resources_from_deployment(deployment)
+        self._resources_map = {resource["id"]: resource for resource in resources}
+        self._map = get_rule_map_for_resources(resources)
+
+    def match(self, context: RestApiInvocationContext) -> tuple[Resource, dict[str, str]]:
+        """
+        Matches the given request to the resource it targets (or raises an exception if no resource matches).
+
+        :param context:
+        :return: A tuple with the matched resource and the (already parsed) path params
+        :raises: TODO: Gateway exception in case the given request does not match any operation
+        """
+
+        request = context.request
+        # bind the map to get the actual matcher
+        matcher: MapAdapter = self._map.bind(context.request.host)
+
+        # perform the matching
+        try:
+            # trailing slashes are ignored in APIGW
+            path = context.invocation_request["path"].rstrip("/")
+
+            rule, args = matcher.match(path, method=request.method, return_rule=True)
+        except MethodNotAllowed as e:
+            # MethodNotAllowed (405) exception is raised if a path is matching, but the method does not.
+            # Our router handles this as a 404.
+            # TODO: raise proper Gateway exception
+            raise Exception("Not found") from e
+
+        # post process the arg keys and values
+        # - the path param keys need to be "un-sanitized", i.e. sanitized rule variable names need to be reverted
+        # - the path param values might still be url-encoded
+        args = {_post_process_arg_name(k): v for k, v in args.items()}
+
+        # extract the operation model from the rule
+        resource_id: str = rule.endpoint
+        resource = self._resources_map[resource_id]
+
+        return resource, args
+
+
+class InvocationRequestRouter(RestApiGatewayHandler):
+    def __call__(
+        self,
+        chain: RestApiGatewayHandlerChain,
+        context: RestApiInvocationContext,
+        response: Response,
+    ):
+        self.route_and_enrich(context)
+
+    def route_and_enrich(self, context: RestApiInvocationContext):
+        router = self.get_router_for_deployment(context.deployment)
+
+        resource, path_parameters = router.match(context)
+
+        context.invocation_request["path_parameters"] = path_parameters
+        context.resource = resource
+
+        method = (
+            resource["resourceMethods"].get(context.request.method)
+            or resource["resourceMethods"]["ANY"]
+        )
+        context.resource_method = method
+
+    @staticmethod
+    @cache
+    def get_router_for_deployment(deployment: RestApiDeployment) -> RestAPIResourceRouter:
+        return RestAPIResourceRouter(deployment)
+
+
+def get_rule_map_for_resources(resources: ListOfResource) -> Map:
+    rules = []
+    for resource in resources:
+        for method, resource_method in resource.get("resourceMethods", {}).items():
+            path = resource["path"]
+            # translate the requestUri to a Werkzeug rule string
+            rule_string = _path_param_regex.sub(_transform_path_params_to_rule_vars, path)
+            rules.append(
+                _StrictMethodRule(string=rule_string, method=method, endpoint=resource["id"])
+            )  # type: ignore
+
+    return Map(
+        rules=rules,
+        # don't be strict about trailing slashes when matching
+        strict_slashes=False,
+        # we can't really use werkzeug's merge-slashes since it uses HTTP redirects to solve it
+        merge_slashes=False,
+        # get service-specific converters
+        converters={"path": GreedyPathConverter},
+    )
+
+
+# TODO: there are private imports from `localstack/aws/protocol/op_router.py`, we could also copy paste them for now

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -8,6 +8,8 @@ from localstack.services.apigateway.next_gen.execute_api.api import RestApiGatew
 from localstack.services.apigateway.next_gen.execute_api.context import RestApiInvocationContext
 from localstack.services.apigateway.next_gen.execute_api.handlers.parse import (
     InvocationRequestParser,
+)
+from localstack.services.apigateway.next_gen.execute_api.handlers.resource_router import (
     InvocationRequestRouter,
 )
 from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -131,22 +131,45 @@ class TestRoutingHandler:
     def deployment_with_routes(self, dummy_deployment):
         """
         This can be represented by the following routes:
-        - /
-        - GET /test
-        - PUT /test/{param}
-        - DELETE /{proxy+}
+        - (No method) - /
+        - GET         - /foo
+        - PUT         - /foo/{param}
+        - (No method) - /proxy
+        - DELETE      - /proxy/{proxy+}
+        - (No method) - /proxy/bar
+        - DELETE      - /proxy/bar/{param}
+
+        Note: we have the base `/proxy` route to not have greedy matching on the base route, and the other child routes
+        are to assert the `{proxy+} has less priority than hardcoded routes
         """
+        # path: /
         root_resource = dummy_deployment.moto_rest_api.default
+        # path: /foo
         hard_coded_resource = dummy_deployment.moto_rest_api.add_child(
-            path="test", parent_id=root_resource.id
+            path="foo", parent_id=root_resource.id
         )
+        # path: /foo/{param}
         param_resource = dummy_deployment.moto_rest_api.add_child(
             path="{param}",
             parent_id=hard_coded_resource.id,
         )
+        # path: /proxy
+        hard_coded_resource_2 = dummy_deployment.moto_rest_api.add_child(
+            path="proxy", parent_id=root_resource.id
+        )
+        # path: /proxy/bar
+        hard_coded_resource_3 = dummy_deployment.moto_rest_api.add_child(
+            path="bar", parent_id=hard_coded_resource_2.id
+        )
+        # path: /proxy/bar/{param}
+        param_resource_2 = dummy_deployment.moto_rest_api.add_child(
+            path="{param}",
+            parent_id=hard_coded_resource_3.id,
+        )
+        # path: /proxy/{proxy+}
         proxy_resource = dummy_deployment.moto_rest_api.add_child(
             path="{proxy+}",
-            parent_id=root_resource.id,
+            parent_id=hard_coded_resource_2.id,
         )
         hard_coded_resource.add_method(
             method_type="GET",
@@ -159,6 +182,11 @@ class TestRoutingHandler:
             api_key_required=False,
         )
         proxy_resource.add_method(
+            method_type="DELETE",
+            authorization_type="NONE",
+            api_key_required=False,
+        )
+        param_resource_2.add_method(
             method_type="DELETE",
             authorization_type="NONE",
             api_key_required=False,
@@ -177,19 +205,18 @@ class TestRoutingHandler:
     def test_route_request_no_param(self, deployment_with_routes, parse_handler_chain, addressing):
         request = Request(
             "GET",
-            path=self.get_path_from_addressing("/test", addressing),
+            path=self.get_path_from_addressing("/foo", addressing),
         )
 
         context = RestApiInvocationContext(request)
         context.deployment = deployment_with_routes
 
         parse_handler_chain.handle(context, Response())
-        # manually invoking the handler here as exceptions would be swallowed by the chain
         handler = InvocationRequestRouter()
         handler(parse_handler_chain, context, Response())
 
-        assert context.resource["pathPart"] == "test"
-        assert context.resource["path"] == "/test"
+        assert context.resource["pathPart"] == "foo"
+        assert context.resource["path"] == "/foo"
         assert context.resource["resourceMethods"]["GET"]
         # TODO: maybe assert more regarding the data inside Resource Methods, but we don't use it yet
 
@@ -202,19 +229,18 @@ class TestRoutingHandler:
     ):
         request = Request(
             "PUT",
-            path=self.get_path_from_addressing("/test/random-value", addressing),
+            path=self.get_path_from_addressing("/foo/random-value", addressing),
         )
 
         context = RestApiInvocationContext(request)
         context.deployment = deployment_with_routes
 
         parse_handler_chain.handle(context, Response())
-        # manually invoking the handler here as exceptions would be swallowed by the chain
         handler = InvocationRequestRouter()
         handler(parse_handler_chain, context, Response())
 
         assert context.resource["pathPart"] == "{param}"
-        assert context.resource["path"] == "/test/{param}"
+        assert context.resource["path"] == "/foo/{param}"
         # TODO: maybe assert more regarding the data inside Resource Methods, but we don't use it yet
         assert context.resource_method == context.resource["resourceMethods"]["PUT"]
 
@@ -224,9 +250,68 @@ class TestRoutingHandler:
     def test_route_request_with_greedy_parameter(
         self, deployment_with_routes, parse_handler_chain, addressing
     ):
+        # assert that a path which does not contain `/proxy/bar` will be routed to {proxy+}
         request = Request(
             "DELETE",
-            path=self.get_path_from_addressing("/this/is/a/proxy/req2%Fuest", addressing),
+            path=self.get_path_from_addressing("/proxy/this/is/a/proxy/req2%Fuest", addressing),
+        )
+        router_handler = InvocationRequestRouter()
+
+        context = RestApiInvocationContext(request)
+        context.deployment = deployment_with_routes
+
+        parse_handler_chain.handle(context, Response())
+        router_handler(parse_handler_chain, context, Response())
+
+        assert context.resource["pathPart"] == "{proxy+}"
+        assert context.resource["path"] == "/proxy/{proxy+}"
+        # TODO: maybe assert more regarding the data inside Resource Methods, but we don't use it yet
+        assert context.resource_method == context.resource["resourceMethods"]["DELETE"]
+
+        assert context.invocation_request["path_parameters"] == {
+            "proxy": "this/is/a/proxy/req2%Fuest"
+        }
+
+        # assert that a path which does contain `/proxy/bar` will be routed to `/proxy/bar/{param}` if it has only
+        # one resource after `bar`
+        request = Request(
+            "DELETE",
+            path=self.get_path_from_addressing("/proxy/bar/foobar", addressing),
+        )
+        context = RestApiInvocationContext(request)
+        context.deployment = deployment_with_routes
+
+        parse_handler_chain.handle(context, Response())
+        router_handler(parse_handler_chain, context, Response())
+
+        assert context.resource["path"] == "/proxy/bar/{param}"
+        assert context.invocation_request["path_parameters"] == {"param": "foobar"}
+
+        # assert that a path which does contain `/proxy/bar` will be routed to {proxy+} if it does not conform to
+        # `/proxy/bar/{param}`
+        # TODO: validate this with AWS
+        request = Request(
+            "DELETE",
+            path=self.get_path_from_addressing("/proxy/test2/is/a/proxy/req2%Fuest", addressing),
+        )
+        context = RestApiInvocationContext(request)
+        context.deployment = deployment_with_routes
+
+        parse_handler_chain.handle(context, Response())
+        router_handler(parse_handler_chain, context, Response())
+
+        assert context.resource["path"] == "/proxy/{proxy+}"
+        assert context.invocation_request["path_parameters"] == {
+            "proxy": "test2/is/a/proxy/req2%Fuest"
+        }
+
+    @pytest.mark.parametrize("addressing", ["host", "user_request"])
+    def test_route_request_no_match_on_path(
+        self, deployment_with_routes, parse_handler_chain, addressing
+    ):
+        request = Request(
+            "GET",
+            path=self.get_path_from_addressing("/wrong-test", addressing),
         )
 
         context = RestApiInvocationContext(request)
@@ -235,22 +320,16 @@ class TestRoutingHandler:
         parse_handler_chain.handle(context, Response())
         # manually invoking the handler here as exceptions would be swallowed by the chain
         handler = InvocationRequestRouter()
-        handler(parse_handler_chain, context, Response())
-
-        assert context.resource["pathPart"] == "{proxy+}"
-        assert context.resource["path"] == "/{proxy+}"
-        # TODO: maybe assert more regarding the data inside Resource Methods, but we don't use it yet
-        assert context.resource_method == context.resource["resourceMethods"]["DELETE"]
-
-        assert context.invocation_request["path_parameters"] == {
-            "proxy": "this/is/a/proxy/req2%Fuest"
-        }
+        with pytest.raises(Exception, match="Not found"):
+            handler(parse_handler_chain, context, Response())
 
     @pytest.mark.parametrize("addressing", ["host", "user_request"])
-    def test_route_request_no_match(self, deployment_with_routes, parse_handler_chain, addressing):
+    def test_route_request_no_match_on_method(
+        self, deployment_with_routes, parse_handler_chain, addressing
+    ):
         request = Request(
-            "GET",
-            path=self.get_path_from_addressing("/wrong-test", addressing),
+            "POST",
+            path=self.get_path_from_addressing("/test", addressing),
         )
 
         context = RestApiInvocationContext(request)
@@ -268,8 +347,8 @@ class TestRoutingHandler:
     ):
         request = Request(
             "PUT",
-            path=self.get_path_from_addressing("/test/foo%2Fbar/", addressing),
-            raw_path=self.get_path_from_addressing("//test/foo%2Fbar/", addressing),
+            path=self.get_path_from_addressing("/foo/foo%2Fbar/", addressing),
+            raw_path=self.get_path_from_addressing("//foo/foo%2Fbar/", addressing),
         )
 
         context = RestApiInvocationContext(request)
@@ -279,5 +358,5 @@ class TestRoutingHandler:
         handler = InvocationRequestRouter()
         handler(parse_handler_chain, context, Response())
 
-        assert context.resource["path"] == "/test/{param}"
+        assert context.resource["path"] == "/foo/{param}"
         assert context.invocation_request["path_parameters"] == {"param": "foo%2Fbar"}

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -226,7 +226,7 @@ class TestRoutingHandler:
     ):
         request = Request(
             "DELETE",
-            path=self.get_path_from_addressing("/this/is/a/proxy/request", addressing),
+            path=self.get_path_from_addressing("/this/is/a/proxy/req2%Fuest", addressing),
         )
 
         context = RestApiInvocationContext(request)
@@ -242,7 +242,9 @@ class TestRoutingHandler:
         # TODO: maybe assert more regarding the data inside Resource Methods, but we don't use it yet
         assert context.resource_method == context.resource["resourceMethods"]["DELETE"]
 
-        assert context.invocation_request["path_parameters"] == {"proxy": "this/is/a/proxy/request"}
+        assert context.invocation_request["path_parameters"] == {
+            "proxy": "this/is/a/proxy/req2%Fuest"
+        }
 
     @pytest.mark.parametrize("addressing", ["host", "user_request"])
     def test_route_request_no_match(self, deployment_with_routes, parse_handler_chain, addressing):
@@ -261,13 +263,13 @@ class TestRoutingHandler:
             handler(parse_handler_chain, context, Response())
 
     @pytest.mark.parametrize("addressing", ["host", "user_request"])
-    def test_route_request_with_double_slash_and_trailing(
+    def test_route_request_with_double_slash_and_trailing_and_encoded(
         self, deployment_with_routes, parse_handler_chain, addressing
     ):
         request = Request(
             "PUT",
-            path=self.get_path_from_addressing("/test/random/", addressing),
-            raw_path=self.get_path_from_addressing("//test/random/", addressing),
+            path=self.get_path_from_addressing("/test/foo%2Fbar/", addressing),
+            raw_path=self.get_path_from_addressing("//test/foo%2Fbar/", addressing),
         )
 
         context = RestApiInvocationContext(request)
@@ -278,4 +280,4 @@ class TestRoutingHandler:
         handler(parse_handler_chain, context, Response())
 
         assert context.resource["path"] == "/test/{param}"
-        assert context.invocation_request["path_parameters"] == {"param": "random"}
+        assert context.invocation_request["path_parameters"] == {"param": "foo%2Fbar"}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR is currently target #11051.

Follow up from #11051, looking at the `op_router` code, I realized the format of the paths for our specs were the same as API Gateway, so much that we could reuse a simplified version of the `RestServiceOperationRouter` (we do not need to match on required headers and query string parameters, so that makes it much, much simpler). 

All the logic to already create the rules were there, so I've re-used most of the code.
Only issue is that some of the code is private, I'm not sure how to re-architecture to make it re-usable, maybe in some `routing` package? \cc @alexrashed 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- migrate the previous legacy routing and path parameters extraction to the Werkzeug routing

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
