### PR TITLE
Add idempotency when calling StartExecution in Standard Step Functions

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -247,6 +247,38 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
                 return state_machine
         return None
 
+    def _idempotent_start_execution(
+        self,
+        context: RequestContext,
+        exec_arn: Arn,
+        state_machine: StateMachineInstance,
+        name: Name,
+        input_data: SensitiveData,
+    ) -> Optional[Execution]:
+        # StartExecution is idempotent for STANDARD workflows. For a STANDARD workflow,
+        # if you call StartExecution with the same name and input as a running execution,
+        # the call succeeds and return the same response as the original request.
+        # If the execution is closed or if the input is different,
+        # it returns a 400 ExecutionAlreadyExists error. You can reuse names after 90 days.
+
+        execution = self.get_store(context).executions.get(exec_arn)
+        if not execution:
+            return None
+
+        match (name, input_data, execution.exec_status, state_machine.sm_type):
+            case (
+                execution.name,
+                execution.input_data,
+                ExecutionStatus.RUNNING,
+                StateMachineType.STANDARD,
+            ):
+                return execution
+
+        raise CommonServiceException(
+            code="ExecutionAlreadyExists",
+            message=f"Execution Already Exists: '{exec_arn}'",
+        )
+
     def _revision_by_name(
         self, context: RequestContext, name: str
     ) -> Optional[StateMachineInstance]:
@@ -508,7 +540,17 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
             normalised_state_machine_arn, exec_name
         )
         if exec_arn in self.get_store(context).executions:
-            raise InvalidName()  # TODO
+            # Return already running execution if name and input match
+            existing_execution = self._idempotent_start_execution(
+                context=context,
+                exec_arn=exec_arn,
+                state_machine=state_machine_clone,
+                name=name,
+                input_data=input_data,
+            )
+
+            if existing_execution:
+                return existing_execution.to_start_output()
 
         # Create the execution logging session, if logging is configured.
         cloud_watch_logging_session = None
@@ -531,6 +573,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
             trace_header=trace_header,
             activity_store=self.get_store(context).activities,
         )
+
         self.get_store(context).executions[exec_arn] = execution
 
         execution.start()

--- a/tests/aws/services/stepfunctions/templates/base/base_templates.py
+++ b/tests/aws/services/stepfunctions/templates/base/base_templates.py
@@ -11,6 +11,9 @@ class BaseTemplate(TemplateLoader):
     BASE_PASS_RESULT: Final[str] = os.path.join(_THIS_FOLDER, "statemachines/pass_result.json5")
     BASE_TASK_SEQ_2: Final[str] = os.path.join(_THIS_FOLDER, "statemachines/task_seq_2.json5")
     BASE_WAIT_1_MIN: Final[str] = os.path.join(_THIS_FOLDER, "statemachines/wait_1_min.json5")
+    BASE_WAIT_10_SEC: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/wait_10_sec_and_pass.json5"
+    )
     BASE_RAISE_FAILURE: Final[str] = os.path.join(_THIS_FOLDER, "statemachines/raise_failure.json5")
     BASE_RAISE_FAILURE_PATH: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/raise_failure_path.json5"

--- a/tests/aws/services/stepfunctions/templates/base/statemachines/wait_10_sec_and_pass.json5
+++ b/tests/aws/services/stepfunctions/templates/base/statemachines/wait_10_sec_and_pass.json5
@@ -1,0 +1,18 @@
+{
+  "Comment": "WAIT_10_SEC",
+  "StartAt": "State_1",
+  "States": {
+    "State_1": {
+      "Type": "Wait",
+      "Seconds": 10,
+      "Next": "State_2"
+    },
+    "State_2": {
+      "Type": "Pass",
+      "Result": {
+        "Arg1": "argument1",
+      },
+      "End": true,
+    },
+  },
+}

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.py
@@ -365,7 +365,8 @@ class TestSnfApi:
 
         assert exec_resp_idempotent["executionArn"] == execution_arn
 
