### PR TITLE
APIGW NG add Integration Response selection and parameter mapping

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
@@ -1,10 +1,13 @@
 import logging
+import re
 
-from localstack.aws.api.apigateway import Integration, IntegrationType
+from localstack.aws.api.apigateway import Integration, IntegrationResponse, IntegrationType
 from localstack.http import Response
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import RestApiInvocationContext
+from ..gateway_response import Default5xxError
+from ..parameters_mapping import ParametersMapper, ResponseDataMapping
 
 LOG = logging.getLogger(__name__)
 
@@ -14,6 +17,9 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
     This class will take care of the Integration Response part, which is mostly linked to template mapping
     See https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-integration-settings-integration-response.html
     """
+
+    def __init__(self):
+        self._param_mapper = ParametersMapper()
 
     def __call__(
         self,
@@ -31,7 +37,29 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
             # TODO: verify assumptions against AWS
             return
 
+        # we first need to find the right IntegrationResponse based on their selection template, linked to the status
+        # code of the Response
+        # TODO: create util to get the AWS integration type from the URI
+        #  maybe we could cache the result in the context? in an IntegrationDetails field?
+        is_lambda = False
+        if integration_type == IntegrationType.AWS and is_lambda:
+            # fetch errorMessage
+            selection_value = ""
+        else:
+            selection_value = str(response.status_code)
+
+        integration_response: IntegrationResponse = self.select_integration_response(
+            selection_value,
+            integration["integrationResponses"],
+        )
+
         # we then need to apply Integration Response parameters mapping, to only return select headers
+        response_parameters = integration_response["responseParameters"] or {}
+        response_data_mapping = self.get_method_response_data(
+            context=context,
+            response=response,
+            response_parameters=response_parameters,
+        )
 
         # we can also apply the Response Templates, they will depend on status code + accept header?
 
@@ -40,3 +68,58 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
         # here we update the `Response`. We basically need to remove all headers and replace them with the mapping, then
         # override them if there are overrides.
         # for the body, it will maybe depend on configuration?
+
+        response.headers.clear()
+        # there must be some default headers set, snapshot those?
+        if mapped_headers := response_data_mapping.get("header"):
+            response.headers.update(mapped_headers)
+
+    def get_method_response_data(
+        self,
+        context: RestApiInvocationContext,
+        response: Response,
+        response_parameters: dict[str, str],
+    ) -> ResponseDataMapping:
+        return self._param_mapper.map_integration_response(
+            response_parameters=response_parameters,
+            integration_response=response,
+            context_variables=context.context_variables,
+            stage_variables=context.stage_variables,
+        )
+
+    @staticmethod
+    def select_integration_response(
+        selection_value: str, integration_responses: dict[str, IntegrationResponse]
+    ) -> IntegrationResponse:
+        if select_by_pattern := [
+            response
+            for response in integration_responses.values()
+            if (selectionPatten := response.get("selectionPattern"))
+            and re.match(selectionPatten, selection_value)
+        ]:
+            selected_response = select_by_pattern[0]
+            if len(select_by_pattern) > 1:
+                LOG.warning(
+                    "Multiple integration responses matching '%s' statuscode. Choosing '%s' (first).",
+                    selection_value,
+                    selected_response["statusCode"],
+                )
+        else:
+            # choose default return code
+            # TODO: the provider should check this, as we should only have one default with no value in selectionPattern
+            default_responses = [
+                response
+                for response in integration_responses.values()
+                if not response.get("selectionPattern")
+            ]
+            if not default_responses:
+                # TODO: verify exception
+                raise Default5xxError("Internal server error")
+
+            selected_response = default_responses[0]
+            if len(default_responses) > 1:
+                LOG.warning(
+                    "Multiple default integration responses. Choosing %s (first).",
+                    selected_response["statusCode"],
+                )
+        return selected_response

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
@@ -1,5 +1,6 @@
 import logging
 
+from localstack.aws.api.apigateway import Integration, IntegrationType
 from localstack.http import Response
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
@@ -20,5 +21,22 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
         context: RestApiInvocationContext,
         response: Response,
     ):
-        # TODO: if the integration type is AWS_PROXY, return
-        return
+        # TODO: we should log the response coming in from the Integration, either in Integration or here.
+        #  before modification / after?
+        integration: Integration = context.resource_method["methodIntegration"]
+        integration_type = integration["type"]
+
+        if integration_type in (IntegrationType.AWS_PROXY, IntegrationType.HTTP_PROXY):
+            # `PROXY` types cannot use integration response mapping templates
+            # TODO: verify assumptions against AWS
+            return
+
+        # we then need to apply Integration Response parameters mapping, to only return select headers
+
+        # we can also apply the Response Templates, they will depend on status code + accept header?
+
+        # then responseOverride
+
+        # here we update the `Response`. We basically need to remove all headers and replace them with the mapping, then
+        # override them if there are overrides.
+        # for the body, it will maybe depend on configuration?

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_response.py
@@ -20,4 +20,6 @@ class MethodResponseHandler(RestApiGatewayHandler):
         context: RestApiInvocationContext,
         response: Response,
     ):
+        # TODO: for AWS/HTTP/MOCK integration:
+        #  > If no method response is defined for the returned status code, API Gateway returns a 500 error.
         return

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_response.py
@@ -20,6 +20,4 @@ class MethodResponseHandler(RestApiGatewayHandler):
         context: RestApiInvocationContext,
         response: Response,
     ):
-        # TODO: for AWS/HTTP/MOCK integration:
-        #  > If no method response is defined for the returned status code, API Gateway returns a 500 error.
         return

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
@@ -275,7 +275,7 @@ class ParametersMapper:
             return None
 
     @staticmethod
-    def _json_load(body: bytes | str) -> dict | list:
+    def _json_load(body: bytes) -> dict | list:
         """
         AWS only tries to JSON decode the body if it starts with some leading characters ({, [, ", ')
         otherwise, it ignores it

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
@@ -10,6 +10,7 @@ import json
 import logging
 from typing import TypedDict
 
+from localstack.http import Response
 from localstack.utils.json import extract_jsonpath
 from localstack.utils.strings import to_str
 
@@ -28,6 +29,12 @@ class RequestDataMapping(TypedDict):
     querystring: dict[str, str | list[str]]
 
 
+class ResponseDataMapping(TypedDict):
+    # Method response header parameters can be mapped from any integration response header or integration response body,
+    # $context variables, or static values.
+    header: dict[str, str]
+
+
 class ParametersMapper:
     def map_integration_request(
         self,
@@ -41,7 +48,6 @@ class ParametersMapper:
             path={},
             querystring={},
         )
-        # TODO: maybe extract functionality and re-use in `map_integration_response`
 
         for integration_mapping, request_mapping in request_parameters.items():
             integration_param_location, param_name = integration_mapping.removeprefix(
@@ -54,39 +60,140 @@ class ParametersMapper:
                     method_req_expr, invocation_request
                 )
 
-            elif request_mapping.startswith("context."):
-                context_var_expr = request_mapping.removeprefix("context.")
-                value = self._retrieve_parameter_from_context_variables(
-                    context_var_expr, context_variables
-                )
-
-            elif request_mapping.startswith("stageVariables."):
-                stage_var_name = request_mapping.removeprefix("stageVariables.")
-                value = self._retrieve_parameter_from_stage_variables(
-                    stage_var_name, stage_variables
-                )
-
-            elif request_mapping.startswith("'") and request_mapping.endswith("'"):
-                value = request_mapping.strip("'")
-
             else:
-                LOG.warning(
-                    "Unrecognized requestParameter value: '%s'. Skipping the parameter mapping.",
-                    request_mapping,
+                value = self._retrieve_parameter_from_variables_and_static(
+                    mapping_value=request_mapping,
+                    context_variables=context_variables,
+                    stage_variables=stage_variables,
                 )
-                value = None
 
             if value:
                 request_data_mapping[integration_param_location][param_name] = value
 
         return request_data_mapping
 
-    def map_integration_response(self):
-        pass
+    def map_integration_response(
+        self,
+        response_parameters: dict[str, str],
+        integration_response: Response,
+        context_variables: ContextVariables,
+        stage_variables: dict[str, str],
+    ) -> ResponseDataMapping:
+        response_data_mapping = ResponseDataMapping(header={})
+
+        for response_mapping, integration_mapping in response_parameters.items():
+            header_name = response_mapping.removeprefix("method.response.header.")
+
+            if integration_mapping.startswith("integration.response."):
+                method_req_expr = integration_mapping.removeprefix("integration.response.")
+                value = self._retrieve_parameter_from_integration_response(
+                    method_req_expr, integration_response
+                )
+            else:
+                value = self._retrieve_parameter_from_variables_and_static(
+                    mapping_value=integration_mapping,
+                    context_variables=context_variables,
+                    stage_variables=stage_variables,
+                )
+
+            if value:
+                response_data_mapping["header"][header_name] = value
+
+        return response_data_mapping
+
+    def _retrieve_parameter_from_variables_and_static(
+        self,
+        mapping_value: str,
+        context_variables: ContextVariables,
+        stage_variables: dict[str, str],
+    ):
+        if mapping_value.startswith("context."):
+            context_var_expr = mapping_value.removeprefix("context.")
+            return self._retrieve_parameter_from_context_variables(
+                context_var_expr, context_variables
+            )
+
+        elif mapping_value.startswith("stageVariables."):
+            stage_var_name = mapping_value.removeprefix("stageVariables.")
+            return self._retrieve_parameter_from_stage_variables(stage_var_name, stage_variables)
+
+        elif mapping_value.startswith("'") and mapping_value.endswith("'"):
+            return mapping_value.strip("'")
+
+        else:
+            LOG.warning(
+                "Unrecognized parameter mapping value: '%s'. Skipping this mapping.",
+                mapping_value,
+            )
+            return None
+
+    def _retrieve_parameter_from_integration_response(
+        self,
+        expr: str,
+        integration_response: Response,
+    ) -> str | None:
+        """
+        See https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html#mapping-response-parameters
+        :param expr: mapping expression stripped from `integration.response.`:
+                     Can be of the following: `header.<param_name>`, multivalueheader.<param_name>, `body` and
+                     `body.<JSONPath_expression>.`
+        :param integration_response: the Response to map parameters from
+        :return: the value to map in the ResponseDataMapping
+        """
+        if expr.startswith("body"):
+            body = integration_response.get_data(as_text=True)
+            body = body.strip()
+            try:
+                decoded_body = self._json_load(body)
+            except ValueError:
+                # TODO: change
+                raise Default4xxError(message="Invalid JSON in request body")
+
+            if expr == "body":
+                return body
+
+            elif expr.startswith("body."):
+                json_path = expr.removeprefix("body.")
+                return self._get_json_path_from_dict(decoded_body, json_path)
+            else:
+                LOG.warning(
+                    "Unrecognized integration.response parameter: '%s'. Skipping the parameter mapping.",
+                    expr,
+                )
+                return None
+
+        param_type, param_name = expr.split(".")
+
+        if param_type == "header":
+            # TODO: validate casing! for request it was strict?
+            multi_headers = integration_response.headers.getlist(param_name)
+            if multi_headers:
+                return multi_headers[-1]
+
+        elif param_type == "multivalueheader":
+            # TODO: validate casing! for request it was strict?
+            multi_headers = integration_response.headers.getlist(param_name)
+            # TODO: format?
+            return ",".join(multi_headers)
+
+        else:
+            LOG.warning(
+                "Unrecognized integration.response parameter: '%s'. Skipping the parameter mapping.",
+                expr,
+            )
 
     def _retrieve_parameter_from_invocation_request(
         self, expr: str, invocation_request: InvocationRequest
     ) -> str | list[str] | None:
+        """
+        See https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html#mapping-response-parameters
+        :param expr: mapping expression stripped from `method.request.`:
+                     Can be of the following: `path.<param_name>`, `querystring.<param_name>`,
+                     `multivaluequerystring.<param_name>`, `header.<param_name>`, `multivalueheader.<param_name>`,
+                     `body` and `body.<JSONPath_expression>.`
+        :param invocation_request: the InvocationRequest to map parameters from
+        :return: the value to map in the RequestDataMapping
+        """
         if expr.startswith("body"):
             body = invocation_request["body"] or b"{}"
             body = body.strip()
@@ -163,7 +270,7 @@ class ParametersMapper:
             return None
 
     @staticmethod
-    def _json_load(body: bytes) -> dict | list:
+    def _json_load(body: bytes | str) -> dict | list:
         """
         AWS only tries to JSON decode the body if it starts with some leading characters ({, [, ", ')
         otherwise, it ignores it

--- a/tests/unit/services/apigateway/test_handler_integration_response.py
+++ b/tests/unit/services/apigateway/test_handler_integration_response.py
@@ -1,0 +1,95 @@
+import pytest
+
+from localstack.aws.api.apigateway import IntegrationResponse
+from localstack.services.apigateway.next_gen.execute_api.gateway_response import (
+    ApiConfigurationError,
+)
+from localstack.services.apigateway.next_gen.execute_api.handlers import IntegrationResponseHandler
+
+
+class TestSelectionPattern:
+    def test_selection_pattern_status_code(self):
+        integration_responses = {
+            "2OO": IntegrationResponse(
+                statusCode="200",
+            ),
+            "400": IntegrationResponse(
+                statusCode="400",
+                selectionPattern="400",
+            ),
+            "500": IntegrationResponse(
+                statusCode="500",
+                selectionPattern=r"5\d{2}",
+            ),
+        }
+
+        def select_int_response(selection_value: str) -> IntegrationResponse:
+            return IntegrationResponseHandler.select_integration_response(
+                selection_value=selection_value,
+                integration_responses=integration_responses,
+            )
+
+        int_response = select_int_response("200")
+        assert int_response["statusCode"] == "200"
+
+        int_response = select_int_response("400")
+        assert int_response["statusCode"] == "400"
+
+        int_response = select_int_response("404")
+        # fallback to default
+        assert int_response["statusCode"] == "200"
+
+        int_response = select_int_response("500")
+        assert int_response["statusCode"] == "500"
+
+        int_response = select_int_response("501")
+        assert int_response["statusCode"] == "500"
+
+    def test_selection_pattern_no_default(self):
+        integration_responses = {
+            "2OO": IntegrationResponse(
+                statusCode="200",
+                selectionPattern="200",
+            ),
+        }
+
+        with pytest.raises(ApiConfigurationError) as e:
+            IntegrationResponseHandler.select_integration_response(
+                selection_value="404",
+                integration_responses=integration_responses,
+            )
+        assert e.value.message == "Internal server error"
+
+    def test_selection_pattern_string(self):
+        integration_responses = {
+            "2OO": IntegrationResponse(
+                statusCode="200",
+            ),
+            "400": IntegrationResponse(
+                statusCode="400",
+                selectionPattern="Malformed.*",
+            ),
+            "500": IntegrationResponse(
+                statusCode="500",
+                selectionPattern="Internal.*",
+            ),
+        }
+
+        def select_int_response(selection_value: str) -> IntegrationResponse:
+            return IntegrationResponseHandler.select_integration_response(
+                selection_value=selection_value,
+                integration_responses=integration_responses,
+            )
+
+        # this would basically no error message from AWS lambda
+        int_response = select_int_response("")
+        assert int_response["statusCode"] == "200"
+
+        int_response = select_int_response("Malformed request")
+        assert int_response["statusCode"] == "400"
+
+        int_response = select_int_response("Internal server error")
+        assert int_response["statusCode"] == "500"
+
+        int_response = select_int_response("Random error")
+        assert int_response["statusCode"] == "200"

--- a/tests/unit/services/apigateway/test_parameters_mapping.py
+++ b/tests/unit/services/apigateway/test_parameters_mapping.py
@@ -47,7 +47,7 @@ def default_invocation_request() -> InvocationRequest:
     )
 
 
-class TestApigatewayParametersMapping:
+class TestApigatewayRequestParametersMapping:
     def test_default_request_mapping(self, default_invocation_request, default_context_variables):
         mapper = ParametersMapper()
         request_parameters = {
@@ -397,3 +397,12 @@ class TestApigatewayParametersMapping:
             "path": {},
             "querystring": {},
         }
+
+
+class TestApigatewayResponseParametersMapping:
+    """
+    Only `method.response` headers can be mapping from `responseParameters`.
+    https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html#mapping-response-parameters
+    """
+
+    pass


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR starts implementing the Integration Response handler, who's responsible for selecting the right `IntegrationResponse` based on the response status code (or an `errorMessage` field very specific to the `AWS` integration with Lambda, which we will tackle later). 

The handler should then do the response parameters mapping, then the VTL rendering of the body. 
We do not test the handler yet, same as the Integration Request handler, as the behavior is incomplete yet.

Instead, we can focus on the integration response selection, and the response parameters mapping. All of the unit tests have been manually tested against AWS, with the console and a SSH tunnel with localhost.run to my own small flask server to be able to return arbitrary payload from my HTTP payload. 

More informations about the different subjects of the PR:

- https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html#mapping-response-parameters
- https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-integration-settings-integration-response.html
- https://docs.aws.amazon.com/apigateway/latest/developerguide/handle-errors-in-lambda-integration.html?icmpid=apigateway_console_help

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement the base of the Integration Response handler, still very WIP, with comments outlining what I currently think is happening
- ported the current `selectionPattern` util to select the right integration response (thanks @dfangl for implementing it!) and unit test it
- refactor the parameter mapping a bit to share code between request and response parameter mappings (code is still pretty similar, but has a few distinct difference, we could always refactor later on)
- add the response parameter mapping logic 
- add unit tests for response parameter mapping


## TODO

What's left to do:

- [x] add unit tests for Response Parameters by validating with AWS
- [x] add unit tests for selecting the integration response
