### PR TITLE
Mark acceptance test marker as GA

### DIFF
--- a/localstack-core/localstack/testing/pytest/marking.py
+++ b/localstack-core/localstack/testing/pytest/marking.py
@@ -57,9 +57,7 @@ class Markers:
     multiruntime: MultiRuntimeMarker = pytest.mark.multiruntime
 
     # test selection
-    acceptance_test_beta = (
-        pytest.mark.acceptance_test
-    )  # for now with a _beta suffix to make clear they are not really used as acceptance tests yet
+    acceptance_test = pytest.mark.acceptance_test
     skip_offline = pytest.mark.skip_offline
     only_on_amd64 = pytest.mark.only_on_amd64
     only_on_arm64 = pytest.mark.only_on_arm64

--- a/tests/aws/scenario/bookstore/test_bookstore.py
+++ b/tests/aws/scenario/bookstore/test_bookstore.py
@@ -45,7 +45,7 @@ SEARCH_KEY = "search.zip"
 SEARCH_UPDATE_KEY = "search_update.zip"
 
 
-@markers.acceptance_test_beta
+@markers.acceptance_test
 class TestBookstoreApplication:
     @pytest.fixture(scope="class")
     def patch_opensearch_strategy(self):

--- a/tests/aws/services/apigateway/test_apigateway_lambda_cfn.py
+++ b/tests/aws/services/apigateway/test_apigateway_lambda_cfn.py
@@ -17,7 +17,7 @@ def handler(event, context):
 """
 
 
-@markers.acceptance_test_beta
+@markers.acceptance_test
 class TestApigatewayLambdaIntegration:
     @pytest.fixture(scope="class", autouse=True)
     def infrastructure(self, aws_client, infrastructure_setup):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The acceptance tests are used as proper acceptance tests now in the main pipeline (#11049). However, their marker still indicates a beta status. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

This PR removes the `_beta` suffix from the acceptance test marker.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
