### PR TITLE
parity: kinesis event payload

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_listeners/kinesis_event_source_listener.py
+++ b/localstack-core/localstack/services/lambda_/event_source_listeners/kinesis_event_source_listener.py
@@ -116,6 +116,7 @@ class KinesisEventSourceListener(StreamEventSourceListener):
                         **record_payload,
                         # boto3 automatically decodes records in get_records(), so we must re-encode
                         "data": to_str(base64.b64encode(record_payload["data"])),
+                        "kinesisSchemaVersion": "1.0",
                     },
                 }
             )

--- a/tests/aws/services/lambda_/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_kinesis.py
@@ -47,7 +47,6 @@ def _snapshot_transformers(snapshot):
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         "$..Records..eventID",
-        "$..Records..kinesis.kinesisSchemaVersion",
         "$..BisectBatchOnFunctionError",
         "$..DestinationConfig",
         "$..FunctionResponseTypes",

--- a/tests/aws/services/lambda_/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_kinesis.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping": {
-    "recorded-date": "27-02-2023, 16:54:02",
+    "recorded-date": "24-06-2024, 21:55:17",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 100,

--- a/tests/aws/services/lambda_/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_kinesis.validation.json
@@ -3,7 +3,7 @@
     "last_validated_date": "2023-12-07T08:15:24+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping": {
-    "last_validated_date": "2023-02-27T15:54:02+00:00"
+    "last_validated_date": "2024-06-24T21:55:16+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping_multiple_lambdas_single_kinesis_event_stream": {
     "last_validated_date": "2024-02-02T10:58:36+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes a minor parity issue for AWS Lambda Kinesis Data Streams event source mappings.
As per [docs](https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html), the event payload should have a `kinesisSchemaVersion` key.
Few libraries (e.g., AWS Java SDK) seem to expect this value.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- adding `kinesisSchemaVersion` to the event payload;
- removing snapshot skip from our tests;

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
