### PR TITLE
add context variables and stage variables to API NG context

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -65,6 +65,8 @@ class RestApiInvocationContext(RequestContext):
     """The REST API identifier of the invoked API"""
     stage: Optional[str]
     """The REST API stage linked to this invocation"""
+    deployment_id: Optional[str]
+    """The REST API deployment linked to this invocation"""
     region: Optional[str]
     """The region the REST API is living in."""
     account_id: Optional[str]
@@ -87,6 +89,7 @@ class RestApiInvocationContext(RequestContext):
         self.deployment = None
         self.api_id = None
         self.stage = None
+        self.deployment_id = None
         self.account_id = None
         self.region = None
         self.invocation_request = None

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -8,6 +8,8 @@ from werkzeug.datastructures import Headers
 from localstack.aws.api.apigateway import Method, Resource
 from localstack.services.apigateway.models import RestApiDeployment
 
+from .variables import ContextVariables, LoggingContextVariables
+
 
 class InvocationRequest(TypedDict, total=False):
     http_method: Optional[HTTPMethod]
@@ -23,6 +25,23 @@ class InvocationRequest(TypedDict, total=False):
     # TODO: need to check if we need the raw headers (as it's practical for casing reasons)
     raw_headers: Optional[Headers]
     """Raw headers using the Headers datastructure which allows access with no regards to casing"""
+    headers: Optional[dict[str, str]]
+    """Headers of the request"""
+    multi_value_query_string_parameters: Optional[dict[str, list[str]]]
+    """Multi value query string parameters of the request"""
+    multi_value_headers: Optional[dict[str, list[str]]]
+    """Multi value headers of the request"""
+    body: Optional[bytes]
+    """Body content of the request"""
+
+
+class IntegrationRequest(TypedDict, total=False):
+    http_method: Optional[HTTPMethod]
+    """HTTP Method of the incoming request"""
+    uri: Optional[str]
+    """URI of the integration"""
+    query_string_parameters: Optional[dict[str, str]]
+    """Query string parameters of the request"""
     headers: Optional[dict[str, str]]
     """Headers of the request"""
     multi_value_query_string_parameters: Optional[dict[str, list[str]]]
@@ -79,11 +98,6 @@ class IdentityContext(TypedDict, total=False):
     """The Amazon Resource Name (ARN) of the effective user identified after authentication."""
 
 
-class ContextVariables(TypedDict, total=False):
-    authorizer: AuthorizerContext
-    identity: IdentityContext
-
-
 class RestApiInvocationContext(RequestContext):
     """
     This context is going to be used to pass relevant information across an API Gateway invocation.
@@ -105,8 +119,14 @@ class RestApiInvocationContext(RequestContext):
     """The resource the invocation matched"""  # TODO: verify if needed through the invocation
     resource_method: Optional[Method]
     """The method of the resource the invocation matched"""
+    stage_variables: Optional[dict[str, str]]
+    """The Stage variables, also used in parameters mapping and mapping templates"""
     context_variables: Optional[ContextVariables]
-    """Variables can be used in data models, authorizers, mapping templates, and CloudWatch access logging."""
+    """The $context used in data models, authorizers, mapping templates, and CloudWatch access logging"""
+    logging_context_variables: Optional[LoggingContextVariables]
+    """Additional $context variables available only for access logging, not yet implemented"""
+    integration_request: Optional[IntegrationRequest]
+    """Contains the data needed to construct an HTTP request to an Integration"""
 
     def __init__(self, request: Request):
         super().__init__(request)
@@ -118,4 +138,7 @@ class RestApiInvocationContext(RequestContext):
         self.invocation_request = None
         self.resource = None
         self.resource_method = None
+        self.stage_variables = None
         self.context_variables = None
+        self.logging_context_variables = None
+        self.integration_request = None

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -52,52 +52,6 @@ class IntegrationRequest(TypedDict, total=False):
     """Body content of the request"""
 
 
-class AuthorizerContext(TypedDict, total=False):
-    # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
-    claims: Optional[dict[str, str]]
-    """Claims returned from the Amazon Cognito user pool after the method caller is successfully authenticated"""
-    principal_id: Optional[str]
-    """The principal user identification associated with the token sent by the client and returned from an API Gateway Lambda authorizer"""
-    context: Optional[dict[str, str]]
-    """The stringified value of the specified key-value pair of the context map returned from an API Gateway Lambda authorizer function"""
-
-
-class IdentityContext(TypedDict, total=False):
-    # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
-    accountId: Optional[str]
-    """The AWS account ID associated with the request."""
-    apiKey: Optional[str]
-    """For API methods that require an API key, this variable is the API key associated with the method request."""
-    apiKeyId: Optional[str]
-    """The API key ID associated with an API request that requires an API key."""
-    caller: Optional[str]
-    """The principal identifier of the caller that signed the request. Supported for resources that use IAM authorization."""
-    cognitoAuthenticationProvider: Optional[str]
-    """A comma-separated list of the Amazon Cognito authentication providers used by the caller making the request"""
-    cognitoAuthenticationType: Optional[str]
-    """The Amazon Cognito authentication type of the caller making the request"""
-    cognitoIdentityId: Optional[str]
-    """The Amazon Cognito identity ID of the caller making the request"""
-    cognitoIdentityPoolId: Optional[str]
-    """The Amazon Cognito identity pool ID of the caller making the request"""
-    principalOrgId: Optional[str]
-    """The AWS organization ID."""
-    sourceIp: Optional[str]
-    """The source IP address of the immediate TCP connection making the request to the API Gateway endpoint"""
-    clientCert: Optional[dict[str, str]]
-    """Certificate that a client presents. Present only in access logs if mutual TLS authentication fails."""
-    vpcId: Optional[str]
-    """The VPC ID of the VPC making the request to the API Gateway endpoint."""
-    vpceId: Optional[str]
-    """The VPC endpoint ID of the VPC endpoint making the request to the API Gateway endpoint."""
-    user: Optional[str]
-    """The principal identifier of the user that will be authorized against resource access for resources that use IAM authorization."""
-    userAgent: Optional[str]
-    """The User-Agent header of the API caller."""
-    userArn: Optional[str]
-    """The Amazon Resource Name (ARN) of the effective user identified after authentication."""
-
-
 class RestApiInvocationContext(RequestContext):
     """
     This context is going to be used to pass relevant information across an API Gateway invocation.

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -1,5 +1,6 @@
 import logging
 
