### PR TITLE
Apigw NG create method request handler

### DIFF
--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -327,6 +327,9 @@ class ModelResolver:
                 def_resolved, was_resolved = self._get_resolved_submodel(model_name=ref_model_name)
 
                 if not def_resolved:
+                    LOG.debug(
+                        f"Failed to resolve submodel {ref_model_name} for model {self._current_resolving_name}"
+                    )
                     return
                 # if the ref was already resolved, we copy the result to not alter the already resolved schema
                 if was_resolved:
@@ -365,12 +368,15 @@ class ModelResolver:
                 return None
             schema = json.loads(model["schema"])
             resolved_model = self.resolve_model(schema)
+            print(f"{resolved_model=}")
             if not resolved_model:
                 return None
             # attach the resolved dependencies of the schema
             if self._deps:
+                print(f"{self._deps=}")
                 resolved_model["$defs"] = self._deps
             self.rest_api_container.resolved_models[self.model_name] = resolved_model
+            print(f"{resolved_model=}")
 
         return resolved_model
 

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -368,15 +368,12 @@ class ModelResolver:
                 return None
             schema = json.loads(model["schema"])
             resolved_model = self.resolve_model(schema)
-            print(f"{resolved_model=}")
             if not resolved_model:
                 return None
             # attach the resolved dependencies of the schema
             if self._deps:
-                print(f"{self._deps=}")
                 resolved_model["$defs"] = self._deps
             self.rest_api_container.resolved_models[self.model_name] = resolved_model
-            print(f"{resolved_model=}")
 
         return resolved_model
 

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -328,7 +328,9 @@ class ModelResolver:
 
                 if not def_resolved:
                     LOG.debug(
-                        f"Failed to resolve submodel {ref_model_name} for model {self._current_resolving_name}"
+                        "Failed to resolve submodel %s for model %s",
+                        ref_model_name,
+                        self._current_resolving_name,
                     )
                     return
                 # if the ref was already resolved, we copy the result to not alter the already resolved schema

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_request.py
@@ -123,9 +123,7 @@ class MethodRequestHandler(RestApiGatewayHandler):
                     is_missing = param_value not in request.get("headers", [])
                 case "path":
                     path = request.get("path", "")
-                    print(param_value in path)
                     is_missing = param_value not in path
-                    print(f"{is_missing=}")
                 case "querystring":
                     is_missing = param_value not in request.get("query_string_parameters", [])
                 case _:

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_request.py
@@ -1,9 +1,17 @@
+import json
 import logging
 
+from jsonschema import ValidationError, validate
+
+from localstack.aws.api.apigateway import Method
+from localstack.constants import APPLICATION_JSON
 from localstack.http import Response
+from localstack.services.apigateway.helpers import EMPTY_MODEL, ModelResolver
+from localstack.services.apigateway.models import RestApiContainer
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
-from ..context import RestApiInvocationContext
+from ..context import InvocationRequest, RestApiInvocationContext
+from ..gateway_response import BadRequestBodyError, BadRequestParametersError
 
 LOG = logging.getLogger(__name__)
 
@@ -20,4 +28,118 @@ class MethodRequestHandler(RestApiGatewayHandler):
         context: RestApiInvocationContext,
         response: Response,
     ):
+        self.validate_request(
+            context.resource_method,
+            context.deployment.rest_api,
+            context.invocation_request,
+        )
+
+    def validate_request(
+        self, method: Method, rest_api: RestApiContainer, request: InvocationRequest
+    ) -> None:
+        """
+        :raises BadRequestParameters if the request has required parameters which are not present
+        :raises BadRequestBody if the request has required body validation with a model and it does not respect it
+        :return: None
+        """
+
+        # check if there is validator for the method
+        if not (request_validator_id := method.get("requestValidatorId") or "").strip():
+            return
+
+        # check if there is a validator for this request
+        if not (validator := rest_api.validators.get(request_validator_id)):
+            # TODO Should we raise an exception instead?
+            return
+
+        if self.should_validate_request(validator) and (
+            missing_parameters := self._get_missing_required_parameters(method, request)
+        ):
+            message = f"Missing required request parameters: [{', '.join(missing_parameters)}]"
+            raise BadRequestParametersError(message=message)
+
+        if self.should_validate_body(validator) and not self._is_body_valid(
+            method, rest_api, request
+        ):
+            raise BadRequestBodyError(message="Invalid request body")
+
         return
