### PR TITLE
Add custom lambda function URLs via _custom_id_ tag

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
+++ b/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
@@ -345,7 +345,7 @@ class FunctionUrlConfig:
     function_arn: str  # fully qualified ARN
     function_name: str  # resolved name
     cors: Cors
-    url_id: str  # generated unique subdomain id  e.g. pfn5bdb2dl5mzkbn6eb2oi3xfe0nthdn
+    url_id: str  # Custom URL (via tag), or generated unique subdomain id  e.g. pfn5bdb2dl5mzkbn6eb2oi3xfe0nthdn
     url: str  # full URL (e.g. "https://pfn5bdb2dl5mzkbn6eb2oi3xfe0nthdn.lambda-url.eu-west-3.on.aws/")
     auth_type: FunctionUrlAuthType
     creation_time: str  # time

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -213,6 +213,8 @@ LAMBDA_DEFAULT_MEMORY_SIZE = 128
 LAMBDA_TAG_LIMIT_PER_RESOURCE = 50
 LAMBDA_LAYERS_LIMIT_PER_FUNCTION = 5
 
+TAG_KEY_CUSTOM_URL = "_custom_id_"
+
 
 class LambdaProvider(LambdaApi, ServiceLifecycleHook):
     lambda_service: LambdaService
@@ -2069,8 +2071,31 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             else api_utils.unqualified_lambda_arn(function_name, account_id, region)
         )
 
-        # create function URL config
-        url_id = api_utils.generate_random_url_id()
+        # The url_id is the subdomain used for the URL we're creating. This
+        # is either created randomly (as in AWS), or can be passed as a tag
+        # to the lambda itself (localstack-only).
+        url_id: str
+        if fn.tags is None:
+            url_id = api_utils.generate_random_url_id()
+
+        else:
+            # Note: currently this only works with $LATEST. However, it would
+            # be nice if we could specify a custom URL for any alias being
+            # passed via the qualifier parameter. Once a strategy for that has
+            # been decided on, it can go here.
+            if normalized_qualifier == "$LATEST" and TAG_KEY_CUSTOM_URL in fn.tags:
+                # Note: I really wanted to add verification here that the
+                # url_id is unique, so we could surface that to the user ASAP.
+                # However, it seems like that information isn't available yet,
+                # since (as far as I can tell) we call
+                # self.router.register_routes() once, in a single shot, for all
+                # of the routes -- and we need to verify that it's unique not
+                # just for this particular lambda function, but for the entire
+                # lambda provider. Therefore... that idea proved non-trivial!
+                url_id = fn.tags[TAG_KEY_CUSTOM_URL]
+
+            else:
+                url_id = api_utils.generate_random_url_id()
 
         host_definition = localstack_host(custom_port=config.GATEWAY_LISTEN[0].port)
         fn.function_url_configs[normalized_qualifier] = FunctionUrlConfig(

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -2099,7 +2099,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 url_id = fn.tags[TAG_KEY_CUSTOM_URL]
                 if not TAG_KEY_CUSTOM_URL_VALIDATOR.match(url_id):
                     raise ValidationException(
-                        "1 validation error detected: invalid _custom_id_ value"
+                        f"1 validation error detected: invalid _custom_id_ value (`{url_id}` is not a valid subdomain)."
                     )
 
             else:

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -217,7 +217,7 @@ LAMBDA_LAYERS_LIMIT_PER_FUNCTION = 5
 TAG_KEY_CUSTOM_URL = "_custom_id_"
 # Requirements (from RFC3986 & co): not longer than 63, first char must be
 # alpha, then alphanumeric or hyphen, except cannot start or end with hyphen
-TAG_KEY_CUSTOM_URL_VALIDATOR = re.compile(r'^[A-Za-z]([A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$')
+TAG_KEY_CUSTOM_URL_VALIDATOR = re.compile(r"^[A-Za-z]([A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$")
 
 
 class LambdaProvider(LambdaApi, ServiceLifecycleHook):

--- a/localstack-core/localstack/services/lambda_/urlrouter.py
+++ b/localstack-core/localstack/services/lambda_/urlrouter.py
@@ -66,7 +66,10 @@ class FunctionUrlRouter:
             store = lambda_stores[account_id][region]
             for fn in store.functions.values():
                 for url_config in fn.function_url_configs.values():
-                    if url_config.url_id == api_id:
+                    # AWS tags are case sensitive, but domains are not.
+                    # So we normalize them here to maximize both AWS and RFC
+                    # conformance
+                    if url_config.url_id.lower() == api_id.lower():
                         lambda_url_config = url_config
 
         # TODO: check if errors are different when the URL has existed previously

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -853,7 +853,9 @@ class TestLambdaURL:
         ],
     )
     @markers.aws.validated
