### PR TITLE
Reduce Lambda RIE log level

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/execution_environment.py
+++ b/localstack-core/localstack/services/lambda_/invocation/execution_environment.py
@@ -168,8 +168,8 @@ class ExecutionEnvironment:
         # Forcefully overwrite the user might break debugging!
         if config.LAMBDA_INIT_USER is not None:
             env_vars["LOCALSTACK_USER"] = config.LAMBDA_INIT_USER
-        if config.DEBUG:
-            env_vars["LOCALSTACK_INIT_LOG_LEVEL"] = "debug"
+        if config.LS_LOG in config.TRACE_LOG_LEVELS:
+            env_vars["LOCALSTACK_INIT_LOG_LEVEL"] = "info"
         if config.LAMBDA_INIT_POST_INVOKE_WAIT_MS:
             env_vars["LOCALSTACK_POST_INVOKE_WAIT_MS"] = int(config.LAMBDA_INIT_POST_INVOKE_WAIT_MS)
         if config.LAMBDA_LIMITS_MAX_FUNCTION_PAYLOAD_SIZE_BYTES:


### PR DESCRIPTION
## Motivation

The Lambda RIE logs are extremely verbose and customers miss their application errors within these verbose logs.
This issue was also raised by the SaaS team upon sharing their dogfooding experience with Lambda.


## Changes

* `DEBUG=1` does not affect the Lambda RIE log level anymore (using default `warn` level)
* `LS_LOG=trace|trace-internal` sets the Lambda RIE log level to `info` (rather than `debug` before)

## Notes

It is always possible to explicitly configure the Lambda RIE log level using: `LAMBDA_DOCKER_FLAGS=-e LOCALSTACK_INIT_LOG_LEVEL=debug` 

Options: trace, debug, info, warn (default), error, fatal, panic

The RIE and X-Ray logs are currently mixed and log level configuration coupled as defined in `main.go` of our RIE.

## Examples

Using the test case `aws.services.lambda_.test_lambda.TestLambdaBehavior.test_runtime_introspection_x86`

Modified the Lambda to `print(event)` to showcase how application logs appear

Using `LAMBDA_REMOVE_CONTAINERS=0` to capture shutdown logs

### debug

