### PR TITLE
APIGW NG fix routing with `ANY` request and remove stage from path

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -15,6 +15,7 @@ class InvocationRequest(TypedDict, total=False):
     http_method: Optional[HTTPMethod]
     """HTTP Method of the incoming request"""
     raw_path: Optional[str]
+    # TODO: verify if raw_path is needed
     """Raw path of the incoming request with no modification, needed to keep double forward slashes"""
     path: Optional[str]
     """Path of the request with no URL decoding"""

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -138,9 +138,8 @@ class InvocationRequestParser(RestApiGatewayHandler):
             domainPrefix=domain_prefix,
             extendedRequestId=short_uid(),  # TODO: use snapshot tests to verify format
             httpMethod=invocation_request["http_method"],
-            path=invocation_request[
-                "path"
-            ],  # TODO: check if we need the raw path? with forward slashes
+            # TODO: check if we need the raw path? with forward slashes
+            path=f"/{context.stage}{invocation_request['path']}",
             protocol="HTTP/1.1",
             requestId=short_uid(),  # TODO: use snapshot tests to verify format
             requestTime=timestamp(time=now, format=REQUEST_TIME_DATE_FORMAT),

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -33,7 +33,7 @@ class InvocationRequestParser(RestApiGatewayHandler):
 
     def parse_and_enrich(self, context: RestApiInvocationContext):
         # first, create the InvocationRequest with the incoming request
-        context.invocation_request = self.create_invocation_request(context.request)
+        context.invocation_request = self.create_invocation_request(context)
         # then we can create the ContextVariables, used throughout the invocation as payload and to render authorizer
         # payload, mapping templates and such.
         context.context_variables = self.create_context_variables(context)
@@ -43,7 +43,8 @@ class InvocationRequestParser(RestApiGatewayHandler):
         context.stage_variables = self.fetch_stage_variables(context)
         LOG.debug("Initializing $stageVariables='%s'", context.stage_variables)
 
-    def create_invocation_request(self, request: Request) -> InvocationRequest:
+    def create_invocation_request(self, context: RestApiInvocationContext) -> InvocationRequest:
+        request = context.request
         params, multi_value_params = self._get_single_and_multi_values_from_multidict(request.args)
         headers, multi_value_headers = self._get_single_and_multi_values_from_headers(
             request.headers
@@ -58,12 +59,14 @@ class InvocationRequestParser(RestApiGatewayHandler):
             body=restore_payload(request),
         )
 
-        self._enrich_with_raw_path(request, invocation_request)
+        self._enrich_with_raw_path(request, invocation_request, stage_name=context.stage)
 
         return invocation_request
 
     @staticmethod
-    def _enrich_with_raw_path(request: Request, invocation_request: InvocationRequest):
+    def _enrich_with_raw_path(
+        request: Request, invocation_request: InvocationRequest, stage_name: str
+    ):
         # Base path is not URL-decoded, so we need to get the `RAW_URI` from the request
         raw_uri = request.environ.get("RAW_URI") or request.path
 
@@ -72,7 +75,11 @@ class InvocationRequestParser(RestApiGatewayHandler):
         if "_user_request_" in raw_uri:
             raw_uri = raw_uri.partition("_user_request_")[2]
 
+        # remove the stage from the path
+        raw_uri = raw_uri.replace(f"/{stage_name}", "")
+
         if raw_uri.startswith("//"):
+            # TODO: AWS validate this assumption
             # if the RAW_URI starts with double slashes, `urlparse` will fail to decode it as path only
             # it also means that we already only have the path, so we just need to remove the query string
             raw_uri = raw_uri.split("?")[0]

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -125,6 +125,7 @@ class TestParsingHandler:
 
         assert context.context_variables["domainName"] == host_header
         assert context.context_variables["domainPrefix"] == TEST_API_ID
+        assert context.context_variables["path"] == f"/{TEST_API_STAGE}/normal-path"
 
     def test_parse_raw_path(self, dummy_deployment, parse_handler_chain, get_invocation_context):
         request = Request(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As @cloutierMat reported, when actually using the next gen APIGW provider, we would not properly route requests, because we had the full path containing the `stage` which didn't map properly to any created Werkzeug Rule. This is how APIGW represents their `path`, this is only what is after the `stage`. 

Only the `$context.path` contains the `stage` and `path`, so we can get weird snapshot with one field named `path` containing `/your-path` and one named `requestContext.path` containing `/stage-name/your-path`. 🤷‍♂️ 

We also had the issue with the `ANY` method, we would try to pass that when creating a Werkzeug Rule. 
We now create a special case where `ANY` gets mapped to `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, and `PUT` (the supported HTTP methods of APIGW).

I was worried about having a rule order issue in Werkzeug, but this proved to not be a problem because we only return the `Resource` from the match, and we can manually get the right `resourceMethod` afterwards. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- create a new Werkzeug Rule to take into account the `ANY` method
- remove the stage from the path in the parsing step
- add new tests for the `ANY` method with different order of creation
- update tests to have the stage in the `Request` path 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