-    def test_lambda_url_invocation(self, create_lambda_function, snapshot, returnvalue, custom_id, aws_client):
+    def test_lambda_url_invocation(
+        self, create_lambda_function, snapshot, returnvalue, custom_id, aws_client
+    ):
         snapshot.add_transformer(
             snapshot.transform.key_value(
                 "FunctionUrl", "<function-url>", reference_replacement=False
@@ -875,7 +877,7 @@ class TestLambdaURL:
             func_name=function_name,
             handler_file=handler_file,
             runtime=Runtime.python3_12,
-            Tags=tags
+            Tags=tags,
         )
 
         url_config = aws_client.lambda_.create_function_url_config(

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -4035,10 +4035,11 @@ class TestLambdaUrl:
         )
 
         caplog.clear()
-        url_config_created = aws_client.lambda_.create_function_url_config(
-            FunctionName=function_name,
-            AuthType="NONE",
-        )
+        with caplog.at_level(logging.INFO):
+            url_config_created = aws_client.lambda_.create_function_url_config(
+                FunctionName=function_name,
+                AuthType="NONE",
+            )
         assert any("Invalid custom ID tag value" in record.message for record in caplog.records)
         assert f"://{custom_id_value}.lambda-url." not in url_config_created["FunctionUrl"]
 

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -28,6 +28,7 @@ from localstack_snapshot.snapshots.transformer import SortingTransformer
 from localstack import config
 from localstack.aws.api.lambda_ import Architecture, LogFormat, Runtime
 from localstack.services.lambda_.api_utils import ARCHITECTURES
+from localstack.services.lambda_.provider import TAG_KEY_CUSTOM_URL
 from localstack.services.lambda_.runtimes import (
     ALL_RUNTIMES,
     SNAP_START_SUPPORTED_RUNTIMES,
@@ -3997,6 +3998,26 @@ class TestLambdaUrl:
         with pytest.raises(aws_client.lambda_.exceptions.ResourceNotFoundException) as ex:
             aws_client.lambda_.get_function_url_config(FunctionName=function_name)
         snapshot.match("failed_getter", ex.value.response)
+
+    @markers.aws.only_localstack
+    def test_create_url_config_custom_id_tag(self, create_lambda_function, aws_client):
+        custom_id_value = "my_custom_subdomain"
+
+        function_name = f"test-function-{short_uid()}"
+        create_lambda_function(
+            func_name=function_name,
+            zip_file=testutil.create_zip_file(TEST_LAMBDA_NODEJS, get_content=True),
+            runtime=Runtime.nodejs20_x,
+            handler="lambda_handler.handler",
+            Tags={TAG_KEY_CUSTOM_URL: custom_id_value},
+        )
+        url_config_created = aws_client.lambda_.create_function_url_config(
+            FunctionName=function_name,
+            AuthType="NONE",
+        )
+        # Since we're not comparing the entire string, this should be robust to
+        # region changes, https vs http, etc
+        assert f"://{custom_id_value}.lambda-url." in url_config_created["FunctionUrl"]
 
 
 class TestLambdaSizeLimits:

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -4039,7 +4039,7 @@ class TestLambdaUrl:
             FunctionName=function_name,
             AuthType="NONE",
         )
-        assert any("Invalid custom ID tag value" in record.mesage for record in caplog.records)
+        assert any("Invalid custom ID tag value" in record.message for record in caplog.records)
         assert f"://{custom_id_value}.lambda-url." not in url_config_created["FunctionUrl"]
 
 


### PR DESCRIPTION
## Motivation

This PR allows users to apply a tag to a lambda function that results in a deterministic, user-specified function URL when subsequently calling the ``create_function_url_config`` endpoint.

This is useful, for example, in static scripts or code samples, where fetching the randomly-generated ID from the created URL is undesirable.

**Note: I'll create a separate PR for updating the docs accordingly.**

## Changes

+ Added module global for the tag key
+ Updated the ``create_function_url_config`` endpoint to find the tag and, if available, use it
+ Added a test to verify desired behavior

## Testing
 
In addition to the added unit test, I also verified locally that it works (using ``awslocal``).

## Out of scope

Lambda functions can actually have more than one custom URL:
+ URLs are associated with a ``(function, [version alias])`` pair
+ you can't create a new function URL with a duplicate pairing, but you *can* create a new URL for a different alias of the same function. For example, a function could have ``https://foo-latest.lambda-url...`` pointing to ``(my_func_foo, '$LATEST')`` and ``https://foo-prod.lambda-url...`` pointing to ``(my_func_foo, 1)``
+ (Note that neither the function URL itself, nor the function alias, can be tagged)

This was deemed out-of-scope, but would be relatively straightforward to add, for example, by regex-based tag matching.