```py
2024-06-19 21:04:46 time="2024-06-19T19:04:46Z" level=debug msg="No code archives set. Skipping download." func=main.DownloadCodeArchives file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/cmd/localstack/codearchive.go:21"
2024-06-19 21:04:46 time="2024-06-19T19:04:46Z" level=debug msg="Process running as root user." func=main.main file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/cmd/localstack/main.go:162" euid=0 gid=0 uid=0 username=root
2024-06-19 21:04:46 time="2024-06-19T19:04:46Z" level=debug msg="Process running as non-root user." func=main.main file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/cmd/localstack/main.go:167" euid=993 gid=990 uid=993 username=sbx_user1051
2024-06-19 21:04:46 time="2024-06-19T19:04:46Z" level=debug msg="Starting runtime init." func=main.main file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/cmd/localstack/main.go:230"
2024-06-19 21:04:46 time="2024-06-19T19:04:46Z" level=debug msg="Awaiting initialization of runtime init." func=main.main file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/cmd/localstack/main.go:233"
2024-06-19 21:04:46 time="2024-06-19T19:04:46Z" level=debug msg="Hot reloading disabled." func=main.RunHotReloadingListener file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/cmd/localstack/awsutil.go:144"
2024-06-19 21:04:46 time="2024-06-19T19:04:46Z" level=info msg="Configure environment for Init Caching." func="go.amzn.com/lambda/rapid.(*rapidContext).acceptInitRequestForInitCaching" file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:559"
2024-06-19 21:04:46 time="2024-06-19T19:04:46Z" level=info msg="INIT START(type: snap-start, phase: init)" func=go.amzn.com/lambda/rapid.sendInitStartLogEvent file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:929"
2024-06-19 21:04:46 time="2024-06-19T19:04:46Z" level=info msg="The extension's directory \"/opt/extensions\" does not exist, assuming no extensions to be loaded." func=go.amzn.com/lambda/agents.ListExternalAgentPaths file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/agents/agent.go:26"
2024-06-19 21:04:46 time="2024-06-19T19:04:46Z" level=debug msg="Preregister runtime" func=go.amzn.com/lambda/rapid.doRuntimeDomainInit file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:313"
2024-06-19 21:04:46 time="2024-06-19T19:04:46Z" level=debug msg="Start runtime" func=go.amzn.com/lambda/rapid.doRuntimeDomainInit file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:330"
2024-06-19 21:04:46 time="2024-06-19T19:04:46Z" level=debug msg="Runtime API Server listening on 127.0.0.1:9001" func="go.amzn.com/lambda/rapi.(*Server).Listen" file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapi/server.go:108"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="API request - GET /2018-06-01/runtime/invocation/next, Headers:map[Accept:[*/*] User-Agent:[aws-lambda-python/3.12.3-2.0.10]]" func=go.amzn.com/lambda/rapi/middleware.AccessLogMiddleware.func1.1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapi/middleware/middleware.go:76"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="API request - GET /2018-06-01/runtime/invocation/next, Headers:map[Accept:[*/*] User-Agent:[aws-lambda-python/3.12.3-2.0.10]]" func=go.amzn.com/lambda/rapi/middleware.AccessLogMiddleware.func1.1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapi/middleware/middleware.go:76"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=info msg="INIT RTDONE(status: success)" func=go.amzn.com/lambda/rapid.sendInitRuntimeDoneLogEvent file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:952"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=info msg="INIT REPORT(durationMs: 224.666000)" func=go.amzn.com/lambda/rapid.sendInitReportLogEvent file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:978"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="Completed initialization of runtime init. Sending status ready to LocalStack." func=main.main file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/cmd/localstack/main.go:242"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=info msg="INVOKE START(requestId: 878f8f73-4abf-4a44-82cc-8180e7afa6a1)" func=go.amzn.com/lambda/rapid.sendInvokeStartLogEvent file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:991"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="Initialize invoke flow barriers" func=go.amzn.com/lambda/rapid.doInvoke.func1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:435"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="Set renderer for invoke" func=go.amzn.com/lambda/rapid.doInvoke.func1.2 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:456"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="Release agents conditions" func=go.amzn.com/lambda/rapid.doInvoke.func1.2 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:464"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="Release runtime condition" func=go.amzn.com/lambda/rapid.doInvoke.func1.2 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:475"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="Await runtime response" func=go.amzn.com/lambda/rapid.doInvoke.func1.2 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:479"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="API request - POST /2018-06-01/runtime/invocation/878f8f73-4abf-4a44-82cc-8180e7afa6a1/response, Headers:map[Accept:[*/*] Content-Length:[584] Content-Type:[application/json] User-Agent:[aws-lambda-python/3.12.3-2.0.10]]" func=go.amzn.com/lambda/rapi/middleware.AccessLogMiddleware.func1.1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapi/middleware/middleware.go:76"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="API request - POST /2018-06-01/runtime/invocation/878f8f73-4abf-4a44-82cc-8180e7afa6a1/response, Headers:map[Accept:[*/*] Content-Length:[584] Content-Type:[application/json] User-Agent:[aws-lambda-python/3.12.3-2.0.10]]" func=go.amzn.com/lambda/rapi/middleware.AccessLogMiddleware.func1.1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapi/middleware/middleware.go:76"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="Await runtime ready" func=go.amzn.com/lambda/rapid.doInvoke.func1.3 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:488"
2024-06-19 21:04:46 2024-06-19T19:04:46Z [Info] Initializing AWS X-Ray daemon unknown
2024-06-19 21:04:46 2024-06-19T19:04:46Z [Debug] Listening on UDP 127.0.0.1:2000
2024-06-19 21:04:46 2024-06-19T19:04:46Z [Info] Using buffer memory limit of 78 MB
2024-06-19 21:04:46 2024-06-19T19:04:46Z [Info] 1248 segment buffers allocated
2024-06-19 21:04:46 2024-06-19T19:04:46Z [Debug] Using Endpoint read from Config file: http://192.168.65.254:4566
2024-06-19 21:04:46 2024-06-19T19:04:46Z [Debug] Using proxy address: 
2024-06-19 21:04:46 2024-06-19T19:04:46Z [Debug] Fetch region us-east-1 from commandline/config file
2024-06-19 21:04:46 2024-06-19T19:04:46Z [Info] Using region: us-east-1
2024-06-19 21:04:46 2024-06-19T19:04:46Z [Info] HTTP Proxy server using X-Ray Endpoint : http://192.168.65.254:4566
2024-06-19 21:04:46 2024-06-19T19:04:46Z [Debug] Using Endpoint: http://192.168.65.254:4566
2024-06-19 21:04:46 2024-06-19T19:04:46Z [Debug] Batch size: 10
2024-06-19 21:04:46 2024-06-19T19:04:46Z [Info] Starting proxy http server on 127.0.0.1:2000
2024-06-19 21:04:47 {}
2024-06-19 21:04:47 2024-06-19T19:04:47Z [Debug] processor: done!
2024-06-19 21:04:47 2024-06-19T19:04:47Z [Debug] Trace segment: received: 0, truncated: 0, processed: 0
2024-06-19 21:04:47 2024-06-19T19:04:47Z [Debug] Shutdown finished. Current epoch in nanoseconds: 1718823887555544805
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="API request - GET /2018-06-01/runtime/invocation/next, Headers:map[Accept:[*/*] User-Agent:[aws-lambda-python/3.12.3-2.0.10]]" func=go.amzn.com/lambda/rapi/middleware.AccessLogMiddleware.func1.1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapi/middleware/middleware.go:76"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="API request - GET /2018-06-01/runtime/invocation/next, Headers:map[Accept:[*/*] User-Agent:[aws-lambda-python/3.12.3-2.0.10]]" func=go.amzn.com/lambda/rapi/middleware.AccessLogMiddleware.func1.1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapi/middleware/middleware.go:76"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=info msg="INVOKE RTDONE(status: success, produced bytes: 0, duration: 75.887000ms)" func=go.amzn.com/lambda/rapid.doInvoke.func1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:504"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="Invoke() success" func="go.amzn.com/lambda/rapidcore.(*Server).Invoke" file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapidcore/server.go:731"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="execute finished, autoreset cancelled" func="go.amzn.com/lambda/rapidcore.(*Server).Invoke.func1" file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapidcore/server.go:639"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=info msg="Sending to /response" func=main.NewCustomInteropServer.func1.1.1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/cmd/localstack/custom_interop.go:179"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=info msg="Received signal" func=go.amzn.com/lambda/rapidcore.signalHandler file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapidcore/sandbox_builder.go:217" signal=terminated
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=info msg="Shutting down..." func=go.amzn.com/lambda/rapidcore.NewSandboxBuilder.func1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapidcore/sandbox_builder.go:70"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="Canceling flows: errResetReceived" func="go.amzn.com/lambda/core.(*registrationServiceImpl).CancelFlows.func1" file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/core/registrations.go:392"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=warning msg="Reset initiated: SandboxTerminated" func=go.amzn.com/lambda/rapid.handleReset file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:710"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="SIGKILLing the runtime as no agents are registered." func="go.amzn.com/lambda/rapid.(*shutdownContext).shutdown" file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/shutdown.go:323"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=info msg="Sending SIGKILL to runtime-1(14)." func=go.amzn.com/lambda/supervisor.kill file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/supervisor/local_supervisor.go:157"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=info msg="Waiting for runtime domain processes termination" func="go.amzn.com/lambda/rapid.(*shutdownContext).shutdown" file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/shutdown.go:360"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="The events handler received the event {Time:1718823887555 Event:{EvType: Domain:0x40000d84e0 Name:0x40000d84d0 Cause:<nil> Signo:0x40000a6778 ExitStatus:<nil> Size:<nil>}}." func="go.amzn.com/lambda/rapid.(*rapidContext).watchEvents" file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:224"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="Stopping file watcher" func=main.main.func1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/cmd/localstack/main.go:183"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="Shutting down xray daemon" func=main.main.func2 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/cmd/localstack/main.go:196"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=debug msg="Flushing segments in xray daemon" func=main.main.func2 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/cmd/localstack/main.go:198"
2024-06-19 21:04:47 time="2024-06-19T19:04:47Z" level=info msg="Runtime API Server closed" func="go.amzn.com/lambda/rapi.(*Server).Close" file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapi/server.go:158"

```

