### PR TITLE
fix CBOR timestamp parsing

### DIFF
--- a/localstack-core/localstack/aws/protocol/parser.py
+++ b/localstack-core/localstack/aws/protocol/parser.py
@@ -72,7 +72,6 @@ from email.utils import parsedate_to_datetime
 from typing import IO, Any, Dict, List, Mapping, Optional, Tuple, Union
 from xml.etree import ElementTree as ETree
 
-import cbor2
 import dateutil.parser
 from botocore.model import (
     ListShape,
@@ -83,6 +82,9 @@ from botocore.model import (
     Shape,
     StructureShape,
 )
+
+# cbor2: explicitly load from private _decoder module to avoid using the (non-patched) C-version
+from cbor2._decoder import loads as cbor2_loads
 from werkzeug.exceptions import BadRequest, NotFound
 
 from localstack.aws.protocol.op_router import RestServiceOperationRouter
@@ -868,7 +870,7 @@ class BaseJSONRequestParser(RequestParser, ABC):
             return {}
         if request.mimetype.startswith("application/x-amz-cbor"):
             try:
-                return cbor2.loads(body_contents)
+                return cbor2_loads(body_contents)
             except ValueError as e:
                 raise ProtocolParserError("HTTP body could not be parsed as CBOR.") from e
         else:
@@ -888,17 +890,13 @@ class BaseJSONRequestParser(RequestParser, ABC):
         if not shape.serialization.get("timestampFormat") and request.mimetype.startswith(
             "application/x-amz-cbor"
         ):
+            # cbor2 has native support for timestamp decoding, so this node could already have the right type
+            if isinstance(node, datetime.datetime):
+                return node
+            # otherwise parse the timestamp using the AWS CBOR timestamp format
+            # (non-CBOR-standard conform, uses millis instead of floating-point-millis)
             return self._convert_str_to_timestamp(node, self.CBOR_TIMESTAMP_FORMAT)
         return super()._parse_timestamp(request, shape, node, uri_params)
-
-    def _parse_blob(
-        self, request: Request, shape: Shape, node: bool, uri_params: Mapping[str, Any] = None
-    ) -> bytes:
-        if isinstance(node, bytes) and request.mimetype.startswith("application/x-amz-cbor"):
-            # CBOR does not base64 encode binary data
-            return bytes(node)
-        else:
-            return super()._parse_blob(request, shape, node, uri_params)
 
 
 class JSONRequestParser(BaseJSONRequestParser):

--- a/tests/aws/services/kinesis/test_kinesis.validation.json
+++ b/tests/aws/services/kinesis/test_kinesis.validation.json
@@ -20,7 +20,13 @@
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_at_timestamp": {
     "last_validated_date": "2024-06-21T15:20:46+00:00"
   },
+  "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_at_timestamp_cbor": {
+    "last_validated_date": "2024-07-04T09:16:32+00:00"
+  },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_sequence_number_as_iterator": {
     "last_validated_date": "2022-08-26T07:29:21+00:00"
+  },
+  "tests/aws/services/kinesis/test_kinesis.py::test_subscribe_to_shard_with_at_timestamp_cbor": {
+    "last_validated_date": "2024-07-04T07:13:22+00:00"
   }
 }

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -642,7 +642,7 @@ def test_json_cbor_blob_parsing():
             "X-Amz-Target": "Kinesis_20131202.PutRecord",
             "x-localstack-tgt-api": "kinesis",
         },
-        "body": b"\xbfjStreamNamedtestdDataMhello, world!lPartitionKeylpartitionkey\xff",
+        "body": b"\xa3dDataTaGVsbG8sIHdvcmxkIQ==jStreamNamedtestlPartitionKeylpartitionkey",
         "url": "/",
         "context": {},
     }

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -7,11 +7,13 @@ from io import BytesIO
 from typing import Any, Dict, Iterator, List, Optional
 from xml.etree import ElementTree
 
-import cbor2
 import pytest
 from botocore.awsrequest import HeadersDict
 from botocore.endpoint import convert_to_response_dict
 from botocore.parsers import ResponseParser, create_parser
+
+# cbor2: explicitly load from private _decoder module to avoid using the (non-patched) C-version
+from cbor2._decoder import loads as cbor2_loads
 from dateutil.tz import tzlocal, tzutc
 from requests.models import Response as RequestsResponse
 from urllib3 import HTTPResponse as UrlLibHttpResponse
