### PR TITLE
[SFN] Enhancements to Parsing Support for Map Toleration Fields

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/state_map.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/state_map.py
@@ -129,10 +129,10 @@ class StateMap(ExecutionState):
         self.max_concurrency_decl.eval(env=env)
         max_concurrency_num = env.stack.pop()
 
-        # Despite MaxConcurrency and Tolerance fields being state level fields, AWS StepFunctions evaluates only the
-        # former as a state level field. With the latter evaluating only after the state start event but being logged
-        # with event ids coherent with state level fields. To adhere with this quirk, an evaluation frame from this
-        # point is created for Tolerance fields evaluation following the state start event.
+        # Despite MaxConcurrency and Tolerance fields being state level fields, AWS StepFunctions evaluates only
+        # MaxConcurrency as a state level field. In contrast, Tolerance is evaluated only after the state start
+        # event but is logged with event IDs coherent with state level fields. To adhere to this quirk, an evaluation
+        # frame from this point is created for the evaluation of Tolerance fields following the state start event.
         frame: Environment = env.open_frame()
         frame.inp = copy.deepcopy(env.inp)
         frame.stack = copy.deepcopy(env.stack)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/state_map.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/state_map.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Optional
 
 from localstack.aws.api.stepfunctions import HistoryEventType, MapStateStartedEventDetails
@@ -58,9 +59,9 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.state
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.tolerated_failure import (
     ToleratedFailureCount,
-    ToleratedFailureCountPath,
+    ToleratedFailureCountDecl,
     ToleratedFailurePercentage,
-    ToleratedFailurePercentagePath,
+    ToleratedFailurePercentageDecl,
 )
 from localstack.services.stepfunctions.asl.component.state.state_props import StateProps
 from localstack.services.stepfunctions.asl.eval.environment import Environment
@@ -74,12 +75,12 @@ class StateMap(ExecutionState):
     item_selector: Optional[ItemSelector]
     parameters: Optional[Parameters]
     max_concurrency_decl: MaxConcurrencyDecl
+    tolerated_failure_count_decl: ToleratedFailureCountDecl
+    tolerated_failure_percentage_decl: ToleratedFailurePercentage
     result_path: Optional[ResultPath]
     result_selector: ResultSelector
     retry: Optional[RetryDecl]
     catch: Optional[CatchDecl]
