### PR TITLE
Fix docker image digest in startup runtime information for new runtime

### DIFF
--- a/localstack-core/localstack/runtime/main.py
+++ b/localstack-core/localstack/runtime/main.py
@@ -42,8 +42,9 @@ def print_runtime_information(in_docker: bool = False):
             inspect_result = DOCKER_CLIENT.inspect_container(container_name)
             container_id = inspect_result["Id"]
             print("LocalStack Docker container id: %s" % container_id[:12])
-            image_sha = inspect_result["Image"]
-            print("LocalStack Docker image sha: %s" % image_sha)
+            image_details = DOCKER_CLIENT.inspect_image(inspect_result["Image"])
+            digests = image_details.get("RepoDigests") or ["Unavailable"]
+            print("LocalStack Docker image sha: %s" % digests[0])
         except ContainerException:
             print(
                 "LocalStack Docker container info: Failed to inspect the LocalStack docker container. "


### PR DESCRIPTION
## Motivation

Follow-up to a minor regression from https://github.com/localstack/localstack/pull/10942

Equivalent to https://github.com/localstack/localstack/pull/10951 but for the code path of the new runtime startup now.

## Changes

- On startup the value of LocalStack Docker image sha is now again the actual digest that can be pulled from the registry. 