### PR TITLE
Skip flaky EventBridge test for scheduled expression

### DIFF
--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -225,6 +225,7 @@ class TestEvents:
 
     @markers.aws.unknown
     # TODO move to schedule
+    @pytest.mark.skip(reason="flaky")
     @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_scheduled_expression_events(
         self,


### PR DESCRIPTION
## Motivation

Flaky run: https://app.circleci.com/pipelines/github/localstack/localstack/26062/workflows/5e87f5ba-ee9f-4641-9e9a-0808d4873612/jobs/220558/tests
I didn't notice any further test failures in the CI health dashboard (but they might be shadowed by reruns).

//cc @maxhoheiser 

## Changes

Skip test `test_scheduled_expression_events`