### PR TITLE
Print LocalStackExitErrors in the new runtime

### DIFF
--- a/localstack-core/localstack/runtime/main.py
+++ b/localstack-core/localstack/runtime/main.py
@@ -96,6 +96,7 @@ def main_v2():
     try:
         runtime.run()
     except LocalstackExit as e:
+        sys.stdout.write(f"Localstack returning with exit code {e.code}. Reason: {e}")
         sys.exit(e.code)
     except Exception as e:
         sys.stdout.write(f"ERROR: the LocalStack runtime exited unexpectedly: {e}\n")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With #10942, we switched to the new runtime framework.

However, with that change, we stopped logging `LocalStackExit` errors, which especially were used during license activation. This leads to the activation error message not being logged correctly (e.g. if both `LOCALSTACK_API_KEY` and `LOCALSTACK_AUTH_TOKEN` are set).

To avoid that, I reintroduced printing the error before exiting.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* LocalStack prints a LocalStackExit error before exiting in the new runtime, for example during activation

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
