### PR TITLE
remove dead code related to S3 v1 (pre-ASF)

### DIFF
--- a/localstack-core/localstack/aws/protocol/serializer.py
+++ b/localstack-core/localstack/aws/protocol/serializer.py
@@ -334,7 +334,6 @@ class ResponseSerializer(abc.ABC):
         # wrap the generator in operation specific serialization
         def event_stream_serializer() -> Iterable[bytes]:
             yield self._encode_event_payload("initial-response")
-            # yield convert_to_binary_event_payload("", event_type="initial-response")
 
             # create a default response
             serialized_event_response = self._create_default_response(operation_model, mime_type)

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -46,7 +46,6 @@ from localstack.services.apigateway.models import (
     apigateway_stores,
 )
 from localstack.utils import common
-from localstack.utils.aws import queries
 from localstack.utils.aws import resources as resource_utils
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.aws.aws_responses import requests_error_response_json, requests_response
@@ -725,6 +724,31 @@ def get_cors_response(headers):
     return response
 
 
+def get_apigateway_path_for_resource(
+    api_id, resource_id, path_suffix="", resources=None, region_name=None
+):
+    if resources is None:
+        apigateway = connect_to(region_name=region_name).apigateway
+        resources = apigateway.get_resources(restApiId=api_id, limit=100)["items"]
+    target_resource = list(filter(lambda res: res["id"] == resource_id, resources))[0]
+    path_part = target_resource.get("pathPart", "")
+    if path_suffix:
+        if path_part:
+            path_suffix = "%s/%s" % (path_part, path_suffix)
+    else:
+        path_suffix = path_part
+    parent_id = target_resource.get("parentId")
+    if not parent_id:
+        return "/%s" % path_suffix
+    return get_apigateway_path_for_resource(
+        api_id,
+        parent_id,
+        path_suffix=path_suffix,
+        resources=resources,
+        region_name=region_name,
+    )
+
+
 def get_rest_api_paths(account_id: str, region_name: str, rest_api_id: str):
     apigateway = connect_to(aws_access_key_id=account_id, region_name=region_name).apigateway
     resources = apigateway.get_resources(restApiId=rest_api_id, limit=100)
@@ -733,7 +757,7 @@ def get_rest_api_paths(account_id: str, region_name: str, rest_api_id: str):
         path = resource.get("path")
         # TODO: check if this is still required in the general case (can we rely on "path" being
         #  present?)
-        path = path or queries.get_apigateway_path_for_resource(
+        path = path or get_apigateway_path_for_resource(
             rest_api_id, resource["id"], region_name=region_name
         )
         resource_map[path] = resource

--- a/localstack-core/localstack/utils/aws/aws_responses.py
+++ b/localstack-core/localstack/utils/aws/aws_responses.py
@@ -3,7 +3,6 @@ import datetime
 import json
 import re
 from binascii import crc32
-from struct import pack
 from typing import Any, Dict, Optional, Union
 from urllib.parse import parse_qs
 
@@ -12,7 +11,6 @@ from flask import Response as FlaskResponse
 from requests.models import CaseInsensitiveDict
 from requests.models import Response as RequestsResponse
 
-from localstack.config import DEFAULT_ENCODING
 from localstack.constants import APPLICATION_JSON, HEADER_CONTENT_TYPE
 from localstack.utils.json import json_safe
 from localstack.utils.strings import short_uid, str_startswith_ignore_case, to_bytes, to_str
@@ -249,55 +247,6 @@ def parse_query_string(url_or_qs: str, multi_values=False) -> Dict[str, str]:
 
 def calculate_crc32(content: Union[str, bytes]) -> int:
     return crc32(to_bytes(content)) & 0xFFFFFFFF
-
-
-# TODO Remove this constant with the function below
-AWS_BINARY_DATA_TYPE_STRING = 7
-
-
-def convert_to_binary_event_payload(result, event_type=None, message_type=None):
-    # TODO This encoding has been migrated to the ASF Serializer.
-    #  Remove this function after S3 and Kinesis have been migrated to ASF.
-    # e.g.: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html
-    # e.g.: https://docs.aws.amazon.com/transcribe/latest/dg/event-stream.html
-
-    header_descriptors = {
-        ":event-type": event_type or "Records",
-        ":message-type": message_type or "event",
-    }
-
-    # construct headers
-    headers = b""
-    for key, value in header_descriptors.items():
-        header_name = key.encode(DEFAULT_ENCODING)
-        header_value = to_bytes(value)
-        headers += pack("!B", len(header_name))
-        headers += header_name
-        headers += pack("!B", AWS_BINARY_DATA_TYPE_STRING)
-        headers += pack("!H", len(header_value))
-        headers += header_value
-
-    # construct body
-    if isinstance(result, str):
-        body = bytes(result, DEFAULT_ENCODING)
-    else:
-        body = result
-
-    # calculate lengths
-    headers_length = len(headers)
-    body_length = len(body)
-
-    # construct message
-    result = pack("!I", body_length + headers_length + 16)
-    result += pack("!I", headers_length)
-    prelude_crc = binascii.crc32(result)
-    result += pack("!I", prelude_crc)
-    result += headers
-    result += body
-    payload_crc = binascii.crc32(result)
-    result += pack("!I", payload_crc)
-
-    return result
 
 
 class LambdaResponse:

--- a/localstack-core/localstack/utils/aws/queries.py
+++ b/localstack-core/localstack/utils/aws/queries.py
@@ -11,47 +11,6 @@ def sqs_receive_message(queue_arn):
     return response
 
 
-def get_apigateway_resource_for_path(api_id, path, parent=None, resources=None):
-    if resources is None:
-        apigateway = connect_to().apigateway
-        resources = apigateway.get_resources(restApiId=api_id, limit=100)
-    if not isinstance(path, list):
-        path = path.split("/")
-    if not path:
-        return parent
-    for resource in resources:
-        if resource["pathPart"] == path[0] and (not parent or parent["id"] == resource["parentId"]):
-            return get_apigateway_resource_for_path(
-                api_id, path[1:], parent=resource, resources=resources
-            )
-    return None
-
-
-def get_apigateway_path_for_resource(
-    api_id, resource_id, path_suffix="", resources=None, region_name=None
-):
-    if resources is None:
-        apigateway = connect_to(region_name=region_name).apigateway
-        resources = apigateway.get_resources(restApiId=api_id, limit=100)["items"]
-    target_resource = list(filter(lambda res: res["id"] == resource_id, resources))[0]
-    path_part = target_resource.get("pathPart", "")
-    if path_suffix:
-        if path_part:
-            path_suffix = "%s/%s" % (path_part, path_suffix)
-    else:
-        path_suffix = path_part
-    parent_id = target_resource.get("parentId")
-    if not parent_id:
-        return "/%s" % path_suffix
-    return get_apigateway_path_for_resource(
-        api_id,
-        parent_id,
-        path_suffix=path_suffix,
-        resources=resources,
-        region_name=region_name,
-    )
-
-
 def kinesis_get_latest_records(
     stream_name: str, shard_id: str, count: int = 10, client=None
 ) -> list[dict]:


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Looking at #11090, I saw some dead code related to the legacy S3 provider(true legacy, the legacy v1 and not v2 😄)

This PR removes it the dead code, and move a bit of code around related to APIGW as it is only used there. 

<!-- What notable changes does this PR make? -->
## Changes
- remove dead code related to S3 select
- move one function to APIGW helpers
- remove a comment related to the dead code

<!-- The following sections are optional, but can be useful!

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->
