### PR TITLE
refactor Moto out of APIGW next-gen invocation logic

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -51,7 +51,7 @@ class RestApiInvocationContext(RequestContext):
     account_id: Optional[str]
     """The account the REST API is living in."""
     resource: Optional[Resource]
-    """The resource the invocation matched"""
+    """The resource the invocation matched"""  # TODO: verify if needed through the invocation
     resource_method: Optional[Method]
     """The method of the resource the invocation matched"""
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/gateway_exception.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/gateway_exception.py
@@ -47,7 +47,7 @@ class GatewayExceptionHandler(RestApiGatewayExceptionHandler):
         self, exception: BaseGatewayException, context: RestApiInvocationContext
     ):
         gateway_response = get_gateway_response_or_default(
-            exception.type, context.deployment.localstack_rest_api.gateway_responses
+            exception.type, context.deployment.rest_api.gateway_responses
         )
 
         content = self._build_response_content(exception)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
@@ -2,44 +2,27 @@ import copy
 
 from moto.apigateway.models import RestAPI as MotoRestAPI
 
-from localstack.aws.api.apigateway import ListOfResource, Resource
-from localstack.services.apigateway.models import RestApiContainer, RestApiDeployment
+from localstack.services.apigateway.models import MergedRestApi, RestApiContainer, RestApiDeployment
+
+from .moto_helpers import get_resources_from_moto_rest_api
 
 
 def freeze_rest_api(
     account_id: str, region: str, moto_rest_api: MotoRestAPI, localstack_rest_api: RestApiContainer
 ) -> RestApiDeployment:
-    """Snapshot a REST API in time to create a deployment"""
+    """
+    Snapshot a REST API in time to create a deployment
+    This will merge the Moto and LocalStack data into one `MergedRestApi`
+    """
+    moto_resources = get_resources_from_moto_rest_api(moto_rest_api)
+
+    rest_api = MergedRestApi.from_rest_api_container(
+        rest_api_container=localstack_rest_api,
+        resources=moto_resources,
+    )
+
     return RestApiDeployment(
         account_id=account_id,
         region=region,
-        moto_rest_api=copy.deepcopy(moto_rest_api),
-        localstack_rest_api=copy.deepcopy(localstack_rest_api),
+        rest_api=copy.deepcopy(rest_api),
     )
-
-
-def get_resources_from_deployment(deployment: RestApiDeployment) -> ListOfResource:
-    """
-    This returns the `Resources` from a deployment
-    This allows to decouple the underlying split of resources between Moto and LocalStack, and always return the right
-    format.
-    """
-    moto_resources = deployment.moto_rest_api.resources
-
-    resources: ListOfResource = []
-    for moto_resource in moto_resources.values():
-        resource = Resource(
-            id=moto_resource.id,
-            parentId=moto_resource.parent_id,
-            pathPart=moto_resource.path_part,
-            path=moto_resource.get_path(),
-            resourceMethods={
-                # TODO: check if resource_methods.to_json() returns everything we need/want
-                k: v.to_json()
-                for k, v in moto_resource.resource_methods.items()
-            },
-        )
-
-        resources.append(resource)
-
-    return resources

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/moto_helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/moto_helpers.py
@@ -1,0 +1,30 @@
+from moto.apigateway.models import RestAPI as MotoRestAPI
+
+from localstack.aws.api.apigateway import Resource
+
+
+def get_resources_from_moto_rest_api(moto_rest_api: MotoRestAPI) -> dict[str, Resource]:
+    """
+    This returns the `Resources` from a Moto REST API
+    This allows to decouple the underlying split of resources between Moto and LocalStack, and always return the right
+    format.
+    """
+    moto_resources = moto_rest_api.resources
+
+    resources: dict[str, Resource] = {}
+    for moto_resource in moto_resources.values():
+        resource = Resource(
+            id=moto_resource.id,
+            parentId=moto_resource.parent_id,
+            pathPart=moto_resource.path_part,
+            path=moto_resource.get_path(),
+            resourceMethods={
+                # TODO: check if resource_methods.to_json() returns everything we need/want
+                k: v.to_json()
+                for k, v in moto_resource.resource_methods.items()
+            },
+        )
+
+        resources[moto_resource.id] = resource
+
+    return resources

--- a/tests/unit/services/apigateway/test_handler_exception.py
+++ b/tests/unit/services/apigateway/test_handler_exception.py
@@ -2,7 +2,7 @@ import pytest
 from rolo import Response
 
 from localstack.aws.api.apigateway import GatewayResponse, GatewayResponseType
