### PR TITLE
Added ARN support for get-parameter and get-parameters in SSM

### DIFF
--- a/localstack-core/localstack/services/ssm/provider.py
+++ b/localstack-core/localstack/services/ssm/provider.py
@@ -377,7 +377,7 @@ class SsmProvider(SsmApi, ABC):
                 if match is None or match.group(1) != region_name:
                     raise ValidationException("Incorrect region in: " + param_name)
             return param_name
-        return SsmProvider._normalize_name(param_name, region_name, validate)
+        return SsmProvider._normalize_name(param_name, validate)
 
     @staticmethod
     def _normalize_name(param_name: ParameterName, validate=False) -> ParameterName:

--- a/localstack-core/localstack/services/ssm/provider.py
+++ b/localstack-core/localstack/services/ssm/provider.py
@@ -372,9 +372,9 @@ class SsmProvider(SsmApi, ABC):
             if validate:
                 if not re.match(r"^arn:aws:.+:.+:.+:.+$", param_name):
                     raise ValidationException("Invalid arn: " + param_name)
-                region_pattern = r":(af|ap|ca|eu|me|sa|us)-(central|north|(north(?:east|west))|south|south(?:east|west)|east|west)-\d+:"
+                region_pattern = r"(af|ap|ca|eu|me|sa|us)-(central|north|(north(?:east|west))|south|south(?:east|west)|east|west)-\d+"
                 match = re.search(region_pattern, param_name)
-                if match is None or match.group(1) != region_name:
+                if match is None or match.group(0) != region_name:
                     raise ValidationException("Incorrect region in: " + param_name)
             return param_name
         return SsmProvider._normalize_name(param_name, validate)

--- a/localstack-core/localstack/services/ssm/provider.py
+++ b/localstack-core/localstack/services/ssm/provider.py
@@ -1,9 +1,9 @@
 import copy
 import json
 import logging
+import re
 import time
 from abc import ABC
-import re
 from typing import Dict, Optional
 
 from moto.ssm.models import SimpleSystemManagerBackend, ssm_backends
@@ -127,7 +127,10 @@ class SsmProvider(SsmApi, ABC):
         if SsmProvider._has_secrets(names):
             return SsmProvider._get_params_and_secrets(context.account_id, context.region, names)
 
-        norm_names = [SsmProvider._normalize_name_or_arn(name, context.region, validate=True) for name in names]
+        norm_names = [
+            SsmProvider._normalize_name_or_arn(name, context.region, validate=True)
+            for name in names
+        ]
         request = {"Names": norm_names, "WithDecryption": bool(with_decryption)}
         res = call_moto_with_request(context, request)
 
@@ -362,7 +365,9 @@ class SsmProvider(SsmApi, ABC):
         return maybe_secret is not None
 
     @staticmethod
-    def _normalize_name_or_arn(param_name: ParameterName, region_name: str, validate=False) -> ParameterName:
+    def _normalize_name_or_arn(
+        param_name: ParameterName, region_name: str, validate=False
+    ) -> ParameterName:
         if param_name.startswith("arn:"):
             if validate:
                 if not re.match(r"^arn:aws:.+:.+:.+:.+$", param_name):
@@ -373,12 +378,12 @@ class SsmProvider(SsmApi, ABC):
                     raise ValidationException("Incorrect region in: " + param_name)
             return param_name
         return SsmProvider._normalize_name(param_name, region_name, validate)
-        
+
     @staticmethod
     def _normalize_name(param_name: ParameterName, validate=False) -> ParameterName:
         if validate:
             if re.match(r"^arn:aws:.+$", param_name):
-                raise 
+                raise
             if "//" in param_name or ("/" in param_name and not param_name.startswith("/")):
                 raise InvalidParameterNameException()
         param_name = param_name.strip("/")

--- a/tests/aws/services/ssm/test_ssm.py
+++ b/tests/aws/services/ssm/test_ssm.py
@@ -58,6 +58,20 @@ class TestSSM:
         exc.match("sub-paths divided by slash symbol")
 
     @markers.aws.validated
+    def test_get_parameter_by_arn(self, create_parameter, aws_client):
+        param_name = f"param-{short_uid()}"
+        create_parameter(
+            Name=param_name,
+            Description="test",
+            Value="123",
+            Type="String",
+        )
+        arn = aws_client.ssm.get_parameter(Name=param_name).get("Parameter").get("ARN")
+        result = aws_client.ssm.get_parameter(Name=arn)
+        assert param_name == result.get("Parameter").get("Name")
+        assert "123" == result.get("Parameter").get("Value")
+
+    @markers.aws.validated
     def test_get_secret_parameter(self, create_secret, aws_client):
         secret_name = f"test_secret-{short_uid()}"
         create_secret(


### PR DESCRIPTION
Fix to https://github.com/localstack/localstack/issues/11048
## Motivation

Adding correct validation for ARN inputs to `ssm get-parameter` and `ssm get-parameters`

## Changes

Adds an internal validation method to `localstack.services.ssm.provider.SSMProvider` (`._normalize_name_or_arn`) which validates either ARNs or parameter names, and throws errors consistent with the AWS implementation (to the best of my knowledge).

## Testing

- [x] Added unit test `TestSSM.test_get_parameter_by_arn`

## TODO

- [ ] Add parity test to verify comparability responses (these should pass already, but have not implemented)
- [ ] Partity test: incorrect ARN format, with regex pattern `^arn:aws:.+:.+:.+:.+$`
  - Test designed to check parity with call `aws ssm get-parameter --name arn:`
- [ ] Parity test: invalid region (either not matching a valid AWS region, or not the same region as the call context)
  - Test designed to check parity with call `aws ssm get-parameter --name arn:aws:service:incorrect-region:0000000000:parameter/myparam`
  - Note that the official implementation does not check that the service name is correct (i.e. there is no stipulation that `service` in the above is `ssm`; the following passes validation: `aws ssm get-parameter --name arn:aws:service:us-east-1:0000000000:parameter/myparam`)
