### PR TITLE
improve CFN APIGW Method parity

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.py
@@ -51,7 +51,8 @@ Resources:
 """
 
 
-@markers.aws.unknown
+# this is an `only_localstack` test because it makes use of _custom_id_ tag
+@markers.aws.only_localstack
 def test_cfn_apigateway_aws_integration(deploy_cfn_template, aws_client):
     api_name = f"rest-api-{short_uid()}"
     custom_id = short_uid()
@@ -214,10 +215,6 @@ def test_cfn_with_apigateway_resources(deploy_cfn_template, aws_client, snapshot
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         "$.get-resources.items..resourceMethods.ANY",  # TODO: empty in AWS
-        "$..requestParameters",  # FIXME: it seems AWS does not return empty dicts anymore, will need to fix
-        "$..responseTemplates",  # FIXME: it seems AWS does not return empty dicts anymore, will need to fix
-        "$.get-method-any..responseModels",
-        "$.get-method-any..responseParameters",
     ]
 )
 def test_cfn_deploy_apigateway_models(deploy_cfn_template, snapshot, aws_client):
@@ -267,17 +264,6 @@ def test_cfn_deploy_apigateway_models(deploy_cfn_template, snapshot, aws_client)
     assert result.status_code == 400
 
 
-@markers.snapshot.skip_snapshot_verify(
-    paths=[
-        "$..methodIntegration.integrationResponses",
-        "$..methodIntegration.requestParameters",  # missing {}
-        "$..methodIntegration.requestTemplates",  # missing {}
-        "$..methodResponses",  # missing {}
-        "$..requestModels",  # missing {}
-        "$..requestParameters",  # missing {}
-        "$..rootResourceId",  # shouldn't exist
-    ]
-)
 @markers.aws.validated
 def test_cfn_deploy_apigateway_integration(deploy_cfn_template, snapshot, aws_client):
     snapshot.add_transformer(snapshot.transform.key_value("cacheNamespace"))

--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -165,7 +165,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_models": {
-    "recorded-date": "19-12-2023, 19:04:52",
+    "recorded-date": "21-06-2024, 00:09:05",
     "recorded-content": {
       "get-resources": {
         "items": [
@@ -297,7 +297,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_with_apigateway_resources": {
-    "recorded-date": "05-07-2023, 20:54:14",
+    "recorded-date": "20-06-2024, 23:54:26",
     "recorded-content": {
       "get-method-post": {
         "apiKeyRequired": false,
@@ -308,7 +308,6 @@
           "cacheNamespace": "<cache-namespace:1>",
           "integrationResponses": {
             "202": {
-              "responseParameters": {},
               "responseTemplates": {
                 "application/json": {
                   "operation": "celeste_account_create",
@@ -321,8 +320,16 @@
               "selectionPattern": "2\\d{2}",
               "statusCode": "202"
             },
+            "404": {
+              "responseTemplates": {
+                "application/json": {
+                  "message": "Not Found"
+                }
+              },
+              "selectionPattern": "404",
+              "statusCode": "404"
+            },
             "500": {
-              "responseParameters": {},
               "responseTemplates": {
                 "application/json": {
                   "message": "Unknown <name:2>"
@@ -333,7 +340,6 @@
             }
           },
           "passthroughBehavior": "WHEN_NO_TEMPLATES",
-          "requestParameters": {},
           "requestTemplates": {
             "application/json": "<name:3>"
           },
@@ -345,19 +351,16 @@
             "responseModels": {
               "application/json": "<name:4>"
             },
-            "responseParameters": {},
             "statusCode": "202"
           },
           "500": {
             "responseModels": {
               "application/json": "<name:4>"
             },
-            "responseParameters": {},
             "statusCode": "500"
           }
         },
         "operationName": "create_account",
-        "requestModels": {},
         "requestParameters": {
           "method.request.path.account": true
         },

--- a/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
@@ -12,10 +12,10 @@
     "last_validated_date": "2024-02-21T12:54:34+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_models": {
-    "last_validated_date": "2023-07-05T18:11:14+00:00"
+    "last_validated_date": "2024-06-21T00:09:05+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_with_apigateway_resources": {
-    "last_validated_date": "2023-07-05T18:54:14+00:00"
+    "last_validated_date": "2024-06-20T23:54:26+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_rest_api_serverless_ref_resolving": {
     "last_validated_date": "2023-07-06T19:01:08+00:00"

--- a/tests/aws/templates/template35.yaml
+++ b/tests/aws/templates/template35.yaml
@@ -86,6 +86,10 @@ Resources:
               application/json: "{\"message\":\"Unknown Error\"}"
             SelectionPattern: '5\d{2}'
             StatusCode: '500'
+          - ResponseTemplates:
+              application/json: "{\"message\":\"Not Found\"}"
+            SelectionPattern: 404
+            StatusCode: '404'
         PassthroughBehavior: WHEN_NO_TEMPLATES
         RequestTemplates:
           application/json: !Ref CreateAccountRequestModel


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We got a report in our Slack channel regarding a type cast error for the `selectionPattern` field for `APIGW::Method` resource. 

After taking a look and updating one of our test to validate the fix, I've realized we've had a few parity issues and snapshot skips. I've also fixed them in the meantime 😄 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add type casting of `selectionPattern`
- remove default value of `{}` for multiple fields, which should not be sent at all if they are not set. AWS can accept empty dicts from them, so we have to check against `None` value directly

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
