### PR TITLE
split routing utilities not related to service operation routing out of op_router.py

### DIFF
--- a/localstack-core/localstack/aws/protocol/routing.py
+++ b/localstack-core/localstack/aws/protocol/routing.py
@@ -1,0 +1,83 @@
+import re
+from typing import AnyStr
+
+from werkzeug.routing import PathConverter, Rule
+
+# Regex to find path parameters in requestUris of AWS service specs (f.e. /{param1}/{param2+})
+path_param_regex = re.compile(r"({.+?})")
+# Translation table which replaces characters forbidden in Werkzeug rule names with temporary replacements
+# Note: The temporary replacements must not occur in any requestUri of any operation in any service!
+_rule_replacements = {"-": "_0_"}
+# String translation table for #_rule_replacements for str#translate
+_rule_replacement_table = str.maketrans(_rule_replacements)
+
+
+class GreedyPathConverter(PathConverter):
+    """
+    This converter makes sure that the path ``/mybucket//mykey`` can be matched to the pattern
+    ``<Bucket>/<path:Key>`` and will result in `Key` being `/mykey`.
+    """
+
+    regex = ".*?"
+
+    part_isolating = False
+    """From the werkzeug docs: If a custom converter can match a forward slash, /, it should have the
+    attribute part_isolating set to False. This will ensure that rules using the custom converter are
+    correctly matched."""
+
+
+class StrictMethodRule(Rule):
+    """
+    Small extension to Werkzeug's Rule class which reverts unwanted assumptions made by Werkzeug.
+    Reverted assumptions:
+    - Werkzeug automatically matches HEAD requests to the corresponding GET request (i.e. Werkzeug's rule automatically
+      adds the HEAD HTTP method to a rule which should only match GET requests). This is implemented to simplify
+      implementing an app compliant with HTTP (where a HEAD request needs to return the headers of a corresponding GET
+      request), but it is unwanted for our strict rule matching in here.
+    """
+
+    def __init__(self, string: str, method: str, **kwargs) -> None:
+        super().__init__(string=string, methods=[method], **kwargs)
+
+        # Make sure Werkzeug's Rule does not add any other methods
+        # (f.e. the HEAD method even though the rule should only match GET)
+        self.methods = {method.upper()}
+
+
+def transform_path_params_to_rule_vars(match: re.Match[AnyStr]) -> str:
+    """
+    Transforms a request URI path param to a valid Werkzeug Rule string variable placeholder.
+    This transformation function should be used in combination with _path_param_regex on the request URIs (without any
+    query params).
+
+    :param match: Regex match which contains a single group. The match group is a request URI path param, including the
+                    surrounding curly braces.
+    :return: Werkzeug rule string variable placeholder which is semantically equal to the given request URI path param
+
+    """
+    # get the group match and strip the curly braces
+    request_uri_variable: str = match.group(0)[1:-1]
+
+    # if the request URI param is greedy (f.e. /foo/{Bar+}), add Werkzeug's "path" prefix (/foo/{path:Bar})
+    greedy_prefix = ""
+    if request_uri_variable.endswith("+"):
+        greedy_prefix = "path:"
+        request_uri_variable = request_uri_variable.strip("+")
+
+    # replace forbidden chars (not allowed in Werkzeug rule variable names) with their placeholder
+    escaped_request_uri_variable = request_uri_variable.translate(_rule_replacement_table)
+
+    return f"<{greedy_prefix}{escaped_request_uri_variable}>"
+
+
+def post_process_arg_name(arg_key: str) -> str:
+    """
+    Reverses previous manipulations to the path parameters names (like replacing forbidden characters with
+    placeholders).
+    :param arg_key: Path param key name extracted using Werkzeug rules
+    :return: Post-processed ("un-sanitized") path param key
+    """
+    result = arg_key
+    for original, substitution in _rule_replacements.items():
+        result = result.replace(substitution, original)
+    return result


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #11057 and this comment: https://github.com/localstack/localstack/pull/11057#pullrequestreview-2130154194

I've pulled everything not directly related to service-operation-routing out of `op_router`, in order to be able to use them in API Gateway resource routing as well. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- pull some utilities outside of `op_router.py` into `routing.py` and update the imports

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
