### PR TITLE
Add support for docker container log configs

### DIFF
--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -438,6 +438,12 @@ class VolumeInfo(NamedTuple):
 
 
 @dataclasses.dataclass
+class LogConfig:
+    type: Literal["json-file", "syslog", "journald", "gelf", "fluentd", "none", "awslogs", "splunk"]
+    config: Dict[str, str] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass
 class ContainerConfiguration:
     image_name: str
     name: Optional[str] = None
@@ -467,6 +473,7 @@ class ContainerConfiguration:
     ulimits: Optional[List[Ulimit]] = None
     labels: Optional[Dict[str, str]] = None
     init: Optional[bool] = None
+    log_config: Optional[LogConfig] = None
 
 
 class ContainerConfigurator(Protocol):
@@ -876,6 +883,7 @@ class ContainerClient(metaclass=ABCMeta):
         platform: Optional[DockerPlatform] = None,
         ulimits: Optional[List[Ulimit]] = None,
         init: Optional[bool] = None,
+        log_config: Optional[LogConfig] = None,
     ) -> str:
         """Creates a container with the given image
 
@@ -912,6 +920,7 @@ class ContainerClient(metaclass=ABCMeta):
         privileged: Optional[bool] = None,
         ulimits: Optional[List[Ulimit]] = None,
         init: Optional[bool] = None,
+        log_config: Optional[LogConfig] = None,
     ) -> Tuple[bytes, bytes]:
         """Creates and runs a given docker container
 
@@ -949,6 +958,7 @@ class ContainerClient(metaclass=ABCMeta):
             privileged=container_config.privileged,
             ulimits=container_config.ulimits,
             init=container_config.init,
+            log_config=container_config.log_config,
         )
 
     @abstractmethod

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -18,6 +18,7 @@ from localstack.utils.container_utils.container_client import (
     DockerContainerStatus,
     DockerNotAvailable,
     DockerPlatform,
+    LogConfig,
     NoSuchContainer,
     NoSuchImage,
     NoSuchNetwork,
@@ -736,6 +737,7 @@ class CmdDockerClient(ContainerClient):
         platform: Optional[DockerPlatform] = None,
         ulimits: Optional[List[Ulimit]] = None,
         init: Optional[bool] = None,
+        log_config: Optional[LogConfig] = None,
     ) -> Tuple[List[str], str]:
         env_file = None
         cmd = self._docker_cmd() + [action]
@@ -794,6 +796,10 @@ class CmdDockerClient(ContainerClient):
             )
         if init:
             cmd += ["--init"]
+        if log_config:
+            cmd += ["--log-driver", log_config.type]
+            for key, value in log_config.config.items():
+                cmd += ["--log-opt", f"{key}={value}"]
 
         if additional_flags:
             cmd += shlex.split(additional_flags)

--- a/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
@@ -15,6 +15,7 @@ import docker
 from docker import DockerClient
 from docker.errors import APIError, ContainerError, DockerException, ImageNotFound, NotFound
 from docker.models.containers import Container
+from docker.types import LogConfig as DockerLogConfig
 from docker.utils.socket import STDERR, STDOUT, frames_iter
 
 from localstack.config import LS_LOG
@@ -28,6 +29,7 @@ from localstack.utils.container_utils.container_client import (
     DockerContainerStatus,
     DockerNotAvailable,
     DockerPlatform,
+    LogConfig,
     NoSuchContainer,
     NoSuchImage,
     NoSuchNetwork,
@@ -626,6 +628,7 @@ class SdkDockerClient(ContainerClient):
         platform: Optional[DockerPlatform] = None,
         ulimits: Optional[List[Ulimit]] = None,
         init: Optional[bool] = None,
+        log_config: Optional[LogConfig] = None,
     ) -> str:
         LOG.debug("Creating container with attributes: %s", locals())
         extra_hosts = None
@@ -679,6 +682,10 @@ class SdkDockerClient(ContainerClient):
                 kwargs["init"] = True
             if labels:
                 kwargs["labels"] = labels
