### PR TITLE
Avoid circleci test-runner failure if no tests are run on that runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,6 +412,10 @@ jobs:
               TEST_FILES=$(circleci tests glob "tests/aws/**/test_*.py" "tests/integration/**/test_*.py" | PYTHONPATH=localstack-core python -m localstack.testing.testselection.scripts.filter_by_test_selection target/testselection/test-selection.txt | circleci tests split --verbose --split-by=timings | tr '\n' ' ')
             fi
             echo $TEST_FILES
+            if [[ -z "$TEST_FILES" ]] ; then
+              echo "Skipping test execution because no tests were selected"
+              circleci-agent step halt
+            fi
             PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}-o junit_family=legacy --junitxml=target/reports/test-report-<< parameters.platform >>-${CIRCLE_NODE_INDEX}.xml" \
             COVERAGE_FILE="target/coverage/.coverage.<< parameters.platform >>.${CIRCLE_NODE_INDEX}" \
             TEST_PATH=$TEST_FILES \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,6 @@ jobs:
                   else
                     source .venv/bin/activate
                     PYTHONPATH=localstack-core python -m localstack.testing.testselection.scripts.generate_test_selection /tmp/workspace/repo target/testselection/test-selection.txt --pr-url $CI_PULL_REQUEST
-                    echo "tests/aws/services/iam/" > target/testselection/test-selection.txt
                     cat target/testselection/test-selection.txt
                   fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,12 +416,13 @@ jobs:
             if [[ -z "$TEST_FILES" ]] ; then
               echo "Skipping test execution because no tests were selected"
               circleci-agent step halt
+            else
+              PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}-o junit_family=legacy --junitxml=target/reports/test-report-<< parameters.platform >>-${CIRCLE_NODE_INDEX}.xml" \
+              COVERAGE_FILE="target/coverage/.coverage.<< parameters.platform >>.${CIRCLE_NODE_INDEX}" \
+              TEST_PATH=$TEST_FILES \
+              DEBUG=1 \
+              make docker-run-tests
             fi
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}-o junit_family=legacy --junitxml=target/reports/test-report-<< parameters.platform >>-${CIRCLE_NODE_INDEX}.xml" \
-            COVERAGE_FILE="target/coverage/.coverage.<< parameters.platform >>.${CIRCLE_NODE_INDEX}" \
-            TEST_PATH=$TEST_FILES \
-            DEBUG=1 \
-            make docker-run-tests
       - store_test_results:
           path: target/reports/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
                   else
                     source .venv/bin/activate
                     PYTHONPATH=localstack-core python -m localstack.testing.testselection.scripts.generate_test_selection /tmp/workspace/repo target/testselection/test-selection.txt --pr-url $CI_PULL_REQUEST
+                    echo "tests/aws/services/iam/" > target/testselection/test-selection.txt
                     cat target/testselection/test-selection.txt
                   fi
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
During executing the tests of PR #11097, I noticed that the pipeline failed on runners which did not have a single test selected:
https://app.circleci.com/pipelines/github/localstack/localstack/26179/workflows/2df3bb7b-5594-41db-ac5a-3009c0ed19b9/jobs/221845

The `TEST_PATH` ended up being empty, so all tests are selected - leading to diverse import and pytest errors.

To circumvent that, I added (thanks @silv-io for your help with this), a skip step, so the pipeline would not be executed, to be discussed.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Skip an integration test run on a runner if no tests are selected.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