+from localstack.aws.api.apigateway import Integration, IntegrationType
 from localstack.http import Response
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
@@ -20,4 +21,20 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
         context: RestApiInvocationContext,
         response: Response,
     ):
+        integration: Integration = context.resource_method["methodIntegration"]
+        integration_type = integration["type"]
+
+        if integration_type in (IntegrationType.AWS_PROXY, IntegrationType.HTTP_PROXY):
+            # `PROXY` types cannot use integration mapping templates
+            # TODO: check if PROXY can still parameters mapping and substitution in URI for example?
+            # See
+            return
+
+        if integration_type == IntegrationType.MOCK:
+            # TODO: only apply partial rendering of the VTL context
+            return
+
+        # TODO: apply rendering, and attach the Integration Request needed for the Integration to construct its HTTP
+        #  request to send
+
         return

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -119,6 +119,7 @@ class InvocationRequestParser(RestApiGatewayHandler):
         domain_prefix = domain_name.split(".")[0]
         now = datetime.datetime.now()
 
+        # TODO: verify which values needs to explicitly have None set
         context_variables = ContextVariables(
             accountId=context.account_id,
             apiId=context.api_id,

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -115,7 +115,7 @@ class InvocationRequestParser(RestApiGatewayHandler):
     @staticmethod
     def create_context_variables(context: RestApiInvocationContext) -> ContextVariables:
         invocation_request: InvocationRequest = context.invocation_request
-        domain_name = invocation_request["headers"].get("Host", "")
+        domain_name = invocation_request["raw_headers"].get("Host", "")
         domain_prefix = domain_name.split(".")[0]
         now = datetime.datetime.now()
 
@@ -126,11 +126,13 @@ class InvocationRequestParser(RestApiGatewayHandler):
             deploymentId=context.deployment_id,
             domainName=domain_name,
             domainPrefix=domain_prefix,
-            extendedRequestId=short_uid(),
+            extendedRequestId=short_uid(),  # TODO: use snapshot tests to verify format
             httpMethod=invocation_request["http_method"],
-            path=invocation_request["path"],
+            path=invocation_request[
+                "path"
+            ],  # TODO: check if we need the raw path? with forward slashes
             protocol="HTTP/1.1",
-            requestId=short_uid(),
+            requestId=short_uid(),  # TODO: use snapshot tests to verify format
             requestTime=timestamp(time=now, format=REQUEST_TIME_DATE_FORMAT),
             requestTimeEpoch=int(now.timestamp() * 1000),
             stage=context.stage,

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -37,8 +37,11 @@ class InvocationRequestParser(RestApiGatewayHandler):
         # then we can create the ContextVariables, used throughout the invocation as payload and to render authorizer
         # payload, mapping templates and such.
         context.context_variables = self.create_context_variables(context)
+        # TODO: maybe adjust the logging
+        LOG.debug("Initializing $context='%s'", context.context_variables)
         # then populate the stage variables
         context.stage_variables = self.fetch_stage_variables(context)
+        LOG.debug("Initializing $stageVariables='%s'", context.stage_variables)
 
     def create_invocation_request(self, request: Request) -> InvocationRequest:
         params, multi_value_params = self._get_single_and_multi_values_from_multidict(request.args)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
@@ -18,6 +18,7 @@ from localstack.services.apigateway.models import RestApiDeployment
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import RestApiInvocationContext
+from ..variables import ContextVariables
 
 LOG = logging.getLogger(__name__)
 
@@ -84,6 +85,7 @@ class InvocationRequestRouter(RestApiGatewayHandler):
         router = self.get_router_for_deployment(context.deployment)
 
         resource, path_parameters = router.match(context)
+        resource: Resource
 
         context.invocation_request["path_parameters"] = path_parameters
         context.resource = resource
@@ -93,6 +95,16 @@ class InvocationRequestRouter(RestApiGatewayHandler):
             or resource["resourceMethods"]["ANY"]
         )
         context.resource_method = method