-from localstack.services.apigateway.models import RestApiContainer, RestApiDeployment
+from localstack.services.apigateway.models import MergedRestApi, RestApiDeployment
 from localstack.services.apigateway.next_gen.execute_api.context import RestApiInvocationContext
 from localstack.services.apigateway.next_gen.execute_api.gateway_response import (
     AccessDeniedError,
@@ -19,11 +19,10 @@ class TestGatewayResponseHandler:
             context.deployment = RestApiDeployment(
                 account_id=TEST_AWS_ACCOUNT_ID,
                 region=TEST_AWS_REGION_NAME,
-                localstack_rest_api=RestApiContainer(None),
-                moto_rest_api=None,
+                rest_api=MergedRestApi(None),
             )
             if gateway_responses:
-                context.deployment.localstack_rest_api.gateway_responses = gateway_responses
+                context.deployment.rest_api.gateway_responses = gateway_responses
             return context
 
         return _create_context_with_deployment

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -3,7 +3,7 @@ from moto.apigateway.models import APIGatewayBackend, apigateway_backends
 from werkzeug.datastructures import Headers
 
 from localstack.http import Request, Response
-from localstack.services.apigateway.models import MotoRestAPI, RestApiContainer, RestApiDeployment
+from localstack.services.apigateway.models import MotoRestAPI, RestApiContainer
 from localstack.services.apigateway.next_gen.execute_api.api import RestApiGatewayHandlerChain
 from localstack.services.apigateway.next_gen.execute_api.context import RestApiInvocationContext
 from localstack.services.apigateway.next_gen.execute_api.handlers.parse import (
@@ -12,6 +12,7 @@ from localstack.services.apigateway.next_gen.execute_api.handlers.parse import (
 from localstack.services.apigateway.next_gen.execute_api.handlers.resource_router import (
     InvocationRequestRouter,
 )
+from localstack.services.apigateway.next_gen.execute_api.helpers import freeze_rest_api
 from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 
 TEST_API_ID = "testapi"
@@ -34,11 +35,11 @@ def dummy_deployment():
 
     moto_backend.apis[TEST_API_ID] = moto_rest_api
 
-    yield RestApiDeployment(
+    yield freeze_rest_api(
         account_id=TEST_AWS_ACCOUNT_ID,
         region=TEST_AWS_REGION_NAME,
-        localstack_rest_api=RestApiContainer(rest_api={}),
         moto_rest_api=moto_rest_api,
+        localstack_rest_api=RestApiContainer(rest_api={}),
     )
 
     moto_backend.reset()
@@ -142,32 +143,33 @@ class TestRoutingHandler:
         Note: we have the base `/proxy` route to not have greedy matching on the base route, and the other child routes
         are to assert the `{proxy+} has less priority than hardcoded routes
         """
+        moto_backend: APIGatewayBackend = apigateway_backends[TEST_AWS_ACCOUNT_ID][
+            TEST_AWS_REGION_NAME
+        ]
+        moto_rest_api = moto_backend.apis[TEST_API_ID]
+
         # path: /
-        root_resource = dummy_deployment.moto_rest_api.default
+        root_resource = moto_rest_api.default
         # path: /foo
-        hard_coded_resource = dummy_deployment.moto_rest_api.add_child(
-            path="foo", parent_id=root_resource.id
-        )
+        hard_coded_resource = moto_rest_api.add_child(path="foo", parent_id=root_resource.id)
         # path: /foo/{param}
-        param_resource = dummy_deployment.moto_rest_api.add_child(
+        param_resource = moto_rest_api.add_child(
             path="{param}",
             parent_id=hard_coded_resource.id,
         )
         # path: /proxy
-        hard_coded_resource_2 = dummy_deployment.moto_rest_api.add_child(
-            path="proxy", parent_id=root_resource.id
-        )
+        hard_coded_resource_2 = moto_rest_api.add_child(path="proxy", parent_id=root_resource.id)
         # path: /proxy/bar
-        hard_coded_resource_3 = dummy_deployment.moto_rest_api.add_child(
+        hard_coded_resource_3 = moto_rest_api.add_child(
             path="bar", parent_id=hard_coded_resource_2.id
         )
         # path: /proxy/bar/{param}
-        param_resource_2 = dummy_deployment.moto_rest_api.add_child(
+        param_resource_2 = moto_rest_api.add_child(
             path="{param}",
             parent_id=hard_coded_resource_3.id,
         )
         # path: /proxy/{proxy+}
-        proxy_resource = dummy_deployment.moto_rest_api.add_child(
+        proxy_resource = moto_rest_api.add_child(
             path="{proxy+}",
             parent_id=hard_coded_resource_2.id,
         )
@@ -192,7 +194,12 @@ class TestRoutingHandler:
             api_key_required=False,
         )
 
-        return dummy_deployment
+        return freeze_rest_api(
+            account_id=dummy_deployment.account_id,
+            region=dummy_deployment.region,
+            moto_rest_api=moto_rest_api,
+            localstack_rest_api=dummy_deployment.rest_api,
+        )
 
     @staticmethod
     def get_path_from_addressing(path: str, addressing: str) -> str:

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -1,9 +1,10 @@
 import pytest
 from moto.apigateway.models import APIGatewayBackend, apigateway_backends
+from moto.apigateway.models import RestAPI as MotoRestAPI
 from werkzeug.datastructures import Headers
 
 from localstack.http import Request, Response
-from localstack.services.apigateway.models import MotoRestAPI, RestApiContainer
+from localstack.services.apigateway.models import RestApiContainer
 from localstack.services.apigateway.next_gen.execute_api.api import RestApiGatewayHandlerChain
 from localstack.services.apigateway.next_gen.execute_api.context import RestApiInvocationContext
 from localstack.services.apigateway.next_gen.execute_api.handlers.parse import (


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
During a pair programmation session with @cloutierMat, he emphasized the need to get decoupled from Moto very early, so that we would not be polluted nor have a lot of tech debt across the new invocation logic. 

We then removed the `MotoRestAPI` usage in our deployment/invocation, and only return the APIGW `Resources` needed for the invocation.

If we realize we need more things from Moto, we will need to pull them out of it in  `reeze_rest_api` and add fields to the `MergedRestApi` class.

Once we tackle the removal and split brain situation of Moto from APIGW, we can remove the `MergedRestApi` class and only use the container from our store. 

This will also help us during testing, as we won't need to setup Moto resources like currently done in `tests/unit/services/apigateway/test_handler_request.py`, which is currently tech debt: it is easier to set up lots of resources for testing routing by using the moto utils than to write a lot of nested dicts. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- refactor the Moto REST API out of the Deployment.
- simplify the signature of the deployment, to have all the resources in only one container
- update our tests to make use of the new signatures

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
