### PR TITLE
Adapt CFn resource scaffolding script to new src layout

### DIFF
--- a/localstack-core/localstack/services/cloudformation/scaffolding/__main__.py
+++ b/localstack-core/localstack/services/cloudformation/scaffolding/__main__.py
@@ -139,10 +139,10 @@ class SchemaProvider:
             ) from e
 
 
-LOCALSTACK_ROOT_DIR = Path(__file__).parent.joinpath("../../../..").resolve()
-LOCALSTACK_PRO_ROOT_DIR = LOCALSTACK_ROOT_DIR.joinpath("../../localstack-ext").resolve()
+LOCALSTACK_ROOT_DIR = Path(__file__).parent.joinpath("../../../../..").resolve()
+LOCALSTACK_PRO_ROOT_DIR = LOCALSTACK_ROOT_DIR.joinpath("../localstack-ext").resolve()
 TESTS_ROOT_DIR = LOCALSTACK_ROOT_DIR.joinpath(
-    "../tests/aws/services/cloudformation/resource_providers"
+    "tests/aws/services/cloudformation/resource_providers"
 )
 TESTS_PRO_ROOT_DIR = LOCALSTACK_PRO_ROOT_DIR.joinpath(
     "tests/aws/services/cloudformation/resource_providers"
@@ -502,6 +502,7 @@ class FileWriter:
 
         self.destination_files = {
             FileType.provider: root_dir(self.pro).joinpath(
+                "localstack-pro-core" if self.pro else "localstack-core",
                 "localstack_ext" if self.pro else "localstack",
                 "services",
                 self.resource_name.python_compatible_service_name.lower(),
@@ -509,6 +510,7 @@ class FileWriter:
                 f"{self.resource_name.namespace.lower()}_{self.resource_name.service.lower()}_{self.resource_name.resource.lower()}.py",
             ),
             FileType.plugin: root_dir(self.pro).joinpath(
+                "localstack-pro-core" if self.pro else "localstack-core",
                 "localstack_ext" if self.pro else "localstack",
                 "services",
                 self.resource_name.python_compatible_service_name.lower(),
@@ -516,6 +518,7 @@ class FileWriter:
                 f"{self.resource_name.namespace.lower()}_{self.resource_name.service.lower()}_{self.resource_name.resource.lower()}_plugin.py",
             ),
             FileType.schema: root_dir(self.pro).joinpath(
+                "localstack-pro-core" if self.pro else "localstack-core",
                 "localstack_ext" if self.pro else "localstack",
                 "services",
                 self.resource_name.python_compatible_service_name.lower(),


### PR DESCRIPTION
## Motivation

Recent changes when migrating to a src layout in both community/pro have broken the resource provider generation. This PR fixes this by adapting the paths to their new nesting structure.

## Changes

- CFn resource provider scaffolding script should now work correctly again with both pro and community.

## Testing

- run `python -m localstack.services.cloudformation.scaffolding generate -w -r "AWS::<svc>::<model>"` to test community generation
- run `python -m localstack.services.cloudformation.scaffolding generate -w -r --pro "AWS::<svc>::<model>"` to test pro generation

