### PR TITLE
APIGW NG implement request data mapping for integration request

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
@@ -16,10 +16,23 @@ class BaseGatewayException(Exception):
 
     message: str = "Unimplemented Response"
     type: GatewayResponseType
+    status_code: int | str = None
 
-    def __init__(self, message: str = None):
+    def __init__(self, message: str = None, status_code: int | str = None):
         if message is not None:
             self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+
+
+class Default4xxError(BaseGatewayException):
+    type: GatewayResponseType.DEFAULT_4XX
+    status_code = 400
+
+
+class Default5xxError(BaseGatewayException):
+    type: GatewayResponseType.DEFAULT_5XX
+    status_code = 500
 
 
 class AccessDeniedError(BaseGatewayException):

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/gateway_exception.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/gateway_exception.py
@@ -55,6 +55,8 @@ class GatewayExceptionHandler(RestApiGatewayExceptionHandler):
         headers = self._build_response_headers()
 
         status_code = gateway_response.get("statusCode")
+        if not status_code:
+            status_code = exception.status_code or 500
 
         return Response(response=content, headers=headers, status=status_code)
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -52,8 +52,14 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
         # TODO: create helper method to render the different URI with stageVariables and parameters
         rendered_integration_uri = integration["uri"]  # use request_data_mapping["path"]
 
