### PR TITLE
add empty integrations for NG APIGW

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration.py
@@ -4,18 +4,33 @@ from localstack.http import Response
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import RestApiInvocationContext
+from ..integrations import RestApiPluginManager
 
 LOG = logging.getLogger(__name__)
 
 
 # TODO: this will need to use ApiGatewayIntegration class, using Plugin for discoverability and a PluginManager,
 #  in order to automatically have access to defined Integrations that we can extend
-# this might be a bit closer to our AWS Skeleton in a way
 class IntegrationHandler(RestApiGatewayHandler):
+    def __init__(self):
+        self._plugin_manager: RestApiPluginManager = RestApiPluginManager.get()
+
     def __call__(
         self,
         chain: RestApiGatewayHandlerChain,
         context: RestApiInvocationContext,
         response: Response,
     ):
-        return
+        integration_type = context.resource_method["methodIntegration"]["type"].lower()
+
+        integration_plugin = self._plugin_manager.get_plugin(
+            integration_type=integration_type.lower()
+        )
+        if not integration_plugin:
+            # TODO: raise proper exception?
+            raise NotImplementedError(
+                f"This integration type is not yet supported: {integration_type}"
+            )
+
+        integration_response = integration_plugin.invoke(context)
+        response.update_from(integration_response)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration.py
@@ -4,7 +4,7 @@ from localstack.http import Response
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import RestApiInvocationContext
-from ..integrations import RestApiPluginManager
+from ..integrations import REST_API_INTEGRATIONS
 
 LOG = logging.getLogger(__name__)
 
@@ -12,25 +12,21 @@ LOG = logging.getLogger(__name__)
 # TODO: this will need to use ApiGatewayIntegration class, using Plugin for discoverability and a PluginManager,
 #  in order to automatically have access to defined Integrations that we can extend
 class IntegrationHandler(RestApiGatewayHandler):
-    def __init__(self):
-        self._plugin_manager: RestApiPluginManager = RestApiPluginManager.get()
-
     def __call__(
         self,
         chain: RestApiGatewayHandlerChain,
         context: RestApiInvocationContext,
         response: Response,
     ):
-        integration_type = context.resource_method["methodIntegration"]["type"].lower()
+        integration_type = context.resource_method["methodIntegration"]["type"]
 
-        integration_plugin = self._plugin_manager.get_plugin(
-            integration_type=integration_type.lower()
-        )
-        if not integration_plugin:
+        integration = REST_API_INTEGRATIONS.get(integration_type)
+
+        if not integration:
             # TODO: raise proper exception?
             raise NotImplementedError(
                 f"This integration type is not yet supported: {integration_type}"
             )
 
-        integration_response = integration_plugin.invoke(context)
+        integration_response = integration.invoke(context)
         response.update_from(integration_response)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/__init__.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/__init__.py
@@ -1,5 +1,15 @@
-from .core import RestApiPluginManager
+from .aws import RestApiAwsIntegration, RestApiAwsProxyIntegration
+from .http import RestApiHttpIntegration, RestApiHttpProxyIntegration
+from .mock import RestApiMockIntegration
+
+REST_API_INTEGRATIONS = {
+    RestApiAwsIntegration.name: RestApiAwsIntegration(),
+    RestApiAwsProxyIntegration.name: RestApiAwsProxyIntegration(),
+    RestApiHttpIntegration.name: RestApiHttpIntegration(),
+    RestApiHttpProxyIntegration.name: RestApiHttpProxyIntegration(),
+    RestApiMockIntegration.name: RestApiMockIntegration(),
+}
 
 __all__ = [
-    "RestApiPluginManager",
+    "REST_API_INTEGRATIONS",
 ]

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/__init__.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/__init__.py
@@ -1,0 +1,5 @@
+from .core import RestApiPluginManager
+
+__all__ = [
+    "RestApiPluginManager",
+]

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -1,10 +1,39 @@
 from .core import RestApiIntegrationPlugin
 
 
-# TODO: verify if we can create a global AWS integration type, or if we need subtypes with a sub namespace
 class RestApiAwsIntegration(RestApiIntegrationPlugin):
+    """
+    This is a REST API integration responsible to directly interact with AWS services. It uses the `uri` to
+    map the incoming request to the concerned AWS service, and can have 2 types.
+    - `path`: the request is targeting the direct URI of the AWS service, like you would with an HTTP client
+     example: For S3 GetObject call: arn:aws:apigateway:us-west-2:s3:path/{bucket}/{key}
+    - `action`: this is a simpler way, where you can pass the request parameters like you would do with an SDK, and you
+     can specify the service action (for ex. here S3 `GetObject`). It seems the request parameters can be pass as query
+     string parameters, JSON body and maybe more. TODO: verify, 2 documentation pages indicates divergent information.
+    (one indicates parameters through QS, one through request body)
+     example: arn:aws:apigateway:us-west-2:s3:action/GetObject&Bucket={bucket}&Key={key}
+
+    https://docs.aws.amazon.com/apigateway/latest/developerguide/integration-request-basic-setup.html
+
+
+    TODO: it seems we can global AWS integration type, we should not need to subclass for each service
+     we just need to separate usage between the `path` URI type and the `action` URI type.
+     - `path`, we can simply pass along the full rendered request along with specific `mocked` AWS headers
+     that are dependant of the service (retrieving for the ARN in the uri)
+     - `action`, we might need either a full Boto call or use the Boto request serializer, as it seems the request
+     parameters are expected as parameters
+    """
+
     name = "aws"
 
 
 class RestApiAwsProxyIntegration(RestApiIntegrationPlugin):
