### PR TITLE
fix kinesis cbor timestamp parsing

### DIFF
--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -1,4 +1,6 @@
+import logging
 import time
+from datetime import datetime
 from unittest.mock import patch
 
 import cbor2
@@ -8,6 +10,7 @@ from botocore.config import Config as BotoConfig
 from botocore.exceptions import ClientError
 
 from localstack import config, constants
+from localstack.aws.api.kinesis import ShardIteratorType, SubscribeToShardInput
 from localstack.services.kinesis import provider as kinesis_provider
 from localstack.testing.config import TEST_AWS_ACCESS_KEY_ID
 from localstack.testing.pytest import markers
@@ -15,6 +18,8 @@ from localstack.utils.aws import resources
 from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.common import retry, select_attributes, short_uid
 from localstack.utils.kinesis import kinesis_connector
+
+LOGGER = logging.getLogger(__name__)
 
 
 def get_shard_iterator(stream_name, kinesis_client):
@@ -153,6 +158,119 @@ class TestKinesis:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..Records..EncryptionType"])
+    def test_subscribe_to_shard_with_at_timestamp(
+        self,
+        kinesis_create_stream,
+        wait_for_stream_ready,
+        kinesis_register_consumer,
+        wait_for_kinesis_consumer_ready,
+        snapshot,
+        aws_client,
+    ):
+        # create stream and consumer
+        stream_name = kinesis_create_stream(ShardCount=1)
+        stream_arn = aws_client.kinesis.describe_stream(StreamName=stream_name)[
+            "StreamDescription"
+        ]["StreamARN"]
+        wait_for_stream_ready(stream_name)
+
+        consumer_name = "c1"
+        response = kinesis_register_consumer(stream_arn, consumer_name)
+        consumer_arn = response["Consumer"]["ConsumerARN"]
+        wait_for_kinesis_consumer_ready(consumer_arn=consumer_arn)
+
+        # subscribe to shard with iterator type as AT_TIMESTAMP
+        response = aws_client.kinesis.describe_stream(StreamName=stream_name)
+        shard_id = response.get("StreamDescription").get("Shards")[0].get("ShardId")
+        result = aws_client.kinesis.subscribe_to_shard(
+            ConsumerARN=consumer_arn,
+            ShardId=shard_id,
+            StartingPosition={"Type": "AT_TIMESTAMP", "Timestamp": datetime(2015, 1, 1)},
+        )
+        stream = result["EventStream"]
+
+        # put records
+        num_records = 5
+        msg = "Hello world"
+        for i in range(num_records):
+            aws_client.kinesis.put_records(
+                StreamName=stream_name, Records=[{"Data": f"{msg}_{i}", "PartitionKey": "1"}]
+            )
+
+        # read out results
+        results = []
+        for entry in stream:
+            records = entry["SubscribeToShardEvent"]["Records"]
+            results.extend(records)
+            if len(results) >= num_records:
+                break
+
+        results.sort(key=lambda k: k.get("Data"))
+        snapshot.match("Records", results)
+
+    @markers.aws.needs_fixing
+    def test_subscribe_to_shard_cbor_at_timestamp(
+        self,
+        kinesis_create_stream,
+        wait_for_stream_ready,
+        aws_client,
+        kinesis_register_consumer,
+        region_name,
+    ):
+        # create stream
+        stream_name = kinesis_create_stream(ShardCount=1)
+        wait_for_stream_ready(stream_name)
+
+        # subscribe to shard with CBOR encoding
+        response = aws_client.kinesis.describe_stream(StreamName=stream_name)
+        shard_id = response.get("StreamDescription").get("Shards")[0].get("ShardId")
+
+        # create consumer
+        consumer_name = "c1"
+        response = kinesis_register_consumer(
+            response["StreamDescription"]["StreamARN"], consumer_name
+        )
+        consumer_arn = response["Consumer"]["ConsumerARN"]
+
+        url = config.internal_service_url()
+        headers = mock_aws_request_headers(
+            "kinesis",
+            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
+            region_name=region_name,
+        )
+        headers["Content-Type"] = constants.APPLICATION_AMZ_CBOR_1_1
+        headers["X-Amz-Target"] = "Kinesis_20131202.SubscribeToShard"
+        data = cbor2.dumps(
+            SubscribeToShardInput(
+                ConsumerARN=consumer_arn,
+                ShardId=shard_id,
+                StartingPosition={
+                    "Type": ShardIteratorType.AT_TIMESTAMP,
+                    # manually set a UTC epoch with milliseconds
+                    "Timestamp": "1718960048000",
+                },
+            )
+        )
+        found_record = False
+        with requests.post(url, data, headers=headers, stream=True) as result:
+            assert 200 == result.status_code
+
+            # put records
+            aws_client.kinesis.put_records(
+                StreamName=stream_name, Records=[{"Data": "--RECORD--", "PartitionKey": "1"}]
+            )
+
+            # botocore does not support parsing CBOR responses
+            # just check for the presence of the record marker
+            for chunk in result.iter_lines(delimiter=b"\00"):
+                if b"--RECORD--" in chunk:
+                    found_record = True
+                    break
+
+        assert found_record
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Records..EncryptionType"])
     def test_subscribe_to_shard_with_sequence_number_as_iterator(
         self,
         kinesis_create_stream,
@@ -219,7 +337,13 @@ class TestKinesis:
     # this might be a localstack-only test - there doesn't seem to be an endpoint for kinesis on AWS
     # the test seems to address https://github.com/localstack/localstack/issues/2997 with java AWS SDK usage
     def test_get_records(
-        self, kinesis_create_stream, wait_for_stream_ready, aws_client, region_name
+        self,
+        kinesis_create_stream,
+        wait_for_stream_ready,
+        aws_client,
+        region_name,
+        kinesis_register_consumer,
+        snapshot,
     ):
         # create stream
         stream_name = kinesis_create_stream(ShardCount=1)

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -209,6 +209,10 @@ class TestKinesis:
         snapshot.match("Records", results)
 
     @markers.aws.needs_fixing
+    # TODO validate test against AWS.
+    # - if is_aws_cloud():
+    #   - Use proper URL to AWS instead of LocalStack
+    #   - Properly sign / auth manually crafted CBOR request with real credentials
     def test_subscribe_to_shard_cbor_at_timestamp(
         self,
         kinesis_create_stream,
@@ -231,7 +235,6 @@ class TestKinesis:
             response["StreamDescription"]["StreamARN"], consumer_name
         )
         consumer_arn = response["Consumer"]["ConsumerARN"]
-
         url = config.internal_service_url()
         headers = mock_aws_request_headers(
             "kinesis",
@@ -334,8 +337,10 @@ class TestKinesis:
         snapshot.match("Records", results)
 
     @markers.aws.needs_fixing
-    # this might be a localstack-only test - there doesn't seem to be an endpoint for kinesis on AWS
-    # the test seems to address https://github.com/localstack/localstack/issues/2997 with java AWS SDK usage
+    # TODO validate test against AWS.
+    # - if is_aws_cloud():
+    #   - Use proper URL to AWS instead of LocalStack
+    #   - Properly sign / auth manually crafted CBOR request with real credentials
     def test_get_records(
         self,
         kinesis_create_stream,
@@ -386,8 +391,10 @@ class TestKinesis:
         )
 
     @markers.aws.needs_fixing
-    # this might be a localstack-only test - there doesn't seem to be an endpoint for kinesis on AWS
-    # the test seems to address https://github.com/localstack/localstack/issues/2997 with java AWS SDK usage
+    # TODO validate test against AWS.
+    # - if is_aws_cloud():
+    #   - Use proper URL to AWS instead of LocalStack
+    #   - Properly sign / auth manually crafted CBOR request with real credentials
     def test_get_records_empty_stream(
         self,
         kinesis_create_stream,

--- a/tests/aws/services/kinesis/test_kinesis.snapshot.json
+++ b/tests/aws/services/kinesis/test_kinesis.snapshot.json
@@ -179,5 +179,46 @@
         }
       ]
     }