+
+        self.update_context_variables_with_resource(context.context_variables, resource)
+
+    @staticmethod
+    def update_context_variables_with_resource(
+        context_variables: ContextVariables, resource: Resource
+    ):
+        # TODO: log updating the context_variables?
+        context_variables["resourcePath"] = resource["path"]
+        context_variables["resourceId"] = resource["id"]
 
     @staticmethod
     @cache

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
@@ -102,8 +102,9 @@ class InvocationRequestRouter(RestApiGatewayHandler):
     def update_context_variables_with_resource(
         context_variables: ContextVariables, resource: Resource
     ):
-        # TODO: log updating the context_variables?
+        LOG.debug("Updating $context.resourcePath='%s'", resource["path"])
         context_variables["resourcePath"] = resource["path"]
+        LOG.debug("Updating $context.resourceId='%s'", resource["id"])
         context_variables["resourceId"] = resource["id"]
 
     @staticmethod

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/moto_helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/moto_helpers.py
@@ -1,3 +1,4 @@
+from moto.apigateway.models import APIGatewayBackend, apigateway_backends
 from moto.apigateway.models import RestAPI as MotoRestAPI
 
 from localstack.aws.api.apigateway import Resource
@@ -28,3 +29,12 @@ def get_resources_from_moto_rest_api(moto_rest_api: MotoRestAPI) -> dict[str, Re
         resources[moto_resource.id] = resource
 
     return resources
+
+
+def get_stage_variables(
+    account_id: str, region: str, api_id: str, stage_name: str
+) -> dict[str, str]:
+    apigateway_backend: APIGatewayBackend = apigateway_backends[account_id][region]
+    moto_rest_api = apigateway_backend.apis[api_id]
+    stage = moto_rest_api.stages[stage_name]
+    return stage.variables

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -64,6 +64,7 @@ class ApiGatewayEndpoint:
         context.deployment = frozen_deployment
         context.api_id = api_id
         context.stage = stage
+        context.deployment_id = deployment_id
 
 
 class ApiGatewayRouter:

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
@@ -1,0 +1,139 @@
+from typing import Optional, TypedDict
+
+
+class ContextVarsAuthorizer(TypedDict, total=False):
+    # this is merged with the Context returned by the Authorizer, which can attach any property to this dict in string
+    # format
+    claims: Optional[dict[str, str]]
+    principalId: Optional[str]
+
+
+class ContextVarsIdentityClientCertValidity(TypedDict, total=False):
+    notBefore: str
+    notAfter: str
+
+
+class ContextVarsIdentityClientCert(TypedDict, total=False):
+    clientCertPem: str
+    subjectDN: str
+    issuerDN: str
+    serialNumber: str
+    validity: ContextVarsIdentityClientCertValidity
+
+
+class ContextVarsIdentity(TypedDict, total=False):
+    accountId: str
+    apiKey: Optional[str]
+    apiKeyId: str
+    cognitoAuthenticationProvider: str
+    cognitoAuthenticationType: str
+    cognitoIdentityId: str
+    cognitoIdentityPoolId: str
+    principalOrgId: str
+    sourceIp: str
+    clientCert: ContextVarsIdentityClientCert
+    vpcId: str
+    vpceId: str
+    user: str
+    userAgent: str
+    userArn: str
+
+
+class ContextVarsRequestOverride(TypedDict, total=False):
+    header: dict[str, str]
+    path: dict[str, str]
+    querystring: dict[str, str]
+
+
+class ContextVarsResponseOverride(TypedDict, total=False):
+    header: dict[str, str]
+    querystring: dict[str, str]
+    status: int
+
+
+class ContextVariables(TypedDict, total=False):
+    # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#context-variable-reference
+    accountId: str
+    apiId: str
+    awsEndpointRequestId: str
+    deploymentId: str
+    domainName: Optional[str]
+    domainPrefix: str
+    extendedRequestId: str
+    httpMethod: str  # TODO: type?
+    identity: ContextVarsIdentity
+    isCanaryRequest: bool | str  # TODO: verify type
+    path: str
+    protocol: str
+    requestId: str
+    requestTime: str
+    requestTimeEpoch: str  # TODO: type?
+    resourceId: str
+    resourcePath: str
+    stage: str
+    wafResponseCode: Optional[str]
+    webaclArn: Optional[str]
+
+
+class GatewayResponseContextVarsError(TypedDict, total=False):
+    # This variable can only be used for simple variable substitution in a GatewayResponse body-mapping template,
+    # which is not processed by the Velocity Template Language engine, and in access logging.
+    message: str
+    messageString: str
+    responseType: str
+    validationErrorString: str
+
+
+class LoggingContextVarsAuthorize(TypedDict, total=False):
+    error: str
+    latency: str
+    status: str
+
+
+class LoggingContextVarsAuthorizer(TypedDict, total=False):
+    error: str
+    integrationLatency: str
+    integrationStatus: str
+    latency: str
+    requestId: str
+    status: str
+
+
+class LoggingContextVarsAuthenticate(TypedDict, total=False):
+    error: str
+    latency: str
+    status: str
+
+
+class LoggingContextVarsCustomDomain(TypedDict, total=False):
+    basePathMatched: str
+
+
+class LoggingContextVarsIntegration(TypedDict, total=False):
+    error: str
+    integrationStatus: str
+    latency: str
+    requestId: str
+    status: str
+
+
+class LoggingContextVarsWaf(TypedDict, total=False):
+    error: str
+    latency: str
+    status: str
+
+
+class LoggingContextVariables(TypedDict, total=False):
+    authorize: LoggingContextVarsAuthorize
+    authorizer: LoggingContextVarsAuthorizer
+    authenticate: LoggingContextVarsAuthenticate
+    customDomain: LoggingContextVarsCustomDomain
+    endpointType: str
+    integration: LoggingContextVarsIntegration
+    integrationLatency: str
+    integrationStatus: str
+    responseLatency: str
+    responseLength: str
+    status: str
+    waf: LoggingContextVarsWaf
+    xrayTraceId: str

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
@@ -4,8 +4,12 @@ from typing import Optional, TypedDict
 class ContextVarsAuthorizer(TypedDict, total=False):
     # this is merged with the Context returned by the Authorizer, which can attach any property to this dict in string
     # format
+
+    # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
     claims: Optional[dict[str, str]]
-    principalId: Optional[str]
+    """Claims returned from the Amazon Cognito user pool after the method caller is successfully authenticated"""
+    principal_id: Optional[str]
+    """The principal user identification associated with the token sent by the client and returned from an API Gateway Lambda authorizer"""
 
 
 class ContextVarsIdentityClientCertValidity(TypedDict, total=False):
@@ -14,6 +18,8 @@ class ContextVarsIdentityClientCertValidity(TypedDict, total=False):
 
 
 class ContextVarsIdentityClientCert(TypedDict, total=False):
+    """Certificate that a client presents. Present only in access logs if mutual TLS authentication fails."""
+
     clientCertPem: str
     subjectDN: str
     issuerDN: str
@@ -22,21 +28,38 @@ class ContextVarsIdentityClientCert(TypedDict, total=False):
 
 
 class ContextVarsIdentity(TypedDict, total=False):
-    accountId: str
+    # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+    accountId: Optional[str]
+    """The AWS account ID associated with the request."""
     apiKey: Optional[str]
-    apiKeyId: str
-    cognitoAuthenticationProvider: str
-    cognitoAuthenticationType: str
-    cognitoIdentityId: str
-    cognitoIdentityPoolId: str
-    principalOrgId: str
-    sourceIp: str
+    """For API methods that require an API key, this variable is the API key associated with the method request."""
+    apiKeyId: Optional[str]
+    """The API key ID associated with an API request that requires an API key."""
+    caller: Optional[str]
+    """The principal identifier of the caller that signed the request. Supported for resources that use IAM authorization."""
+    cognitoAuthenticationProvider: Optional[str]
+    """A comma-separated list of the Amazon Cognito authentication providers used by the caller making the request"""
+    cognitoAuthenticationType: Optional[str]
+    """The Amazon Cognito authentication type of the caller making the request"""
+    cognitoIdentityId: Optional[str]
+    """The Amazon Cognito identity ID of the caller making the request"""
+    cognitoIdentityPoolId: Optional[str]
+    """The Amazon Cognito identity pool ID of the caller making the request"""
+    principalOrgId: Optional[str]
+    """The AWS organization ID."""
+    sourceIp: Optional[str]
+    """The source IP address of the immediate TCP connection making the request to the API Gateway endpoint"""
     clientCert: ContextVarsIdentityClientCert
-    vpcId: str
-    vpceId: str
-    user: str
-    userAgent: str
-    userArn: str
+    vpcId: Optional[str]
+    """The VPC ID of the VPC making the request to the API Gateway endpoint."""
+    vpceId: Optional[str]
+    """The VPC endpoint ID of the VPC endpoint making the request to the API Gateway endpoint."""
+    user: Optional[str]
+    """The principal identifier of the user that will be authorized against resource access for resources that use IAM authorization."""
+    userAgent: Optional[str]
+    """The User-Agent header of the API caller."""
+    userArn: Optional[str]
+    """The Amazon Resource Name (ARN) of the effective user identified after authentication."""
 
 
 class ContextVarsRequestOverride(TypedDict, total=False):
@@ -54,25 +77,44 @@ class ContextVarsResponseOverride(TypedDict, total=False):
 class ContextVariables(TypedDict, total=False):
     # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#context-variable-reference
     accountId: str
+    """The API owner's AWS account ID."""
     apiId: str
-    awsEndpointRequestId: str
+    """The identifier API Gateway assigns to your API."""
+    awsEndpointRequestId: Optional[str]
+    """The AWS endpoint's request ID."""
     deploymentId: str
-    domainName: Optional[str]
+    """The ID of the API deployment."""
+    domainName: str
+    """The full domain name used to invoke the API. This should be the same as the incoming Host header."""
     domainPrefix: str
+    """The first label of the $context.domainName."""
     extendedRequestId: str
-    httpMethod: str  # TODO: type?
-    identity: ContextVarsIdentity
-    isCanaryRequest: bool | str  # TODO: verify type
+    """The extended ID that API Gateway generates and assigns to the API request. """
+    httpMethod: str
+    """The HTTP method used"""
+    identity: Optional[ContextVarsIdentity]
+    isCanaryRequest: Optional[bool | str]  # TODO: verify type
+    """Indicates if the request was directed to the canary"""
     path: str
+    """The request path."""
     protocol: str
+    """The request protocol"""
     requestId: str
+    """An ID for the request. Clients can override this request ID. """
     requestTime: str
-    requestTimeEpoch: str  # TODO: type?
-    resourceId: str
-    resourcePath: str
+    """The CLF-formatted request time (dd/MMM/yyyy:HH:mm:ss +-hhmm)."""
+    requestTimeEpoch: int
+    """The Epoch-formatted request time, in milliseconds."""
+    resourceId: Optional[str]
+    """The identifier that API Gateway assigns to your resource."""
+    resourcePath: Optional[str]
+    """The path to your resource"""
     stage: str
+    """The deployment stage of the API request """
     wafResponseCode: Optional[str]
+    """The response received from AWS WAF: WAF_ALLOW or WAF_BLOCK. Will not be set if the stage is not associated with a web ACL"""
     webaclArn: Optional[str]
+    """The complete ARN of the web ACL that is used to decide whether to allow or block the request. Will not be set if the stage is not associated with a web ACL."""
 
 
 class GatewayResponseContextVarsError(TypedDict, total=False):
@@ -85,55 +127,55 @@ class GatewayResponseContextVarsError(TypedDict, total=False):
 
 
 class LoggingContextVarsAuthorize(TypedDict, total=False):
-    error: str
-    latency: str
-    status: str
+    error: Optional[str]
+    latency: Optional[str]
+    status: Optional[str]
 
 
 class LoggingContextVarsAuthorizer(TypedDict, total=False):
-    error: str
-    integrationLatency: str
-    integrationStatus: str
-    latency: str
-    requestId: str
-    status: str
+    error: Optional[str]
+    integrationLatency: Optional[str]
+    integrationStatus: Optional[str]
+    latency: Optional[str]
+    requestId: Optional[str]
+    status: Optional[str]
 
 
 class LoggingContextVarsAuthenticate(TypedDict, total=False):
-    error: str
-    latency: str
-    status: str
+    error: Optional[str]
+    latency: Optional[str]
+    status: Optional[str]
 
 
 class LoggingContextVarsCustomDomain(TypedDict, total=False):
-    basePathMatched: str
+    basePathMatched: Optional[str]
 
 
 class LoggingContextVarsIntegration(TypedDict, total=False):
-    error: str
-    integrationStatus: str
-    latency: str
-    requestId: str
-    status: str
+    error: Optional[str]
+    integrationStatus: Optional[str]
+    latency: Optional[str]
+    requestId: Optional[str]
+    status: Optional[str]
 
 
 class LoggingContextVarsWaf(TypedDict, total=False):
-    error: str
-    latency: str
-    status: str
+    error: Optional[str]
+    latency: Optional[str]
+    status: Optional[str]
 
 
 class LoggingContextVariables(TypedDict, total=False):
-    authorize: LoggingContextVarsAuthorize
-    authorizer: LoggingContextVarsAuthorizer
-    authenticate: LoggingContextVarsAuthenticate
-    customDomain: LoggingContextVarsCustomDomain
-    endpointType: str
-    integration: LoggingContextVarsIntegration
-    integrationLatency: str
-    integrationStatus: str
-    responseLatency: str
-    responseLength: str
-    status: str
-    waf: LoggingContextVarsWaf
-    xrayTraceId: str
+    authorize: Optional[LoggingContextVarsAuthorize]
+    authorizer: Optional[LoggingContextVarsAuthorizer]
+    authenticate: Optional[LoggingContextVarsAuthenticate]
+    customDomain: Optional[LoggingContextVarsCustomDomain]
+    endpointType: Optional[str]
+    integration: Optional[LoggingContextVarsIntegration]
+    integrationLatency: Optional[str]
+    integrationStatus: Optional[str]
+    responseLatency: Optional[str]
+    responseLength: Optional[str]
+    status: Optional[str]
+    waf: Optional[LoggingContextVarsWaf]
+    xrayTraceId: Optional[str]

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -1,5 +1,5 @@
 import pytest
-from moto.apigateway.models import APIGatewayBackend, apigateway_backends
+from moto.apigateway.models import APIGatewayBackend, Stage, apigateway_backends
 from moto.apigateway.models import RestAPI as MotoRestAPI
 from werkzeug.datastructures import Headers
 
@@ -35,6 +35,7 @@ def dummy_deployment():
     )
 
     moto_backend.apis[TEST_API_ID] = moto_rest_api