+    """
+    This is a custom, simplified REST API integration focused only on the Lambda service, with minimal modification from
+    API Gateway. It passes the incoming request almost as is, in a custom created event payload, to the configured
+    Lambda function.
+
+    https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+    """
+
     name = "aws_proxy"

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -1,7 +1,7 @@
-from .core import RestApiIntegrationPlugin
+from .core import RestApiIntegration
 
 
-class RestApiAwsIntegration(RestApiIntegrationPlugin):
+class RestApiAwsIntegration(RestApiIntegration):
     """
     This is a REST API integration responsible to directly interact with AWS services. It uses the `uri` to
     map the incoming request to the concerned AWS service, and can have 2 types.
@@ -24,10 +24,10 @@ class RestApiAwsIntegration(RestApiIntegrationPlugin):
      parameters are expected as parameters
     """
 
-    name = "aws"
+    name = "AWS"
 
 
-class RestApiAwsProxyIntegration(RestApiIntegrationPlugin):
+class RestApiAwsProxyIntegration(RestApiIntegration):
     """
     This is a custom, simplified REST API integration focused only on the Lambda service, with minimal modification from
     API Gateway. It passes the incoming request almost as is, in a custom created event payload, to the configured
@@ -36,4 +36,4 @@ class RestApiAwsProxyIntegration(RestApiIntegrationPlugin):
     https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
     """
 
-    name = "aws_proxy"
+    name = "AWS_PROXY"

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -1,0 +1,10 @@
+from .core import RestApiIntegrationPlugin
+
+
+# TODO: verify if we can create a global AWS integration type, or if we need subtypes with a sub namespace
+class RestApiAwsIntegration(RestApiIntegrationPlugin):
+    name = "aws"
+
+
+class RestApiAwsProxyIntegration(RestApiIntegrationPlugin):
+    name = "aws_proxy"

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/core.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/core.py
@@ -1,46 +1,20 @@
 from abc import abstractmethod
 
-from plux import Plugin, PluginManager
-
 from localstack.http import Response
-from localstack.utils.objects import singleton_factory
 
 from ..api import RestApiInvocationContext
 
 
-class RestApiIntegrationPlugin(Plugin):
+class RestApiIntegration:
     """
-    This REST API Integration plugin exposes an API to invoke the specific Integration with a common interface.
+    This REST API Integration exposes an API to invoke the specific Integration with a common interface.
 
     https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-integration-settings.html
     TODO: Add more abstractmethods when starting to work on the Integration handler
     """
 
-    namespace = "localstack.services.apigateway.restapi.integrations"
+    name: str
 
     @abstractmethod
     def invoke(self, context: RestApiInvocationContext) -> Response:
         pass
-
-
-class RestApiPluginManager(PluginManager[RestApiIntegrationPlugin]):
-    def __init__(self):
-        super().__init__(RestApiIntegrationPlugin.namespace)
-
-    @staticmethod
-    @singleton_factory
-    def get() -> "RestApiPluginManager":
-        """Returns a singleton instance of the manager."""
-        return RestApiPluginManager()
-
-    def get_plugin(self, integration_type: str) -> RestApiIntegrationPlugin | None:
-        """
-        Get the API Gateway REST API Integration plugin for the specific Integration Type.
-
-        :param integration_type: Integration type the REST API Integration plugin will be returned for
-        :return: RestApiIntegrationPlugin for the specified Integration Type, None if not existent.
-        """
-        try:
-            return self.load(integration_type)
-        except ValueError:
-            return None

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/core.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/core.py
@@ -1,0 +1,39 @@
+from abc import abstractmethod
+
+from plux import Plugin, PluginManager
+
+from localstack.http import Response
+from localstack.utils.objects import singleton_factory
+
+from ..api import RestApiInvocationContext
+
+
+class RestApiIntegrationPlugin(Plugin):
+    namespace = "localstack.services.apigateway.restapi.integrations"
+
+    @abstractmethod
+    def invoke(self, context: RestApiInvocationContext) -> Response:
+        pass
+
+
+class RestApiPluginManager(PluginManager[RestApiIntegrationPlugin]):
+    def __init__(self):
+        super().__init__(RestApiIntegrationPlugin.namespace)
+
+    @staticmethod
+    @singleton_factory
+    def get() -> "RestApiPluginManager":
+        """Returns a singleton instance of the manager."""
+        return RestApiPluginManager()
+
+    def get_plugin(self, integration_type: str) -> RestApiIntegrationPlugin | None:
+        """
+        Get the API Gateway REST API Integration plugin for the specific Integration Type.
+
+        :param integration_type: Integration type the REST API Integration plugin will be returned for
+        :return: RestApiIntegrationPlugin for the specified Integration Type, None if not existent.
+        """
+        try:
+            return self.load(integration_type)
+        except ValueError:
+            return None

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/core.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/core.py
@@ -9,6 +9,13 @@ from ..api import RestApiInvocationContext
 
 
 class RestApiIntegrationPlugin(Plugin):
