### PR TITLE
Fix a typographical error introduced in push-to-tinybird

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -776,7 +776,7 @@ jobs:
 
             # Determine if reporting the workflow even is necessary and what the workflow variant is
             if [[ << pipeline.parameters.randomize-aws-credentials >> == "true" ]] && [[ $ONLY_ACCEPTANCE_TESTS == "true" ]] ; then
-              echo "Don't report only-acceptance-test workflows with randomized aws credentials
+              echo "Don't report only-acceptance-test workflows with randomized aws credentials"
               circleci-agent step halt
             elif [[ << pipeline.parameters.randomize-aws-credentials >> == "true" ]] ; then
               TINYBIRD_WORKFLOW=tests_circleci_ma_mr


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The `push-to-tinybird` job in the CircleCI workflow is only executed on master. Due to this, changes introduced with #11049 could not be sufficiently tested and therefore introduced a typo in an echo statement.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Fix the typo. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