@@ -1860,7 +1862,7 @@ def test_json_protocol_cbor_serialization(headers_dict):
     assert result is not None
     assert result.content_type is not None
     assert result.content_type == "application/cbor"
-    parsed_data = cbor2.loads(result.data)
+    parsed_data = cbor2_loads(result.data)
     assert parsed_data == response_data
 
 


### PR DESCRIPTION
## Motivation
Kinesis supports _CBOR_ (Concise Binary Object Representation) encoding as `Content-Type` in addition to JSON.
CBOR support was added for LocalStack with #6494 by extending our ASF parsers and serializers, and patching CBOR support into `botocore` (when being used as a proxy to `kinesis-mock`).
Unfortunately, AWS does not properly implement the CBOR spec when it comes to timestamp handling:
- [RFC8949](https://datatracker.ietf.org/doc/html/rfc8949) defines CBOR timestamps as floating-point epoch seconds:
  > The tag content MUST be an unsigned or negative integer (major types 0 and 1) or a floating-point number (major type 7 with additional information 25, 26, or 27).
  > ...
  > To indicate fractional seconds, floating-point values can be used within tag number 1 instead of integer values.
- AWS however uses milliseconds as nicely described in this issue: https://github.com/aws/aws-sdk-java-v2/issues/4661
  - This means that when using a standard-compliant parser, the timestamps multiplied by 1000 (resulting in an error - "ValueError: year 56474 is out of range"):
    ```
    2024-07-03T13:30:33.095 ERROR --- [et.reactor-1] l.aws.handlers.logging     : exception during call chain
    ValueError: year 56474 is out of range
    
    The above exception was the direct cause of the following exception:
    
    Traceback (most recent call last):
      File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/protocol/parser.py", line 871, in _parse_body_as_json
        return cbor2.loads(body_contents)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
    _cbor2.CBORDecodeValueError: error decoding datetime from epoch
    
    The above exception was the direct cause of the following exception:
    
    Traceback (most recent call last):
      File "/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo/gateway/chain.py", line 166, in handle
        handler(self, self.context, response)
      File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/handlers/service.py", line 63, in __call__
        return self.parse_and_enrich(context)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/handlers/service.py", line 67, in parse_and_enrich
        operation, instance = parser.parse(context.request)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/protocol/parser.py", line 172, in wrapper
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/protocol/parser.py", line 921, in parse
        final_parsed = self._do_parse(request, shape, uri_params)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/protocol/parser.py", line 933, in _do_parse
        parsed = self._handle_json_body(request, shape, uri_params)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/protocol/parser.py", line 945, in _handle_json_body
        parsed_json = self._parse_body_as_json(request)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/protocol/parser.py", line 873, in _parse_body_as_json
        raise ProtocolParserError("HTTP body could not be parsed as CBOR.") from e
    localstack.aws.protocol.parser.ProtocolParserError: HTTP body could not be parsed as CBOR.
    2024-07-03T13:30:33.097  INFO --- [et.reactor-1] localstack.request.http    : POST / => 500
    2024-07-03T13:30:33.151 ERROR --- [t.reactor-11] l.aws.handlers.logging     : exception during call chain
    ```

This already caused a few issues in the past, which were addressed with #6791 and #11071.
But these fixes are only working if the datetime fields are serialized as numbers instead of native timestamps.
The AWS SDK does perform a native timestamp serialization, which again leads to parsing errors (mentioned above, see reproducer linked in "Testing").

This PR addresses the CBOR timestamp parsing/serialization issues directly when using `cbor2` to en-/decode the binary data.

Unfortunately, cbor2 does not easily allow patching standard en-/decoder functions, which is why the fix only works if the Python-native cbor loading code is explicitly imported from the respective private modules (happy for any input on how to make this more stable / better): https://github.com/agronholm/cbor2/issues/192

## Changes
- Patches `cbor2` datetime encoding and decoding.
- Adjusts all imports of `cbor2` to explicitly use the Python implementation instead of the C / native library.
- Fixes the parser (removes an invalid assumption that binary data is not also base64 encoded).
- Fixes the serializer (removed timestamp handling in the serializer - done natively by `cbor2` now).

## Testing
- I created a reproducer using the AWS Java SDK to showcase this issue: https://github.com/alexrashed/kinesis-cbor-reproducer and verified the changes here with this reproducer / the AWS Java SDK.
- I added an AWS-verified plain-request CBOR integration test, testing CBOR serialization and deserialization.

Fixes #9699