+
+    @staticmethod
+    def _is_body_valid(
+        method: Method, rest_api: RestApiContainer, request: InvocationRequest
+    ) -> bool:
+        # if there's no model to validate the body, use the Empty model
+        # https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-apigateway.EmptyModel.html
+        if not (request_models := method.get("requestModels")):
+            model_name = EMPTY_MODEL
+        else:
+            model_name = request_models.get(
+                APPLICATION_JSON, request_models.get("$default", EMPTY_MODEL)
+            )
+
+        model_resolver = ModelResolver(
+            rest_api_container=rest_api,
+            model_name=model_name,
+        )
+
+        # try to get the resolved model first
+        resolved_schema = model_resolver.get_resolved_model()
+        if not resolved_schema:
+            LOG.exception(
+                f"An exception occurred while trying to validate the request: could not resolve the model {model_name}"
+            )
+            return False
+
+        try:
+            # if the body is empty, replace it with an empty JSON body
+            validate(
+                instance=json.loads(request.get("body") or "{}"),
+                schema=resolved_schema,
+            )
+            return True
+        except ValidationError as e:
+            LOG.warning("failed to validate request body %s", e)
+            return False
+        except json.JSONDecodeError as e:
+            LOG.warning("failed to validate request body, request data is not valid JSON %s", e)
+            return False
+
+    @staticmethod
+    def _get_missing_required_parameters(method: Method, request: InvocationRequest) -> list[str]:
+        missing_params = []
+        if not (request_parameters := method.get("requestParameters")):
+            return missing_params
+
+        for request_parameter, required in sorted(request_parameters.items()):
+            if not required:
+                continue
+
+            param_type, param_value = request_parameter.removeprefix("method.request.").split(".")
+            match param_type:
+                case "header":
+                    is_missing = param_value not in request.get("headers", [])
+                case "path":
+                    path = request.get("path", "")
+                    print(param_value in path)
+                    is_missing = param_value not in path
+                    print(f"{is_missing=}")
+                case "querystring":
+                    is_missing = param_value not in request.get("query_string_parameters", [])
+                case _:
+                    # This shouldn't happen
+                    LOG.debug("Found an invalid request parameter: %s", request_parameter)
+                    is_missing = False
+
+            if is_missing:
+                missing_params.append(param_value)
+
+        return missing_params
+
+    @staticmethod
+    def should_validate_body(validator):
+        return validator.get("validateRequestBody")
+
+    @staticmethod
+    def should_validate_request(validator):
+        return validator.get("validateRequestParameters")

