### PR TITLE
update pro source code location

### DIFF
--- a/localstack-core/localstack/dev/run/configurators.py
+++ b/localstack-core/localstack/dev/run/configurators.py
@@ -132,7 +132,7 @@ class SourceVolumeMountConfigurator:
 
         # ext source code if available
         if self.pro:
-            source = self.host_paths.localstack_ext_project_dir / "localstack_ext"
+            source = self.host_paths.localstack_ext_project_dir / "localstack-pro-core" / "localstack_ext"
             if source.exists():
                 cfg.volumes.add(
                     VolumeBind(

--- a/localstack-core/localstack/dev/run/configurators.py
+++ b/localstack-core/localstack/dev/run/configurators.py
@@ -132,7 +132,11 @@ class SourceVolumeMountConfigurator:
 
         # ext source code if available
         if self.pro:
-            source = self.host_paths.localstack_ext_project_dir / "localstack-pro-core" / "localstack_ext"
+            source = (
+                self.host_paths.localstack_ext_project_dir
+                / "localstack-pro-core"
+                / "localstack_ext"
+            )
             if source.exists():
                 cfg.volumes.add(
                     VolumeBind(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Following source code refactor in -ext initiated by #10860, the command `python -m localstack.dev.run --mount-source-code` was failing to mount -pro source code as the location change. This is a very useful command allowing for running localstack in docker mode with local code mounted. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Point the pro source code to the new code directory.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