+  },
+  "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_cbor_at_timestamp": {
+    "recorded-date": "21-06-2024, 15:18:03",
+    "recorded-content": {}
+  },
+  "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_at_timestamp": {
+    "recorded-date": "21-06-2024, 15:19:50",
+    "recorded-content": {
+      "Records": [
+        {
+          "SequenceNumber": "<sequence_number:1>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_0'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:2>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_1'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:3>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_2'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:4>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_3'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:5>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_4'",
+          "PartitionKey": "1"
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/kinesis/test_kinesis.validation.json
+++ b/tests/aws/services/kinesis/test_kinesis.validation.json
@@ -17,6 +17,9 @@
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard": {
     "last_validated_date": "2022-08-26T07:33:29+00:00"
   },
+  "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_at_timestamp": {
+    "last_validated_date": "2024-06-21T15:20:46+00:00"
+  },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_sequence_number_as_iterator": {
     "last_validated_date": "2022-08-26T07:29:21+00:00"
   }

--- a/tests/unit/aws/protocol/test_parser.snapshot.json
+++ b/tests/unit/aws/protocol/test_parser.snapshot.json
@@ -1,0 +1,15 @@
+{
+  "tests/unit/aws/protocol/test_parser.py::test_json_cbor_blob_parsing_w_timestamp": {
+    "recorded-date": "21-06-2024, 13:58:29",
+    "recorded-content": {
+      "parsed_request": {
+        "ConsumerARN": "<test-consumer-arn>",
+        "ShardId": "<test-shard-id>",
+        "StartingPosition": {
+          "Timestamp": "2024-06-21 08:54:08.123000",
+          "Type": "AT_TIMESTAMP"
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/aws/protocol/test_parser.validation.json
+++ b/tests/unit/aws/protocol/test_parser.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/unit/aws/protocol/test_parser.py::test_json_cbor_blob_parsing_w_timestamp": {
+    "last_validated_date": "2024-06-21T13:58:29+00:00"
+  }
+}


### PR DESCRIPTION
## Motivation
This PR fixes the Kinesis request parsing in ASF for timestamp fields.
Where JSON timestamps are normal unix timestamps (where milliseconds can be defined via floating point), for CBOR the timestamp contains the milliseconds (so it's basically JSON * 1000).
#6791 fixed this issue for the serialier, but it was overlooked that the same format used for responses also needs to be considered when parsing incoming requests from clients.

Fixes #10037.

## Changes
- Uses `unixtimestampmillis` for CBOR timestamp request fields when parsing.
  - The integration tests are unfortunately not AWS validated because `botocore` does not yet support CBOR requests to AWS.
  - However, the issue reported in #10037 was verified, and the fix and test directly address this issue.