### PR TITLE
generalize tracing for gateway and handler chain

### DIFF
--- a/localstack-core/localstack/aws/app.py
+++ b/localstack-core/localstack/aws/app.py
@@ -4,7 +4,7 @@ from localstack.aws.api import RequestContext
 from localstack.aws.chain import HandlerChain
 from localstack.aws.handlers.metric_handler import MetricHandler
 from localstack.aws.handlers.service_plugin import ServiceLoader, ServiceLoaderForDataPlane
-from localstack.aws.trace import TracingHandlerChain
+from localstack.http.trace import TracingHandlerChain
 from localstack.services.plugins import SERVICE_PLUGINS, ServiceManager, ServicePluginManager
 from localstack.utils.ssl import create_ssl_cert, install_predefined_cert_if_available
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

More efforts towards #10946. I wanted to debug something in a different emulator using `DEBUG_HANDLER_CHAIN`, but couldn't re-use it because of the coupling to the AWS request context.

This PR generalizes the `TracingHandlerChain` so it can be re-used outside AWS. The biggest change was just to create a loop over `context.__dict__` rather than hard-coding each attribute.
I also removed the `Handler` and `ExceptionHandler` from the list of implemented classes, since in rolo they are Protocols, and you shouldn't inherit from protocol classes unless you are creating other protocols.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* The `TracingHandlerChain` is now generalized and free of AWS concepts
* The `TracingHandlerChain` now lives in `localstack.http` instead of `localstack.aws`

<!-- Optional section: How to test these changes? -->

## Testing

* check out the PR and run ls with `DEBUG_HANDLER_CHAIN=1`. observe it still works when making aws calls

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