+        # TODO: verify the assumptions about the method with an AWS validated test
+        # if the integration method is defined and is not ANY, we can use it for the integration
+        if not (integration_method := integration["httpMethod"]) or integration_method == "ANY":
+            # otherwise, fallback to the request's method
+            integration_method = context.invocation_request["method"]
+
         integration_request = IntegrationRequest(
-            http_method=integration["httpMethod"],
+            http_method=integration_method,
             uri=rendered_integration_uri,
             query_string_parameters=request_data_mapping["querystring"],
             headers=request_data_mapping["header"],

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -30,7 +30,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
 
         if integration_type in (IntegrationType.AWS_PROXY, IntegrationType.HTTP_PROXY):
             # `PROXY` types cannot use integration mapping templates
-            # TODO: check if PROXY can still parameters mapping and substitution in URI for example?
+            # TODO: check if PROXY can still parameters mapping and substitution in URI for example? normally not
             # See
             return
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -38,7 +38,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
 
         # TODO: this handler might not be tested yet until `TemplateMappings` are implemented, as overall behavior will
         #  change
-        integration_request_parameters = integration["requestParameters"]
+        integration_request_parameters = integration["requestParameters"] or {}
         request_data_mapping = self.get_integration_request_data(
             context, integration_request_parameters
         )

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -4,7 +4,8 @@ from localstack.aws.api.apigateway import Integration, IntegrationType
 from localstack.http import Response
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
-from ..context import RestApiInvocationContext
+from ..context import IntegrationRequest, RestApiInvocationContext
+from ..parameters_mapping import ParametersMapper, RequestDataMapping
 
 LOG = logging.getLogger(__name__)
 
@@ -14,6 +15,9 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
     This class will take care of the Integration Request part, which is mostly linked to template mapping
     See https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-integration-settings-integration-request.html
     """
+
+    def __init__(self):
+        self._param_mapper = ParametersMapper()
 
     def __call__(
         self,
@@ -30,11 +34,41 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
             # See
             return
 
-        if integration_type == IntegrationType.MOCK:
-            # TODO: only apply partial rendering of the VTL context
-            return
+        # TODO: maybe first do the `passthroughBehavior` and determine if there's a mapping template?
 
-        # TODO: apply rendering, and attach the Integration Request needed for the Integration to construct its HTTP
-        #  request to send
+        integration_request_parameters = integration["requestParameters"]
+        request_data_mapping = self.get_integration_request_data(
+            context, integration_request_parameters
+        )
 
-        return
+        # TODO: work on TemplateMappings with VTL to render the body of the request
+        #  it might populate the context requestOverride too, maybe deepcopy the ContextVariables because it will
+        #  get mutated, or pop it directly? might just be better!
+
+        # TODO: extract the code under into its own method
+
+        # TODO: create helper method to render the different URI with stageVariables and parameters
+        rendered_integration_uri = integration["uri"]  # use request_data_mapping["path"]
+
+        integration_request = IntegrationRequest(
+            http_method=integration["httpMethod"],
+            uri=rendered_integration_uri,
+            query_string_parameters=request_data_mapping["querystring"],
+            headers=request_data_mapping["headers"],
+            body=b"",  # TODO: from MappingTemplates, see default value?
+        )
+        # TODO: log every override that happens afterwards
+
+        # This is the data downstream integration might use if they are not of `PROXY_` type
+        # LOG.debug("Created integration request from xxx")
+        context.integration_request = integration_request
+
+    def get_integration_request_data(
+        self, context: RestApiInvocationContext, request_parameters: dict[str, str]
+    ) -> RequestDataMapping:
+        return self._param_mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=context.invocation_request,
+            context_variables=context.context_variables,
+            stage_variables=context.stage_variables,
+        )

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -36,6 +36,8 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
 
         # TODO: maybe first do the `passthroughBehavior` and determine if there's a mapping template?
 
+        # TODO: this handler might not be tested yet until `TemplateMappings` are implemented, as overall behavior will
+        #  change
         integration_request_parameters = integration["requestParameters"]
         request_data_mapping = self.get_integration_request_data(
             context, integration_request_parameters
@@ -54,12 +56,12 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
             http_method=integration["httpMethod"],
             uri=rendered_integration_uri,
             query_string_parameters=request_data_mapping["querystring"],
-            headers=request_data_mapping["headers"],
-            body=b"",  # TODO: from MappingTemplates, see default value?
+            headers=request_data_mapping["header"],
+            body=b"",  # TODO: from MappingTemplates or passthrough
         )
         # TODO: log every override that happens afterwards
 
-        # This is the data downstream integration might use if they are not of `PROXY_` type
+        # This is the data that downstream integrations might use if they are not of `PROXY_` type
         # LOG.debug("Created integration request from xxx")
         context.integration_request = integration_request
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
@@ -95,7 +95,6 @@ class ParametersMapper:
                 return to_str(body)
 
             elif expr.startswith("body."):
-                # TODO: error handling
                 json_path = expr.removeprefix("body.")
                 return self._get_json_path_from_dict(decoded_body, json_path)
 
@@ -148,7 +147,7 @@ class ParametersMapper:
             return None
 
     @staticmethod
-    def _json_load(body: bytes) -> dict:
+    def _json_load(body: bytes) -> dict | list:
         """
         AWS only tries to JSON decode the body if it starts with some leading characters ({, [, ", ')
         otherwise, it ignores it

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
@@ -1,0 +1,121 @@
+# > This section explains how to set up data mappings from an API's method request data, including other data
+# stored in context, stage, or util variables, to the corresponding integration request parameters and from an
+# integration response data, including the other data, to the method response parameters. The method request
+# data includes request parameters (path, query string, headers) and the body. The integration response data
+# includes response parameters (headers) and the body. For more information about using the stage variables,
+# see API Gateway stage variables reference.
+#
+# https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html
+import json
+from typing import TypedDict
+
+from localstack.utils.json import extract_jsonpath
+from localstack.utils.strings import to_str
+
+from .context import InvocationRequest
+
+# Integration request parameters, in the form of path variables, query strings or headers, can be mapped from any
+# defined method request parameters and the payload.
+from .variables import ContextVariables
+
+
+class RequestDataMapping(TypedDict):
+    headers: dict[str, str]
+    path: dict[str, str]
+    querystring: dict[str, str]
+
+
+class ParametersMapper:
+    def map_integration_request(
+        self,
+        request_parameters: dict[str, str],
+        invocation_request: InvocationRequest,
+        context_variables: ContextVariables,
+        stage_variables: dict[str, str],
+    ):
+        request_data_mapping = RequestDataMapping(
+            headers={},
+            path={},
+            querystring={},
+        )
+        # TODO: maybe extract functionality and re-use in `map_integration_response`
+
+        for integration_mapping, request_mapping in request_parameters.items():
+            integration_param_location, param_name = integration_mapping.removeprefix(
+                "integration.request."
+            ).split(".")
+
+            if request_mapping.startswith("method.request."):
+                method_req_expr = request_mapping.removeprefix("method.request.")
+                value = self._retrieve_parameter_from_invocation_request(
+                    method_req_expr, invocation_request
+                )
+
+            elif request_mapping.startswith("context."):
+                context_var_expr = request_mapping.removeprefix("context.")
+                value = self._retrieve_parameter_from_context_variables(
+                    context_var_expr, context_variables
+                )
+
+            elif request_mapping.startswith("stageVariables."):
+                stage_var_name = request_mapping.removeprefix("stageVariables.")
+                value = self._retrieve_parameter_from_stage_variables(
+                    stage_var_name, stage_variables
+                )
+
+            elif request_mapping.startswith("'") and request_mapping.endswith("'"):
+                value = request_mapping.strip("'")
+
+            else:
+                # TODO: verify this
+                value = None
+
+            request_data_mapping[integration_param_location][param_name] = value
+
+        return request_data_mapping
+
+    def map_integration_response(self):
+        pass
+
+    def _retrieve_parameter_from_invocation_request(
+        self, expr: str, invocation_request: InvocationRequest
+    ) -> str:
+        if expr == "body":
+            return to_str(invocation_request["body"])
+        elif expr.startswith("body."):
+            # TODO: error handling
+            json_path = expr.removeprefix("body.")
+            decoded_body = json.loads(invocation_request["body"])
+            return self._get_json_path_from_dict(decoded_body, json_path)
+
+        param_type, param_name = expr.split(".")
+        if param_type == "path":
+            return invocation_request["path_parameters"].get(param_name)
+        elif param_type == "querystring":
+            return invocation_request["query_string_parameters"].get(param_name)
+        elif param_type == "multivaluequerystring":
+            # TODO: verify typing here, what is returned and how?
+            return invocation_request["multi_value_query_string_parameters"].get(param_name)
+        elif param_type == "header":
+            # TODO: verify casing here?
+            return invocation_request["raw_headers"].get(param_name)
+        elif param_type == "multivalueheader":
+            # TODO: verify typing here, what is returned and how?
+            return invocation_request["multi_value_headers"].get(param_name)
+
+    def _retrieve_parameter_from_context_variables(
+        self, expr: str, context_variables: ContextVariables
+    ) -> str:
+        # we're using JSON path here because we could access nested properties like `context.identity.sourceIp`
+        return self._get_json_path_from_dict(context_variables, expr)
+
+    @staticmethod
+    def _retrieve_parameter_from_stage_variables(
+        stage_var_name: str, stage_variables: dict[str, str]
+    ) -> str:
+        return stage_variables.get(stage_var_name)
+
+    @staticmethod
+    def _get_json_path_from_dict(body: dict, path: str) -> str:
+        # TODO: verify we don't have special cases
+        return extract_jsonpath(body, f"$.{path}")

--- a/tests/unit/services/apigateway/test_parameters_mapping.py
+++ b/tests/unit/services/apigateway/test_parameters_mapping.py
@@ -1,0 +1,380 @@
+import json
+from http import HTTPMethod
+
+import pytest
+from werkzeug.datastructures import Headers
+
+from localstack.services.apigateway.next_gen.execute_api.context import InvocationRequest
+from localstack.services.apigateway.next_gen.execute_api.gateway_response import Default4xxError
+from localstack.services.apigateway.next_gen.execute_api.parameters_mapping import ParametersMapper
+from localstack.services.apigateway.next_gen.execute_api.variables import (
+    ContextVariables,
+    ContextVarsIdentity,
+)
+from localstack.utils.strings import to_bytes
+
+TEST_API_ID = "test-api"
+TEST_IDENTITY_API_KEY = "random-api-key"
+TEST_USER_AGENT = "test/user-agent"
+
+
+@pytest.fixture
+def default_context_variables() -> ContextVariables:
+    return ContextVariables(
+        resourceId="resource-id",
+        apiId=TEST_API_ID,
+        identity=ContextVarsIdentity(
+            apiKey=TEST_IDENTITY_API_KEY,
+            userAgent=TEST_USER_AGENT,
+        ),
+    )
+
+
+@pytest.fixture
+def default_invocation_request() -> InvocationRequest:
+    headers = {"header_value": "test-header-value"}
+    return InvocationRequest(
+        http_method=HTTPMethod.POST,
+        raw_path="/test/test-path-value",
+        path="/test/test-path-value",
+        path_parameters={"path_value": "test-path-value"},
+        query_string_parameters={"qs_value": "test-qs-value"},
+        raw_headers=Headers(headers),
+        headers=headers,
+        multi_value_query_string_parameters={"qs_value": ["test-qs-value"]},
+        multi_value_headers={"header_value": ["test-header-value"]},
+        body=b"",
+    )
+
+
+class TestApigatewayParametersMapping:
+    def test_default_request_mapping(self, default_invocation_request, default_context_variables):
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.header.test": "method.request.querystring.qs_value",
+            "integration.request.querystring.test": "method.request.path.path_value",
+            "integration.request.path.test": "method.request.header.header_value",
+        }
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=default_invocation_request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+
+        print(f"{default_invocation_request=}")
+
+        assert mapping == {
+            "header": {"test": "test-qs-value"},
+            "path": {"test": "test-header-value"},
+            "querystring": {"test": "test-path-value"},
+        }
+
+    def test_context_variables(self, default_invocation_request, default_context_variables):
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.header.api_id": "context.apiId",
+        }
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=default_invocation_request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+
+        assert mapping == {
+            "header": {"api_id": TEST_API_ID},
+            "path": {},
+            "querystring": {},
+        }
+
+    def test_nested_context_var(self, default_invocation_request, default_context_variables):
+        # TODO: test in AWS casing of context variables??
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.header.my_api_key": "context.identity.apiKey",
+            "integration.request.querystring.userAgent": "context.identity.userAgent",
+        }
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=default_invocation_request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+
+        assert mapping == {
+            "header": {"my_api_key": TEST_IDENTITY_API_KEY},
+            "path": {},
+            "querystring": {"userAgent": TEST_USER_AGENT},
+        }
+
+    def test_stage_variable_mapping(self, default_invocation_request, default_context_variables):
+        # TODO: test in AWS casing of stage Variables??
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.header.my_stage_var": "stageVariables.test_var",
+        }
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=default_invocation_request,
+            context_variables=default_context_variables,
+            stage_variables={"test_var": "a stage variable"},
+        )
+
+        assert mapping == {
+            "header": {"my_stage_var": "a stage variable"},
+            "path": {},
+            "querystring": {},
+        }
+
+    def test_body_mapping(self, default_invocation_request, default_context_variables):
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.header.body_value": "method.request.body",
+        }
+        default_invocation_request["body"] = b"<This is a body value>"
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=default_invocation_request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+
+        assert mapping == {
+            "header": {"body_value": "<This is a body value>"},
+            "path": {},
+            "querystring": {},
+        }
+
+    def test_body_mapping_empty(self, default_invocation_request, default_context_variables):
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.header.body_value": "method.request.body",
+        }
+        default_invocation_request["body"] = b""
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=default_invocation_request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+        # this was validated against AWS
+        # it does not forward the body even with passthrough, but the content of `method.request.body` is `{}`
+        # if the body is empty
+        assert mapping == {
+            "header": {"body_value": "{}"},
+            "path": {},
+            "querystring": {},
+        }
+
+    def test_json_body_mapping(self, default_invocation_request, default_context_variables):
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.header.body_value": "method.request.body.petstore.pets[0].name",
+        }
+
+        default_invocation_request["body"] = to_bytes(
+            json.dumps(
+                {
+                    "petstore": {
+                        "pets": [
+                            {"name": "nested pet name value", "type": "Dog"},
+                            {"name": "second nested value", "type": "Cat"},
+                        ]
+                    }
+                }
+            )
+        )
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=default_invocation_request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+
+        assert mapping == {
+            "header": {"body_value": "nested pet name value"},
+            "path": {},
+            "querystring": {},
+        }
+
+    def test_json_body_mapping_not_found(
+        self, default_invocation_request, default_context_variables
+    ):
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.header.body_value": "method.request.body.petstore.pets[0].name",
+        }
+
+        default_invocation_request["body"] = to_bytes(
+            json.dumps(
+                {
+                    "petstore": {
+                        "pets": {
+                            "name": "nested pet name value",
+                            "type": "Dog",
+                        }
+                    }
+                }
+            )
+        )
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=default_invocation_request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+
+        assert mapping == {
+            "header": {},
+            "path": {},
+            "querystring": {},
+        }
+
+    def test_invalid_json_body_mapping(self, default_invocation_request, default_context_variables):
+        mapper = ParametersMapper()
+        # the only way AWS raises wrong JSON is if the body starts with `{`
+        default_invocation_request["body"] = b"\n{wrongjson"
+
+        request_parameters = {
+            "integration.request.header.body_value": "method.request.body.petstore.pets[0].name",
+        }
+
+        with pytest.raises(Default4xxError) as e:
+            mapper.map_integration_request(
+                request_parameters=request_parameters,
+                invocation_request=default_invocation_request,
+                context_variables=default_context_variables,
+                stage_variables={},
+            )
+        assert e.value.status_code == 400
+        assert e.value.message == "Invalid JSON in request body"
+
+        request_parameters = {
+            "integration.request.header.body_value": "method.request.body",
+        }
+
+        # this is weird, but even if `method.request.body` should not expect JSON and can accept any string (as a
+        # string is valid JSON per definition), it fails if it's malformed JSON.
+        # maybe this is because the AWS console sends `Content-Type: application/json` by default?
+        # TODO: write more AWS validated tests about this
+        with pytest.raises(Default4xxError) as e:
+            mapper.map_integration_request(
+                request_parameters=request_parameters,
+                invocation_request=default_invocation_request,
+                context_variables=default_context_variables,
+                stage_variables={},
+            )
+
+        assert e.value.status_code == 400
+        assert e.value.message == "Invalid JSON in request body"
+
+    def test_multi_headers_mapping(self, default_invocation_request, default_context_variables):
+        # this behavior has been tested manually with the AWS console. TODO: write an AWS validated test
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.header.test": "method.request.header.testMultiHeader",
+            "integration.request.header.test_multi": "method.request.multivalueheader.testMultiHeader",
+            "integration.request.header.test_multi_solo": "method.request.multivalueheader.testHeader",
+        }
+
+        headers = {"testMultiHeader": ["value1", "value2"], "testHeader": "value"}
+
+        default_invocation_request["raw_headers"] = Headers(headers)
+        # this is how AWS maps to the variables passed to proxy integration, it only picks the first of the multi values
+        default_invocation_request["headers"] = {"testMultiHeader": "value1", "testHeader": "value"}
+
+        default_invocation_request["multi_value_headers"] = {
+            "testMultiHeader": ["value1", "value2"],
+            "testHeader": ["value"],
+        }
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=default_invocation_request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+
+        # it seems the mapping picks the last value of the multivalues, but the `headers` part of the context picks the
+        # first one
+        assert mapping == {
+            "header": {"test": "value2", "test_multi": "value1,value2", "test_multi_solo": "value"},
+            "path": {},
+            "querystring": {},
+        }
+
+    def test_multi_qs_mapping(self, default_invocation_request, default_context_variables):
+        # this behavior has been tested manually with the AWS console. TODO: write an AWS validated test
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.querystring.test": "method.request.querystring.testMultiQuery",
+            "integration.request.querystring.test_multi": "method.request.multivaluequerystring.testMultiQuery",
+            "integration.request.querystring.test_multi_solo": "method.request.multivaluequerystring.testQuery",
+        }
+
+        default_invocation_request["query_string_parameters"] = {
+            "testMultiQuery": "value1",
+            "testQuery": "value",
+        }
+        default_invocation_request["multi_value_query_string_parameters"] = {
+            "testMultiQuery": ["value1", "value2"],
+            "testQuery": ["value"],
+        }
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=default_invocation_request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+
+        # it seems the mapping picks the last value of the multivalues, but the `headers` part of the context picks the
+        # first one
+        assert mapping == {
+            "header": {},
+            "path": {},
+            "querystring": {
+                "test": "value2",
+                "test_multi": ["value1", "value2"],
+                "test_multi_solo": "value",
+            },
+        }
+
+    def test_default_request_mapping_missing_request_values(self, default_context_variables):
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.header.test": "method.request.querystring.qs_value",
+            "integration.request.querystring.test": "method.request.path.path_value",
+            "integration.request.path.test": "method.request.header.header_value",
+        }
+
+        request = InvocationRequest(
+            raw_headers=Headers(),
+            headers={},
+            multi_value_headers={},
+            query_string_parameters={},
+            multi_value_query_string_parameters={},
+            path_parameters={},
+        )
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+
+        assert mapping == {
+            "header": {},
+            "path": {},
+            "querystring": {},
+        }