-    @markers.aws.needs_fixing
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..redriveCount"])
     def test_start_execution(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.py
@@ -315,6 +315,56 @@ class TestSnfApi:
         lst_resp_filter = [sm for sm in lst_resp["stateMachines"] if sm["name"] in sm_names]
         sfn_snapshot.match("lst_resp_del_filter", lst_resp_filter)
 
+    @markers.aws.validated
+    def test_start_execution_idempotent(
+        self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
+    ):
+        snf_role_arn = create_iam_role_for_sfn()
+        sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "snf_role_arn"))
+
+        sm_name: str = f"statemachine_{short_uid()}"
+        execution_name: str = f"execution_name_{short_uid()}"
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_WAIT_10_SEC)
+        definition_str = json.dumps(definition)
+
+        creation_resp = create_state_machine(
+            name=sm_name, definition=definition_str, roleArn=snf_role_arn
+        )
+        sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_create_arn(creation_resp, 0))
+        sfn_snapshot.match("creation_resp", creation_resp)
+        state_machine_arn = creation_resp["stateMachineArn"]
+
+        input_data = '{"body" : "data"}'
+        exec_resp = aws_client.stepfunctions.start_execution(
+            stateMachineArn=state_machine_arn, input=input_data, name=execution_name
+        )
+        sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_exec_arn(exec_resp, 0))
+        sfn_snapshot.match("exec_resp", exec_resp)
+        execution_arn = exec_resp["executionArn"]
+
+        exec_resp_idempotent = aws_client.stepfunctions.start_execution(
+            stateMachineArn=state_machine_arn, input=input_data, name=execution_name
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_exec_arn(exec_resp_idempotent, 0)
+        )
+        sfn_snapshot.match("exec_resp_idempotent", exec_resp_idempotent)
+
+        # Should fail because the execution has the same 'name' as another but a different 'input'.
+        with pytest.raises(Exception) as err:
+            aws_client.stepfunctions.start_execution(
+                stateMachineArn=state_machine_arn,
+                input='{"body" : "different-data"}',
+                name=execution_name,
+            )
+        sfn_snapshot.match("start_exec_already_exists", err.value.response)
+
+        await_execution_success(
+            stepfunctions_client=aws_client.stepfunctions, execution_arn=execution_arn
+        )
+
+        assert exec_resp_idempotent["executionArn"] == execution_arn
+
     @markers.aws.needs_fixing
     def test_start_execution(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
@@ -957,7 +1007,7 @@ class TestSnfApi:
         )
 
         describe_execution = aws_client.stepfunctions.describe_execution(executionArn=execution_arn)
-        sfn_snapshot.match("ddescribe_execution", describe_execution)
+        sfn_snapshot.match("describe_execution", describe_execution)
 
     @markers.aws.validated
     def test_describe_execution_no_such_state_machine(

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
@@ -275,7 +275,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_start_execution": {
-    "recorded-date": "22-06-2023, 13:52:39",
+    "recorded-date": "30-06-2024, 16:12:59",
     "recorded-content": {
       "creation_resp": {
         "creationDate": "datetime",
@@ -298,6 +298,7 @@
           {
             "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
             "name": "<ExecArnPart_0idx>",
+            "redriveCount": 0,
             "startDate": "datetime",
             "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
             "status": "SUCCEEDED",

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
@@ -1534,7 +1534,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_describe_execution": {
-    "recorded-date": "08-03-2024, 11:52:48",
+    "recorded-date": "30-06-2024, 14:51:30",
     "recorded-content": {
       "creation_resp": {
         "creationDate": "datetime",
@@ -1552,7 +1552,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "ddescribe_execution": {
+      "describe_execution": {
         "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
         "input": {},
         "inputDetails": {
@@ -1765,6 +1765,46 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_start_execution_idempotent": {
+    "recorded-date": "30-06-2024, 15:26:21",
+    "recorded-content": {
+      "creation_resp": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_resp": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_resp_idempotent": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_exec_already_exists": {
+        "Error": {
+          "Code": "ExecutionAlreadyExists",
+          "Message": "Execution Already Exists: 'arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>'"
+        },
+        "message": "Execution Already Exists: 'arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
@@ -93,7 +93,7 @@
     "last_validated_date": "2023-08-29T17:40:19+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_start_execution": {
-    "last_validated_date": "2023-06-22T11:52:39+00:00"
+    "last_validated_date": "2024-06-30T16:12:59+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_start_execution_idempotent": {
     "last_validated_date": "2024-06-30T15:26:21+00:00"

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
@@ -45,7 +45,7 @@
     "last_validated_date": "2023-06-22T11:47:36+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_describe_execution": {
-    "last_validated_date": "2024-03-08T11:52:48+00:00"
+    "last_validated_date": "2024-06-30T14:51:30+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_describe_execution_arn_containing_punctuation": {
     "last_validated_date": "2024-06-11T14:54:08+00:00"
@@ -94,6 +94,9 @@
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_start_execution": {
     "last_validated_date": "2023-06-22T11:52:39+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_start_execution_idempotent": {
+    "last_validated_date": "2024-06-30T15:26:21+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_state_machine_status_filter": {
     "last_validated_date": "2024-03-14T21:59:25+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
- Calling `StartExecution` with the same `name` and `input` payload as a currently running execution should be idempotent for `STANDARD` workflows . 
- That is, the  `StartExecution` request should succeed and return the same response as the original `StartExecution` request (from #11104)

From [AWS StartExecution docs](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html):
> StartExecution is idempotent for STANDARD workflows. For a STANDARD workflow, if you call StartExecution with the same name and input as a running execution, the call succeeds and return the same response as the original request. If the execution is closed or if the input is different, it returns a 400 ExecutionAlreadyExists error. You can reuse names after 90 days.
>
> StartExecution isn't idempotent for EXPRESS workflows.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added `_idempotent_start_execution` function that returns a `RUNNING` execution matching `input` and `name` parameters for workflows of type `STANDARD`;  and associated tests in `test_start_execution_idempotent`
- Added a shorter wait-and-pass BaseTemplate that waits 10 seconds before passing.
- Fixed a typo when naming snapshot in `test_describe_execution`  (`ddescribe -> describe`).
- Fixed `test_start_execution` test by skipping `redriveCount` check.
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
