### PR TITLE
APIGW NG implement api key validation handler

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway.py
@@ -23,6 +23,7 @@ class RestApiGateway(Gateway):
                 handlers.parse_request,
                 handlers.route_request,
                 handlers.preprocess_request,
+                handlers.api_key_validation_handler,
                 handlers.method_request_handler,
                 handlers.integration_request_handler,
                 handlers.integration_handler,

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/__init__.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/__init__.py
@@ -1,5 +1,6 @@
 from rolo.gateway import CompositeHandler
 
+from .api_key_validation import ApiKeyValidationHandler
 from .gateway_exception import GatewayExceptionHandler
 from .integration import IntegrationHandler
 from .integration_request import IntegrationRequestHandler
@@ -20,3 +21,4 @@ integration_handler = IntegrationHandler()
 integration_response_handler = IntegrationResponseHandler()
 method_response_handler = MethodResponseHandler()
 gateway_exception_handler = GatewayExceptionHandler()
+api_key_validation_handler = ApiKeyValidationHandler()

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/api_key_validation.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/api_key_validation.py
@@ -1,0 +1,112 @@
+import logging
+from typing import Optional
+
+from localstack.aws.api.apigateway import ApiKey, ApiKeySourceType, RestApi
+from localstack.http import Response
+
+from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
+from ..context import IdentityContext, InvocationRequest, RestApiInvocationContext
+from ..gateway_response import InvalidAPIKeyError
+from ..moto_helpers import get_api_key, get_usage_plan_keys, get_usage_plans
+
+LOG = logging.getLogger(__name__)
+
+
+class ApiKeyValidationHandler(RestApiGatewayHandler):
+    """
+    Handles Api key validation.
+    If an api key is required, we will validate that a usage plan associated with that stage
+    has a usage plan key with the corresponding value.
+    """
+
+    # TODO We currently do not support rate limiting or quota limit. As such we are not raising any related Exception
+
+    def __call__(
+        self,
+        chain: RestApiGatewayHandlerChain,
+        context: RestApiInvocationContext,
+        response: Response,
+    ):
+        method = context.resource_method
+
+        # If api key is not required by the method, we can exit the handler
+        if not method.get("apiKeyRequired"):
+            return
+
+        identity = context.context_variables["identity"]
+        request = context.invocation_request
+        rest_api = context.deployment.rest_api.rest_api
+
+        # Look for the api key value in the request. If it is not found, raise an exception
+        if not (api_key_value := self.get_request_api_key(rest_api, request, identity)):
+            LOG.debug("API Key is empty")
+            raise InvalidAPIKeyError("Forbidden")
+
+        # Get the validated key, if no key is found, raise an exception
+        if not (validated_key := self.get_validated_key(api_key_value, context)):
+            LOG.debug("Provided API Key is not valid")
+            raise InvalidAPIKeyError("Forbidden")
+
+        # Update context's identity with the key value and Id
+        if not identity["apikey"]:
+            LOG.debug("Updating $context.identity.apiKey='%s'", validated_key["value"])
+            identity["apiKey"] = validated_key["value"]
+
+        LOG.debug("Updating $context.identity.apiKeyId='%s'", validated_key["id"])
+        identity["apiKeyId"] = validated_key["id"]
+
+    def validate_api_key(
+        self, api_key_value, context: RestApiInvocationContext
+    ) -> Optional[ApiKey]:
+        api_id = context.api_id
+        stage = context.stage
+        account_id = context.account_id
+        region = context.region
+
+        # Get usage plans from the store
+        usage_plans = get_usage_plans(account_id=account_id, region_name=region)
+
+        # Loop through usage plans and keep ids of the plans associated with the deployment stage
+        usage_plan_ids = []
+        for usage_plan in usage_plans:
+            api_stages = usage_plan.get("apiStages", [])
+            usage_plan_ids.extend(
+                usage_plan.get("id")
+                for api_stage in api_stages
+                if (api_stage.get("stage") == stage and api_stage.get("apiId") == api_id)
+            )
+        if not usage_plan_ids:
+            LOG.debug("No associated usage plans found stage '%s'", stage)
+            return
+
+        # Loop through plans with an association with the stage find a key with matching value
+        for usage_plan_id in usage_plan_ids:
+            usage_plan_keys = get_usage_plan_keys(
+                usage_plan_id=usage_plan_id, account_id=account_id, region_name=region
+            )
+            for key in usage_plan_keys:
+                if key["value"] == api_key_value:
+                    api_key = get_api_key(
+                        api_key_id=key["id"], account_id=account_id, region_name=region
+                    )
+                    LOG.debug("Found Api Key '%s'", api_key["id"])
+                    return api_key if api_key["enabled"] else None
+
+    def get_request_api_key(
+        self, rest_api: RestApi, request: InvocationRequest, identity: IdentityContext
+    ) -> Optional[str]:
+        """https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-key-source.html
+        The source of the API key for metering requests according to a usage plan.
+        Valid values are:
+        - HEADER to read the API key from the X-API-Key header of a request.
+        - AUTHORIZER to read the API key from the Context Variables.
+        """
+        match api_key_source := rest_api.get("apiKeySource"):
+            case ApiKeySourceType.HEADER:
+                LOG.debug("Looking for api key in header 'X-API-Key'")
+                return request.get("raw_headers", {}).get("X-API-Key")
+            case ApiKeySourceType.AUTHORIZER:
+                LOG.debug("Looking for api key in Identity Context")
+                return identity.get("apiKey")
+            case _:
+                LOG.debug("Api Key Source is not valid: '%s'", api_key_source)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/api_key_validation.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/api_key_validation.py
@@ -5,9 +5,10 @@ from localstack.aws.api.apigateway import ApiKey, ApiKeySourceType, RestApi
 from localstack.http import Response
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
-from ..context import IdentityContext, InvocationRequest, RestApiInvocationContext
+from ..context import InvocationRequest, RestApiInvocationContext
 from ..gateway_response import InvalidAPIKeyError
 from ..moto_helpers import get_api_key, get_usage_plan_keys, get_usage_plans
