### PR TITLE
remove flask

### DIFF
--- a/localstack-core/localstack/aws/patches.py
+++ b/localstack-core/localstack/aws/patches.py
@@ -51,8 +51,5 @@ def apply_aws_runtime_patches():
     """
     if find_spec("moto"):
         # only load patches when moto is importable
-        from localstack.utils.aws.request_context import patch_moto_request_handling
-
-        patch_moto_request_handling()
         patch_moto_iam_config()
         patch_moto_instance_tracker_meta()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,6 @@ base-runtime = [
     "Werkzeug>=3.0.0",
     "xmltodict>=0.13.0",
     "rolo>=0.4",
-    # TODO: to be removed when the last usages of Flask in API GW have been removed
-    "flask>=3.0.0",
 ]
 
 # required to actually run localstack on the host

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -8,8 +8,6 @@ attrs==23.2.0
     # via localstack-twisted
 awscrt==0.20.12
     # via localstack-core (pyproject.toml)
-blinker==1.8.2
-    # via flask
 boto3==1.34.131
     # via localstack-core (pyproject.toml)
 botocore==1.34.131
@@ -30,9 +28,7 @@ cffi==1.16.0
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via
-    #   flask
-    #   localstack-core (pyproject.toml)
+    # via localstack-core (pyproject.toml)
 constantly==23.10.4
     # via localstack-twisted
 cryptography==42.0.8
@@ -46,8 +42,6 @@ dnslib==0.9.24
 dnspython==2.6.1
     # via localstack-core (pyproject.toml)
 docker==7.1.0
-    # via localstack-core (pyproject.toml)
-flask==3.0.3
     # via localstack-core (pyproject.toml)
 h11==0.14.0
     # via
@@ -72,10 +66,6 @@ idna==3.7
     #   requests
 incremental==22.10.0
     # via localstack-twisted
-itsdangerous==2.2.0
-    # via flask
-jinja2==3.1.4
-    # via flask
 jmespath==1.0.1
     # via
     #   boto3
@@ -89,9 +79,7 @@ localstack-twisted==24.3.0
 markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
-    # via
-    #   jinja2
-    #   werkzeug
+    # via werkzeug
 mdurl==0.1.2
     # via markdown-it-py
 packaging==24.1
@@ -156,7 +144,6 @@ urllib3==2.2.2
     #   requests
 werkzeug==3.0.3
     # via
-    #   flask
     #   localstack-core (pyproject.toml)
     #   rolo
 wsproto==1.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,8 +45,6 @@ awscli==1.33.13
     # via localstack-core
 awscrt==0.20.12
     # via localstack-core
-blinker==1.8.2
-    # via flask
 boto3==1.34.131
     # via
     #   amazon-kclpy
@@ -85,13 +83,12 @@ cffi==1.16.0
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
-cfn-lint==1.3.4
+cfn-lint==1.3.5
     # via moto-ext
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
-    #   flask
     #   localstack-core
     #   localstack-core (pyproject.toml)
 colorama==0.4.6
@@ -150,8 +147,6 @@ events==0.5
     # via opensearch-py
 filelock==3.15.4
     # via virtualenv
-flask==3.0.3
-    # via localstack-core
 graphql-core==3.2.3
     # via moto-ext
 h11==0.14.0
@@ -191,12 +186,8 @@ incremental==22.10.0
     # via localstack-twisted
 iniconfig==2.0.0
     # via pytest
-itsdangerous==2.2.0
-    # via flask
 jinja2==3.1.4
-    # via
-    #   flask
-    #   moto-ext
+    # via moto-ext
 jmespath==1.0.1
     # via
     #   boto3
@@ -234,7 +225,7 @@ jsonschema==4.22.0
     #   aws-sam-translator
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.2
+jsonschema-path==0.3.3
     # via openapi-spec-validator
 jsonschema-specifications==2023.12.1
     # via
@@ -380,7 +371,7 @@ pyyaml==6.0.1
     #   responses
 readerwriterlock==1.0.9
     # via localstack-core
-referencing==0.31.1
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-path
@@ -479,7 +470,6 @@ websocket-client==1.8.0
     # via localstack-core
 werkzeug==3.0.3
     # via
-    #   flask
     #   localstack-core
     #   moto-ext
     #   pytest-httpserver

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -33,8 +33,6 @@ awscli==1.33.13
     # via localstack-core (pyproject.toml)
 awscrt==0.20.12
     # via localstack-core
-blinker==1.8.2
-    # via flask
 boto3==1.34.131
     # via
     #   amazon-kclpy
@@ -66,13 +64,12 @@ certifi==2024.6.2
     #   requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==1.3.4
+cfn-lint==1.3.5
     # via moto-ext
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
-    #   flask
     #   localstack-core
     #   localstack-core (pyproject.toml)
 colorama==0.4.6
@@ -111,8 +108,6 @@ docutils==0.16
     # via awscli
 events==0.5
     # via opensearch-py
-flask==3.0.3
-    # via localstack-core
 graphql-core==3.2.3
     # via moto-ext
 h11==0.14.0
@@ -138,12 +133,8 @@ idna==3.7
     #   requests
 incremental==22.10.0
     # via localstack-twisted
-itsdangerous==2.2.0
-    # via flask
 jinja2==3.1.4
-    # via
-    #   flask
-    #   moto-ext
+    # via moto-ext
 jmespath==1.0.1
     # via
     #   boto3
@@ -173,7 +164,7 @@ jsonschema==4.22.0
     #   aws-sam-translator
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.2
+jsonschema-path==0.3.3
     # via openapi-spec-validator
 jsonschema-specifications==2023.12.1
     # via
@@ -271,7 +262,7 @@ pyyaml==6.0.1
     #   responses
 readerwriterlock==1.0.9
     # via localstack-core
-referencing==0.31.1
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-path
@@ -347,7 +338,6 @@ urllib3==2.2.2
     #   responses
 werkzeug==3.0.3
     # via
-    #   flask
     #   localstack-core
     #   moto-ext
     #   rolo

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -45,8 +45,6 @@ awscli==1.33.13
     # via localstack-core
 awscrt==0.20.12
     # via localstack-core
-blinker==1.8.2
-    # via flask
 boto3==1.34.131
     # via
     #   amazon-kclpy
@@ -83,13 +81,12 @@ certifi==2024.6.2
     #   requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==1.3.4
+cfn-lint==1.3.5
     # via moto-ext
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
-    #   flask
     #   localstack-core
     #   localstack-core (pyproject.toml)
 colorama==0.4.6
@@ -136,8 +133,6 @@ docutils==0.16
     # via awscli
 events==0.5
     # via opensearch-py
-flask==3.0.3
-    # via localstack-core
 graphql-core==3.2.3
     # via moto-ext
 h11==0.14.0
@@ -175,12 +170,8 @@ incremental==22.10.0
     # via localstack-twisted
 iniconfig==2.0.0
     # via pytest
-itsdangerous==2.2.0
-    # via flask
 jinja2==3.1.4
-    # via
-    #   flask
-    #   moto-ext
+    # via moto-ext
 jmespath==1.0.1
     # via
     #   boto3
@@ -218,7 +209,7 @@ jsonschema==4.22.0
     #   aws-sam-translator
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.2
+jsonschema-path==0.3.3
     # via openapi-spec-validator
 jsonschema-specifications==2023.12.1
     # via
@@ -348,7 +339,7 @@ pyyaml==6.0.1
     #   responses
 readerwriterlock==1.0.9
     # via localstack-core
-referencing==0.31.1
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-path
@@ -440,7 +431,6 @@ websocket-client==1.8.0
     # via localstack-core (pyproject.toml)
 werkzeug==3.0.3
     # via
-    #   flask
     #   localstack-core
     #   moto-ext
     #   pytest-httpserver

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -45,8 +45,6 @@ awscli==1.33.13
     # via localstack-core
 awscrt==0.20.12
     # via localstack-core
-blinker==1.8.2
-    # via flask
 boto3==1.34.131
     # via
     #   amazon-kclpy
@@ -89,13 +87,12 @@ cffi==1.16.0
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
-cfn-lint==1.3.4
+cfn-lint==1.3.5
     # via moto-ext
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
-    #   flask
     #   localstack-core
     #   localstack-core (pyproject.toml)
 colorama==0.4.6
@@ -154,8 +151,6 @@ events==0.5
     # via opensearch-py
 filelock==3.15.4
     # via virtualenv
-flask==3.0.3
-    # via localstack-core
 graphql-core==3.2.3
     # via moto-ext
 h11==0.14.0
@@ -195,12 +190,8 @@ incremental==22.10.0
     # via localstack-twisted
 iniconfig==2.0.0
     # via pytest
-itsdangerous==2.2.0
-    # via flask
 jinja2==3.1.4
-    # via
-    #   flask
-    #   moto-ext
+    # via moto-ext
 jmespath==1.0.1
     # via
     #   boto3
@@ -238,7 +229,7 @@ jsonschema==4.22.0
     #   aws-sam-translator
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.2
+jsonschema-path==0.3.3
     # via openapi-spec-validator
 jsonschema-specifications==2023.12.1
     # via
@@ -284,7 +275,7 @@ mypy-boto3-appsync==1.34.92
     # via boto3-stubs
 mypy-boto3-athena==1.34.130
     # via boto3-stubs
-mypy-boto3-autoscaling==1.34.54
+mypy-boto3-autoscaling==1.34.133
     # via boto3-stubs
 mypy-boto3-backup==1.34.64
     # via boto3-stubs
@@ -316,7 +307,7 @@ mypy-boto3-dynamodb==1.34.131
     # via boto3-stubs
 mypy-boto3-dynamodbstreams==1.34.0
     # via boto3-stubs
-mypy-boto3-ec2==1.34.132
+mypy-boto3-ec2==1.34.133
     # via boto3-stubs
 mypy-boto3-ecr==1.34.101
     # via boto3-stubs
@@ -576,7 +567,7 @@ pyyaml==6.0.1
     #   responses
 readerwriterlock==1.0.9
     # via localstack-core
-referencing==0.31.1
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-path
@@ -776,7 +767,6 @@ websocket-client==1.8.0
     # via localstack-core
 werkzeug==3.0.3
     # via
-    #   flask
     #   localstack-core
     #   moto-ext
     #   pytest-httpserver


### PR DESCRIPTION
## Motivation
We don't use the moto server in a long time, and we also don't use flask to serve anything in LocalStack itself anymore for quite a while.
Now that we [finally got rid of the thread local](https://github.com/localstack/localstack/pull/11069) (thanks @bentsku!) access to the flask request context, we can just remove the dependency completely.

## Changes
- Removes any remaining references to `flask`:
  - A weird indirection of creating a `requests` response via a `flask` response (might just have been a leftover from a previous cleanup?)
  - The patching of the moto server (since we don't use it anymore this patch should not be necessary anyways?)
- Updates the dependency pins after removing the dependency definition from the `pyproject.toml`

## Testing
- If all our pipelines are green, we should be good to go 😄 
- I also ran a test in our downstream repo against this branch (Ext IT #9677195344) which was also successful.