--- a/tests/unit/services/apigateway/test_handler_method_request.py
+++ b/tests/unit/services/apigateway/test_handler_method_request.py
@@ -1,0 +1,288 @@
+import json
+
+import pytest
+
+from localstack.aws.api.apigateway import Method, Model, RequestValidator, RestApi
+from localstack.http import Request, Response
+from localstack.services.apigateway.models import MergedRestApi, RestApiDeployment
+from localstack.services.apigateway.next_gen.execute_api.api import RestApiGatewayHandlerChain
+from localstack.services.apigateway.next_gen.execute_api.context import (
+    InvocationRequest,
+    RestApiInvocationContext,
+)
+from localstack.services.apigateway.next_gen.execute_api.gateway_response import (
+    BadRequestBodyError,
+    BadRequestParametersError,
+)
+from localstack.services.apigateway.next_gen.execute_api.handlers import MethodRequestHandler
+from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
+
+
+@pytest.fixture
+def method_handler_chain() -> RestApiGatewayHandlerChain:
+    """Returns a dummy chain for testing."""
+    method_handler_chain = RestApiGatewayHandlerChain(request_handlers=[MethodRequestHandler()])
+    # Sets raise_on_error to allow capturing the Exceptions raised by the validator
+    method_handler_chain.raise_on_error = True
+    return method_handler_chain
+
+
+@pytest.fixture
+def dummy_context():
+    context = RestApiInvocationContext(Request())
+    context.deployment = RestApiDeployment(
+        TEST_AWS_ACCOUNT_ID,
+        TEST_AWS_REGION_NAME,
+        rest_api=MergedRestApi(rest_api=RestApi()),
+    )
+    context.resource_method = Method()
+    return context
+
+
+class TestMethodRequestHandler:
+    def test_no_validator(self, method_handler_chain, dummy_context):
+        method_handler_chain.handle(dummy_context, Response())
+
+    def test_validator_no_validation_required(self, method_handler_chain, dummy_context):
+        validator_id = "validatorId"
+        validator = RequestValidator(id=validator_id, validateRequestParameters=False)
+        dummy_context.deployment.rest_api.validators = {validator_id: validator}
+        dummy_context.resource_method = Method(
+            requestValidatorId=validator_id,
+            requestParameters={
+                "method.request.querystring.foo": True,
+                "method.request.header.foo": True,
+            },
+        )
+        method_handler_chain.handle(dummy_context, Response())
+
+    def test_validator_no_params_to_validate(self, method_handler_chain, dummy_context):
+        validator_id = "validatorId"
+        validator = RequestValidator(id=validator_id, validateRequestParameters=False)
+        dummy_context.deployment.rest_api.validators = {validator_id: validator}
+        dummy_context.resource_method = Method(
+            requestValidatorId=validator_id,
+            requestParameters={
+                "method.request.querystring.foo": False,
+                "method.request.header.foo": False,
+            },
+        )
+        method_handler_chain.handle(dummy_context, Response())
+
+    def test_validator_request_parameters(self, method_handler_chain, dummy_context):
+        validator_id = "validatorId"
+        validator = RequestValidator(id=validator_id, validateRequestParameters=True)
+        dummy_context.deployment.rest_api.validators = {validator_id: validator}
+        dummy_context.resource_method = Method(
+            requestValidatorId=validator_id,
+            requestParameters={
+                "method.request.querystring.query": True,
+                "method.request.header.x-header": True,
+                "method.request.path.proxy": True,
+            },
+        )
+
+        # Invocation with no valid element
+        dummy_context.invocation_request = InvocationRequest(
+            headers={}, query_string_parameters={}, path=""
+        )
+        with pytest.raises(BadRequestParametersError) as e:
+            method_handler_chain.handle(dummy_context, Response())
+        assert e.value.message == "Missing required request parameters: [x-header, proxy, query]"
+
+        # invocation with valid header
+        dummy_context.invocation_request["headers"]["x-header"] = "foobar"
+        method_handler_chain.error = None
+        with pytest.raises(BadRequestParametersError) as e:
+            method_handler_chain.handle(dummy_context, Response())
+        assert e.value.message == "Missing required request parameters: [proxy, query]"
+
+        # invocation with valid header and querystring
+        dummy_context.invocation_request["query_string_parameters"]["query"] = "result"
+        method_handler_chain.error = None
+        with pytest.raises(BadRequestParametersError) as e:
+            method_handler_chain.handle(dummy_context, Response())
+        assert e.value.message == "Missing required request parameters: [proxy]"
+
+        # invocation with valid request
+        dummy_context.invocation_request["path"] = "/proxy/path"
+        method_handler_chain.error = None
+        method_handler_chain.handle(dummy_context, Response())
+
+    def test_validator_request_body_empty_model(self, method_handler_chain, dummy_context):
+        validator_id = "validatorId"
+        model_id = "model_id"
+        validator = RequestValidator(id=validator_id, validateRequestBody=True)
+        dummy_context.deployment.rest_api.validators = {validator_id: validator}
+        dummy_context.deployment.rest_api.models = {
+            model_id: Model(
+                id=model_id,
+                name=model_id,
+                schema=json.dumps({"$schema": "http://json-schema.org/draft-04/schema#"}),
+                contentType="application/json",
+            )
+        }
+        dummy_context.resource_method = Method(
+            requestValidatorId=validator_id, requestModels={"application/json": model_id}
+        )
+
+        # Invocation with no body
+        dummy_context.invocation_request = InvocationRequest(body=b"{}")
+        method_handler_chain.handle(dummy_context, Response())
+
+        # Invocation with a body
+        dummy_context.invocation_request = InvocationRequest(body=b'{"foo": "bar"}')
+        method_handler_chain.handle(dummy_context, Response())
+
+    def test_validator_validate_body_with_schema(self, method_handler_chain, dummy_context):
+        validator_id = "validatorId"
+        model_id = "model_id"
+        validator = RequestValidator(id=validator_id, validateRequestBody=True)
+        dummy_context.deployment.rest_api.validators = {validator_id: validator}
+        dummy_context.deployment.rest_api.models = {
+            model_id: Model(
+                id=model_id,
+                name=model_id,
+                schema=json.dumps(
+                    {"$schema": "http://json-schema.org/draft-04/schema#", "required": ["foo"]}
+                ),
+                contentType="application/json",
+            )
+        }
+        dummy_context.resource_method = Method(
+            requestValidatorId=validator_id, requestModels={"application/json": model_id}
+        )
+
+        # Invocation with no body
+        dummy_context.invocation_request = InvocationRequest(body=b"{}")
+        method_handler_chain.error = None
+        with pytest.raises(BadRequestBodyError) as e:
+            method_handler_chain.handle(dummy_context, Response())
+        assert e.value.message == "Invalid request body"
+
+        # Invocation with an invalid body
+        dummy_context.invocation_request = InvocationRequest(body=b'{"not": "foo"}')
+        method_handler_chain.error = None
+        with pytest.raises(BadRequestBodyError) as e:
+            method_handler_chain.handle(dummy_context, Response())
+        assert e.value.message == "Invalid request body"
+
+        # Invocation with a valid body
+        dummy_context.invocation_request = InvocationRequest(body=b'{"foo": "bar"}')
+        method_handler_chain.error = None
+        method_handler_chain.handle(dummy_context, Response())
+
+    def test_validator_validate_body_with_no_model_for_schema_name(
+        self, method_handler_chain, dummy_context
+    ):
+        # TODO verify this is required as it might not be a possible scenario on aws
+        validator_id = "validatorId"
+        model_id = "model_id"
+        validator = RequestValidator(id=validator_id, validateRequestBody=True)
+        dummy_context.deployment.rest_api.validators = {validator_id: validator}
+        dummy_context.resource_method = Method(
+            requestValidatorId=validator_id, requestModels={"application/json": model_id}
+        )
+
+        dummy_context.invocation_request = InvocationRequest(body=b"{}")
+        method_handler_chain.error = None
+        with pytest.raises(BadRequestBodyError) as e:
+            method_handler_chain.handle(dummy_context, Response())
+        assert e.value.message == "Invalid request body"
+
+    def test_validate_body_with_circular_and_recursive_model(
+        self, method_handler_chain, dummy_context
+    ):
+        validator_id = "validatorId"
+        model_1 = "Person"
+        model_2 = "House"
+        validator = RequestValidator(id=validator_id, validateRequestBody=True)
+        dummy_context.deployment.rest_api.validators = {validator_id: validator}
+        dummy_context.deployment.rest_api.models = {
+            # set up the model, Person, which references House
+            model_1: Model(
+                id=model_1,
+                name=model_1,
+                schema=json.dumps(
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                            },
+                            "house": {
+                                "$ref": "House",
+                            },
+                        },
+                        "required": ["name"],
+                    }
+                ),
+                contentType="application/json",
+            ),
+            # set up the model House, which references the Person model, we have a circular ref, and House itself
+            model_2: Model(
+                id=model_2,
+                name=model_2,
+                schema=json.dumps(
+                    {
+                        "type": "object",
+                        "required": ["houseType"],
+                        "properties": {
+                            "houseType": {
+                                "type": "string",
+                            },
+                            "contains": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "Person",
+                                },
+                            },
+                            "houses": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "/House",
+                                },
+                            },
+                        },
+                    }
+                ),
+                contentType="application/json",
+            ),
+        }
+        dummy_context.resource_method = Method(
+            requestValidatorId=validator_id, requestModels={"application/json": model_1}
+        )
+
+        # Invalid body
+        dummy_context.invocation_request = InvocationRequest(
+            body=json.dumps(
+                {
+                    "name": "test",
+                    "house": {  # the House object is missing "houseType"
+                        "contains": [{"name": "test"}],  # the Person object has the required "name"
+                        "houses": [{"coucou": "test"}],  # the House object is missing "houseType"
+                    },
+                }
+            ).encode()
+        )
+        with pytest.raises(BadRequestBodyError) as e:
+            method_handler_chain.handle(dummy_context, Response())
+        assert e.value.message == "Invalid request body"
+
+        # Valid body
+        dummy_context.invocation_request = InvocationRequest(
+            body=json.dumps(
+                {
+                    "name": "test",
+                    "house": {
+                        "houseType": "random",  # the House object has the required ""houseType"
+                        "contains": [{"name": "test"}],  # the Person object has the required "name"
+                        "houses": [
+                            {"houseType": "test"}  # the House object has the required "houseType"
+                        ],
+                    },
+                }
+            ).encode()
+        )
+        method_handler_chain.error = None
+        method_handler_chain.handle(dummy_context, Response())


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR ports the functionality from `apigateway/invocations.py:RequestValidator` to a method request handler.

The old invocation process wasn't routing the request before validation so some "passthrough" were required when no matching method were found. Cleaning up some of that code will make it cleaner and more obvious as to what is happening.

We can also start raising error from the gateway responses to be prepared for it's future implmentation.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- updated the method request handler to validate the request parameters and the body.
- removed passthrough when no methods exists
- raise proper gateway exceptions
- added tests porting from the previous unit tests of the `RequestValidator` to ensure the functionality hasn't regressed.
- added a debug statement when the `ModelResolver` fails to find it's ref. There might be more work to do here, but that is the statement that helped me understand why my model wasn't resolving! :)

### Out of scope

While there could be an argument to include validation of api key as part of this handler as they are configured together,  they are separate enough in implementation that we can simplify readability/maintainability of the code by further breaking it down into it's own handler. All of the api key validation is done before request validation so a new handler seems like the best solution.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
