### PR TITLE
Adapt localstack.dev.kubernetes script to new src layout

### DIFF
--- a/localstack-core/localstack/dev/kubernetes/__main__.py
+++ b/localstack-core/localstack/dev/kubernetes/__main__.py
@@ -26,7 +26,7 @@ def generate_k8s_cluster_config(pro: bool = False, mount_moto: bool = False, por
     )
     if pro:
         ext_path = os.path.join(root_path, "..", "localstack-ext")
-        ext_code_path = os.path.join(ext_path, "localstack_ext")
+        ext_code_path = os.path.join(ext_path, "localstack-pro-core", "localstack_ext")
         volumes.append(
             {
                 "volume": f"{os.path.normpath(ext_code_path)}:/code/localstack_ext",

--- a/localstack-core/localstack/dev/kubernetes/__main__.py
+++ b/localstack-core/localstack/dev/kubernetes/__main__.py
@@ -34,7 +34,9 @@ def generate_k8s_cluster_config(pro: bool = False, mount_moto: bool = False, por
             }
         )
 
-        egg_path = os.path.join(ext_path, "localstack_ext.egg-info/entry_points.txt")
+        egg_path = os.path.join(
+            ext_path, "localstack-pro-core", "localstack_ext.egg-info/entry_points.txt"
+        )
         volumes.append(
             {
                 "volume": f"{os.path.normpath(egg_path)}:/code/entry_points_ext",

--- a/localstack-core/localstack/dev/kubernetes/__main__.py
+++ b/localstack-core/localstack/dev/kubernetes/__main__.py
@@ -17,7 +17,9 @@ def generate_k8s_cluster_config(pro: bool = False, mount_moto: bool = False, por
         }
     )
 
-    egg_path = os.path.join(root_path, "localstack_core.egg-info/entry_points.txt")
+    egg_path = os.path.join(
+        root_path, "localstack-core", "localstack_core.egg-info/entry_points.txt"
+    )
     volumes.append(
         {
             "volume": f"{os.path.normpath(egg_path)}:/code/entry_points_community",


### PR DESCRIPTION
## Motivation

Recent changes when migrating to a src layout in pro have broken the `localstack.dev.kubernetes` CLI. This PR fixes this by adapting the path to the new nesting structure.

## Changes

- Fixed mounting of pro code into k8s cluster via `localstack.dev.kubernetes` script.
- Fixed mounting of community entrypoints

## Testing
- `python -m localstack.dev.kubernetes --pro` (and check the volume mount paths in the output)