+            if log_config:
+                kwargs["log_config"] = DockerLogConfig(
+                    type=log_config.type, config=log_config.config
+                )
             if ulimits:
                 kwargs["ulimits"] = [
                     docker.types.Ulimit(
@@ -750,6 +757,7 @@ class SdkDockerClient(ContainerClient):
         privileged: Optional[bool] = None,
         ulimits: Optional[List[Ulimit]] = None,
         init: Optional[bool] = None,
+        log_config: Optional[LogConfig] = None,
     ) -> Tuple[bytes, bytes]:
         LOG.debug("Running container with image: %s", image_name)
         container = None
@@ -780,6 +788,7 @@ class SdkDockerClient(ContainerClient):
                 init=init,
                 labels=labels,
                 ulimits=ulimits,
+                log_config=log_config,
             )
             result = self.start_container(
                 container_name_or_id=container,

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1,5 +1,6 @@
 import datetime
 import ipaddress
+import json
 import logging
 import os
 import re
@@ -21,6 +22,7 @@ from localstack.utils.container_utils.container_client import (
     ContainerException,
     DockerContainerStatus,
     DockerNotAvailable,
+    LogConfig,
     NoSuchContainer,
     NoSuchImage,
     NoSuchNetwork,
@@ -41,6 +43,7 @@ from localstack.utils.docker_utils import (
 )
 from localstack.utils.net import Port, PortNotAvailableException, get_free_tcp_port
 from localstack.utils.strings import to_bytes
+from localstack.utils.sync import retry
 from localstack.utils.threads import FuncThread
 from tests.integration.docker_utils.conftest import is_podman_test, skip_for_podman
 
@@ -1740,6 +1743,54 @@ class TestDockerNetworking:
         init_thread.join()
         # verify that the client is available
         assert sdk_client.docker_client is not None
+
+
+class TestDockerLogging:
+    def test_docker_logging_none_disables_logs(
+        self, docker_client: ContainerClient, create_container
+    ):
+        container = create_container(
+            "alpine", command=["sh", "-c", "echo test"], log_config=LogConfig("none")
+        )
+        docker_client.start_container(container.container_id, attach=True)
+        with pytest.raises(ContainerException):
+            docker_client.get_container_logs(container_name_or_id=container.container_id)
+
+    def test_docker_logging_fluentbit(self, docker_client: ContainerClient, create_container):
+        ports = PortMappings(bind_host="0.0.0.0")
+        ports.add(24224, 24224)
+        fluentd_container = create_container(
+            "fluent/fluent-bit",
+            command=["-i", "forward", "-o", "stdout", "-p", "format=json_lines", "-f", "1", "-q"],
+            ports=ports,
+        )
+        docker_client.start_container(fluentd_container.container_id)
+
+        container = create_container(
+            "alpine",
+            command=["sh", "-c", "echo test"],
+            log_config=LogConfig(
+                "fluentd", config={"fluentd-address": "127.0.0.1:24224", "fluentd-async": "true"}
+            ),
+        )
+        docker_client.start_container(container.container_id, attach=True)
+
+        def _get_logs():
+            logs = docker_client.get_container_logs(
+                container_name_or_id=fluentd_container.container_id
+            )
+            message = None
+            for log in logs.splitlines():
+                if log.strip():
+                    message = json.loads(log.strip())
+            assert message
+            return message
+
+        log = retry(_get_logs, retries=10, sleep=1)
+        assert log["log"] == "test"
+        assert log["source"] == "stdout"
+        assert log["container_id"] == container.container_id
+        assert log["container_name"] == f"/{container.container_name}"
 
 
 class TestDockerPermissions:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We currently have no support for docker logs configs, to set different docker log drivers, in our docker client implementation.

In order to facilitate some future functionality, we need to be able to use different log drivers.

This PR adds this functionality, and an example test which streams the logs to fluent-bit.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Support docker log configuration in the docker client

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
