### PR TITLE
fix NG APIGW unit tests usage of RestApiDeployment

### DIFF
--- a/tests/unit/services/apigateway/test_handler_exception.py
+++ b/tests/unit/services/apigateway/test_handler_exception.py
@@ -8,6 +8,7 @@ from localstack.services.apigateway.next_gen.execute_api.gateway_response import
     AccessDeniedError,
 )
 from localstack.services.apigateway.next_gen.execute_api.handlers import GatewayExceptionHandler
+from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 
 
 class TestGatewayResponseHandler:
@@ -15,7 +16,12 @@ class TestGatewayResponseHandler:
     def get_context(self):
         def _create_context_with_deployment(gateway_responses=None) -> RestApiInvocationContext:
             context = RestApiInvocationContext(None)
-            context.deployment = RestApiDeployment(RestApiContainer(None), None)
+            context.deployment = RestApiDeployment(
+                account_id=TEST_AWS_ACCOUNT_ID,
+                region=TEST_AWS_REGION_NAME,
+                localstack_rest_api=RestApiContainer(None),
+                moto_rest_api=None,
+            )
             if gateway_responses:
                 context.deployment.localstack_rest_api.gateway_responses = gateway_responses
             return context


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following #11062 and #11051, we've had hidden merge conflicts, the signature of one of the class changed, weirdly the CI run was green even though the other PR had been merge quite much earlier. 

Not exactly sure why it happened, ~maybe some caching regarding unit tests~? 

edit: ah, I think this is because CircleCI checks out the repo on the branch, whereas GitHub Actions adds your PR on top of master, which would have caught this. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix the usage of `RestApiDeployment` to match the signature

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