### info

```py
2024-06-19 21:06:33 2024-06-19T19:06:33Z [Info] Initializing AWS X-Ray daemon unknown
2024-06-19 21:06:33 2024-06-19T19:06:33Z [Info] Using buffer memory limit of 78 MB
2024-06-19 21:06:33 2024-06-19T19:06:33Z [Info] 1248 segment buffers allocated
2024-06-19 21:06:33 2024-06-19T19:06:33Z [Info] Using region: us-east-1
2024-06-19 21:06:33 2024-06-19T19:06:33Z [Info] HTTP Proxy server using X-Ray Endpoint : http://192.168.65.254:4566
2024-06-19 21:06:33 2024-06-19T19:06:33Z [Info] Starting proxy http server on 127.0.0.1:2000
2024-06-19 21:06:33 {}
2024-06-19 21:06:33 time="2024-06-19T19:06:33Z" level=info msg="Configure environment for Init Caching." func="go.amzn.com/lambda/rapid.(*rapidContext).acceptInitRequestForInitCaching" file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:559"
2024-06-19 21:06:33 time="2024-06-19T19:06:33Z" level=info msg="INIT START(type: snap-start, phase: init)" func=go.amzn.com/lambda/rapid.sendInitStartLogEvent file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:929"
2024-06-19 21:06:33 time="2024-06-19T19:06:33Z" level=info msg="The extension's directory \"/opt/extensions\" does not exist, assuming no extensions to be loaded." func=go.amzn.com/lambda/agents.ListExternalAgentPaths file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/agents/agent.go:26"
2024-06-19 21:06:33 time="2024-06-19T19:06:33Z" level=info msg="INIT RTDONE(status: success)" func=go.amzn.com/lambda/rapid.sendInitRuntimeDoneLogEvent file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:952"
2024-06-19 21:06:33 time="2024-06-19T19:06:33Z" level=info msg="INIT REPORT(durationMs: 174.820000)" func=go.amzn.com/lambda/rapid.sendInitReportLogEvent file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:978"
2024-06-19 21:06:33 time="2024-06-19T19:06:33Z" level=info msg="INVOKE START(requestId: beb360d5-1e62-4385-921b-8bdc2ffeed20)" func=go.amzn.com/lambda/rapid.sendInvokeStartLogEvent file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:991"
2024-06-19 21:06:33 time="2024-06-19T19:06:33Z" level=info msg="INVOKE RTDONE(status: success, produced bytes: 0, duration: 50.231000ms)" func=go.amzn.com/lambda/rapid.doInvoke.func1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:504"
2024-06-19 21:06:33 time="2024-06-19T19:06:33Z" level=info msg="Sending to /response" func=main.NewCustomInteropServer.func1.1.1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/cmd/localstack/custom_interop.go:179"
2024-06-19 21:06:34 time="2024-06-19T19:06:34Z" level=info msg="Received signal" func=go.amzn.com/lambda/rapidcore.signalHandler file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapidcore/sandbox_builder.go:217" signal=terminated
2024-06-19 21:06:34 time="2024-06-19T19:06:34Z" level=info msg="Shutting down..." func=go.amzn.com/lambda/rapidcore.NewSandboxBuilder.func1 file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapidcore/sandbox_builder.go:70"
2024-06-19 21:06:34 time="2024-06-19T19:06:34Z" level=warning msg="Reset initiated: SandboxTerminated" func=go.amzn.com/lambda/rapid.handleReset file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:710"
2024-06-19 21:06:34 time="2024-06-19T19:06:34Z" level=info msg="Sending SIGKILL to runtime-1(15)." func=go.amzn.com/lambda/supervisor.kill file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/supervisor/local_supervisor.go:157"
2024-06-19 21:06:34 time="2024-06-19T19:06:34Z" level=info msg="Waiting for runtime domain processes termination" func="go.amzn.com/lambda/rapid.(*shutdownContext).shutdown" file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/shutdown.go:360"
2024-06-19 21:06:34 time="2024-06-19T19:06:34Z" level=info msg="Runtime API Server closed" func="go.amzn.com/lambda/rapi.(*Server).Close" file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapi/server.go:158"
```

### warn

```py
2024-06-19 21:05:31 {}
2024-06-19 21:05:31 time="2024-06-19T19:05:31Z" level=warning msg="Reset initiated: SandboxTerminated" func=go.amzn.com/lambda/rapid.handleReset file="/home/runner/work/lambda-runtime-init/lambda-runtime-init/lambda/rapid/handlers.go:710"
```