### PR TITLE
harden test_dynamodb_stream_records_with_update_item

### DIFF
--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1267,7 +1267,7 @@
     }
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_records_with_update_item": {
-    "recorded-date": "06-06-2024, 13:02:16",
+    "recorded-date": "26-06-2024, 14:28:27",
     "recorded-content": {
       "create-table": {
         "TableDescription": {

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -45,7 +45,7 @@
     "last_validated_date": "2023-08-23T14:33:43+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_records_with_update_item": {
-    "last_validated_date": "2024-06-06T13:02:16+00:00"
+    "last_validated_date": "2024-06-26T14:28:26+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_stream_view_type": {
     "last_validated_date": "2024-05-31T14:49:56+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following up another test failure in https://app.circleci.com/pipelines/github/localstack/localstack/26140/workflows/8cc6ef1b-70fd-4e35-bea3-77ff3637a2db/jobs/221443/tests

And follow up from #10973 which was unsuccessful at fixing the test as it didn't tackle the proper origin of the problem. 

I've tried to harden the test to be more resilient. It seems the flake came from the fact that we would try to fetch the records, and if there weren't enough in the kinesis stream, we would fetch again and extend the already existing list of records with newly fetched records, leading to duplicate items (we can see the two`INSERT` events have the same `SequenceNumber`

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update the logic to fetch the records from DynamoDB Streams

\cc @alexrashed 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