-    tolerated_failure_count: Optional[ToleratedFailureCount]
-    tolerated_failure_percentage: Optional[ToleratedFailurePercentage]
 
     def __init__(self):
         super(StateMap, self).__init__(
@@ -94,14 +95,18 @@ class StateMap(ExecutionState):
         self.item_selector = state_props.get(ItemSelector)
         self.parameters = state_props.get(Parameters)
         self.max_concurrency_decl = state_props.get(MaxConcurrencyDecl) or MaxConcurrency()
+        self.tolerated_failure_count_decl = (
+            state_props.get(ToleratedFailureCountDecl) or ToleratedFailureCount()
+        )
+        self.tolerated_failure_percentage_decl = (
+            state_props.get(ToleratedFailurePercentageDecl) or ToleratedFailurePercentage()
+        )
         self.result_path = state_props.get(ResultPath) or ResultPath(
             result_path_src=ResultPath.DEFAULT_PATH
         )
         self.result_selector = state_props.get(ResultSelector)
         self.retry = state_props.get(RetryDecl)
         self.catch = state_props.get(CatchDecl)
-
-        # TODO: add check for itemreader used in distributed mode only.
 
         iterator_decl = state_props.get(typ=IteratorDecl)
         item_processor_decl = state_props.get(typ=ItemProcessorDecl)
@@ -120,52 +125,47 @@ class StateMap(ExecutionState):
         else:
             raise ValueError(f"Unknown value for IteratorDecl '{iteration_decl}'.")
 
-        tolerated_failure_count = state_props.get(ToleratedFailureCount)
-        tolerated_failure_count_path = state_props.get(ToleratedFailureCountPath)
-
-        if tolerated_failure_count and tolerated_failure_count_path:
-            raise ValueError(
-                "Cannot define both ToleratedFailureCount and ToleratedFailureCountPath."
-            )
-        self.tolerated_failure_count = (
-            tolerated_failure_count or tolerated_failure_count_path or ToleratedFailureCount()
-        )
-
-        tolerated_failure_percentage = state_props.get(ToleratedFailurePercentage)
-        tolerated_failure_percentage_path = state_props.get(ToleratedFailurePercentagePath)
-
-        if tolerated_failure_percentage and tolerated_failure_percentage_path:
-            raise ValueError(
-                "Cannot define both ToleratedFailurePercentage and ToleratedFailurePercentagePath."
-            )
-        self.tolerated_failure_percentage = (
-            tolerated_failure_percentage
-            or tolerated_failure_percentage_path
-            or ToleratedFailurePercentage()
-        )
-
     def _eval_execution(self, env: Environment) -> None:
+        self.max_concurrency_decl.eval(env=env)
         max_concurrency_num = env.stack.pop()
 
-        self.items_path.eval(env)
-        if self.item_reader:
-            env.event_manager.add_event(
-                context=env.event_history_context,
-                event_type=HistoryEventType.MapStateStarted,
-                event_details=EventDetails(
-                    mapStateStartedEventDetails=MapStateStartedEventDetails(length=0)
-                ),
-            )
-            input_items = None
-        else:
-            input_items = env.stack.pop()
-            env.event_manager.add_event(
-                context=env.event_history_context,
-                event_type=HistoryEventType.MapStateStarted,
-                event_details=EventDetails(
-                    mapStateStartedEventDetails=MapStateStartedEventDetails(length=len(input_items))
-                ),
-            )
+        # Despite MaxConcurrency and Tolerance fields being state level fields, AWS StepFunctions evaluates only the
+        # former as a state level field. With the latter evaluating only after the state start event but being logged
+        # with event ids coherent with state level fields. To adhere with this quirk, an evaluation frame from this
+        # point is created for Tolerance fields evaluation following the state start event.
+        frame: Environment = env.open_frame()
+        frame.inp = copy.deepcopy(env.inp)
+        frame.stack = copy.deepcopy(env.stack)
+
+        try:
+            self.items_path.eval(env)
+            if self.item_reader:
+                env.event_manager.add_event(
+                    context=env.event_history_context,
+                    event_type=HistoryEventType.MapStateStarted,
+                    event_details=EventDetails(
+                        mapStateStartedEventDetails=MapStateStartedEventDetails(length=0)
+                    ),
+                )
+                input_items = None
+            else:
+                input_items = env.stack.pop()
+                env.event_manager.add_event(
+                    context=env.event_history_context,
+                    event_type=HistoryEventType.MapStateStarted,
+                    event_details=EventDetails(
+                        mapStateStartedEventDetails=MapStateStartedEventDetails(
+                            length=len(input_items)
+                        )
+                    ),
+                )
+
+            self.tolerated_failure_count_decl.eval(env=frame)
+            tolerated_failure_count = frame.stack.pop()
+            self.tolerated_failure_percentage_decl.eval(env=frame)
+            tolerated_failure_percentage = frame.stack.pop()
+        finally:
+            env.close_frame(frame)
 
         if isinstance(self.iteration_component, InlineIterator):
             eval_input = InlineIteratorEvalInput(
@@ -176,10 +176,6 @@ class StateMap(ExecutionState):
                 item_selector=self.item_selector,
             )
         elif isinstance(self.iteration_component, DistributedIterator):
-            self.tolerated_failure_count.eval(env)
-            tolerated_failure_count = env.stack.pop()
-            self.tolerated_failure_percentage.eval(env)
-            tolerated_failure_percentage = env.stack.pop()
             eval_input = DistributedIteratorEvalInput(
                 state_name=self.name,
                 max_concurrency=max_concurrency_num,
@@ -199,10 +195,6 @@ class StateMap(ExecutionState):
                 parameters=self.parameters,
             )
         elif isinstance(self.iteration_component, DistributedItemProcessor):
-            self.tolerated_failure_count.eval(env)
-            tolerated_failure_count = env.stack.pop()
-            self.tolerated_failure_percentage.eval(env)
-            tolerated_failure_percentage = env.stack.pop()
             eval_input = DistributedItemProcessorEvalInput(
                 state_name=self.name,
                 max_concurrency=max_concurrency_num,
@@ -231,9 +223,6 @@ class StateMap(ExecutionState):
         # Initialise the retry counter for execution states.
         env.context_object_manager.context_object["State"]["RetryCount"] = 0
 
-        # Evaluate state level properties.
-        self.max_concurrency_decl.eval(env=env)
-
         # Attempt to evaluate the state's logic through until it's successful, caught, or retries have run out.
         while True:
             try:
@@ -249,10 +238,11 @@ class StateMap(ExecutionState):
                     if retry_outcome == RetryOutcome.CanRetry:
                         continue
 
-                env.event_manager.add_event(
-                    context=env.event_history_context,
-                    event_type=HistoryEventType.MapStateFailed,
-                )
+                if failure_event.event_type != HistoryEventType.ExecutionFailed:
+                    env.event_manager.add_event(
+                        context=env.event_history_context,
+                        event_type=HistoryEventType.MapStateFailed,
+                    )
 
                 if self.catch:
                     catch_outcome: CatchOutcome = self._handle_catch(

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/tolerated_failure.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/tolerated_failure.py
@@ -1,44 +1,155 @@
-import copy
+import abc
 from typing import Final
 
+from localstack.aws.api.stepfunctions import ExecutionFailedEventDetails, HistoryEventType
+from localstack.services.stepfunctions.asl.component.common.error_name.failure_event import (
+    FailureEvent,
+    FailureEventException,
+)
+from localstack.services.stepfunctions.asl.component.common.error_name.states_error_name import (
+    StatesErrorName,
+)
+from localstack.services.stepfunctions.asl.component.common.error_name.states_error_name_type import (
+    StatesErrorNameType,
+)
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 from localstack.services.stepfunctions.asl.eval.environment import Environment
+from localstack.services.stepfunctions.asl.eval.event.event_detail import EventDetails
+from localstack.services.stepfunctions.asl.utils.encoding import to_json_str
 from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
 
-
-class ToleratedFailureCount(EvalComponent):
-    DEFAULT: Final[int] = 0  # No threshold.
-
-    def __init__(self, count: int = DEFAULT):
-        self.count: Final[int] = count
-
-    def _eval_body(self, env: Environment) -> None:
-        env.stack.append(self.count)
+TOLERATED_FAILURE_COUNT_MIN: Final[int] = 0
+TOLERATED_FAILURE_COUNT_DEFAULT: Final[int] = 0
+TOLERATED_FAILURE_PERCENTAGE_MIN: Final[float] = 0.0
+TOLERATED_FAILURE_PERCENTAGE_DEFAULT: Final[float] = 0.0
+TOLERATED_FAILURE_PERCENTAGE_MAX: Final[float] = 100.0
 
 
-class ToleratedFailureCountPath(EvalComponent):
-    def __init__(self, path: str):
-        self.path: Final[str] = path
+class ToleratedFailureCountDecl(EvalComponent, abc.ABC):
+    @abc.abstractmethod
+    def _eval_tolerated_failure_count(self, env: Environment) -> int: ...
 
     def _eval_body(self, env: Environment) -> None:
-        value = JSONPathUtils.extract_json(self.path, env.stack[-1])
-        env.stack.append(copy.deepcopy(value))
+        tolerated_failure_count = self._eval_tolerated_failure_count(env=env)
+        env.stack.append(tolerated_failure_count)
 
 
-class ToleratedFailurePercentage(EvalComponent):
-    DEFAULT: Final[float] = 0.0
+class ToleratedFailureCount(ToleratedFailureCountDecl):
+    tolerated_failure_count: Final[int]
 
-    def __init__(self, percentage: float = DEFAULT):
-        self.percentage: Final[float] = percentage
+    def __init__(self, tolerated_failure_count: int = TOLERATED_FAILURE_COUNT_DEFAULT):
+        self.tolerated_failure_count = tolerated_failure_count
+
+    def _eval_tolerated_failure_count(self, env: Environment) -> int:
+        return self.tolerated_failure_count
+
+
+class ToleratedFailureCountPath(ToleratedFailureCountDecl):
+    tolerated_failure_count_path: Final[str]
+
+    def __init__(self, tolerated_failure_count_path: str):
+        self.tolerated_failure_count_path = tolerated_failure_count_path
+
+    def _eval_tolerated_failure_count(self, env: Environment) -> int:
+        inp = env.stack[-1]
+        tolerated_failure_count = JSONPathUtils.extract_json(self.tolerated_failure_count_path, inp)
+
+        error_cause = None
+        if not isinstance(tolerated_failure_count, int):
+            value_str = (
+                to_json_str(tolerated_failure_count)
+                if not isinstance(tolerated_failure_count, str)
+                else tolerated_failure_count
+            )
+            error_cause = (
+                f'The ToleratedFailureCountPath field refers to value "{value_str}" '
+                f"which is not a valid integer: {self.tolerated_failure_count_path}"
+            )
+
+        elif tolerated_failure_count < TOLERATED_FAILURE_COUNT_MIN:
+            error_cause = "ToleratedFailureCount cannot be negative."
+
+        if error_cause is not None:
+            raise FailureEventException(
+                failure_event=FailureEvent(
+                    env=env,
+                    error_name=StatesErrorName(typ=StatesErrorNameType.StatesRuntime),
+                    event_type=HistoryEventType.ExecutionFailed,
+                    event_details=EventDetails(
+                        executionFailedEventDetails=ExecutionFailedEventDetails(
+                            error=StatesErrorNameType.StatesRuntime.to_name(), cause=error_cause
+                        )
+                    ),
+                )
+            )
+
+        return tolerated_failure_count
+
+
+class ToleratedFailurePercentageDecl(EvalComponent, abc.ABC):
+    @abc.abstractmethod
+    def _eval_tolerated_failure_percentage(self, env: Environment) -> float: ...
 
     def _eval_body(self, env: Environment) -> None:
-        env.stack.append(self.percentage)
+        tolerated_failure_percentage = self._eval_tolerated_failure_percentage(env=env)
+        env.stack.append(tolerated_failure_percentage)
 
 
-class ToleratedFailurePercentagePath(EvalComponent):
-    def __init__(self, path: str):
-        self.path: Final[str] = path
+class ToleratedFailurePercentage(ToleratedFailurePercentageDecl):
+    tolerated_failure_percentage: Final[float]
 
-    def _eval_body(self, env: Environment) -> None:
-        value = JSONPathUtils.extract_json(self.path, env.stack[-1])
-        env.stack.append(copy.deepcopy(value))
+    def __init__(self, tolerated_failure_percentage: float = TOLERATED_FAILURE_PERCENTAGE_DEFAULT):
+        self.tolerated_failure_percentage = tolerated_failure_percentage
+
+    def _eval_tolerated_failure_percentage(self, env: Environment) -> float:
+        return self.tolerated_failure_percentage
+
+
+class ToleratedFailurePercentagePath(ToleratedFailurePercentageDecl):
+    tolerate_failure_percentage_path: Final[str]
+
+    def __init__(self, tolerate_failure_percentage_path: str):
+        self.tolerate_failure_percentage_path = tolerate_failure_percentage_path
+
+    def _eval_tolerated_failure_percentage(self, env: Environment) -> float:
+        inp = env.stack[-1]
+        tolerated_failure_percentage = JSONPathUtils.extract_json(
+            self.tolerate_failure_percentage_path, inp
+        )
+
+        if isinstance(tolerated_failure_percentage, int):
+            tolerated_failure_percentage = float(tolerated_failure_percentage)
+
+        error_cause = None
+        if not isinstance(tolerated_failure_percentage, float):
+            value_str = (
+                to_json_str(tolerated_failure_percentage)
+                if not isinstance(tolerated_failure_percentage, str)
+                else tolerated_failure_percentage
+            )
+            error_cause = (
+                f'The ToleratedFailurePercentagePath field refers to value "{value_str}" '
+                f"which is not a valid float: {self.tolerate_failure_percentage_path}"
+            )
+        elif (
+            not TOLERATED_FAILURE_PERCENTAGE_MIN
+            <= tolerated_failure_percentage
+            <= TOLERATED_FAILURE_PERCENTAGE_MAX
+        ):
+            error_cause = "ToleratedFailurePercentage must be between 0 and 100."
+
+        if error_cause is not None:
+            raise FailureEventException(
+                failure_event=FailureEvent(
+                    env=env,
+                    error_name=StatesErrorName(typ=StatesErrorNameType.StatesRuntime),
+                    event_type=HistoryEventType.ExecutionFailed,
+                    event_details=EventDetails(
+                        executionFailedEventDetails=ExecutionFailedEventDetails(
+                            error=StatesErrorNameType.StatesRuntime.to_name(), cause=error_cause
+                        )
+                    ),
+                )
+            )
+
+        return tolerated_failure_percentage

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_props.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_props.py
@@ -10,6 +10,10 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.state
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.max_concurrency import (
     MaxConcurrencyDecl,
 )
+from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.tolerated_failure import (
+    ToleratedFailureCountDecl,
+    ToleratedFailurePercentageDecl,
+)
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     Resource,
 )
@@ -27,6 +31,8 @@ UNIQUE_SUBINSTANCES: Final[set[type]] = {
     Heartbeat,
     MaxItemsDecl,
     MaxConcurrencyDecl,
+    ToleratedFailureCountDecl,
+    ToleratedFailurePercentageDecl,
     ErrorDecl,
     CauseDecl,
 }

--- a/localstack-core/localstack/services/stepfunctions/asl/parse/preprocessor.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/parse/preprocessor.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Optional
 
 from antlr4 import ParserRuleContext
@@ -236,6 +237,8 @@ from localstack.services.stepfunctions.asl.component.state.state_wait.wait_funct
 )
 from localstack.services.stepfunctions.asl.component.states import States
 from localstack.services.stepfunctions.asl.parse.typed_props import TypedProps
+
+LOG = logging.getLogger(__name__)
 
 
 class Preprocessor(ASLParserVisitor):
@@ -704,24 +707,38 @@ class Preprocessor(ASLParserVisitor):
     def visitTolerated_failure_count_decl(
         self, ctx: ASLParser.Tolerated_failure_count_declContext
     ) -> ToleratedFailureCount:
-        return ToleratedFailureCount(count=int(ctx.INT().getText()))
+        LOG.warning(
+            "ToleratedFailureCount declarations currently have no effect on the program evaluation."
+        )
+        count = int(ctx.INT().getText())
+        return ToleratedFailureCount(tolerated_failure_count=count)
 
     def visitTolerated_failure_count_path_decl(
         self, ctx: ASLParser.Tolerated_failure_count_path_declContext
     ) -> ToleratedFailureCountPath:
+        LOG.warning(
+            "ToleratedFailureCountPath declarations currently have no effect on the program evaluation."
+        )
         path: str = self._inner_string_of(parse_tree=ctx.STRINGPATH())
-        return ToleratedFailureCountPath(path=path)
+        return ToleratedFailureCountPath(tolerated_failure_count_path=path)
 
     def visitTolerated_failure_percentage_decl(
         self, ctx: ASLParser.Tolerated_failure_percentage_declContext
     ) -> ToleratedFailurePercentage:
-        return ToleratedFailurePercentage(percentage=float(ctx.NUMBER().getText()))
+        LOG.warning(
+            "ToleratedFailurePercentage declarations currently have no effect on the program evaluation."
+        )
+        percentage = float(ctx.NUMBER().getText())
+        return ToleratedFailurePercentage(tolerated_failure_percentage=percentage)
 
     def visitTolerated_failure_percentage_path_decl(
         self, ctx: ASLParser.Tolerated_failure_percentage_path_declContext
     ) -> ToleratedFailurePercentagePath:
+        LOG.warning(
+            "ToleratedFailurePercentagePath declarations currently have no effect on the program evaluation."
+        )
         path: str = self._inner_string_of(parse_tree=ctx.STRINGPATH())
-        return ToleratedFailurePercentagePath(path=path)
+        return ToleratedFailurePercentagePath(tolerate_failure_percentage_path=path)
 
     def visitRetry_decl(self, ctx: ASLParser.Retry_declContext) -> RetryDecl:
         retriers: list[RetrierDecl] = list()

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_tolerated_failure_count.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_tolerated_failure_count.json5
@@ -1,34 +1,26 @@
 {
-  "Comment": "MAP_STATE_TOLERATED_FAILURE_COUNT_JSON",
+  "Comment": "MAP_STATE_TOLERATED_FAILURE_COUNT",
   "StartAt": "MapState",
   "States": {
     "MapState": {
       "Type": "Map",
-      "ItemReader": {
-        "ReaderConfig": {
-          "InputType": "JSON",
-        },
-        "Resource": "arn:aws:states:::s3:getObject",
-        "Parameters": {
-          "Bucket.$": "$.Bucket",
-          "Key.$": "$.Key"
-        }
-      },
+      "InputPath": "$",
+      "MaxConcurrency": 1,
       "ItemProcessor": {
         "ProcessorConfig": {
           "Mode": "DISTRIBUTED",
           "ExecutionType": "STANDARD"
         },
-        "StartAt": "PassItem",
+        "StartAt": "HandleItem",
         "States": {
-          "PassItem": {
+          "HandleItem": {
             "Type": "Pass",
             "End": true
           }
-        },
+        }
       },
       "ToleratedFailureCount": 10,
-      "End": true
+      "End": true,
     }
   }
 }

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_tolerated_failure_count_path.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_tolerated_failure_count_path.json5
@@ -1,34 +1,26 @@
 {
-  "Comment": "MAP_STATE_TOLERATED_FAILURE_COUNT_PATH_JSON",
+  "Comment": "MAP_STATE_TOLERATED_FAILURE_COUNT_PATH",
   "StartAt": "MapState",
   "States": {
     "MapState": {
       "Type": "Map",
-      "ItemReader": {
-        "ReaderConfig": {
-          "InputType": "JSON",
-        },
-        "Resource": "arn:aws:states:::s3:getObject",
-        "Parameters": {
-          "Bucket.$": "$.Bucket",
-          "Key.$": "$.Key"
-        }
-      },
+      "ItemsPath": "$.Items",
+      "MaxConcurrency": 1,
       "ItemProcessor": {
         "ProcessorConfig": {
           "Mode": "DISTRIBUTED",
           "ExecutionType": "STANDARD"
         },
-        "StartAt": "PassItem",
+        "StartAt": "HandleItem",
         "States": {
-          "PassItem": {
+          "HandleItem": {
             "Type": "Pass",
             "End": true
           }
-        },
+        }
       },
       "ToleratedFailureCountPath": "$.ToleratedFailureCount",
-      "End": true
+      "End": true,
     }
   }
 }

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_tolerated_failure_percentage.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_tolerated_failure_percentage.json5
@@ -1,34 +1,26 @@
 {
-  "Comment": "MAP_STATE_TOLERATED_FAILURE_PERCENTAGE_JSON",
+  "Comment": "MAP_STATE_TOLERATED_FAILURE_PERCENTAGE",
   "StartAt": "MapState",
   "States": {
     "MapState": {
       "Type": "Map",
-      "ItemReader": {
-        "ReaderConfig": {
-          "InputType": "JSON",
-        },
-        "Resource": "arn:aws:states:::s3:getObject",
-        "Parameters": {
-          "Bucket.$": "$.Bucket",
-          "Key.$": "$.Key"
-        }
-      },
+      "InputPath": "$",
+      "MaxConcurrency": 1,
       "ItemProcessor": {
         "ProcessorConfig": {
           "Mode": "DISTRIBUTED",
           "ExecutionType": "STANDARD"
         },
-        "StartAt": "PassItem",
+        "StartAt": "HandleItem",
         "States": {
-          "PassItem": {
+          "HandleItem": {
             "Type": "Pass",
             "End": true
           }
-        },
+        }
       },
       "ToleratedFailurePercentage": 0.5,
-      "End": true
+      "End": true,
     }
   }
 }

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_tolerated_failure_percentage_path.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_tolerated_failure_percentage_path.json5
@@ -1,34 +1,26 @@
 {
-  "Comment": "MAP_STATE_TOLERATED_FAILURE_PERCENTAGE_PATH_JSON",
+  "Comment": "MAP_STATE_TOLERATED_FAILURE_PERCENTAGE_PATH",
   "StartAt": "MapState",
   "States": {
     "MapState": {
       "Type": "Map",
-      "ItemReader": {
-        "ReaderConfig": {
-          "InputType": "JSON",
-        },
-        "Resource": "arn:aws:states:::s3:getObject",
-        "Parameters": {
-          "Bucket.$": "$.Bucket",
-          "Key.$": "$.Key"
-        }
-      },
+      "ItemsPath": "$.Items",
+      "MaxConcurrency": 1,
       "ItemProcessor": {
         "ProcessorConfig": {
           "Mode": "DISTRIBUTED",
           "ExecutionType": "STANDARD"
         },
-        "StartAt": "PassItem",
+        "StartAt": "HandleItem",
         "States": {
-          "PassItem": {
+          "HandleItem": {
             "Type": "Pass",
             "End": true
           }
-        },
+        }
       },
       "ToleratedFailurePercentagePath": "$.ToleratedFailurePercentage",
-      "End": true
+      "End": true,
     }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
@@ -1004,25 +1004,23 @@ class TestBaseScenarios:
         )
 
     @markers.aws.validated
-    def test_map_state_tolerated_failure_count(
+    @pytest.mark.parametrize(
+        "tolerance_template",
+        [ST.MAP_STATE_TOLERATED_FAILURE_COUNT, ST.MAP_STATE_TOLERATED_FAILURE_PERCENTAGE],
+        ids=["count_literal", "percentage_literal"],
+    )
+    def test_map_state_tolerated_failure_values(
         self,
         aws_client,
-        s3_create_bucket,
         create_iam_role_for_sfn,
         create_state_machine,
         sfn_snapshot,
+        tolerance_template,
     ):
-        bucket_name = s3_create_bucket()
-        sfn_snapshot.add_transformer(RegexTransformer(bucket_name, "bucket-name"))
-
-        key = "file.json"
-        json_file = json.dumps([{"key1": "value1", "key2": "value2"}])
-        aws_client.s3.put_object(Bucket=bucket_name, Key=key, Body=json_file)
-
-        template = ST.load_sfn_template(ST.MAP_STATE_TOLERATED_FAILURE_COUNT)
+        template = ST.load_sfn_template(tolerance_template)
         definition = json.dumps(template)
 
-        exec_input = json.dumps({"Bucket": bucket_name, "Key": key})
+        exec_input = json.dumps([0])
         create_and_record_execution(
             aws_client.stepfunctions,
             create_iam_role_for_sfn,
@@ -1033,25 +1031,21 @@ class TestBaseScenarios:
         )
 
     @markers.aws.validated
+    @pytest.mark.parametrize("tolerated_failure_count_value", [dict(), "NoNumber", -1, 0, 1])
     def test_map_state_tolerated_failure_count_path(
         self,
         aws_client,
-        s3_create_bucket,
         create_iam_role_for_sfn,
         create_state_machine,
         sfn_snapshot,
+        tolerated_failure_count_value,
     ):
-        bucket_name = s3_create_bucket()
-        sfn_snapshot.add_transformer(RegexTransformer(bucket_name, "bucket-name"))
-
-        key = "file.json"
-        json_file = json.dumps([{"key1": "value1", "key2": "value2"}])
-        aws_client.s3.put_object(Bucket=bucket_name, Key=key, Body=json_file)
-
         template = ST.load_sfn_template(ST.MAP_STATE_TOLERATED_FAILURE_COUNT_PATH)
         definition = json.dumps(template)
 
-        exec_input = json.dumps({"Bucket": bucket_name, "Key": key, "ToleratedFailureCount": 10})
+        exec_input = json.dumps(
+            {"Items": [0], "ToleratedFailureCount": tolerated_failure_count_value}
+        )
         create_and_record_execution(
             aws_client.stepfunctions,
             create_iam_role_for_sfn,
@@ -1062,35 +1056,9 @@ class TestBaseScenarios:
         )
 
     @markers.aws.validated
-    def test_map_state_tolerated_failure_percentage(
-        self,
-        aws_client,
-        s3_create_bucket,
-        create_iam_role_for_sfn,
-        create_state_machine,
-        sfn_snapshot,
-    ):
-        bucket_name = s3_create_bucket()
-        sfn_snapshot.add_transformer(RegexTransformer(bucket_name, "bucket-name"))
-
-        key = "file.json"
-        json_file = json.dumps([{"key1": "value1", "key2": "value2"}])
-        aws_client.s3.put_object(Bucket=bucket_name, Key=key, Body=json_file)
-
-        template = ST.load_sfn_template(ST.MAP_STATE_TOLERATED_FAILURE_PERCENTAGE)
-        definition = json.dumps(template)
-
-        exec_input = json.dumps({"Bucket": bucket_name, "Key": key})
-        create_and_record_execution(
-            aws_client.stepfunctions,
-            create_iam_role_for_sfn,
-            create_state_machine,
-            sfn_snapshot,
-            definition,
-            exec_input,
-        )
-
-    @markers.aws.validated
+    @pytest.mark.parametrize(
+        "tolerated_failure_percentage_value", [dict(), "NoNumber", -1.1, -1, 0, 1, 1.1, 100, 100.1]
+    )
     def test_map_state_tolerated_failure_percentage_path(
         self,
         aws_client,
@@ -1098,19 +1066,13 @@ class TestBaseScenarios:
         create_iam_role_for_sfn,
         create_state_machine,
         sfn_snapshot,
+        tolerated_failure_percentage_value,
     ):
-        bucket_name = s3_create_bucket()
-        sfn_snapshot.add_transformer(RegexTransformer(bucket_name, "bucket-name"))
-
-        key = "file.json"
-        json_file = json.dumps([{"key1": "value1", "key2": "value2"}])
-        aws_client.s3.put_object(Bucket=bucket_name, Key=key, Body=json_file)
-
         template = ST.load_sfn_template(ST.MAP_STATE_TOLERATED_FAILURE_PERCENTAGE_PATH)
         definition = json.dumps(template)
 
         exec_input = json.dumps(
-            {"Bucket": bucket_name, "Key": key, "ToleratedFailurePercentage": 0.5}
+            {"Items": [0], "ToleratedFailurePercentage": tolerated_failure_percentage_value}
         )
         create_and_record_execution(
             aws_client.stepfunctions,

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
@@ -15653,7 +15653,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_max_concurrency_path[max_concurrency_value0]": {
-    "recorded-date": "22-04-2024, 19:57:20",
+    "recorded-date": "19-06-2024, 13:49:19",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -15712,7 +15712,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_max_concurrency_path[0]": {
-    "recorded-date": "22-04-2024, 19:57:47",
+    "recorded-date": "19-06-2024, 13:49:47",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -15873,7 +15873,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_max_concurrency_path[1]": {
-    "recorded-date": "22-04-2024, 19:58:01",
+    "recorded-date": "19-06-2024, 13:50:01",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -16065,7 +16065,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_max_concurrency_path[NoNumber]": {
-    "recorded-date": "22-04-2024, 19:57:33",
+    "recorded-date": "19-06-2024, 13:49:33",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -18196,17 +18196,14 @@
       }
     }
   },
-  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_count": {
-    "recorded-date": "15-06-2024, 02:25:44",
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_values[count_literal]": {
+    "recorded-date": "19-06-2024, 12:31:11",
     "recorded-content": {
       "get_execution_history": {
         "events": [
           {
             "executionStartedEventDetails": {
-              "input": {
-                "Bucket": "bucket-name",
-                "Key": "file.json"
-              },
+              "input": "[0]",
               "inputDetails": {
                 "truncated": false
               },
@@ -18221,10 +18218,7 @@
             "id": 2,
             "previousEventId": 0,
             "stateEnteredEventDetails": {
-              "input": {
-                "Bucket": "bucket-name",
-                "Key": "file.json"
-              },
+              "input": "[0]",
               "inputDetails": {
                 "truncated": false
               },
@@ -18236,7 +18230,7 @@
           {
             "id": 3,
             "mapStateStartedEventDetails": {
-              "length": 0
+              "length": 1
             },
             "previousEventId": 2,
             "timestamp": "timestamp",
@@ -18268,7 +18262,7 @@
             "previousEventId": 5,
             "stateExitedEventDetails": {
               "name": "MapState",
-              "output": "[{\"key1\":\"value1\",\"key2\":\"value2\"}]",
+              "output": "[0]",
               "outputDetails": {
                 "truncated": false
               }
@@ -18278,7 +18272,7 @@
           },
           {
             "executionSucceededEventDetails": {
-              "output": "[{\"key1\":\"value1\",\"key2\":\"value2\"}]",
+              "output": "[0]",
               "outputDetails": {
                 "truncated": false
               }
@@ -18296,18 +18290,14 @@
       }
     }
   },
-  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_count_path": {
-    "recorded-date": "15-06-2024, 02:27:56",
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_values[percentage_literal]": {
+    "recorded-date": "19-06-2024, 12:31:29",
     "recorded-content": {
       "get_execution_history": {
         "events": [
           {
             "executionStartedEventDetails": {
-              "input": {
-                "Bucket": "bucket-name",
-                "Key": "file.json",
-                "ToleratedFailureCount": 10
-              },
+              "input": "[0]",
               "inputDetails": {
                 "truncated": false
               },
@@ -18322,11 +18312,7 @@
             "id": 2,
             "previousEventId": 0,
             "stateEnteredEventDetails": {
-              "input": {
-                "Bucket": "bucket-name",
-                "Key": "file.json",
-                "ToleratedFailureCount": 10
-              },
+              "input": "[0]",
               "inputDetails": {
                 "truncated": false
               },
@@ -18338,7 +18324,7 @@
           {
             "id": 3,
             "mapStateStartedEventDetails": {
-              "length": 0
+              "length": 1
             },
             "previousEventId": 2,
             "timestamp": "timestamp",
@@ -18370,7 +18356,7 @@
             "previousEventId": 5,
             "stateExitedEventDetails": {
               "name": "MapState",
-              "output": "[{\"key1\":\"value1\",\"key2\":\"value2\"}]",
+              "output": "[0]",
               "outputDetails": {
                 "truncated": false
               }
@@ -18380,7 +18366,7 @@
           },
           {
             "executionSucceededEventDetails": {
-              "output": "[{\"key1\":\"value1\",\"key2\":\"value2\"}]",
+              "output": "[0]",
               "outputDetails": {
                 "truncated": false
               }
@@ -18398,16 +18384,18 @@
       }
     }
   },
-  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage": {
-    "recorded-date": "15-06-2024, 02:28:25",
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_count_path[tolerated_failure_count_value0]": {
+    "recorded-date": "19-06-2024, 12:38:12",
     "recorded-content": {
       "get_execution_history": {
         "events": [
           {
             "executionStartedEventDetails": {
               "input": {
-                "Bucket": "bucket-name",
-                "Key": "file.json"
+                "Items": [
+                  0
+                ],
+                "ToleratedFailureCount": {}
               },
               "inputDetails": {
                 "truncated": false
@@ -18424,8 +18412,10 @@
             "previousEventId": 0,
             "stateEnteredEventDetails": {
               "input": {
-                "Bucket": "bucket-name",
-                "Key": "file.json"
+                "Items": [
+                  0
+                ],
+                "ToleratedFailureCount": {}
               },
               "inputDetails": {
                 "truncated": false
@@ -18438,7 +18428,211 @@
           {
             "id": 3,
             "mapStateStartedEventDetails": {
-              "length": 0
+              "length": 1
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'MapState' (entered at the event id #2). The ToleratedFailureCountPath field refers to value \"{}\" which is not a valid integer: $.ToleratedFailureCount",
+              "error": "States.Runtime"
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_count_path[NoNumber]": {
+    "recorded-date": "19-06-2024, 12:38:26",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailureCount": "NoNumber"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailureCount": "NoNumber"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 1
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'MapState' (entered at the event id #2). The ToleratedFailureCountPath field refers to value \"NoNumber\" which is not a valid integer: $.ToleratedFailureCount",
+              "error": "States.Runtime"
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_count_path[-1]": {
+    "recorded-date": "19-06-2024, 12:38:41",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailureCount": -1
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailureCount": -1
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 1
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'MapState' (entered at the event id #2). ToleratedFailureCount cannot be negative.",
+              "error": "States.Runtime"
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_count_path[0]": {
+    "recorded-date": "19-06-2024, 12:38:58",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailureCount": 0
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailureCount": 0
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 1
             },
             "previousEventId": 2,
             "timestamp": "timestamp",
@@ -18470,7 +18664,7 @@
             "previousEventId": 5,
             "stateExitedEventDetails": {
               "name": "MapState",
-              "output": "[{\"key1\":\"value1\",\"key2\":\"value2\"}]",
+              "output": "[0]",
               "outputDetails": {
                 "truncated": false
               }
@@ -18480,7 +18674,7 @@
           },
           {
             "executionSucceededEventDetails": {
-              "output": "[{\"key1\":\"value1\",\"key2\":\"value2\"}]",
+              "output": "[0]",
               "outputDetails": {
                 "truncated": false
               }
@@ -18498,17 +18692,18 @@
       }
     }
   },
-  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path": {
-    "recorded-date": "15-06-2024, 02:28:36",
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_count_path[1]": {
+    "recorded-date": "19-06-2024, 12:39:14",
     "recorded-content": {
       "get_execution_history": {
         "events": [
           {
             "executionStartedEventDetails": {
               "input": {
-                "Bucket": "bucket-name",
-                "Key": "file.json",
-                "ToleratedFailurePercentage": 0.5
+                "Items": [
+                  0
+                ],
+                "ToleratedFailureCount": 1
               },
               "inputDetails": {
                 "truncated": false
@@ -18525,9 +18720,10 @@
             "previousEventId": 0,
             "stateEnteredEventDetails": {
               "input": {
-                "Bucket": "bucket-name",
-                "Key": "file.json",
-                "ToleratedFailurePercentage": 0.5
+                "Items": [
+                  0
+                ],
+                "ToleratedFailureCount": 1
               },
               "inputDetails": {
                 "truncated": false
@@ -18540,7 +18736,7 @@
           {
             "id": 3,
             "mapStateStartedEventDetails": {
-              "length": 0
+              "length": 1
             },
             "previousEventId": 2,
             "timestamp": "timestamp",
@@ -18572,7 +18768,7 @@
             "previousEventId": 5,
             "stateExitedEventDetails": {
               "name": "MapState",
-              "output": "[{\"key1\":\"value1\",\"key2\":\"value2\"}]",
+              "output": "[0]",
               "outputDetails": {
                 "truncated": false
               }
@@ -18582,7 +18778,7 @@
           },
           {
             "executionSucceededEventDetails": {
-              "output": "[{\"key1\":\"value1\",\"key2\":\"value2\"}]",
+              "output": "[0]",
               "outputDetails": {
                 "truncated": false
               }
@@ -18591,6 +18787,762 @@
             "previousEventId": 7,
             "timestamp": "timestamp",
             "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[tolerated_failure_percentage_value0]": {
+    "recorded-date": "19-06-2024, 14:36:53",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": {}
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": {}
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 1
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'MapState' (entered at the event id #2). The ToleratedFailurePercentagePath field refers to value \"{}\" which is not a valid float: $.ToleratedFailurePercentage",
+              "error": "States.Runtime"
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[NoNumber]": {
+    "recorded-date": "19-06-2024, 14:37:07",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": "NoNumber"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": "NoNumber"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 1
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'MapState' (entered at the event id #2). The ToleratedFailurePercentagePath field refers to value \"NoNumber\" which is not a valid float: $.ToleratedFailurePercentage",
+              "error": "States.Runtime"
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[-1.1]": {
+    "recorded-date": "19-06-2024, 14:37:21",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": -1.1
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": -1.1
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 1
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'MapState' (entered at the event id #2). ToleratedFailurePercentage must be between 0 and 100.",
+              "error": "States.Runtime"
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[-1]": {
+    "recorded-date": "19-06-2024, 14:37:35",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": -1
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": -1
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 1
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'MapState' (entered at the event id #2). ToleratedFailurePercentage must be between 0 and 100.",
+              "error": "States.Runtime"
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[0]": {
+    "recorded-date": "19-06-2024, 14:37:51",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": 0
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": 0
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 1
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "id": 4,
+            "mapRunStartedEventDetails": {
+              "mapRunArn": "arn:aws:states:<region>:111111111111:mapRun:<ArnPart_0idx>/<MapRunArnPart0_0idx>:<MapRunArnPart1_0idx>"
+            },
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "MapRunStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "timestamp": "timestamp",
+            "type": "MapRunSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "MapStateSucceeded"
+          },
+          {
+            "id": 7,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "MapState",
+              "output": "[0]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "[0]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 8,
+            "previousEventId": 7,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[1]": {
+    "recorded-date": "19-06-2024, 14:38:08",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": 1
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": 1
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 1
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "id": 4,
+            "mapRunStartedEventDetails": {
+              "mapRunArn": "arn:aws:states:<region>:111111111111:mapRun:<ArnPart_0idx>/<MapRunArnPart0_0idx>:<MapRunArnPart1_0idx>"
+            },
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "MapRunStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "timestamp": "timestamp",
+            "type": "MapRunSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "MapStateSucceeded"
+          },
+          {
+            "id": 7,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "MapState",
+              "output": "[0]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "[0]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 8,
+            "previousEventId": 7,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[1.1]": {
+    "recorded-date": "19-06-2024, 14:38:23",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": 1.1
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": 1.1
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 1
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "id": 4,
+            "mapRunStartedEventDetails": {
+              "mapRunArn": "arn:aws:states:<region>:111111111111:mapRun:<ArnPart_0idx>/<MapRunArnPart0_0idx>:<MapRunArnPart1_0idx>"
+            },
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "MapRunStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "timestamp": "timestamp",
+            "type": "MapRunSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "MapStateSucceeded"
+          },
+          {
+            "id": 7,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "MapState",
+              "output": "[0]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "[0]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 8,
+            "previousEventId": 7,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[100]": {
+    "recorded-date": "19-06-2024, 14:38:39",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": 100
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": 100
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 1
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "id": 4,
+            "mapRunStartedEventDetails": {
+              "mapRunArn": "arn:aws:states:<region>:111111111111:mapRun:<ArnPart_0idx>/<MapRunArnPart0_0idx>:<MapRunArnPart1_0idx>"
+            },
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "MapRunStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "timestamp": "timestamp",
+            "type": "MapRunSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "MapStateSucceeded"
+          },
+          {
+            "id": 7,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "MapState",
+              "output": "[0]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "[0]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 8,
+            "previousEventId": 7,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[100.1]": {
+    "recorded-date": "19-06-2024, 14:38:59",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": 100.1
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Items": [
+                  0
+                ],
+                "ToleratedFailurePercentage": 100.1
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 1
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'MapState' (entered at the event id #2). ToleratedFailurePercentage must be between 0 and 100.",
+              "error": "States.Runtime"
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
           }
         ],
         "ResponseMetadata": {

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
@@ -182,17 +182,65 @@
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_retry_multiple_retriers": {
     "last_validated_date": "2023-08-08T11:20:58+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_count_path[-1]": {
+    "last_validated_date": "2024-06-19T12:38:41+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_count_path[0]": {
+    "last_validated_date": "2024-06-19T12:38:58+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_count_path[1]": {
+    "last_validated_date": "2024-06-19T12:39:14+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_count_path[NoNumber]": {
+    "last_validated_date": "2024-06-19T12:38:26+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_count_path[tolerated_failure_count_value0]": {
+    "last_validated_date": "2024-06-19T12:38:12+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[-1.1]": {
+    "last_validated_date": "2024-06-19T14:37:21+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[-1]": {
+    "last_validated_date": "2024-06-19T14:37:35+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[0]": {
+    "last_validated_date": "2024-06-19T14:37:51+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[1.1]": {
+    "last_validated_date": "2024-06-19T14:38:23+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[100.1]": {
+    "last_validated_date": "2024-06-19T14:38:59+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[100]": {
+    "last_validated_date": "2024-06-19T14:38:39+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[1]": {
+    "last_validated_date": "2024-06-19T14:38:08+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[NoNumber]": {
+    "last_validated_date": "2024-06-19T14:37:07+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_percentage_path[tolerated_failure_percentage_value0]": {
+    "last_validated_date": "2024-06-19T14:36:53+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_values[count_literal]": {
+    "last_validated_date": "2024-06-19T12:31:11+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_tolerated_failure_values[percentage_literal]": {
+    "last_validated_date": "2024-06-19T12:31:29+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_max_concurrency_path[0]": {
-    "last_validated_date": "2024-04-22T19:57:47+00:00"
+    "last_validated_date": "2024-06-19T13:49:47+00:00"
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_max_concurrency_path[1]": {
-    "last_validated_date": "2024-04-22T19:58:01+00:00"
+    "last_validated_date": "2024-06-19T13:50:01+00:00"
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_max_concurrency_path[NoNumber]": {
-    "last_validated_date": "2024-04-22T19:57:33+00:00"
+    "last_validated_date": "2024-06-19T13:49:33+00:00"
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_max_concurrency_path[max_concurrency_value0]": {
-    "last_validated_date": "2024-04-22T19:57:20+00:00"
+    "last_validated_date": "2024-06-19T13:49:19+00:00"
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_max_concurrency_path_negative": {
     "last_validated_date": "2024-04-22T12:40:52+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR is a follow up to https://github.com/localstack/localstack/pull/10057 which recently introduced parsing support for Map tolerance fields. In particular, it improves the preprocessing logic to utilise the same sub-type pattern used in other areas of the interpreter, such as MaxConcurrency. It also provides improvements to the validation and related error messages for the values supplied to these fields, as well as logging warning to let the user know that although the values are recorded and validated, these do not yet affect the evaluation. Finally, positive and negative tests are added.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- preprocessing logic of tolerance declaration
- warning of unsupported tolerance declaration
- error messages for tolerance values
- positive and negative snapshot tests
- adjusted map logging strategy to account for AWS quirk in case of sanitisation failure

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