+    moto_rest_api.stages[TEST_API_STAGE] = Stage(name=TEST_API_STAGE)
 
     yield freeze_rest_api(
         account_id=TEST_AWS_ACCOUNT_ID,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We need a separate context, representing the `$context` variables used to render VTL templates, and which is also passed in the payload to `AWS_PROXY` integrations. 

More informations about `$context` here. 
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#context-variable-reference

It is a bit of duplicated information from the original `RestApiInvocationContext` object and the `InvocationRequest`, but they serve different purposes.

If we need to update different contexts at the same time, then maybe we could simplify. But we learned that creating those context when needed, collecting informations from different sources, can be pretty hard. 

The `InvocationRequest` goal is simply to represent the incoming request "as is", with no transformation. 

The idea would be to go from `InvocationRequest`, get the `Resource`. Use the original `InvocationRequest`, the `Resource`,the `ContextVariables` and `StageVariables` to construct the `IntegrationRequest` and send it down.
The `InvocationRequest` will not be mutated. The `ContextVariables` will be mutated and populated along the way of the different handlers. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add the `ContextVariables` and populate it
- add the not yet used `LoggingContextVariables` which can add more data to the logging
- add `IntegrationRequest` for future work in integration request handler
- add the stage variables and fetch them from the stage
- add small tests to validate we're populate the contexts properly

## TODO

What's left to do:

- [x] add unit tests