+from ..variables import ContextVarsIdentity
 
 LOG = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ class ApiKeyValidationHandler(RestApiGatewayHandler):
             return
 
         # If the Identity context was not created yet, instantiate it and attach it to the context variables
-        if not (identity := context.context_variables.get("identity", IdentityContext())):
+        if not (identity := context.context_variables.get("identity", ContextVarsIdentity())):
             context.context_variables["identity"] = identity
 
         # Look for the api key value in the request. If it is not found, raise an exception
@@ -95,7 +96,7 @@ class ApiKeyValidationHandler(RestApiGatewayHandler):
                     return api_key if api_key["enabled"] else None
 
     def get_request_api_key(
-        self, rest_api: RestApi, request: InvocationRequest, identity: IdentityContext
+        self, rest_api: RestApi, request: InvocationRequest, identity: ContextVarsIdentity
     ) -> Optional[str]:
         """https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-key-source.html
         The source of the API key for metering requests according to a usage plan.

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/api_key_validation.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/api_key_validation.py
@@ -37,8 +37,7 @@ class ApiKeyValidationHandler(RestApiGatewayHandler):
             return
 
         # If the Identity context was not created yet, instantiate it and attach it to the context variables
-        if not (identity := context.context_variables.get("identity", ContextVarsIdentity())):
-            context.context_variables["identity"] = identity
+        identity = context.context_variables.setdefault("identity", ContextVarsIdentity())
 
         # Look for the api key value in the request. If it is not found, raise an exception
         if not (api_key_value := self.get_request_api_key(rest_api, request, identity)):

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/moto_helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/moto_helpers.py
@@ -74,5 +74,5 @@ def get_usage_plan_keys(
     apigateway_backend: APIGatewayBackend = apigateway_backends[account_id][region_name]
     return [
         UsagePlanKey(**usage_plan_key.to_json())
-        for usage_plan_key in apigateway_backend.usage_plan_keys[usage_plan_id].values()
+        for usage_plan_key in apigateway_backend.usage_plan_keys.get(usage_plan_id, {}).values()
     ]

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/moto_helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/moto_helpers.py
@@ -1,7 +1,14 @@
 from moto.apigateway.models import APIGatewayBackend, apigateway_backends
 from moto.apigateway.models import RestAPI as MotoRestAPI
 
-from localstack.aws.api.apigateway import Resource
+from localstack.aws.api.apigateway import (
+    ApiKey,
+    ListOfUsagePlan,
+    ListOfUsagePlanKey,
+    Resource,
+    UsagePlan,
+    UsagePlanKey,
+)
 
 
 def get_resources_from_moto_rest_api(moto_rest_api: MotoRestAPI) -> dict[str, Resource]:
@@ -38,3 +45,34 @@ def get_stage_variables(
     moto_rest_api = apigateway_backend.apis[api_id]
     stage = moto_rest_api.stages[stage_name]
     return stage.variables
+
+
+def get_usage_plans(account_id: str, region_name: str) -> ListOfUsagePlan:
+    """
+    Will return a list of usage plans from the moto store.
+    """
+    apigateway_backend: APIGatewayBackend = apigateway_backends[account_id][region_name]
+    return [
+        UsagePlan(**usage_plan.to_json()) for usage_plan in apigateway_backend.usage_plans.values()
+    ]
+
+
+def get_api_key(api_key_id: str, account_id: str, region_name: str) -> ApiKey:
+    """
+    Will return an api key from the moto store.
+    """
+    apigateway_backend: APIGatewayBackend = apigateway_backends[account_id][region_name]
+    return ApiKey(**apigateway_backend.keys[api_key_id].to_json())
+
+
+def get_usage_plan_keys(
+    usage_plan_id: str, account_id: str, region_name: str
+) -> ListOfUsagePlanKey:
+    """
+    Will return a list of usage plan keys from the moto store.
+    """
+    apigateway_backend: APIGatewayBackend = apigateway_backends[account_id][region_name]
+    return [
+        UsagePlanKey(**usage_plan_key.to_json())
+        for usage_plan_key in apigateway_backend.usage_plan_keys[usage_plan_id].values()
+    ]

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/moto_helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/moto_helpers.py
@@ -1,14 +1,7 @@
 from moto.apigateway.models import APIGatewayBackend, apigateway_backends
 from moto.apigateway.models import RestAPI as MotoRestAPI
 
-from localstack.aws.api.apigateway import (
-    ApiKey,
-    ListOfUsagePlan,
-    ListOfUsagePlanKey,
-    Resource,
-    UsagePlan,
-    UsagePlanKey,
-)
+from localstack.aws.api.apigateway import ApiKey, ListOfUsagePlan, ListOfUsagePlanKey, Resource
 
 
 def get_resources_from_moto_rest_api(moto_rest_api: MotoRestAPI) -> dict[str, Resource]:
@@ -52,9 +45,7 @@ def get_usage_plans(account_id: str, region_name: str) -> ListOfUsagePlan:
     Will return a list of usage plans from the moto store.
     """
     apigateway_backend: APIGatewayBackend = apigateway_backends[account_id][region_name]