+    """
+    This REST API Integration plugin exposes an API to invoke the specific Integration with a common interface.
+
+    https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-integration-settings.html
+    TODO: Add more abstractmethods when starting to work on the Integration handler
+    """
+
     namespace = "localstack.services.apigateway.restapi.integrations"
 
     @abstractmethod

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
@@ -2,8 +2,19 @@ from .core import RestApiIntegrationPlugin
 
 
 class RestApiHttpIntegration(RestApiIntegrationPlugin):
+    """
+    This is a REST API integration responsible to send a request to another HTTP API.
+    https://docs.aws.amazon.com/apigateway/latest/developerguide/setup-http-integrations.html#api-gateway-set-up-http-proxy-integration-on-proxy-resource
+    """
+
     name = "http"
 
 
 class RestApiHttpProxyIntegration(RestApiIntegrationPlugin):
+    """
+    This is a simplified REST API integration responsible to send a request to another HTTP API by proxying it almost
+    directly.
+    https://docs.aws.amazon.com/apigateway/latest/developerguide/setup-http-integrations.html#api-gateway-set-up-http-proxy-integration-on-proxy-resource
+    """
+
     name = "http_proxy"

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
@@ -1,0 +1,9 @@
+from .core import RestApiIntegrationPlugin
+
+
+class RestApiHttpIntegration(RestApiIntegrationPlugin):
+    name = "http"
+
+
+class RestApiHttpProxyIntegration(RestApiIntegrationPlugin):
+    name = "http_proxy"

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
@@ -1,20 +1,20 @@
-from .core import RestApiIntegrationPlugin
+from .core import RestApiIntegration
 
 
-class RestApiHttpIntegration(RestApiIntegrationPlugin):
+class RestApiHttpIntegration(RestApiIntegration):
     """
     This is a REST API integration responsible to send a request to another HTTP API.
     https://docs.aws.amazon.com/apigateway/latest/developerguide/setup-http-integrations.html#api-gateway-set-up-http-proxy-integration-on-proxy-resource
     """
 
-    name = "http"
+    name = "HTTP"
 
 
-class RestApiHttpProxyIntegration(RestApiIntegrationPlugin):
+class RestApiHttpProxyIntegration(RestApiIntegration):
     """
     This is a simplified REST API integration responsible to send a request to another HTTP API by proxying it almost
     directly.
     https://docs.aws.amazon.com/apigateway/latest/developerguide/setup-http-integrations.html#api-gateway-set-up-http-proxy-integration-on-proxy-resource
     """
 
-    name = "http_proxy"
+    name = "HTTP_PROXY"

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/mock.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/mock.py
@@ -1,7 +1,7 @@
-from .core import RestApiIntegrationPlugin
+from .core import RestApiIntegration
 
 
-class RestApiMockIntegration(RestApiIntegrationPlugin):
+class RestApiMockIntegration(RestApiIntegration):
     """
     This is a simple REST API integration but quite limited, allowing you to quickly test your APIs or return
     hardcoded responses to the client.
@@ -11,4 +11,4 @@ class RestApiMockIntegration(RestApiIntegrationPlugin):
     https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-mock-integration.html
     """
 
-    name = "mock"
+    name = "MOCK"

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/mock.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/mock.py
@@ -1,0 +1,5 @@
+from .core import RestApiIntegrationPlugin
+
+
+class RestApiMockIntegration(RestApiIntegrationPlugin):
+    name = "mock"

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/mock.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/mock.py
@@ -2,4 +2,13 @@ from .core import RestApiIntegrationPlugin
 
 
 class RestApiMockIntegration(RestApiIntegrationPlugin):
+    """
+    This is a simple REST API integration but quite limited, allowing you to quickly test your APIs or return
+    hardcoded responses to the client.
+    This integration can never return a proper response, and all the work is done with integration request and response
+    mappings.
+    This can be used to set up CORS response for `OPTIONS` requests.
+    https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-mock-integration.html
+    """
+
     name = "mock"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This is first iteration to introduce the different REST API integrations.
The first idea was to use Plugins for each different `IntegrationType`, which allows easy discovery and to extend the list of integration in a transparent way.

However, while working on the `AWS` integration type, it became apparent that we could pull off all AWS services with a single integration, with no need to subclass like the current code does (we have `KinesisIntegration`, `S3Integration`...). But it happens that the `AWS` integration has the same logic for every service, and we will work to make it possible in the new iteration. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- create the different Integration types with their base class and some documentation

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
