### PR TITLE
Add pagination for SFN ListStateMachines, ListStateMachineVersions, and ListExecutions

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/stepfunctions_utils.py
+++ b/localstack-core/localstack/services/stepfunctions/stepfunctions_utils.py
@@ -1,9 +1,12 @@
+import base64
 import logging
 from typing import Dict
 
+from localstack.aws.api.stepfunctions import ValidationException
 from localstack.aws.connect import connect_to
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.common import retry
+from localstack.utils.strings import to_bytes, to_str
 
 LOG = logging.getLogger(__name__)
 
@@ -23,3 +26,44 @@ def await_sfn_execution_result(execution_arn: str, timeout_secs: int = 60) -> Di
         return result
 
     return retry(_get_result, sleep=2, retries=timeout_secs / 2)
+
+
+def get_next_page_token_from_arn(resource_arn: str) -> str:
+    return to_str(base64.b64encode(to_bytes(resource_arn)))
+
+
+_DEFAULT_SFN_MAX_RESULTS: int = 100
+
+
+def normalise_max_results(max_results: int = 100) -> int:
+    if not max_results:
+        return _DEFAULT_SFN_MAX_RESULTS
+    return max_results
+
+
+def assert_pagination_parameters_valid(
+    max_results: int,
+    next_token: str,
+    next_token_length_limit: int = 1024,
+    max_results_upper_limit: int = 1000,
+) -> tuple[int, str]:
+    validation_errors = []
+
+    match max_results:
+        case int() if max_results > max_results_upper_limit:
+            validation_errors.append(
+                f"Value '{max_results}' at 'maxResults' failed to satisfy constraint: "
+                f"Member must have value less than or equal to {max_results_upper_limit}"
+            )
+
+    match next_token:
+        case str() if len(next_token) > next_token_length_limit:
+            validation_errors.append(
+                f"Value '{next_token}' at 'nextToken' failed to satisfy constraint: "
+                f"Member must have length less than or equal to {next_token_length_limit}"
+            )
+
+    if validation_errors:
+        errors_message = "; ".join(validation_errors)
+        message = f"{len(validation_errors)} validation {'errors' if len(validation_errors) > 1 else 'error'} detected: {errors_message}"
+        raise ValidationException(message)

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
@@ -1881,5 +1881,360 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_list_executions_versions_pagination": {
+    "recorded-date": "01-07-2024, 12:54:55",
+    "recorded-content": {
+      "list-executions-page-1": {
+        "executions": [
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_12idx>",
+            "name": "<ExecArnPart_12idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_11idx>",
+            "name": "<ExecArnPart_11idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_10idx>",
+            "name": "<ExecArnPart_10idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_9idx>",
+            "name": "<ExecArnPart_9idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_8idx>",
+            "name": "<ExecArnPart_8idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_7idx>",
+            "name": "<ExecArnPart_7idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_6idx>",
+            "name": "<ExecArnPart_6idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_5idx>",
+            "name": "<ExecArnPart_5idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_4idx>",
+            "name": "<ExecArnPart_4idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_3idx>",
+            "name": "<ExecArnPart_3idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          }
+        ],
+        "nextToken": "<next-token:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-execution-page-2": {
+        "executions": [
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_2idx>",
+            "name": "<ExecArnPart_2idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_1idx>",
+            "name": "<ExecArnPart_1idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
+            "name": "<ExecArnPart_0idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-executions-invalid-param-too-large": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '1001' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000"
+        },
+        "message": "1 validation error detected: Value '1001' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "list-executions-invalid-param-short-nextToken": {
+        "exception_typename": "ParamValidationError",
+        "exception_value": "Parameter validation failed:\nInvalid length for parameter nextToken, value: 0, valid min length: 1"
+      },
+      "list-executions-invalid-param-long-nextToken": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '<invalid_token_3097_chars>' at 'nextToken' failed to satisfy constraint: Member must have length less than or equal to 3096"
+        },
+        "message": "1 validation error detected: Value '<invalid_token_3097_chars>' at 'nextToken' failed to satisfy constraint: Member must have length less than or equal to 3096",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "deletion_resp": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_list_executions_pagination": {
+    "recorded-date": "01-07-2024, 12:33:00",
+    "recorded-content": {
+      "list-executions-page-1": {
+        "executions": [
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_12idx>",
+            "name": "<ExecArnPart_12idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_11idx>",
+            "name": "<ExecArnPart_11idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_10idx>",
+            "name": "<ExecArnPart_10idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_9idx>",
+            "name": "<ExecArnPart_9idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_8idx>",
+            "name": "<ExecArnPart_8idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_7idx>",
+            "name": "<ExecArnPart_7idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_6idx>",
+            "name": "<ExecArnPart_6idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_5idx>",
+            "name": "<ExecArnPart_5idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_4idx>",
+            "name": "<ExecArnPart_4idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_3idx>",
+            "name": "<ExecArnPart_3idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          }
+        ],
+        "nextToken": "<next-token:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-executions-page-2": {
+        "executions": [
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_2idx>",
+            "name": "<ExecArnPart_2idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_1idx>",
+            "name": "<ExecArnPart_1idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          },
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
+            "name": "<ExecArnPart_0idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-executions-invalid-param-too-large": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '1001' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000"
+        },
+        "message": "1 validation error detected: Value '1001' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "list-executions-invalid-param-short-nextToken": {
+        "exception_typename": "ParamValidationError",
+        "exception_value": "Parameter validation failed:\nInvalid length for parameter nextToken, value: 0, valid min length: 1"
+      },
+      "list-executions-invalid-param-long-nextToken": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '<invalid_token_3097_chars>' at 'nextToken' failed to satisfy constraint: Member must have length less than or equal to 3096"
+        },
+        "message": "1 validation error detected: Value '<invalid_token_3097_chars>' at 'nextToken' failed to satisfy constraint: Member must have length less than or equal to 3096",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "deletion_resp": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
@@ -1768,5 +1768,118 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_list_sms_pagination": {
+    "recorded-date": "01-07-2024, 12:04:17",
+    "recorded-content": {
+      "list-state-machines-page-1": [
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+          "name": "<ArnPart_0idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        },
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_10idx>",
+          "name": "<ArnPart_10idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        },
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_11idx>",
+          "name": "<ArnPart_11idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        },
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_12idx>",
+          "name": "<ArnPart_12idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        },
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_1idx>",
+          "name": "<ArnPart_1idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        },
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_2idx>",
+          "name": "<ArnPart_2idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        },
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_3idx>",
+          "name": "<ArnPart_3idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        },
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_4idx>",
+          "name": "<ArnPart_4idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        },
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_5idx>",
+          "name": "<ArnPart_5idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        },
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_6idx>",
+          "name": "<ArnPart_6idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        }
+      ],
+      "list-state-machines-page-2": [
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_7idx>",
+          "name": "<ArnPart_7idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        },
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_8idx>",
+          "name": "<ArnPart_8idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        },
+        {
+          "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_9idx>",
+          "name": "<ArnPart_9idx>",
+          "type": "STANDARD",
+          "creationDate": "datetime"
+        }
+      ],
+      "list-state-machines-invalid-param-too-large": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '1001' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000"
+        },
+        "message": "1 validation error detected: Value '1001' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "list-state-machines-invalid-param-short-nextToken": {
+        "exception_typename": "ParamValidationError",
+        "exception_value": "Parameter validation failed:\nInvalid length for parameter nextToken, value: 0, valid min length: 1"
+      },
+      "list-state-machines-invalid-param-long-nextToken": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '<invalid_token_1025_chars>' at 'nextToken' failed to satisfy constraint: Member must have length less than or equal to 1024"
+        },
+        "message": "1 validation error detected: Value '<invalid_token_1025_chars>' at 'nextToken' failed to satisfy constraint: Member must have length less than or equal to 1024",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
@@ -89,6 +89,12 @@
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_list_execution_no_such_state_machine": {
     "last_validated_date": "2024-03-08T10:51:46+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_list_executions_pagination": {
+    "last_validated_date": "2024-07-01T12:33:00+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_list_executions_versions_pagination": {
+    "last_validated_date": "2024-07-01T12:54:55+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_list_sms": {
     "last_validated_date": "2023-08-29T17:40:19+00:00"
   },

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
@@ -92,6 +92,9 @@
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_list_sms": {
     "last_validated_date": "2023-08-29T17:40:19+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_list_sms_pagination": {
+    "last_validated_date": "2024-07-01T12:04:17+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_start_execution": {
     "last_validated_date": "2023-06-22T11:52:39+00:00"
   },

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py
@@ -132,6 +132,122 @@ class TestSnfApiVersioning:
         sfn_snapshot.match("describe_resp", describe_resp)
 
     @markers.aws.validated
+    def test_list_state_machine_versions_pagination(
+        self,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+        aws_client,
+    ):
+        snf_role_arn = create_iam_role_for_sfn()
+        sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "snf_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition_str = json.dumps(definition)
+
+        sm_name = f"statemachine_{short_uid()}"
+        creation_resp_1 = create_state_machine(
+            name=sm_name, definition=definition_str, roleArn=snf_role_arn
+        )
+        sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_create_arn(creation_resp_1, 0))
+        sfn_snapshot.match("creation_resp_1", creation_resp_1)
+        state_machine_arn = creation_resp_1["stateMachineArn"]
+
+        state_machine_version_arns = list()
+        for revision_no in range(1, 14):
+            definition["Comment"] = f"{definition['Comment']}-R{revision_no}"
+            definition_raw_str = json.dumps(definition)
+
+            update_resp_1 = aws_client.stepfunctions.update_state_machine(
+                stateMachineArn=state_machine_arn, definition=definition_raw_str, publish=True
+            )
+
+            state_machine_version_arn: str = update_resp_1["stateMachineVersionArn"]
+            assert state_machine_version_arn == f"{state_machine_arn}:{revision_no}"
+
+            state_machine_version_arns.append(state_machine_version_arn)
+
+            await_state_machine_version_listed(
+                aws_client.stepfunctions, state_machine_arn, update_resp_1["stateMachineVersionArn"]
+            )
+
+        page_1_state_machine_versions = aws_client.stepfunctions.list_state_machine_versions(
+            stateMachineArn=state_machine_arn,
+            maxResults=10,
+        )
+        sfn_snapshot.add_transformer(sfn_snapshot.transform.key_value("nextToken"))
+        sfn_snapshot.match("list-state-machine-versions-page-1", page_1_state_machine_versions)
+
+        page_2_state_machine_versions = aws_client.stepfunctions.list_state_machine_versions(
+            stateMachineArn=state_machine_arn,
+            maxResults=3,
+            nextToken=page_1_state_machine_versions["nextToken"],
+        )
+        sfn_snapshot.match("list-state-machine-versions-page-2", page_2_state_machine_versions)
+
+        assert all(
+            sm not in page_1_state_machine_versions["stateMachineVersions"]
+            for sm in page_2_state_machine_versions["stateMachineVersions"]
+        )
+
+        # maxResults value is out of bounds
+        with pytest.raises(Exception) as err:
+            aws_client.stepfunctions.list_state_machine_versions(
+                stateMachineArn=state_machine_arn, maxResults=1001
+            )
+        sfn_snapshot.match(
+            "list-state-machine-versions-invalid-param-too-large", err.value.response
+        )
+
+        # nextToken is too short
+        with pytest.raises(Exception) as err:
+            aws_client.stepfunctions.list_state_machine_versions(
+                stateMachineArn=state_machine_arn, nextToken=""
+            )
+        sfn_snapshot.match(
+            "list-state-machine-versions-param-short-nextToken",
+            {"exception_typename": err.typename, "exception_value": err.value},
+        )
+
+        # nextToken is too long
+        invalid_long_token = "x" * 1025
+        with pytest.raises(Exception) as err:
+            aws_client.stepfunctions.list_state_machine_versions(
+                stateMachineArn=state_machine_arn, nextToken=invalid_long_token
+            )
+        sfn_snapshot.add_transformer(
+            RegexTransformer(invalid_long_token, f"<invalid_token_{len(invalid_long_token)}_chars>")
+        )
+        sfn_snapshot.match(
+            "list-state-machine-versions-invalid-param-long-nextToken", err.value.response
+        )
+
+        # where maxResults is 0, the default of 100 should be returned
+        state_machines_default_all_returned = aws_client.stepfunctions.list_state_machine_versions(
+            stateMachineArn=state_machine_arn, maxResults=0
+        )
+        assert len(state_machines_default_all_returned["stateMachineVersions"]) == 13
+        assert "nextToken" not in state_machines_default_all_returned
+
+        for state_machine_version_arn in state_machine_version_arns:
+            aws_client.stepfunctions.delete_state_machine_version(
+                stateMachineVersionArn=state_machine_version_arn,
+            )
+
+        for state_machine_version_arn in state_machine_version_arns:
+            await_state_machine_version_not_listed(
+                aws_client.stepfunctions, state_machine_arn, state_machine_version_arn
+            )
+
+        ls_with_no_state_machine_versions_present = (
+            aws_client.stepfunctions.list_state_machine_versions(
+                stateMachineArn=state_machine_arn, maxResults=len(state_machine_version_arns)
+            )
+        )
+
+        assert len(ls_with_no_state_machine_versions_present["stateMachineVersions"]) == 0
+
+    @markers.aws.validated
     def test_list_delete_version(
         self,
         create_iam_role_for_sfn,

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.snapshot.json
@@ -808,5 +808,113 @@
         "exception_value": "An error occurred (InvalidArn) when calling the PublishStateMachineVersion operation: Invalid Arn: 'Invalid ARN prefix: invalid_arn'"
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py::TestSnfApiVersioning::test_list_state_machine_versions_pagination": {
+    "recorded-date": "01-07-2024, 12:20:00",
+    "recorded-content": {
+      "creation_resp_1": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-state-machine-versions-page-1": {
+        "nextToken": "<next-token:1>",
+        "stateMachineVersions": [
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:13"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:12"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:11"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:10"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:9"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:8"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:7"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:6"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:5"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:4"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-state-machine-versions-page-2": {
+        "stateMachineVersions": [
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:3"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:2"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-state-machine-versions-invalid-param-too-large": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '1001' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000"
+        },
+        "message": "1 validation error detected: Value '1001' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "list-state-machine-versions-param-short-nextToken": {
+        "exception_typename": "ParamValidationError",
+        "exception_value": "Parameter validation failed:\nInvalid length for parameter nextToken, value: 0, valid min length: 1"
+      },
+      "list-state-machine-versions-invalid-param-long-nextToken": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '<invalid_token_1025_chars>' at 'nextToken' failed to satisfy constraint: Member must have length less than or equal to 1024"
+        },
+        "message": "1 validation error detected: Value '<invalid_token_1025_chars>' at 'nextToken' failed to satisfy constraint: Member must have length less than or equal to 1024",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.validation.json
@@ -29,6 +29,9 @@
   "tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py::TestSnfApiVersioning::test_list_delete_version": {
     "last_validated_date": "2023-08-11T10:10:11+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py::TestSnfApiVersioning::test_list_state_machine_versions_pagination": {
+    "last_validated_date": "2024-07-01T12:20:00+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py::TestSnfApiVersioning::test_publish_state_machine_version": {
     "last_validated_date": "2023-08-11T10:10:42+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Improve parity of StepFunctions provider by adding pagination for [ListStateMachines](https://docs.aws.amazon.com/step-functions/latest/apireference/API_ListStateMachines.html), [ListStateMachineVersions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_ListStateMachineVersions.html), and [ListExecutions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_ListExecutions.html).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Add pagination functionality and parameter validation checks to `list_state_machines`, `list_state_machine_versions`, and `list_executions` using `PaginatedList`.
 - Fix in `list_state_machines`: `ListStateMachine` response now returns `stateMachine` items in alphanumeric order as opposed to by datetime.
 - Fixed typo in `list_state_machine_versions` when raising a `RuntimeError` exception.

## Testing
In order to test pagination functionality, several new integration tests have been added with a `_pagination` suffix:
- Test `list_state_machines` with `test_list_sms_pagination`
- Test `list_state_machine_versions` with `test_list_state_machine_versions_pagination`)
- Test `list_executions` with `test_list_executions_pagination` and `test_list_executions_versions_pagination`