-    return [
-        UsagePlan(**usage_plan.to_json()) for usage_plan in apigateway_backend.usage_plans.values()
-    ]
+    return [usage_plan.to_json() for usage_plan in apigateway_backend.usage_plans.values()]
 
 
 def get_api_key(api_key_id: str, account_id: str, region_name: str) -> ApiKey:
@@ -62,7 +53,7 @@ def get_api_key(api_key_id: str, account_id: str, region_name: str) -> ApiKey:
     Will return an api key from the moto store.
     """
     apigateway_backend: APIGatewayBackend = apigateway_backends[account_id][region_name]
-    return ApiKey(**apigateway_backend.keys[api_key_id].to_json())
+    return apigateway_backend.keys[api_key_id].to_json()
 
 
 def get_usage_plan_keys(
@@ -73,6 +64,6 @@ def get_usage_plan_keys(
     """
     apigateway_backend: APIGatewayBackend = apigateway_backends[account_id][region_name]
     return [
-        UsagePlanKey(**usage_plan_key.to_json())
+        usage_plan_key.to_json()
         for usage_plan_key in apigateway_backend.usage_plan_keys.get(usage_plan_id, {}).values()
     ]

--- a/tests/unit/services/apigateway/test_handler_api_key_validation.py
+++ b/tests/unit/services/apigateway/test_handler_api_key_validation.py
@@ -1,0 +1,240 @@
+import pytest
+from moto.apigateway.models import APIGatewayBackend, apigateway_backends
+from werkzeug.datastructures.headers import Headers
+
+from localstack.aws.api.apigateway import ApiKeySourceType, Method
+from localstack.http import Request, Response
+from localstack.services.apigateway.models import MergedRestApi, RestApiDeployment
+from localstack.services.apigateway.next_gen.execute_api.api import RestApiGatewayHandlerChain
+from localstack.services.apigateway.next_gen.execute_api.context import (
+    ContextVariables,
+    IdentityContext,
+    InvocationRequest,
+    RestApiInvocationContext,
+)
+from localstack.services.apigateway.next_gen.execute_api.gateway_response import InvalidAPIKeyError
+from localstack.services.apigateway.next_gen.execute_api.handlers import ApiKeyValidationHandler
+from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
+
+TEST_API_ID = "testapi"
+TEST_API_STAGE = "dev"
+
+
+@pytest.fixture
+def moto_backend():
+    """
+    because we depend on Moto here, we have to use the backend because the keys and usage plans
+    are fetched at runtime in the store directly. We should avoid using this fixture directly in
+    the tests and favor reusable fixture that could later on be replaced to populate the Localstack
+    store instead without impacting the tests
+    """
+    moto_backend: APIGatewayBackend = apigateway_backends[TEST_AWS_ACCOUNT_ID][TEST_AWS_REGION_NAME]
+    yield moto_backend
+    moto_backend.reset()
+
+
+@pytest.fixture
+def create_context():
+    """
+    Create a context populated with what we would expect to receive from the chain at runtime.
+    We assume that the parser and other handler have successfully populated the context to this point.
+    """
+
+    def _create_context(
+        method: Method = None,
+        api_key_source: ApiKeySourceType = None,
+        headers: dict[str, str] = None,
+        api_key: str = None,
+    ):
+        context = RestApiInvocationContext(Request())
+
+        # The api key validator only relies on the raw headers from the invocation requests
+        context.invocation_request = InvocationRequest(raw_headers=Headers(headers))
+
+        # Frozen deployment populated by the router
+        context.deployment = RestApiDeployment(
+            account_id=TEST_AWS_ACCOUNT_ID,
+            region=TEST_AWS_REGION_NAME,
+            rest_api=MergedRestApi(
+                # TODO validate that this value is always populated by localstack. AWS defaults to HEADERS on all new apis
+                rest_api={"apiKeySource": api_key_source or ApiKeySourceType.HEADER}
+            ),
+        )
+
+        # Context populated by parser handler
+        context.region = TEST_AWS_REGION_NAME
+        context.account_id = TEST_AWS_ACCOUNT_ID
+        context.stage = TEST_API_STAGE
+        context.api_id = TEST_API_ID
+        context.resource_method = method or Method()
+        context.context_variables = ContextVariables()
+
+        # Context populated by a Lambda Authorizer
+        if api_key is not None:
+            context.context_variables["identity"] = IdentityContext(apiKey=api_key)
+        return context
+
+    return _create_context
+
+
+@pytest.fixture
+def api_key_validation_handler():
+    """Returns a dummy api key validation handler invoker for testing."""
+
+    def _handler_invoker(context: RestApiInvocationContext):
+        return ApiKeyValidationHandler()(RestApiGatewayHandlerChain(), context, Response())
+
+    return _handler_invoker
+
+
+@pytest.fixture
+def create_usage_plan(moto_backend):
+    def _create_usage_plan(attach_stage: bool, attach_key_id: str = None, backend=None):
+        backend = backend or moto_backend
+        stage_config = {}
+        if attach_stage:
+            stage_config = {"apiStages": [{"apiId": TEST_API_ID, "stage": TEST_API_STAGE}]}
+        usage_plan = backend.create_usage_plan(stage_config)
+        if attach_key_id:
+            backend.create_usage_plan_key(
+                usage_plan_id=usage_plan.id, payload={"keyId": attach_key_id, "keyType": "API_KEY"}
+            )
+        return usage_plan
+
+    return _create_usage_plan
+
+
+@pytest.fixture
+def create_api_key(moto_backend):
+    def _create_api_key(key_value: str, enabled: bool = True, backend=None):
+        backend = backend or moto_backend
+        return backend.create_api_key({"enabled": enabled, "value": key_value})
+
+    return _create_api_key
+
+
+class TestHandlerApiKeyValidation:
+    def test_no_api_key_required(self, create_context, api_key_validation_handler):
+        api_key_validation_handler(create_context())
+
+    def test_api_key_headers_valid(
+        self, create_context, api_key_validation_handler, create_usage_plan, create_api_key
+    ):
+        method = Method(apiKeyRequired=True)
+        api_key_value = "01234567890123456789"
+
+        # create api key
+        api_key = create_api_key(api_key_value)
+        # create usage plan and attach key
+        create_usage_plan(attach_stage=True, attach_key_id=api_key.id)
+        # pass the key in the request headers
+        ctx = create_context(method=method, headers={"x-api-key": api_key_value})
+
+        # Call handler
+        api_key_validation_handler(context=ctx)
+
+        assert ctx.context_variables["identity"]["apiKey"] == api_key_value
+        assert ctx.context_variables["identity"]["apiKeyId"] == api_key.id
+
+    def test_api_key_headers_absent(
+        self, create_context, api_key_validation_handler, create_api_key, create_usage_plan
+    ):
+        method = Method(apiKeyRequired=True)
+        api_key_value = "01234567890123456789"
+
+        # create api key
+        api_key = create_api_key(api_key_value)
+        # create usage plan and attach key
+        create_usage_plan(attach_stage=True, attach_key_id=api_key.id)
+
+        with pytest.raises(InvalidAPIKeyError) as e:
+            api_key_validation_handler(
+                # missing headers will raise error
+                context=create_context(method=method, headers={})
+            )
+        assert e.value.message == "Forbidden"
+
+    def test_api_key_no_api_key(
+        self, create_context, api_key_validation_handler, create_usage_plan
+    ):
+        method = Method(apiKeyRequired=True)
+        api_key_value = "01234567890123456789"
+
+        # Create usage plan with no keys
+        create_usage_plan(attach_stage=True)
+
+        with pytest.raises(InvalidAPIKeyError) as e:
+            api_key_validation_handler(
+                context=create_context(method=method, headers={"x-api-key": api_key_value})
+            )
+        assert e.value.message == "Forbidden"
+
+    def test_api_key_no_usage_plan_key(
+        self, create_context, api_key_validation_handler, create_api_key, create_usage_plan
+    ):
+        method = Method(apiKeyRequired=True)
+        api_key_value = "01234567890123456789"
+
+        # create api key
+        create_api_key(api_key_value)
+        # Create usage plan but the key won't be associated
+        create_usage_plan(attach_stage=True)
+
+        with pytest.raises(InvalidAPIKeyError) as e:
+            api_key_validation_handler(
+                context=create_context(method=method, headers={"x-api-key": api_key_value})
+            )
+        assert e.value.message == "Forbidden"
+
+    def test_api_key_disabled(
+        self, create_context, api_key_validation_handler, create_api_key, create_usage_plan
+    ):
+        method = Method(apiKeyRequired=True)
+        api_key_value = "01234567890123456789"
+
+        # Create api key but set `Enabled` to False
+        api_key = create_api_key(api_key_value, enabled=False)
+        # create usage plan and attach key
+        create_usage_plan(attach_stage=True, attach_key_id=api_key.id)
+
+        with pytest.raises(InvalidAPIKeyError) as e:
+            api_key_validation_handler(
+                context=create_context(method=method, headers={"x-api-key": api_key_value})
+            )
+        assert e.value.message == "Forbidden"
+
+    def test_api_key_in_identity_context(
+        self, create_context, api_key_validation_handler, create_api_key, create_usage_plan
+    ):
+        method = Method(apiKeyRequired=True)
+        api_key_value = "01234567890123456789"
+
+        # create api key
+        api_key = create_api_key(api_key_value)
+        # create usage plan and attach key
+        create_usage_plan(attach_stage=True, attach_key_id=api_key.id)
+
+        api_key_validation_handler(
+            context=create_context(
+                # The frozen api has key source set to AUTHORIZER and the api_key was populated by the Authorizer
+                method=method,
+                api_key=api_key_value,
+                api_key_source=ApiKeySourceType.AUTHORIZER,
+            )
+        )
+
+    def test_api_key_in_identity_context_api_not_configured(
+        self, create_context, api_key_validation_handler, create_api_key, create_usage_plan
+    ):
+        method = Method(apiKeyRequired=True)
+        api_key_value = "01234567890123456789"
+
+        # create api key
+        api_key = create_api_key(api_key_value)
+        # create usage plan and attach key
+        create_usage_plan(attach_stage=True, attach_key_id=api_key.id)
+
+        with pytest.raises(InvalidAPIKeyError) as e:
+            # The api_key was populated by the Authorizer, but missing frozen api configuration
+            api_key_validation_handler(context=create_context(method=method, api_key=api_key_value))
+        assert e.value.message == "Forbidden"