--- a/tests/unit/services/apigateway/test_parameters_mapping.py
+++ b/tests/unit/services/apigateway/test_parameters_mapping.py
@@ -63,8 +63,6 @@ class TestApigatewayParametersMapping:
             stage_variables={},
         )
 
-        print(f"{default_invocation_request=}")
-
         assert mapping == {
             "header": {"test": "test-qs-value"},
             "path": {"test": "test-header-value"},
@@ -91,7 +89,6 @@ class TestApigatewayParametersMapping:
         }
 
     def test_nested_context_var(self, default_invocation_request, default_context_variables):
-        # TODO: test in AWS casing of context variables??
         mapper = ParametersMapper()
         request_parameters = {
             "integration.request.header.my_api_key": "context.identity.apiKey",
@@ -112,7 +109,6 @@ class TestApigatewayParametersMapping:
         }
 
     def test_stage_variable_mapping(self, default_invocation_request, default_context_variables):
-        # TODO: test in AWS casing of stage Variables??
         mapper = ParametersMapper()
         request_parameters = {
             "integration.request.header.my_stage_var": "stageVariables.test_var",
@@ -369,6 +365,29 @@ class TestApigatewayParametersMapping:
         mapping = mapper.map_integration_request(
             request_parameters=request_parameters,
             invocation_request=request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+
+        assert mapping == {
+            "header": {},
+            "path": {},
+            "querystring": {},
+        }
+
+    def test_default_request_mapping_casing(
+        self, default_invocation_request, default_context_variables
+    ):
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.header.test": "method.request.querystring.QS_value",
+            "integration.request.querystring.test": "method.request.path.PATH_value",
+            "integration.request.path.test": "method.request.header.HEADER_value",
+        }
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=default_invocation_request,
             context_variables=default_context_variables,
             stage_variables={},
         )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR implements Parameter Mappings and the base util class. It is also integrated into the Integration Request handler, but that part is still untested because we will wait for the handler to be complete before testing its behavior. 

More informations about Parameters Mappings in this documentation page:
https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html

It allows you to map values from your incoming request (path parameters, query string and headers), as well as the body and even parts of the body with JSON Path. You can also map values from the `$context` variable and stage variables, as well as static data. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement a small change to Gateway Response, as it seems AWS is raising `DEFAULT_4XX` exceptions directly and that wasn't expected. We can now specify a status code directly at runtime when raising this kind of exception
- implement the `ParametersMapper` class which contains the method to get the needed values for your integration request: header, path parameters and query string. 
- implement unit tests to validate the behavior. Most of these unit tests have been written by checking with the AWS Console, but will need to be ported to a few integration tests to confirm behavior. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
