### PR TITLE
remove THREAD_LOCAL usage

### DIFF
--- a/localstack-core/localstack/aws/app.py
+++ b/localstack-core/localstack/aws/app.py
@@ -28,7 +28,6 @@ class LocalstackAwsGateway(Gateway):
         # the main request handler chain
         self.request_handlers.extend(
             [
-                handlers.push_request_context,
                 handlers.add_internal_request_params,
                 handlers.handle_runtime_shutdown,
                 metric_collector.create_metric_handler_item,
@@ -82,7 +81,6 @@ class LocalstackAwsGateway(Gateway):
             [
                 handlers.set_close_connection_header,
                 handlers.run_custom_finalizers,
-                handlers.pop_request_context,
             ]
         )
 

--- a/localstack-core/localstack/aws/handlers/__init__.py
+++ b/localstack-core/localstack/aws/handlers/__init__.py
@@ -43,5 +43,3 @@ serve_custom_exception_handlers = chain.CompositeExceptionHandler()
 # legacy compatibility handlers
 serve_edge_router_rules = legacy.EdgeRouterHandler()
 set_close_connection_header = legacy.set_close_connection_header
-push_request_context = legacy.push_request_context
-pop_request_context = legacy.pop_request_context

--- a/localstack-core/localstack/aws/handlers/legacy.py
+++ b/localstack-core/localstack/aws/handlers/legacy.py
@@ -12,20 +12,6 @@ from .routes import RouterHandler
 LOG = logging.getLogger(__name__)
 
 
-def push_request_context(_chain: HandlerChain, context: RequestContext, _response: Response):
-    from localstack.utils.aws import request_context
-
-    # TODO remove request_context.THREAD_LOCAL
-    request_context.THREAD_LOCAL.request_context = context.request
-
-
-def pop_request_context(_chain: HandlerChain, _context: RequestContext, _response: Response):
-    from localstack.utils.aws import request_context
-
-    # TODO remove request_context.THREAD_LOCAL
-    request_context.THREAD_LOCAL.request_context = None
-
-
 def set_close_connection_header(_chain: HandlerChain, context: RequestContext, response: Response):
     """This is a hack to work around performance issues with h11 and boto. See
     https://github.com/localstack/localstack/issues/6557"""

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -50,7 +50,6 @@ from localstack.utils.aws import queries
 from localstack.utils.aws import resources as resource_utils
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.aws.aws_responses import requests_error_response_json, requests_response
-from localstack.utils.aws.request_context import MARKER_APIGW_REQUEST_REGION, THREAD_LOCAL
 from localstack.utils.json import try_json
 from localstack.utils.numbers import is_number
 from localstack.utils.strings import canonicalize_bool_to_str, long_uid, short_uid, to_bytes, to_str
@@ -1554,12 +1553,6 @@ def set_api_id_stage_invocation_path(
         raise Exception(
             f"Unable to extract API Gateway details from request: {path} {dict(headers)}"
         )
-    if api_id:
-        # set current region in request thread local, to ensure aws_stack.get_region() works properly
-        # TODO: replace with RequestContextManager
-        if getattr(THREAD_LOCAL, "request_context", None) is not None:
-            _, api_region = get_api_account_id_and_region(api_id)
-            THREAD_LOCAL.request_context.headers[MARKER_APIGW_REQUEST_REGION] = api_region
 
     # set details in invocation context
     invocation_context.api_id = api_id

--- a/localstack-core/localstack/services/apigateway/router_asf.py
+++ b/localstack-core/localstack/services/apigateway/router_asf.py
@@ -147,7 +147,7 @@ class ApigatewayRouter:
             strict_slashes=True,
         )
 
-    def invoke_rest_api(self, request: Request, **url_params: Dict[str, str]) -> Response:
+    def invoke_rest_api(self, request: Request, **url_params: str) -> Response:
         account_id, region_name = get_api_account_id_and_region(url_params["api_id"])
         if not region_name:
             return Response(status=404)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've been meaning too remove the `THREAD_LOCAL` usage since a long time, and we could finally do so while working on the refactor of APIGW. 

This did not have any use anymore, and it relied on setting additional data in a threadlocal, but thanks to the awesome work of @viren-nadkarni, nothing uses `aws_stack.get_region()` anymore, so we can be sure nothing is accessing/reading those values anymore. 

I really want to emphasis that this is only possible thanks to the relentless work of Viren 😄 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- remove `THREAD_LOCAL` and its usages across the codebase

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