--- a/tests/unit/services/apigateway/test_handler_api_key_validation.py
+++ b/tests/unit/services/apigateway/test_handler_api_key_validation.py
@@ -7,13 +7,15 @@ from localstack.http import Request, Response
 from localstack.services.apigateway.models import MergedRestApi, RestApiDeployment
 from localstack.services.apigateway.next_gen.execute_api.api import RestApiGatewayHandlerChain
 from localstack.services.apigateway.next_gen.execute_api.context import (
-    ContextVariables,
-    IdentityContext,
     InvocationRequest,
     RestApiInvocationContext,
 )
 from localstack.services.apigateway.next_gen.execute_api.gateway_response import InvalidAPIKeyError
 from localstack.services.apigateway.next_gen.execute_api.handlers import ApiKeyValidationHandler
+from localstack.services.apigateway.next_gen.execute_api.variables import (
+    ContextVariables,
+    ContextVarsIdentity,
+)
 from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 
 TEST_API_ID = "testapi"
@@ -71,7 +73,7 @@ def create_context():
 
         # Context populated by a Lambda Authorizer
         if api_key is not None:
-            context.context_variables["identity"] = IdentityContext(apiKey=api_key)
+            context.context_variables["identity"] = ContextVarsIdentity(apiKey=api_key)
         return context
 
     return _create_context


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Implementation of a new api key validation handler. There is a mix of moto helpers in the implementation as not all relevant information live in the deployment. 

#### Important configuration in the frozen deployment:
- The resource method describes `apiKeyRequired`, which determines if validation is required or skipped.
- The rest api describes `apiKeySource`, which determines if the key is to be retrieved from the headers or from an identity context populated by an Lambda Authorizer

#### Important configuration in apigateway store.
Those items, when created, modified or deleted, will affect a deployment without the need to redeploy. see https://docs.aws.amazon.com/apigateway/latest/developerguide/updating-api.html
- Api keys and their properties are stored in moto (contradicts the documentation, but manually tested that updating `enabled` from the key will affect without redeploying)
- Usage plans are stored in moto
- Usage plan key (association of a key to a usage plan) are also stored in moto

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Finds and validates api key based on deployment configuration and keys/usage plans stored on the backend
- Updates the `$context` variables with relevant data.
- Added `moto_helpers` to keep moto backend isolated and ease technical debt.
- Added tests to validate functionality

## TODO

What's left to do:

- [x] This PR currently targets #11111, as it requires changes to the imports. When merged, we should rebase and target master


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
- [ ] ...
-->
