### PR TITLE
[SFN] Base Support for Express Workflows

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/eval/environment.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/eval/environment.py
@@ -8,6 +8,7 @@ from typing import Any, Final, Optional
 from localstack.aws.api.stepfunctions import (
     Arn,
     ExecutionFailedEventDetails,
+    StateMachineType,
     Timestamp,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.itemprocessor.map_run_record import (
@@ -50,6 +51,7 @@ class Environment:
     event_history_context: Final[EventHistoryContext]
     cloud_watch_logging_session: Final[Optional[CloudWatchLoggingSession]]
     aws_execution_details: Final[AWSExecutionDetails]
+    execution_type: Final[StateMachineType]
     callback_pool_manager: CallbackPoolManager
     map_run_record_pool_manager: MapRunRecordPoolManager
     context_object_manager: Final[ContextObjectManager]
@@ -65,6 +67,7 @@ class Environment:
     def __init__(
         self,
         aws_execution_details: AWSExecutionDetails,
+        execution_type: StateMachineType,
         context_object_init: ContextObjectInitData,
         event_history_context: EventHistoryContext,
         cloud_watch_logging_session: Optional[CloudWatchLoggingSession],
@@ -80,6 +83,7 @@ class Environment:
         self.event_history_context = event_history_context
 
         self.aws_execution_details = aws_execution_details
+        self.execution_type = execution_type
         self.callback_pool_manager = CallbackPoolManager(activity_store=activity_store)
         self.map_run_record_pool_manager = MapRunRecordPoolManager()
 
@@ -111,6 +115,7 @@ class Environment:
         )
         frame = cls(
             aws_execution_details=env.aws_execution_details,
+            execution_type=env.execution_type,
             context_object_init=context_object_init,
             event_history_context=event_history_frame_cache,
             cloud_watch_logging_session=env.cloud_watch_logging_session,
@@ -214,3 +219,6 @@ class Environment:
 
     def is_frame(self) -> bool:
         return self._is_frame
+
+    def is_standard_workflow(self) -> bool:
+        return self.execution_type == StateMachineType.STANDARD

--- a/localstack-core/localstack/services/stepfunctions/asl/eval/test_state/environment.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/eval/test_state/environment.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Final, Optional
 
-from localstack.aws.api.stepfunctions import Arn, InspectionData
+from localstack.aws.api.stepfunctions import Arn, InspectionData, StateMachineType
 from localstack.services.stepfunctions.asl.eval.aws_execution_details import AWSExecutionDetails
 from localstack.services.stepfunctions.asl.eval.contextobject.contex_object import (
     ContextObjectInitData,
@@ -27,6 +27,7 @@ class TestStateEnvironment(Environment):
     def __init__(
         self,
         aws_execution_details: AWSExecutionDetails,
+        execution_type: StateMachineType,
         context_object_init: ContextObjectInitData,
         event_history_context: EventHistoryContext,
         activity_store: dict[Arn, Activity],
@@ -34,6 +35,7 @@ class TestStateEnvironment(Environment):
     ):
         super().__init__(
             aws_execution_details=aws_execution_details,
+            execution_type=execution_type,
             context_object_init=context_object_init,
             event_history_context=event_history_context,
             cloud_watch_logging_session=cloud_watch_logging_session,

--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/express_static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/express_static_analyser.py
@@ -1,0 +1,34 @@
+from localstack.services.stepfunctions.asl.antlr.runtime.ASLParser import ASLParser
+from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
+    ActivityResource,
+    Resource,
+    ResourceCondition,
+    ServiceResource,
+)
+from localstack.services.stepfunctions.asl.static_analyser.static_analyser import StaticAnalyser
+
+
+class ExpressStaticAnalyser(StaticAnalyser):
+    def visitResource_decl(self, ctx: ASLParser.Resource_declContext) -> None:
+        # TODO add resource path to the error messages.
+
+        resource_str: str = ctx.keyword_or_string().getText()[1:-1]
+        resource = Resource.from_resource_arn(resource_str)
+
+        if isinstance(resource, ActivityResource):
+            raise ValueError(
+                "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: "
+                "Express state machine does not support Activity ARN'"
+            )
+
+        if isinstance(resource, ServiceResource):
+            if resource.condition == ResourceCondition.WaitForTaskToken:
+                raise ValueError(
+                    "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: "
+                    "Express state machine does not support '.sync' service integration."
+                )
+            if resource.condition is not None:
+                raise ValueError(
+                    "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: "
+                    f"Express state machine does not support .'{resource.condition}' service integration."
+                )

--- a/localstack-core/localstack/services/stepfunctions/backend/test_state/execution.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/test_state/execution.py
@@ -8,6 +8,7 @@ from localstack.aws.api.stepfunctions import (
     Arn,
     ExecutionStatus,
     InspectionLevel,
+    StateMachineType,
     TestExecutionStatus,
     TestStateOutput,
     Timestamp,
@@ -64,6 +65,7 @@ class TestStateExecution(Execution):
     ):
         super().__init__(
             name=name,
+            sm_type=StateMachineType.STANDARD,
             role_arn=role_arn,
             exec_arn=exec_arn,
             account_id=account_id,
@@ -83,6 +85,7 @@ class TestStateExecution(Execution):
 
     def _get_start_execution_worker(self) -> TestStateExecutionWorker:
         return TestStateExecutionWorker(
+            execution_type=StateMachineType.STANDARD,
             definition=self.state_machine.definition,
             input_data=self.input_data,
             exec_comm=self._get_start_execution_worker_comm(),

--- a/localstack-core/localstack/services/stepfunctions/backend/test_state/execution_worker.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/test_state/execution_worker.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from localstack.aws.api.stepfunctions import StateMachineType
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.eval.event.event_manager import (
@@ -9,10 +10,10 @@ from localstack.services.stepfunctions.asl.eval.test_state.environment import Te
 from localstack.services.stepfunctions.asl.parse.test_state.asl_parser import (
     TestStateAmazonStateLanguageParser,
 )
-from localstack.services.stepfunctions.backend.execution_worker import ExecutionWorker
+from localstack.services.stepfunctions.backend.execution_worker import SyncExecutionWorker
 
 
-class TestStateExecutionWorker(ExecutionWorker):
+class TestStateExecutionWorker(SyncExecutionWorker):
     env: Optional[TestStateEnvironment]
 
     def _get_evaluation_entrypoint(self) -> EvalComponent:
@@ -21,11 +22,8 @@ class TestStateExecutionWorker(ExecutionWorker):
     def _get_evaluation_environment(self) -> Environment:
         return TestStateEnvironment(
             aws_execution_details=self._aws_execution_details,
+            execution_type=StateMachineType.STANDARD,
             context_object_init=self._context_object_init,
             event_history_context=EventHistoryContext.of_program_start(),
             activity_store=self._activity_store,
         )
-
-    def start(self):
-        # bypass the native async execution of ASL programs.
-        self._execution_logic()

--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -125,6 +125,11 @@ from localstack.services.stepfunctions.backend.state_machine import (
 )
 from localstack.services.stepfunctions.backend.store import SFNStore, sfn_stores
 from localstack.services.stepfunctions.backend.test_state.execution import TestStateExecution
+from localstack.services.stepfunctions.stepfunctions_utils import (
+    assert_pagination_parameters_valid,
+    get_next_page_token_from_arn,
+    normalise_max_results,
+)
 from localstack.state import StateVisitor
 from localstack.utils.aws.arns import (
     stepfunctions_activity_arn,
@@ -132,6 +137,7 @@ from localstack.utils.aws.arns import (
     stepfunctions_standard_execution_arn,
     stepfunctions_state_machine_arn,
 )
+from localstack.utils.collections import PaginatedList
 from localstack.utils.strings import long_uid, short_uid
 
 LOG = logging.getLogger(__name__)

--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -65,10 +65,12 @@ from localstack.aws.api.stepfunctions import (
     SensitiveData,
     SensitiveError,
     StartExecutionOutput,
+    StartSyncExecutionOutput,
     StateMachineAlreadyExists,
     StateMachineDoesNotExist,
     StateMachineList,
     StateMachineType,
+    StateMachineTypeNotSupported,
     StepfunctionsApi,
     StopExecutionOutput,
     TagKeyList,
@@ -111,7 +113,7 @@ from localstack.services.stepfunctions.asl.static_analyser.test_state.test_state
     TestStateStaticAnalyser,
 )
 from localstack.services.stepfunctions.backend.activity import Activity, ActivityTask
-from localstack.services.stepfunctions.backend.execution import Execution
+from localstack.services.stepfunctions.backend.execution import Execution, SyncExecution
 from localstack.services.stepfunctions.backend.state_machine import (
     StateMachineInstance,
     StateMachineRevision,
@@ -120,18 +122,13 @@ from localstack.services.stepfunctions.backend.state_machine import (
 )
 from localstack.services.stepfunctions.backend.store import SFNStore, sfn_stores
 from localstack.services.stepfunctions.backend.test_state.execution import TestStateExecution
-from localstack.services.stepfunctions.stepfunctions_utils import (
-    assert_pagination_parameters_valid,
-    get_next_page_token_from_arn,
-    normalise_max_results,
-)
 from localstack.state import StateVisitor
 from localstack.utils.aws.arns import (
     stepfunctions_activity_arn,
-    stepfunctions_execution_state_machine_arn,
+    stepfunctions_express_execution_arn,
+    stepfunctions_standard_execution_arn,
     stepfunctions_state_machine_arn,
 )
-from localstack.utils.collections import PaginatedList
 from localstack.utils.strings import long_uid, short_uid
 
 LOG = logging.getLogger(__name__)
@@ -152,7 +149,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
     )
 
     _STATE_MACHINE_EXECUTION_ARN_REGEX: Final[re.Pattern] = re.compile(
-        r"^arn:aws:states:[a-z0-9-]+:[0-9]{12}:(stateMachine|execution):[a-zA-Z0-9-_.]+(:\d+)?(:[a-zA-Z0-9-_.]+)?$"
+        r"^arn:aws:states:[a-z0-9-]+:[0-9]{12}:(stateMachine|execution|express):[a-zA-Z0-9-_.]+(:\d+)?(:[a-zA-Z0-9-_.]+)*$"
     )
 
     _ACTIVITY_ARN_REGEX: Final[re.Pattern] = re.compile(
@@ -169,7 +166,8 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
     def _raise_state_machine_does_not_exist(state_machine_arn: str) -> None:
         raise StateMachineDoesNotExist(f"State Machine Does Not Exist: '{state_machine_arn}'")
 
-    def _validate_state_machine_execution_arn(self, execution_arn: str) -> None:
+    @staticmethod
+    def _validate_state_machine_execution_arn(execution_arn: str) -> None:
         # TODO: InvalidArn exception message do not communicate which part of the ARN is incorrect.
         if not StepFunctionsProvider._STATE_MACHINE_EXECUTION_ARN_REGEX.match(execution_arn):
             raise InvalidArn(f"Invalid arn: '{execution_arn}'")
@@ -179,6 +177,18 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         # TODO: InvalidArn exception message do not communicate which part of the ARN is incorrect.
         if not StepFunctionsProvider._ACTIVITY_ARN_REGEX.match(activity_arn):
             raise InvalidArn(f"Invalid arn: '{activity_arn}'")
+
+    def _raise_state_machine_type_not_supported(self):
+        raise StateMachineTypeNotSupported(
+            "This operation is not supported by this type of state machine"
+        )
+
+    @staticmethod
+    def _raise_resource_type_not_in_context(resource_type: str) -> None:
+        lower_resource_type = resource_type.lower()
+        raise InvalidArn(
+            f"Invalid Arn: 'Resource type not valid in this context: {lower_resource_type}'"
+        )
 
     @staticmethod
     def _validate_activity_name(name: str) -> None:
@@ -487,14 +497,14 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         **kwargs,
     ) -> StartExecutionOutput:
         self._validate_state_machine_arn(state_machine_arn)
-        state_machine: Optional[StateMachineInstance] = self.get_store(context).state_machines.get(
-            state_machine_arn
-        )
-        if not state_machine:
+        unsafe_state_machine: Optional[StateMachineInstance] = self.get_store(
+            context
+        ).state_machines.get(state_machine_arn)
+        if not unsafe_state_machine:
             self._raise_state_machine_does_not_exist(state_machine_arn)
 
         # Update event change parameters about the state machine and should not affect those about this execution.
-        state_machine_clone = copy.deepcopy(state_machine)
+        state_machine_clone = copy.deepcopy(unsafe_state_machine)
 
         if input is None:
             input_data = dict()
@@ -505,27 +515,31 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
                 raise InvalidExecutionInput(str(ex))  # TODO: report parsing error like AWS.
 
         normalised_state_machine_arn = (
-            state_machine.source_arn
-            if isinstance(state_machine, StateMachineVersion)
-            else state_machine.arn
+            state_machine_clone.source_arn
+            if isinstance(state_machine_clone, StateMachineVersion)
+            else state_machine_clone.arn
         )
         exec_name = name or long_uid()  # TODO: validate name format
-        exec_arn = stepfunctions_execution_state_machine_arn(
-            normalised_state_machine_arn, exec_name
-        )
+        if state_machine_clone.sm_type == StateMachineType.STANDARD:
+            exec_arn = stepfunctions_standard_execution_arn(normalised_state_machine_arn, exec_name)
+        else:
+            # Exhaustive check on STANDARD and EXPRESS type, validated on creation.
+            exec_arn = stepfunctions_express_execution_arn(normalised_state_machine_arn, exec_name)
+
         if exec_arn in self.get_store(context).executions:
             raise InvalidName()  # TODO
 
         # Create the execution logging session, if logging is configured.
         cloud_watch_logging_session = None
-        if state_machine.cloud_watch_logging_configuration is not None:
+        if state_machine_clone.cloud_watch_logging_configuration is not None:
             cloud_watch_logging_session = CloudWatchLoggingSession(
                 execution_arn=exec_arn,
-                configuration=state_machine.cloud_watch_logging_configuration,
+                configuration=state_machine_clone.cloud_watch_logging_configuration,
             )
 
         execution = Execution(
             name=exec_name,
+            sm_type=state_machine_clone.sm_type,
             role_arn=state_machine_clone.role_arn,
             exec_arn=exec_arn,
             account_id=context.account_id,
@@ -542,11 +556,84 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         execution.start()
         return execution.to_start_output()
 
+    def start_sync_execution(
+        self,
+        context: RequestContext,
+        state_machine_arn: Arn,
+        name: Name = None,
+        input: SensitiveData = None,
+        trace_header: TraceHeader = None,
+        **kwargs,
+    ) -> StartSyncExecutionOutput:
+        self._validate_state_machine_arn(state_machine_arn)
+        unsafe_state_machine: Optional[StateMachineInstance] = self.get_store(
+            context
+        ).state_machines.get(state_machine_arn)
+        if not unsafe_state_machine:
+            self._raise_state_machine_does_not_exist(state_machine_arn)
+
+        if unsafe_state_machine.sm_type == StateMachineType.STANDARD:
+            self._raise_state_machine_type_not_supported()
+
+        # Update event change parameters about the state machine and should not affect those about this execution.
+        state_machine_clone = copy.deepcopy(unsafe_state_machine)
+
+        if input is None:
+            input_data = dict()
+        else:
+            try:
+                input_data = json.loads(input)
+            except Exception as ex:
+                raise InvalidExecutionInput(str(ex))  # TODO: report parsing error like AWS.
+
+        normalised_state_machine_arn = (
+            state_machine_clone.source_arn
+            if isinstance(state_machine_clone, StateMachineVersion)
+            else state_machine_clone.arn
+        )
+        exec_name = name or long_uid()  # TODO: validate name format
+        exec_arn = stepfunctions_express_execution_arn(normalised_state_machine_arn, exec_name)
+
+        if exec_arn in self.get_store(context).executions:
+            raise InvalidName()  # TODO
+
+        # Create the execution logging session, if logging is configured.
+        cloud_watch_logging_session = None
+        if state_machine_clone.cloud_watch_logging_configuration is not None:
+            cloud_watch_logging_session = CloudWatchLoggingSession(
+                execution_arn=exec_arn,
+                configuration=state_machine_clone.cloud_watch_logging_configuration,
+            )
+
+        execution = SyncExecution(
+            name=exec_name,
+            sm_type=state_machine_clone.sm_type,
+            role_arn=state_machine_clone.role_arn,
+            exec_arn=exec_arn,
+            account_id=context.account_id,
+            region_name=context.region,
+            state_machine=state_machine_clone,
+            start_date=datetime.datetime.now(tz=datetime.timezone.utc),
+            cloud_watch_logging_session=cloud_watch_logging_session,
+            input_data=input_data,
+            trace_header=trace_header,
+            activity_store=self.get_store(context).activities,
+        )
+        self.get_store(context).executions[exec_arn] = execution
+
+        execution.start()
+        return execution.to_start_sync_execution_output()
+
     def describe_execution(
         self, context: RequestContext, execution_arn: Arn, **kwargs
     ) -> DescribeExecutionOutput:
         self._validate_state_machine_execution_arn(execution_arn)
         execution: Execution = self._get_execution(context=context, execution_arn=execution_arn)
+
+        # Action only compatible with STANDARD workflows.
+        if execution.sm_type != StateMachineType.STANDARD:
+            self._raise_resource_type_not_in_context(resource_type=execution.sm_type)
+
         return execution.to_describe_output()
 
     @staticmethod
@@ -582,6 +669,11 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         state_machine = self.get_store(context).state_machines.get(state_machine_arn)
         if state_machine is None:
             self._raise_state_machine_does_not_exist(state_machine_arn)
+
+        if state_machine.sm_type != StateMachineType.STANDARD:
+            self._raise_state_machine_type_not_supported()
+
+        # TODO: add support for paging
 
         allowed_execution_status = [
             ExecutionStatus.SUCCEEDED,
@@ -707,6 +799,11 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         # TODO: add support for paging, ordering, and other manipulations.
         self._validate_state_machine_execution_arn(execution_arn)
         execution: Execution = self._get_execution(context=context, execution_arn=execution_arn)
+
+        # Action only compatible with STANDARD workflows.
+        if execution.sm_type != StateMachineType.STANDARD:
+            self._raise_resource_type_not_in_context(resource_type=execution.sm_type)
+
         history: GetExecutionHistoryOutput = execution.to_history_output()
         if reverse_order:
             history["events"].reverse()
@@ -749,6 +846,11 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
     ) -> StopExecutionOutput:
         self._validate_state_machine_execution_arn(execution_arn)
         execution: Execution = self._get_execution(context=context, execution_arn=execution_arn)
+
+        # Action only compatible with STANDARD workflows.
+        if execution.sm_type != StateMachineType.STANDARD:
+            self._raise_resource_type_not_in_context(resource_type=execution.sm_type)
+
         stop_date = datetime.datetime.now(tz=datetime.timezone.utc)
         execution.stop(stop_date=stop_date, cause=cause, error=error)
         return StopExecutionOutput(stopDate=stop_date)
@@ -961,7 +1063,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
             role_arn=role_arn,
             definition=definition,
         )
-        exec_arn = stepfunctions_execution_state_machine_arn(state_machine.arn, name)
+        exec_arn = stepfunctions_standard_execution_arn(state_machine.arn, name)
 
         input_json = json.loads(input)
         execution = TestStateExecution(

--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -108,6 +108,9 @@ from localstack.services.stepfunctions.asl.eval.event.logging import (
 from localstack.services.stepfunctions.asl.parse.asl_parser import (
     ASLParserException,
 )
+from localstack.services.stepfunctions.asl.static_analyser.express_static_analyser import (
+    ExpressStaticAnalyser,
+)
 from localstack.services.stepfunctions.asl.static_analyser.static_analyser import StaticAnalyser
 from localstack.services.stepfunctions.asl.static_analyser.test_state.test_state_analyser import (
     TestStateStaticAnalyser,
@@ -380,9 +383,14 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
             cloud_watch_logging_configuration.validate()
 
         # Run static analysers on the definition given.
-        StepFunctionsProvider._validate_definition(
-            definition=state_machine_definition, static_analysers=[StaticAnalyser()]
-        )
+        if state_machine_type == StateMachineType.EXPRESS:
+            StepFunctionsProvider._validate_definition(
+                definition=state_machine_definition, static_analysers=[ExpressStaticAnalyser()]
+            )
+        else:
+            StepFunctionsProvider._validate_definition(
+                definition=state_machine_definition, static_analysers=[StaticAnalyser()]
+            )
 
         # Create the state machine and add it to the store.
         state_machine = StateMachineRevision(

--- a/localstack-core/localstack/testing/pytest/stepfunctions/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/stepfunctions/fixtures.py
@@ -102,7 +102,6 @@ def stepfunctions_client_test_state(aws_client_factory):
 def stepfunctions_client_sync_executions(aws_client_factory):
     # For StartSyncExecution calls, boto will prepend "sync-" to the endpoint string. As we operate on localhost,
     # this function creates a new stepfunctions client with that functionality disabled.
-    # Using this client only for test_state calls forces future occurrences to handle this issue explicitly.
     return aws_client_factory(config=Config(inject_host_prefix=is_aws_cloud())).stepfunctions
 
 

--- a/localstack-core/localstack/testing/pytest/stepfunctions/utils.py
+++ b/localstack-core/localstack/testing/pytest/stepfunctions/utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 from typing import Callable, Final, Optional
 
 from botocore.exceptions import ClientError
@@ -11,6 +12,7 @@ from localstack_snapshot.snapshots.transformer import (
     TransformContext,
 )
 
+from localstack.aws.api.sqs import Message, MessageList, ReceiveMessageResult
 from localstack.aws.api.stepfunctions import (
     CloudWatchLogsLogGroup,
     CreateStateMachineOutput,
@@ -208,6 +210,35 @@ def await_execution_terminated(stepfunctions_client, execution_arn: str) -> Hist
         execution_arn=execution_arn,
         check_func=_is_last_history_event_terminal,
     )
+
+
+def await_on_sqs_message(
+    sqs_client,
+    queue_url: str,
+    validation_function: Optional[Callable[[Message], bool]] = None,
+    timeout_seconds: int = 120,
+    interval_seconds: int = 1,
+) -> Optional[Message]:
+    result: Optional[Message] = None
+    while not result and timeout_seconds:
+        response: ReceiveMessageResult = sqs_client.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=1, MaxNumberOfMessages=1
+        )
+
+        messages: MessageList = response.get("Messages", [])
+        if messages:
+            message: Message = messages[0]
+            if validation_function is None or validation_function(message):
+                result = message
+                break
+
+        time.sleep(interval_seconds)
+        timeout_seconds -= interval_seconds
+
+    if not result:
+        LOG.warning("Timed out whilst awaiting for sqs message to satisfy condition for execution.")
+
+    return result
 
 
 def await_execution_lists_terminated(
@@ -483,6 +514,109 @@ def create_and_record_logs(
 
     launch_and_record_logs(
         aws_client, state_machine_arn, execution_input, log_level, log_group_name, sfn_snapshot
+    )
+
+
+def launch_and_record_sync_execution(
+    stepfunctions_client,
+    sfn_snapshot,
+    state_machine_arn,
+    execution_input,
+):
+    exec_resp = stepfunctions_client.start_sync_execution(
+        stateMachineArn=state_machine_arn,
+        input=execution_input,
+    )
+    sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_sync_exec_arn(exec_resp, 0))
+    sfn_snapshot.match("start_execution_sync_response", exec_resp)
+
+
+def create_and_record_express_sync_execution(
+    stepfunctions_client,
+    create_iam_role_for_sfn,
+    create_state_machine,
+    sfn_snapshot,
+    definition,
+    execution_input,
+):
+    snf_role_arn = create_iam_role_for_sfn()
+    sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "sfn_role_arn"))
+
+    creation_response = create_state_machine(
+        name=f"express_statemachine_{short_uid()}",
+        definition=definition,
+        roleArn=snf_role_arn,
+        type="EXPRESS",
+    )
+    state_machine_arn = creation_response["stateMachineArn"]
+    sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_create_arn(creation_response, 0))
+    sfn_snapshot.match("creation_response", creation_response)
+
+    launch_and_record_sync_execution(
+        stepfunctions_client,
+        sfn_snapshot,
+        state_machine_arn,
+        execution_input,
+    )
+
+
+def launch_and_record_async_execution(
+    stepfunctions_client,
+    logs_client,
+    sfn_snapshot,
+    state_machine_arn,
+    execution_input,
+    cloud_watch_group_arn,
+):
+    exec_resp = stepfunctions_client.start_execution(
+        stateMachineArn=state_machine_arn,
+        input=execution_input,
+    )
+    sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_exec_arn(exec_resp, 0))
+    sfn_snapshot.match("start_execution_sync_response", exec_resp)
+    # execution_arn = exec_resp["executionArn"]
+
+    # res = logs_client.filter_log_events(logGroupName=cloud_watch_group_arn)
+    # TODO: wait for cloudwatch api.
+
+
+def create_and_record_express_async_execution(
+    stepfunctions_client,
+    logs_client,
+    create_iam_role_for_sfn,
+    create_state_machine,
+    create_cloud_watch_group_for_sfn,
+    sfn_snapshot,
+    definition,
+    execution_input,
+):
+    snf_role_arn = create_iam_role_for_sfn()
+    sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "sfn_role_arn"))
+
+    log_group_arn = create_cloud_watch_group_for_sfn
+
+    creation_response = create_state_machine(
+        name=f"express_statemachine_{short_uid()}",
+        definition=definition,
+        roleArn=snf_role_arn,
+        type="EXPRESS",
+        loggingConfiguration={
+            "level": "ALL",
+            "includeExecutionData": True,
+            "destinations": [{"cloudWatchLogsLogGroup": {"logGroupArn": log_group_arn}}],
+        },
+    )
+    state_machine_arn = creation_response["stateMachineArn"]
+    sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_create_arn(creation_response, 0))
+    sfn_snapshot.match("creation_response", creation_response)
+
+    launch_and_record_async_execution(
+        stepfunctions_client,
+        logs_client,
+        sfn_snapshot,
+        state_machine_arn,
+        execution_input,
+        log_group_arn,
     )
 
 

--- a/localstack-core/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack-core/localstack/testing/snapshots/transformer_utility.py
@@ -639,6 +639,14 @@ class TransformerUtility:
         return RegexTransformer(arn_part, arn_part_repl)
 
     @staticmethod
+    def sfn_sm_express_exec_arn(start_exec: StartExecutionOutput, index: int):
+        arn_parts = start_exec["executionArn"].split(":")
+        return [
+            RegexTransformer(arn_parts[-2], f"<ExpressExecArn_Part1_{index}idx>"),
+            RegexTransformer(arn_parts[-1], f"<ExpressExecArn_Part2_{index}idx>"),
+        ]
+
+    @staticmethod
     def sfn_sm_sync_exec_arn(start_exec: StartSyncExecutionOutput, index: int):
         arn_parts = start_exec["executionArn"].split(":")
         return [

--- a/localstack-core/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack-core/localstack/testing/snapshots/transformer_utility.py
@@ -16,7 +16,12 @@ from localstack_snapshot.snapshots.transformer import (
 )
 
 from localstack.aws.api.secretsmanager import CreateSecretResponse
-from localstack.aws.api.stepfunctions import CreateStateMachineOutput, LongArn, StartExecutionOutput
+from localstack.aws.api.stepfunctions import (
+    CreateStateMachineOutput,
+    LongArn,
+    StartExecutionOutput,
+    StartSyncExecutionOutput,
+)
 from localstack.utils.net import IP_REGEX
 
 LOG = logging.getLogger(__name__)
@@ -632,6 +637,14 @@ class TransformerUtility:
         arn_part_repl = f"<ExecArnPart_{index}idx>"
         arn_part: str = "".join(start_exec["executionArn"].rpartition(":")[-1])
         return RegexTransformer(arn_part, arn_part_repl)
+
+    @staticmethod
+    def sfn_sm_sync_exec_arn(start_exec: StartSyncExecutionOutput, index: int):
+        arn_parts = start_exec["executionArn"].split(":")
+        return [
+            RegexTransformer(arn_parts[-2], f"<SyncExecArn_Part1_{index}idx>"),
+            RegexTransformer(arn_parts[-1], f"<SyncExecArn_Part2_{index}idx>"),
+        ]
 
     @staticmethod
     def sfn_map_run_arn(map_run_arn: LongArn, index: int) -> list[RegexTransformer]:

--- a/localstack-core/localstack/utils/aws/arns.py
+++ b/localstack-core/localstack/utils/aws/arns.py
@@ -7,6 +7,7 @@ from botocore.utils import ArnParser, InvalidArnException
 
 from localstack.aws.accounts import DEFAULT_AWS_ACCOUNT_ID
 from localstack.aws.connect import connect_to
+from localstack.utils.strings import long_uid
 
 LOG = logging.getLogger(__name__)
 
@@ -280,9 +281,9 @@ def stepfunctions_state_machine_arn(name: str, account_id: str, region_name: str
     return _resource_arn(name, pattern, account_id=account_id, region_name=region_name)
 
 
-def stepfunctions_execution_state_machine_arn(state_machine_arn: str, execution_name: str) -> str:
+def stepfunctions_standard_execution_arn(state_machine_arn: str, execution_name: str) -> str:
     arn_data: ArnData = parse_arn(state_machine_arn)
-    execution_arn = ":".join(
+    standard_execution_arn = ":".join(
         [
             "arn",
             arn_data["partition"],
@@ -294,7 +295,25 @@ def stepfunctions_execution_state_machine_arn(state_machine_arn: str, execution_
             execution_name,
         ]
     )
-    return execution_arn
+    return standard_execution_arn
+
+
+def stepfunctions_express_execution_arn(state_machine_arn: str, execution_name: str) -> str:
+    arn_data: ArnData = parse_arn(state_machine_arn)
+    express_execution_arn = ":".join(
+        [
+            "arn",
+            arn_data["partition"],
+            arn_data["service"],
+            arn_data["region"],
+            arn_data["account"],
+            "express",
+            "".join(arn_data["resource"].split(":")[1:]),
+            execution_name,
+            long_uid(),
+        ]
+    )
+    return express_execution_arn
 
 
 def stepfunctions_activity_arn(name: str, account_id: str, region_name: str) -> str:

--- a/tests/aws/services/stepfunctions/v2/base/test_base.py
+++ b/tests/aws/services/stepfunctions/v2/base/test_base.py
@@ -263,7 +263,7 @@ class TestSnfBase:
         template = BaseTemplate.load_sfn_template(BaseTemplate.QUERY_CONTEXT_OBJECT_VALUES)
         definition = json.dumps(template)
 
-        exec_input = json.dumps({"message": "HelloWorld!"})
+        exec_input = json.dumps({"message": "TestMessage"})
         create_and_record_execution(
             aws_client.stepfunctions,
             create_iam_role_for_sfn,

--- a/tests/aws/services/stepfunctions/v2/base/test_base.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/base/test_base.snapshot.json
@@ -524,14 +524,14 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_query_context_object_values": {
-    "recorded-date": "07-02-2024, 13:52:16",
+    "recorded-date": "15-07-2024, 13:00:19",
     "recorded-content": {
       "get_execution_history": {
         "events": [
           {
             "executionStartedEventDetails": {
               "input": {
-                "message": "HelloWorld!"
+                "message": "TestMessage"
               },
               "inputDetails": {
                 "truncated": false
@@ -548,7 +548,7 @@
             "previousEventId": 0,
             "stateEnteredEventDetails": {
               "input": {
-                "message": "HelloWorld!"
+                "message": "TestMessage"
               },
               "inputDetails": {
                 "truncated": false
@@ -564,12 +564,12 @@
             "stateExitedEventDetails": {
               "name": "QueryValues1",
               "output": {
-                "message": "HelloWorld!",
+                "message": "TestMessage",
                 "query_values_1": {
                   "execution": {
                     "Id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                     "Input": {
-                      "message": "HelloWorld!"
+                      "message": "TestMessage"
                     },
                     "StartTime": "start-time",
                     "Name": "<ExecArnPart_0idx>",
@@ -581,7 +581,7 @@
                   "statemachine_id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
                   "execution_id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                   "execution_input": {
-                    "message": "HelloWorld!"
+                    "message": "TestMessage"
                   },
                   "execution_starttime": "start-time",
                   "state_name": "QueryValues1",
@@ -598,7 +598,7 @@
                     "Execution": {
                       "Id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                       "Input": {
-                        "message": "HelloWorld!"
+                        "message": "TestMessage"
                       },
                       "StartTime": "start-time",
                       "Name": "<ExecArnPart_0idx>",
@@ -629,12 +629,12 @@
             "previousEventId": 3,
             "stateEnteredEventDetails": {
               "input": {
-                "message": "HelloWorld!",
+                "message": "TestMessage",
                 "query_values_1": {
                   "execution": {
                     "Id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                     "Input": {
-                      "message": "HelloWorld!"
+                      "message": "TestMessage"
                     },
                     "StartTime": "start-time",
                     "Name": "<ExecArnPart_0idx>",
@@ -646,7 +646,7 @@
                   "statemachine_id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
                   "execution_id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                   "execution_input": {
-                    "message": "HelloWorld!"
+                    "message": "TestMessage"
                   },
                   "execution_starttime": "start-time",
                   "state_name": "QueryValues1",
@@ -663,7 +663,7 @@
                     "Execution": {
                       "Id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                       "Input": {
-                        "message": "HelloWorld!"
+                        "message": "TestMessage"
                       },
                       "StartTime": "start-time",
                       "Name": "<ExecArnPart_0idx>",
@@ -696,12 +696,12 @@
             "stateExitedEventDetails": {
               "name": "QueryValues2",
               "output": {
-                "message": "HelloWorld!",
+                "message": "TestMessage",
                 "query_values_1": {
                   "execution": {
                     "Id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                     "Input": {
-                      "message": "HelloWorld!"
+                      "message": "TestMessage"
                     },
                     "StartTime": "start-time",
                     "Name": "<ExecArnPart_0idx>",
@@ -713,7 +713,7 @@
                   "statemachine_id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
                   "execution_id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                   "execution_input": {
-                    "message": "HelloWorld!"
+                    "message": "TestMessage"
                   },
                   "execution_starttime": "start-time",
                   "state_name": "QueryValues1",
@@ -730,7 +730,7 @@
                     "Execution": {
                       "Id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                       "Input": {
-                        "message": "HelloWorld!"
+                        "message": "TestMessage"
                       },
                       "StartTime": "start-time",
                       "Name": "<ExecArnPart_0idx>",
@@ -753,7 +753,7 @@
                     "Execution": {
                       "Id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                       "Input": {
-                        "message": "HelloWorld!"
+                        "message": "TestMessage"
                       },
                       "StartTime": "start-time",
                       "Name": "<ExecArnPart_0idx>",
@@ -781,12 +781,12 @@
           {
             "executionSucceededEventDetails": {
               "output": {
-                "message": "HelloWorld!",
+                "message": "TestMessage",
                 "query_values_1": {
                   "execution": {
                     "Id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                     "Input": {
-                      "message": "HelloWorld!"
+                      "message": "TestMessage"
                     },
                     "StartTime": "start-time",
                     "Name": "<ExecArnPart_0idx>",
@@ -798,7 +798,7 @@
                   "statemachine_id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
                   "execution_id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                   "execution_input": {
-                    "message": "HelloWorld!"
+                    "message": "TestMessage"
                   },
                   "execution_starttime": "start-time",
                   "state_name": "QueryValues1",
@@ -815,7 +815,7 @@
                     "Execution": {
                       "Id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                       "Input": {
-                        "message": "HelloWorld!"
+                        "message": "TestMessage"
                       },
                       "StartTime": "start-time",
                       "Name": "<ExecArnPart_0idx>",
@@ -838,7 +838,7 @@
                     "Execution": {
                       "Id": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
                       "Input": {
-                        "message": "HelloWorld!"
+                        "message": "TestMessage"
                       },
                       "StartTime": "start-time",
                       "Name": "<ExecArnPart_0idx>",

--- a/tests/aws/services/stepfunctions/v2/base/test_base.validation.json
+++ b/tests/aws/services/stepfunctions/v2/base/test_base.validation.json
@@ -6,7 +6,7 @@
     "last_validated_date": "2024-02-07T13:56:58+00:00"
   },
   "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_query_context_object_values": {
-    "last_validated_date": "2024-02-07T13:52:16+00:00"
+    "last_validated_date": "2024-07-15T13:00:19+00:00"
   },
   "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_state_fail": {
     "last_validated_date": "2024-03-06T10:29:50+00:00"

--- a/tests/aws/services/stepfunctions/v2/express/test_express_async.py
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_async.py
@@ -1,0 +1,164 @@
+import json
+
+from localstack.testing.pytest import markers
+from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
+from tests.aws.services.stepfunctions.utils import (
+    create_and_record_express_async_execution,
+)
+
+
+@markers.snapshot.skip_snapshot_verify(
+    paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..billingDetails"]
+)
+class TestExpressAsync:
+    @markers.aws.validated
+    def test_pass_state(
+        self,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sqs_create_queue,
+        create_cloud_watch_group_for_sfn,
+        sfn_snapshot,
+        aws_client,
+    ):
+        template = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({})
+        create_and_record_express_async_execution(
+            aws_client.stepfunctions,
+            aws_client.logs,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            create_cloud_watch_group_for_sfn,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    # @markers.snapshot.skip_snapshot_verify(paths=["$..RedriveCount"])
+    # @markers.aws.validated
+    # def test_query_runtime_memory(
+    #     self,
+    #     create_iam_role_for_sfn,
+    #     create_state_machine,
+    #     aws_client,
+    #     sfn_snapshot,
+    # ):
+    #     sfn_snapshot.add_transformer(
+    #         JsonpathTransformer(
+    #             jsonpath="$..StartTime", replacement="start-time", replace_reference=False
+    #         )
+    #     )
+    #     sfn_snapshot.add_transformer(
+    #         JsonpathTransformer(
+    #             jsonpath="$..execution_starttime", replacement="start-time", replace_reference=False
+    #         )
+    #     )
+    #     sfn_snapshot.add_transformer(
+    #         JsonpathTransformer(
+    #             jsonpath="$..EnteredTime", replacement="entered-time", replace_reference=False
+    #         )
+    #     )
+    #     sfn_snapshot.add_transformer(
+    #         JsonpathTransformer(
+    #             jsonpath="$..state_enteredtime", replacement="entered-time", replace_reference=False
+    #         )
+    #     )
+    #
+    #     template = BaseTemplate.load_sfn_template(BaseTemplate.QUERY_CONTEXT_OBJECT_VALUES)
+    #     definition = json.dumps(template)
+    #
+    #     exec_input = json.dumps({"message": "HelloWorld!"})
+    #     create_and_record_express_sync_execution(
+    #         aws_client.stepfunctions,
+    #         create_iam_role_for_sfn,
+    #         create_state_machine,
+    #         sfn_snapshot,
+    #         definition,
+    #         exec_input,
+    #     )
+    #
+    # @markers.aws.validated
+    # def test_fail_state(
+    #     self,
+    #     create_iam_role_for_sfn,
+    #     create_state_machine,
+    #     sqs_create_queue,
+    #     sfn_snapshot,
+    #     aws_client,
+    # ):
+    #     template = BaseTemplate.load_sfn_template(BaseTemplate.BASE_RAISE_FAILURE)
+    #     definition = json.dumps(template)
+    #
+    #     exec_input = json.dumps({})
+    #     create_and_record_express_sync_execution(
+    #         aws_client.stepfunctions,
+    #         create_iam_role_for_sfn,
+    #         create_state_machine,
+    #         sfn_snapshot,
+    #         definition,
+    #         exec_input,
+    #     )
+    #
+    # @markers.aws.validated
+    # def test_catch(
+    #     self,
+    #     aws_client,
+    #     create_iam_role_for_sfn,
+    #     create_state_machine,
+    #     create_lambda_function,
+    #     sfn_snapshot,
+    # ):
+    #     function_name = f"lambda_func_{short_uid()}"
+    #     create_lambda_function(
+    #         func_name=function_name,
+    #         handler_file=ErrorHandlingTemplate.LAMBDA_FUNC_RAISE_EXCEPTION,
+    #         runtime=Runtime.python3_12,
+    #     )
+    #     sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
+    #
+    #     template = ErrorHandlingTemplate.load_sfn_template(ErrorHandlingTemplate.AWS_SERVICE_LAMBDA_INVOKE_CATCH_ALL)
+    #     definition = json.dumps(template)
+    #
+    #     exec_input = json.dumps({"FunctionName": function_name, "Payload": None})
+    #     create_and_record_express_sync_execution(
+    #         aws_client.stepfunctions,
+    #         create_iam_role_for_sfn,
+    #         create_state_machine,
+    #         sfn_snapshot,
+    #         definition,
+    #         exec_input,
+    #     )
+    #
+    # @markers.aws.validated
+    # def test_retry(
+    #     self,
+    #     aws_client,
+    #     create_iam_role_for_sfn,
+    #     create_state_machine,
+    #     create_lambda_function,
+    #     sfn_snapshot,
+    # ):
+    #     function_name = f"lambda_func_{short_uid()}"
+    #     create_res = create_lambda_function(
+    #         func_name=function_name,
+    #         handler_file=ErrorHandlingTemplate.LAMBDA_FUNC_RAISE_EXCEPTION,
+    #         runtime=Runtime.python3_12,
+    #     )
+    #     sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
+    #     function_arn = create_res["CreateFunctionResponse"]["FunctionArn"]
+    #
+    #     template = ScenariosTemplate.load_sfn_template(ScenariosTemplate.LAMBDA_INVOKE_WITH_RETRY_BASE_EXTENDED_INPUT)
+    #     template["States"]["InvokeLambdaWithRetry"]["Resource"] = function_arn
+    #     definition = json.dumps(template)
+    #
+    #     exec_input = json.dumps({})
+    #     create_and_record_express_sync_execution(
+    #         aws_client.stepfunctions,
+    #         create_iam_role_for_sfn,
+    #         create_state_machine,
+    #         sfn_snapshot,
+    #         definition,
+    #         exec_input,
+    #     )

--- a/tests/aws/services/stepfunctions/v2/express/test_express_async.py
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_async.py
@@ -18,7 +18,6 @@ from tests.aws.services.stepfunctions.templates.scenarios.scenarios_templates im
 
 @markers.snapshot.skip_snapshot_verify(
     paths=[
-        "$..loggingConfiguration",
         "$..tracingConfiguration",
         "$..billingDetails",
         "$..redrive_count",
@@ -88,7 +87,7 @@ class TestExpressAsync:
         template = BaseTemplate.load_sfn_template(BaseTemplate.QUERY_CONTEXT_OBJECT_VALUES)
         definition = json.dumps(template)
 
-        exec_input = json.dumps({"message": "HelloWorld!"})
+        exec_input = json.dumps({"message": "TestMessage"})
         create_and_record_express_async_execution(
             aws_client,
             create_iam_role_for_sfn,
@@ -116,6 +115,11 @@ class TestExpressAsync:
             runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
+        sfn_snapshot.add_transformer(
+            RegexTransformer(
+                r'\\"requestId\\":\\"([a-f0-9\-]+)\\"', '\\"requestId\\":<request-id>\\"'
+            )
+        )
 
         template = ErrorHandlingTemplate.load_sfn_template(
             ErrorHandlingTemplate.AWS_SERVICE_LAMBDA_INVOKE_CATCH_ALL
@@ -150,6 +154,11 @@ class TestExpressAsync:
             runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
+        sfn_snapshot.add_transformer(
+            RegexTransformer(
+                r'\\"requestId\\": \\"([a-f0-9\-]+)\\"', '\\"requestId\\": \\"<request-id>\\"'
+            )
+        )
         function_arn = create_res["CreateFunctionResponse"]["FunctionArn"]
 
         template = ScenariosTemplate.load_sfn_template(

--- a/tests/aws/services/stepfunctions/v2/express/test_express_async.py
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_async.py
@@ -3,15 +3,17 @@ import json
 import pytest
 from localstack_snapshot.snapshots.transformer import JsonpathTransformer, RegexTransformer
 
-from aws.services.stepfunctions.templates.errorhandling.error_handling_templates import (
-    ErrorHandlingTemplate,
-)
-from aws.services.stepfunctions.templates.scenarios.scenarios_templates import ScenariosTemplate
 from localstack.aws.api.lambda_ import Runtime
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.stepfunctions.utils import create_and_record_express_async_execution
 from localstack.utils.strings import short_uid
 from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
+from tests.aws.services.stepfunctions.templates.errorhandling.error_handling_templates import (
+    ErrorHandlingTemplate,
+)
+from tests.aws.services.stepfunctions.templates.scenarios.scenarios_templates import (
+    ScenariosTemplate,
+)
 
 
 @markers.snapshot.skip_snapshot_verify(

--- a/tests/aws/services/stepfunctions/v2/express/test_express_async.py
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_async.py
@@ -1,164 +1,168 @@
 import json
 
-from localstack.testing.pytest import markers
-from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
-from tests.aws.services.stepfunctions.utils import (
-    create_and_record_express_async_execution,
+import pytest
+from localstack_snapshot.snapshots.transformer import JsonpathTransformer, RegexTransformer
+
+from aws.services.stepfunctions.templates.errorhandling.error_handling_templates import (
+    ErrorHandlingTemplate,
 )
+from aws.services.stepfunctions.templates.scenarios.scenarios_templates import ScenariosTemplate
+from localstack.aws.api.lambda_ import Runtime
+from localstack.testing.pytest import markers
+from localstack.testing.pytest.stepfunctions.utils import create_and_record_express_async_execution
+from localstack.utils.strings import short_uid
+from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
 
 
 @markers.snapshot.skip_snapshot_verify(
-    paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..billingDetails"]
+    paths=[
+        "$..loggingConfiguration",
+        "$..tracingConfiguration",
+        "$..billingDetails",
+        "$..redrive_count",
+        "$..event_timestamp",
+        "$..output.Cause",
+    ]
 )
 class TestExpressAsync:
     @markers.aws.validated
-    def test_pass_state(
+    @pytest.mark.parametrize(
+        "template",
+        [BaseTemplate.BASE_PASS_RESULT, BaseTemplate.BASE_RAISE_FAILURE],
+        ids=["BASE_PASS_RESULT", "BASE_RAISE_FAILURE"],
+    )
+    def test_base(
         self,
         create_iam_role_for_sfn,
         create_state_machine,
-        sqs_create_queue,
-        create_cloud_watch_group_for_sfn,
+        sfn_create_log_group,
         sfn_snapshot,
         aws_client,
+        template,
     ):
-        template = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
-        definition = json.dumps(template)
-
+        definition = json.dumps(BaseTemplate.load_sfn_template(template))
         exec_input = json.dumps({})
         create_and_record_express_async_execution(
-            aws_client.stepfunctions,
-            aws_client.logs,
+            aws_client,
             create_iam_role_for_sfn,
             create_state_machine,
-            create_cloud_watch_group_for_sfn,
+            sfn_create_log_group,
             sfn_snapshot,
             definition,
             exec_input,
         )
 
-    # @markers.snapshot.skip_snapshot_verify(paths=["$..RedriveCount"])
-    # @markers.aws.validated
-    # def test_query_runtime_memory(
-    #     self,
-    #     create_iam_role_for_sfn,
-    #     create_state_machine,
-    #     aws_client,
-    #     sfn_snapshot,
-    # ):
-    #     sfn_snapshot.add_transformer(
-    #         JsonpathTransformer(
-    #             jsonpath="$..StartTime", replacement="start-time", replace_reference=False
-    #         )
-    #     )
-    #     sfn_snapshot.add_transformer(
-    #         JsonpathTransformer(
-    #             jsonpath="$..execution_starttime", replacement="start-time", replace_reference=False
-    #         )
-    #     )
-    #     sfn_snapshot.add_transformer(
-    #         JsonpathTransformer(
-    #             jsonpath="$..EnteredTime", replacement="entered-time", replace_reference=False
-    #         )
-    #     )
-    #     sfn_snapshot.add_transformer(
-    #         JsonpathTransformer(
-    #             jsonpath="$..state_enteredtime", replacement="entered-time", replace_reference=False
-    #         )
-    #     )
-    #
-    #     template = BaseTemplate.load_sfn_template(BaseTemplate.QUERY_CONTEXT_OBJECT_VALUES)
-    #     definition = json.dumps(template)
-    #
-    #     exec_input = json.dumps({"message": "HelloWorld!"})
-    #     create_and_record_express_sync_execution(
-    #         aws_client.stepfunctions,
-    #         create_iam_role_for_sfn,
-    #         create_state_machine,
-    #         sfn_snapshot,
-    #         definition,
-    #         exec_input,
-    #     )
-    #
-    # @markers.aws.validated
-    # def test_fail_state(
-    #     self,
-    #     create_iam_role_for_sfn,
-    #     create_state_machine,
-    #     sqs_create_queue,
-    #     sfn_snapshot,
-    #     aws_client,
-    # ):
-    #     template = BaseTemplate.load_sfn_template(BaseTemplate.BASE_RAISE_FAILURE)
-    #     definition = json.dumps(template)
-    #
-    #     exec_input = json.dumps({})
-    #     create_and_record_express_sync_execution(
-    #         aws_client.stepfunctions,
-    #         create_iam_role_for_sfn,
-    #         create_state_machine,
-    #         sfn_snapshot,
-    #         definition,
-    #         exec_input,
-    #     )
-    #
-    # @markers.aws.validated
-    # def test_catch(
-    #     self,
-    #     aws_client,
-    #     create_iam_role_for_sfn,
-    #     create_state_machine,
-    #     create_lambda_function,
-    #     sfn_snapshot,
-    # ):
-    #     function_name = f"lambda_func_{short_uid()}"
-    #     create_lambda_function(
-    #         func_name=function_name,
-    #         handler_file=ErrorHandlingTemplate.LAMBDA_FUNC_RAISE_EXCEPTION,
-    #         runtime=Runtime.python3_12,
-    #     )
-    #     sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
-    #
-    #     template = ErrorHandlingTemplate.load_sfn_template(ErrorHandlingTemplate.AWS_SERVICE_LAMBDA_INVOKE_CATCH_ALL)
-    #     definition = json.dumps(template)
-    #
-    #     exec_input = json.dumps({"FunctionName": function_name, "Payload": None})
-    #     create_and_record_express_sync_execution(
-    #         aws_client.stepfunctions,
-    #         create_iam_role_for_sfn,
-    #         create_state_machine,
-    #         sfn_snapshot,
-    #         definition,
-    #         exec_input,
-    #     )
-    #
-    # @markers.aws.validated
-    # def test_retry(
-    #     self,
-    #     aws_client,
-    #     create_iam_role_for_sfn,
-    #     create_state_machine,
-    #     create_lambda_function,
-    #     sfn_snapshot,
-    # ):
-    #     function_name = f"lambda_func_{short_uid()}"
-    #     create_res = create_lambda_function(
-    #         func_name=function_name,
-    #         handler_file=ErrorHandlingTemplate.LAMBDA_FUNC_RAISE_EXCEPTION,
-    #         runtime=Runtime.python3_12,
-    #     )
-    #     sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
-    #     function_arn = create_res["CreateFunctionResponse"]["FunctionArn"]
-    #
-    #     template = ScenariosTemplate.load_sfn_template(ScenariosTemplate.LAMBDA_INVOKE_WITH_RETRY_BASE_EXTENDED_INPUT)
-    #     template["States"]["InvokeLambdaWithRetry"]["Resource"] = function_arn
-    #     definition = json.dumps(template)
-    #
-    #     exec_input = json.dumps({})
-    #     create_and_record_express_sync_execution(
-    #         aws_client.stepfunctions,
-    #         create_iam_role_for_sfn,
-    #         create_state_machine,
-    #         sfn_snapshot,
-    #         definition,
-    #         exec_input,
-    #     )
+    @markers.snapshot.skip_snapshot_verify(paths=["$..RedriveCount"])
+    @markers.aws.validated
+    def test_query_runtime_memory(
+        self,
+        create_iam_role_for_sfn,
+        sfn_create_log_group,
+        create_state_machine,
+        aws_client,
+        sfn_snapshot,
+    ):
+        sfn_snapshot.add_transformer(
+            JsonpathTransformer(
+                jsonpath="$..StartTime", replacement="start-time", replace_reference=False
+            )
+        )
+        sfn_snapshot.add_transformer(
+            JsonpathTransformer(
+                jsonpath="$..execution_starttime", replacement="start-time", replace_reference=False
+            )
+        )
+        sfn_snapshot.add_transformer(
+            JsonpathTransformer(
+                jsonpath="$..EnteredTime", replacement="entered-time", replace_reference=False
+            )
+        )
+        sfn_snapshot.add_transformer(
+            JsonpathTransformer(
+                jsonpath="$..state_enteredtime", replacement="entered-time", replace_reference=False
+            )
+        )
+
+        template = BaseTemplate.load_sfn_template(BaseTemplate.QUERY_CONTEXT_OBJECT_VALUES)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"message": "HelloWorld!"})
+        create_and_record_express_async_execution(
+            aws_client,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_create_log_group,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
+    def test_catch(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        sfn_create_log_group,
+        create_state_machine,
+        create_lambda_function,
+        sfn_snapshot,
+    ):
+        function_name = f"lambda_func_{short_uid()}"
+        create_lambda_function(
+            func_name=function_name,
+            handler_file=ErrorHandlingTemplate.LAMBDA_FUNC_RAISE_EXCEPTION,
+            runtime=Runtime.python3_12,
+        )
+        sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
+
+        template = ErrorHandlingTemplate.load_sfn_template(
+            ErrorHandlingTemplate.AWS_SERVICE_LAMBDA_INVOKE_CATCH_ALL
+        )
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"FunctionName": function_name, "Payload": None})
+        create_and_record_express_async_execution(
+            aws_client,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_create_log_group,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
+    def test_retry(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        sfn_create_log_group,
+        create_state_machine,
+        create_lambda_function,
+        sfn_snapshot,
+    ):
+        function_name = f"lambda_func_{short_uid()}"
+        create_res = create_lambda_function(
+            func_name=function_name,
+            handler_file=ErrorHandlingTemplate.LAMBDA_FUNC_RAISE_EXCEPTION,
+            runtime=Runtime.python3_12,
+        )
+        sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
+        function_arn = create_res["CreateFunctionResponse"]["FunctionArn"]
+
+        template = ScenariosTemplate.load_sfn_template(
+            ScenariosTemplate.LAMBDA_INVOKE_WITH_RETRY_BASE_EXTENDED_INPUT
+        )
+        template["States"]["InvokeLambdaWithRetry"]["Resource"] = function_arn
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({})
+        create_and_record_express_async_execution(
+            aws_client,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_create_log_group,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )

--- a/tests/aws/services/stepfunctions/v2/express/test_express_async.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_async.snapshot.json
@@ -54,7 +54,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_query_runtime_memory": {
-    "recorded-date": "03-07-2024, 16:28:15",
+    "recorded-date": "15-07-2024, 12:58:13",
     "recorded-content": {
       "creation_response": {
         "creationDate": "datetime",
@@ -67,12 +67,12 @@
       "end_event": {
         "details": {
           "output": {
-            "message": "HelloWorld!",
+            "message": "TestMessage",
             "query_values_1": {
               "execution": {
                 "Id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
                 "Input": {
-                  "message": "HelloWorld!"
+                  "message": "TestMessage"
                 },
                 "Name": "<ExpressExecArn_Part1_0idx>",
                 "RoleArn": "sfn_role_arn",
@@ -84,7 +84,7 @@
               "statemachine_id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
               "execution_id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
               "execution_input": {
-                "message": "HelloWorld!"
+                "message": "TestMessage"
               },
               "execution_starttime": "start-time",
               "state_name": "QueryValues1",
@@ -101,7 +101,7 @@
                 "Execution": {
                   "Id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
                   "Input": {
-                    "message": "HelloWorld!"
+                    "message": "TestMessage"
                   },
                   "Name": "<ExpressExecArn_Part1_0idx>",
                   "RoleArn": "sfn_role_arn",
@@ -124,7 +124,7 @@
                 "Execution": {
                   "Id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
                   "Input": {
-                    "message": "HelloWorld!"
+                    "message": "TestMessage"
                   },
                   "Name": "<ExpressExecArn_Part1_0idx>",
                   "RoleArn": "sfn_role_arn",
@@ -156,7 +156,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_catch": {
-    "recorded-date": "03-07-2024, 16:33:03",
+    "recorded-date": "15-07-2024, 13:31:21",
     "recorded-content": {
       "creation_response": {
         "creationDate": "datetime",
@@ -170,7 +170,7 @@
         "details": {
           "output": {
             "Error": "Exception",
-            "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"30ebd6a2-7614-461d-a18f-61af2149852c\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+            "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":<request-id>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
           },
           "outputDetails": {
             "truncated": false
@@ -186,7 +186,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_retry": {
-    "recorded-date": "03-07-2024, 16:41:44",
+    "recorded-date": "15-07-2024, 13:37:47",
     "recorded-content": {
       "creation_response": {
         "creationDate": "datetime",
@@ -200,7 +200,7 @@
         "details": {
           "output": {
             "Error": "Exception",
-            "Cause": "{\"errorMessage\": \"Some exception was raised.\", \"errorType\": \"Exception\", \"requestId\": \"6967e9ab-0e08-4f85-9420-f9bd30bc9d50\", \"stackTrace\": [\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+            "Cause": "{\"errorMessage\": \"Some exception was raised.\", \"errorType\": \"Exception\", \"requestId\": \"<request-id>\", \"stackTrace\": [\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
           },
           "outputDetails": {
             "truncated": false

--- a/tests/aws/services/stepfunctions/v2/express/test_express_async.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_async.snapshot.json
@@ -1,6 +1,218 @@
 {
-  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_pass_state": {
-    "recorded-date": "06-04-2024, 17:03:58",
-    "recorded-content": {}
+  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_base[BASE_PASS_RESULT]": {
+    "recorded-date": "03-07-2024, 16:26:21",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "end_event": {
+        "details": {
+          "output": {
+            "Arg1": "argument1"
+          },
+          "outputDetails": {
+            "truncated": false
+          }
+        },
+        "event_timestamp": "timestamp",
+        "execution_arn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
+        "id": "4",
+        "previous_event_id": "3",
+        "redrive_count": "0",
+        "type": "ExecutionSucceeded"
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_base[BASE_RAISE_FAILURE]": {
+    "recorded-date": "03-07-2024, 16:27:05",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "end_event": {
+        "details": {
+          "cause": "This state machines raises a 'SomeFailure' failure.",
+          "error": "SomeFailure"
+        },
+        "event_timestamp": "timestamp",
+        "execution_arn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
+        "id": "3",
+        "previous_event_id": "2",
+        "redrive_count": "0",
+        "type": "ExecutionFailed"
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_query_runtime_memory": {
+    "recorded-date": "03-07-2024, 16:28:15",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "end_event": {
+        "details": {
+          "output": {
+            "message": "HelloWorld!",
+            "query_values_1": {
+              "execution": {
+                "Id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
+                "Input": {
+                  "message": "HelloWorld!"
+                },
+                "Name": "<ExpressExecArn_Part1_0idx>",
+                "RoleArn": "sfn_role_arn",
+                "StartTime": "start-time",
+                "RedriveCount": 0
+              },
+              "execution_rolearn": "sfn_role_arn",
+              "execution_name": "<ExpressExecArn_Part1_0idx>",
+              "statemachine_id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+              "execution_id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
+              "execution_input": {
+                "message": "HelloWorld!"
+              },
+              "execution_starttime": "start-time",
+              "state_name": "QueryValues1",
+              "state_enteredtime": "entered-time",
+              "statemachine": {
+                "Id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+                "Name": "<ArnPart_0idx>"
+              },
+              "state": {
+                "Name": "QueryValues1",
+                "EnteredTime": "entered-time"
+              },
+              "context_object": {
+                "Execution": {
+                  "Id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
+                  "Input": {
+                    "message": "HelloWorld!"
+                  },
+                  "Name": "<ExpressExecArn_Part1_0idx>",
+                  "RoleArn": "sfn_role_arn",
+                  "StartTime": "start-time",
+                  "RedriveCount": 0
+                },
+                "StateMachine": {
+                  "Id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+                  "Name": "<ArnPart_0idx>"
+                },
+                "State": {
+                  "Name": "QueryValues1",
+                  "EnteredTime": "entered-time"
+                }
+              },
+              "statemachine_name": "<ArnPart_0idx>"
+            },
+            "query_values_2": {
+              "context_object": {
+                "Execution": {
+                  "Id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
+                  "Input": {
+                    "message": "HelloWorld!"
+                  },
+                  "Name": "<ExpressExecArn_Part1_0idx>",
+                  "RoleArn": "sfn_role_arn",
+                  "StartTime": "start-time",
+                  "RedriveCount": 0
+                },
+                "StateMachine": {
+                  "Id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+                  "Name": "<ArnPart_0idx>"
+                },
+                "State": {
+                  "Name": "QueryValues2",
+                  "EnteredTime": "entered-time"
+                }
+              }
+            }
+          },
+          "outputDetails": {
+            "truncated": false
+          }
+        },
+        "event_timestamp": "timestamp",
+        "execution_arn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
+        "id": "6",
+        "previous_event_id": "5",
+        "redrive_count": "0",
+        "type": "ExecutionSucceeded"
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_catch": {
+    "recorded-date": "03-07-2024, 16:33:03",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "end_event": {
+        "details": {
+          "output": {
+            "Error": "Exception",
+            "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"30ebd6a2-7614-461d-a18f-61af2149852c\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+          },
+          "outputDetails": {
+            "truncated": false
+          }
+        },
+        "event_timestamp": "timestamp",
+        "execution_arn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
+        "id": "9",
+        "previous_event_id": "8",
+        "redrive_count": "0",
+        "type": "ExecutionSucceeded"
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_retry": {
+    "recorded-date": "03-07-2024, 16:41:44",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "end_event": {
+        "details": {
+          "output": {
+            "Error": "Exception",
+            "Cause": "{\"errorMessage\": \"Some exception was raised.\", \"errorType\": \"Exception\", \"requestId\": \"6967e9ab-0e08-4f85-9420-f9bd30bc9d50\", \"stackTrace\": [\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+          },
+          "outputDetails": {
+            "truncated": false
+          }
+        },
+        "event_timestamp": "timestamp",
+        "execution_arn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
+        "id": "18",
+        "previous_event_id": "17",
+        "redrive_count": "0",
+        "type": "ExecutionSucceeded"
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/express/test_express_async.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_async.snapshot.json
@@ -1,0 +1,6 @@
+{
+  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_pass_state": {
+    "recorded-date": "06-04-2024, 17:03:58",
+    "recorded-content": {}
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/express/test_express_async.validation.json
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_async.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_pass_state": {
+    "last_validated_date": "2024-04-06T16:50:53+00:00"
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/express/test_express_async.validation.json
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_async.validation.json
@@ -6,12 +6,12 @@
     "last_validated_date": "2024-07-03T16:27:05+00:00"
   },
   "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_catch": {
-    "last_validated_date": "2024-07-03T16:33:03+00:00"
+    "last_validated_date": "2024-07-15T13:31:21+00:00"
   },
   "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_query_runtime_memory": {
-    "last_validated_date": "2024-07-03T16:28:15+00:00"
+    "last_validated_date": "2024-07-15T12:58:13+00:00"
   },
   "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_retry": {
-    "last_validated_date": "2024-07-03T16:41:43+00:00"
+    "last_validated_date": "2024-07-15T13:37:46+00:00"
   }
 }

--- a/tests/aws/services/stepfunctions/v2/express/test_express_async.validation.json
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_async.validation.json
@@ -1,5 +1,17 @@
 {
-  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_pass_state": {
-    "last_validated_date": "2024-04-06T16:50:53+00:00"
+  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_base[BASE_PASS_RESULT]": {
+    "last_validated_date": "2024-07-03T16:26:21+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_base[BASE_RAISE_FAILURE]": {
+    "last_validated_date": "2024-07-03T16:27:05+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_catch": {
+    "last_validated_date": "2024-07-03T16:33:03+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_query_runtime_memory": {
+    "last_validated_date": "2024-07-03T16:28:15+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_async.py::TestExpressAsync::test_retry": {
+    "last_validated_date": "2024-07-03T16:41:43+00:00"
   }
 }

--- a/tests/aws/services/stepfunctions/v2/express/test_express_sync.py
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_sync.py
@@ -18,7 +18,6 @@ from tests.aws.services.stepfunctions.templates.scenarios.scenarios_templates im
 
 @markers.snapshot.skip_snapshot_verify(
     paths=[
-        "$..loggingConfiguration",
         "$..tracingConfiguration",
         "$..billingDetails",
         "$..output.Cause",
@@ -84,7 +83,7 @@ class TestExpressSync:
         template = BaseTemplate.load_sfn_template(BaseTemplate.QUERY_CONTEXT_OBJECT_VALUES)
         definition = json.dumps(template)
 
-        exec_input = json.dumps({"message": "HelloWorld!"})
+        exec_input = json.dumps({"message": "TestMessage"})
         create_and_record_express_sync_execution(
             stepfunctions_client_sync_executions,
             create_iam_role_for_sfn,
@@ -110,6 +109,11 @@ class TestExpressSync:
             runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
+        sfn_snapshot.add_transformer(
+            RegexTransformer(
+                r'\\"requestId\\":\\"([a-f0-9\-]+)\\"', '\\"requestId\\":<request-id>\\"'
+            )
+        )
 
         template = ErrorHandlingTemplate.load_sfn_template(
             ErrorHandlingTemplate.AWS_SERVICE_LAMBDA_INVOKE_CATCH_ALL
@@ -143,6 +147,11 @@ class TestExpressSync:
             runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
+        sfn_snapshot.add_transformer(
+            RegexTransformer(
+                r'\\"requestId\\": \\"([a-f0-9\-]+)\\"', '\\"requestId\\": \\"<request-id>\\"'
+            )
+        )
         function_arn = create_res["CreateFunctionResponse"]["FunctionArn"]
 
         template = ScenariosTemplate.load_sfn_template(

--- a/tests/aws/services/stepfunctions/v2/express/test_express_sync.py
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_sync.py
@@ -1,0 +1,175 @@
+import json
+
+from localstack_snapshot.snapshots.transformer import JsonpathTransformer, RegexTransformer
+
+from localstack.aws.api.lambda_ import Runtime
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
+from tests.aws.services.stepfunctions.templates.errorhandling.error_handling_templates import (
+    ErrorHandlingTemplate,
+)
+from tests.aws.services.stepfunctions.templates.scenarios.scenarios_templates import (
+    ScenariosTemplate,
+)
+from tests.aws.services.stepfunctions.utils import (
+    create_and_record_express_sync_execution,
+)
+
+
+@markers.snapshot.skip_snapshot_verify(
+    paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..billingDetails"]
+)
+class TestExpress:
+    @markers.aws.validated
+    def test_pass_state(
+        self,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sqs_create_queue,
+        sfn_snapshot,
+        aws_client,
+    ):
+        template = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({})
+        create_and_record_express_sync_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.snapshot.skip_snapshot_verify(paths=["$..RedriveCount"])
+    @markers.aws.validated
+    def test_query_runtime_memory(
+        self,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        aws_client,
+        sfn_snapshot,
+    ):
+        sfn_snapshot.add_transformer(
+            JsonpathTransformer(
+                jsonpath="$..StartTime", replacement="start-time", replace_reference=False
+            )
+        )
+        sfn_snapshot.add_transformer(
+            JsonpathTransformer(
+                jsonpath="$..execution_starttime", replacement="start-time", replace_reference=False
+            )
+        )
+        sfn_snapshot.add_transformer(
+            JsonpathTransformer(
+                jsonpath="$..EnteredTime", replacement="entered-time", replace_reference=False
+            )
+        )
+        sfn_snapshot.add_transformer(
+            JsonpathTransformer(
+                jsonpath="$..state_enteredtime", replacement="entered-time", replace_reference=False
+            )
+        )
+
+        template = BaseTemplate.load_sfn_template(BaseTemplate.QUERY_CONTEXT_OBJECT_VALUES)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"message": "HelloWorld!"})
+        create_and_record_express_sync_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
+    def test_fail_state(
+        self,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sqs_create_queue,
+        sfn_snapshot,
+        aws_client,
+    ):
+        template = BaseTemplate.load_sfn_template(BaseTemplate.BASE_RAISE_FAILURE)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({})
+        create_and_record_express_sync_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
+    def test_catch(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        create_lambda_function,
+        sfn_snapshot,
+    ):
+        function_name = f"lambda_func_{short_uid()}"
+        create_lambda_function(
+            func_name=function_name,
+            handler_file=ErrorHandlingTemplate.LAMBDA_FUNC_RAISE_EXCEPTION,
+            runtime=Runtime.python3_12,
+        )
+        sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
+
+        template = ErrorHandlingTemplate.load_sfn_template(
+            ErrorHandlingTemplate.AWS_SERVICE_LAMBDA_INVOKE_CATCH_ALL
+        )
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"FunctionName": function_name, "Payload": None})
+        create_and_record_express_sync_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
+    def test_retry(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        create_lambda_function,
+        sfn_snapshot,
+    ):
+        function_name = f"lambda_func_{short_uid()}"
+        create_res = create_lambda_function(
+            func_name=function_name,
+            handler_file=ErrorHandlingTemplate.LAMBDA_FUNC_RAISE_EXCEPTION,
+            runtime=Runtime.python3_12,
+        )
+        sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
+        function_arn = create_res["CreateFunctionResponse"]["FunctionArn"]
+
+        template = ScenariosTemplate.load_sfn_template(
+            ScenariosTemplate.LAMBDA_INVOKE_WITH_RETRY_BASE_EXTENDED_INPUT
+        )
+        template["States"]["InvokeLambdaWithRetry"]["Resource"] = function_arn
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({})
+        create_and_record_express_sync_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )

--- a/tests/aws/services/stepfunctions/v2/express/test_express_sync.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_sync.snapshot.json
@@ -1,0 +1,273 @@
+{
+  "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_base[BASE_PASS_RESULT]": {
+    "recorded-date": "26-06-2024, 19:08:30",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_execution_sync_response": {
+        "billingDetails": {
+          "billedDurationInMilliseconds": 100,
+          "billedMemoryUsedInMB": 64
+        },
+        "executionArn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
+        "input": {},
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<SyncExecArn_Part1_0idx>",
+        "output": {
+          "Arg1": "argument1"
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_base[BASE_RAISE_FAILURE]": {
+    "recorded-date": "26-06-2024, 19:08:43",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_execution_sync_response": {
+        "billingDetails": {
+          "billedDurationInMilliseconds": 100,
+          "billedMemoryUsedInMB": 64
+        },
+        "cause": "This state machines raises a 'SomeFailure' failure.",
+        "error": "SomeFailure",
+        "executionArn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
+        "input": {},
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<SyncExecArn_Part1_0idx>",
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "status": "FAILED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_query_runtime_memory": {
+    "recorded-date": "26-06-2024, 19:08:56",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_execution_sync_response": {
+        "billingDetails": {
+          "billedDurationInMilliseconds": 100,
+          "billedMemoryUsedInMB": 64
+        },
+        "executionArn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
+        "input": {
+          "message": "HelloWorld!"
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<SyncExecArn_Part1_0idx>",
+        "output": {
+          "message": "HelloWorld!",
+          "query_values_1": {
+            "execution": {
+              "Id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
+              "Input": {
+                "message": "HelloWorld!"
+              },
+              "Name": "<SyncExecArn_Part1_0idx>",
+              "RoleArn": "sfn_role_arn",
+              "StartTime": "start-time"
+            },
+            "execution_rolearn": "sfn_role_arn",
+            "execution_name": "<SyncExecArn_Part1_0idx>",
+            "statemachine_id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "execution_id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
+            "execution_input": {
+              "message": "HelloWorld!"
+            },
+            "execution_starttime": "start-time",
+            "state_name": "QueryValues1",
+            "state_enteredtime": "entered-time",
+            "statemachine": {
+              "Id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+              "Name": "<ArnPart_0idx>"
+            },
+            "state": {
+              "Name": "QueryValues1",
+              "EnteredTime": "entered-time"
+            },
+            "context_object": {
+              "Execution": {
+                "Id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
+                "Input": {
+                  "message": "HelloWorld!"
+                },
+                "Name": "<SyncExecArn_Part1_0idx>",
+                "RoleArn": "sfn_role_arn",
+                "StartTime": "start-time"
+              },
+              "StateMachine": {
+                "Id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+                "Name": "<ArnPart_0idx>"
+              },
+              "State": {
+                "Name": "QueryValues1",
+                "EnteredTime": "entered-time"
+              }
+            },
+            "statemachine_name": "<ArnPart_0idx>"
+          },
+          "query_values_2": {
+            "context_object": {
+              "Execution": {
+                "Id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
+                "Input": {
+                  "message": "HelloWorld!"
+                },
+                "Name": "<SyncExecArn_Part1_0idx>",
+                "RoleArn": "sfn_role_arn",
+                "StartTime": "start-time"
+              },
+              "StateMachine": {
+                "Id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+                "Name": "<ArnPart_0idx>"
+              },
+              "State": {
+                "Name": "QueryValues2",
+                "EnteredTime": "entered-time"
+              }
+            }
+          }
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_catch": {
+    "recorded-date": "26-06-2024, 19:09:21",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_execution_sync_response": {
+        "billingDetails": {
+          "billedDurationInMilliseconds": 400,
+          "billedMemoryUsedInMB": 64
+        },
+        "executionArn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
+        "input": {
+          "FunctionName": "lambda_function_name",
+          "Payload": null
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<SyncExecArn_Part1_0idx>",
+        "output": {
+          "Error": "Exception",
+          "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"0c095f1f-4f7a-4a28-bde1-5903a8a0328c\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_retry": {
+    "recorded-date": "26-06-2024, 19:09:44",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_execution_sync_response": {
+        "billingDetails": {
+          "billedDurationInMilliseconds": 7500,
+          "billedMemoryUsedInMB": 64
+        },
+        "executionArn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
+        "input": {},
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<SyncExecArn_Part1_0idx>",
+        "output": {
+          "Error": "Exception",
+          "Cause": "{\"errorMessage\": \"Some exception was raised.\", \"errorType\": \"Exception\", \"requestId\": \"5c1838e9-a1ce-430f-bede-40e86848eb9e\", \"stackTrace\": [\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/express/test_express_sync.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_sync.snapshot.json
@@ -77,7 +77,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_query_runtime_memory": {
-    "recorded-date": "26-06-2024, 19:08:56",
+    "recorded-date": "15-07-2024, 12:59:18",
     "recorded-content": {
       "creation_response": {
         "creationDate": "datetime",
@@ -94,19 +94,19 @@
         },
         "executionArn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
         "input": {
-          "message": "HelloWorld!"
+          "message": "TestMessage"
         },
         "inputDetails": {
           "included": true
         },
         "name": "<SyncExecArn_Part1_0idx>",
         "output": {
-          "message": "HelloWorld!",
+          "message": "TestMessage",
           "query_values_1": {
             "execution": {
               "Id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
               "Input": {
-                "message": "HelloWorld!"
+                "message": "TestMessage"
               },
               "Name": "<SyncExecArn_Part1_0idx>",
               "RoleArn": "sfn_role_arn",
@@ -117,7 +117,7 @@
             "statemachine_id": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
             "execution_id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
             "execution_input": {
-              "message": "HelloWorld!"
+              "message": "TestMessage"
             },
             "execution_starttime": "start-time",
             "state_name": "QueryValues1",
@@ -134,7 +134,7 @@
               "Execution": {
                 "Id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
                 "Input": {
-                  "message": "HelloWorld!"
+                  "message": "TestMessage"
                 },
                 "Name": "<SyncExecArn_Part1_0idx>",
                 "RoleArn": "sfn_role_arn",
@@ -156,7 +156,7 @@
               "Execution": {
                 "Id": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
                 "Input": {
-                  "message": "HelloWorld!"
+                  "message": "TestMessage"
                 },
                 "Name": "<SyncExecArn_Part1_0idx>",
                 "RoleArn": "sfn_role_arn",
@@ -188,7 +188,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_catch": {
-    "recorded-date": "26-06-2024, 19:09:21",
+    "recorded-date": "15-07-2024, 13:29:30",
     "recorded-content": {
       "creation_response": {
         "creationDate": "datetime",
@@ -200,7 +200,7 @@
       },
       "start_execution_sync_response": {
         "billingDetails": {
-          "billedDurationInMilliseconds": 400,
+          "billedDurationInMilliseconds": 300,
           "billedMemoryUsedInMB": 64
         },
         "executionArn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
@@ -214,7 +214,7 @@
         "name": "<SyncExecArn_Part1_0idx>",
         "output": {
           "Error": "Exception",
-          "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"0c095f1f-4f7a-4a28-bde1-5903a8a0328c\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+          "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":<request-id>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
         },
         "outputDetails": {
           "included": true
@@ -231,7 +231,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_retry": {
-    "recorded-date": "26-06-2024, 19:09:44",
+    "recorded-date": "15-07-2024, 13:37:02",
     "recorded-content": {
       "creation_response": {
         "creationDate": "datetime",
@@ -243,7 +243,7 @@
       },
       "start_execution_sync_response": {
         "billingDetails": {
-          "billedDurationInMilliseconds": 7500,
+          "billedDurationInMilliseconds": 7600,
           "billedMemoryUsedInMB": 64
         },
         "executionArn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
@@ -254,7 +254,7 @@
         "name": "<SyncExecArn_Part1_0idx>",
         "output": {
           "Error": "Exception",
-          "Cause": "{\"errorMessage\": \"Some exception was raised.\", \"errorType\": \"Exception\", \"requestId\": \"5c1838e9-a1ce-430f-bede-40e86848eb9e\", \"stackTrace\": [\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+          "Cause": "{\"errorMessage\": \"Some exception was raised.\", \"errorType\": \"Exception\", \"requestId\": \"<request-id>\", \"stackTrace\": [\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
         },
         "outputDetails": {
           "included": true

--- a/tests/aws/services/stepfunctions/v2/express/test_express_sync.validation.json
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_sync.validation.json
@@ -1,0 +1,17 @@
+{
+  "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_base[BASE_PASS_RESULT]": {
+    "last_validated_date": "2024-06-26T19:08:30+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_base[BASE_RAISE_FAILURE]": {
+    "last_validated_date": "2024-06-26T19:08:43+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_catch": {
+    "last_validated_date": "2024-06-26T19:09:21+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_query_runtime_memory": {
+    "last_validated_date": "2024-06-26T19:08:56+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_retry": {
+    "last_validated_date": "2024-06-26T19:09:44+00:00"
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/express/test_express_sync.validation.json
+++ b/tests/aws/services/stepfunctions/v2/express/test_express_sync.validation.json
@@ -6,12 +6,12 @@
     "last_validated_date": "2024-06-26T19:08:43+00:00"
   },
   "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_catch": {
-    "last_validated_date": "2024-06-26T19:09:21+00:00"
+    "last_validated_date": "2024-07-15T13:29:30+00:00"
   },
   "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_query_runtime_memory": {
-    "last_validated_date": "2024-06-26T19:08:56+00:00"
+    "last_validated_date": "2024-07-15T12:59:18+00:00"
   },
   "tests/aws/services/stepfunctions/v2/express/test_express_sync.py::TestExpressSync::test_retry": {
-    "last_validated_date": "2024-06-26T19:09:44+00:00"
+    "last_validated_date": "2024-07-15T13:37:02+00:00"
   }
 }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
@@ -1769,6 +1769,30 @@
       }
     }
   },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_start_sync_execution": {
+    "recorded-date": "03-07-2024, 17:10:25",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_sync_execution_error": {
+        "Error": {
+          "Code": "StateMachineTypeNotSupported",
+          "Message": "This operation is not supported by this type of state machine"
+        },
+        "message": "This operation is not supported by this type of state machine",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_list_sms_pagination": {
     "recorded-date": "01-07-2024, 12:04:17",
     "recorded-content": {

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
@@ -105,7 +105,7 @@
     "last_validated_date": "2023-06-22T11:52:39+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_start_sync_execution": {
-    "last_validated_date": "2024-04-05T20:08:10+00:00"
+    "last_validated_date": "2024-07-03T17:10:25+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_state_machine_status_filter": {
     "last_validated_date": "2024-03-14T21:59:25+00:00"

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
@@ -104,6 +104,9 @@
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_start_execution": {
     "last_validated_date": "2023-06-22T11:52:39+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_start_sync_execution": {
+    "last_validated_date": "2024-04-05T20:08:10+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_state_machine_status_filter": {
     "last_validated_date": "2024-03-14T21:59:25+00:00"
   },

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_express.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_express.py
@@ -22,7 +22,6 @@ from tests.aws.services.stepfunctions.templates.services.services_templates impo
 
 @markers.snapshot.skip_snapshot_verify(
     paths=[
-        "$..loggingConfiguration",
         "$..tracingConfiguration",
         "$..billingDetails",
         "$..redrive_count",

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_express.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_express.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
+from aws.services.stepfunctions.templates.activities.activity_templates import ActivityTemplate
 from localstack.aws.api.stepfunctions import StateMachineType
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.stepfunctions.utils import (
@@ -11,6 +12,9 @@ from localstack.testing.pytest.stepfunctions.utils import (
 )
 from localstack.utils.strings import short_uid
 from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
+from tests.aws.services.stepfunctions.templates.callbacks.callback_templates import (
+    CallbackTemplates,
+)
 from tests.aws.services.stepfunctions.templates.services.services_templates import ServicesTemplates
 
 
@@ -21,6 +25,7 @@ from tests.aws.services.stepfunctions.templates.services.services_templates impo
         "$..billingDetails",
         "$..redrive_count",
         "$..event_timestamp",
+        "$..Error.Message",
     ]
 )
 class TestSfnApiExpress:
@@ -101,7 +106,6 @@ class TestSfnApiExpress:
         self,
         create_iam_role_for_sfn,
         create_state_machine,
-        sqs_create_queue,
         sfn_snapshot,
         stepfunctions_client_sync_executions,
     ):
@@ -117,3 +121,70 @@ class TestSfnApiExpress:
             definition,
             exec_input,
         )
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Message", "$..message"])
+    @pytest.mark.parametrize(
+        "template",
+        [
+            CallbackTemplates.SNS_PUBLIC_WAIT_FOR_TASK_TOKEN,
+            CallbackTemplates.SFN_START_EXECUTION_SYNC,
+        ],
+        ids=["WAIT_FOR_TASK_TOKEN", "SYNC"],
+    )
+    def test_illegal_callbacks(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+        template,
+    ):
+        snf_role_arn = create_iam_role_for_sfn()
+        sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "sfn_role_arn"))
+
+        template = CallbackTemplates.load_sfn_template(template)
+        definition = json.dumps(template)
+
+        with pytest.raises(Exception) as ex:
+            create_state_machine(
+                name=f"express_statemachine_{short_uid()}",
+                definition=definition,
+                roleArn=snf_role_arn,
+                type=StateMachineType.EXPRESS,
+            )
+        sfn_snapshot.match("creation_error", ex.value.response)
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Message", "$..message"])
+    def test_illegal_activity_task(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        create_activity,
+        sfn_activity_consumer,
+        sfn_snapshot,
+    ):
+        snf_role_arn = create_iam_role_for_sfn()
+        sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "sfn_role_arn"))
+
+        activity_name = f"activity-{short_uid()}"
+        create_activity_output = create_activity(name=activity_name)
+        activity_arn = create_activity_output["activityArn"]
+        sfn_snapshot.add_transformer(RegexTransformer(activity_arn, "activity_arn"))
+        sfn_snapshot.add_transformer(RegexTransformer(activity_name, "activity_name"))
+        sfn_snapshot.match("create_activity_output", create_activity_output)
+
+        template = ActivityTemplate.load_sfn_template(ActivityTemplate.BASE_ACTIVITY_TASK)
+        template["States"]["ActivityTask"]["Resource"] = activity_arn
+        definition = json.dumps(template)
+
+        with pytest.raises(Exception) as ex:
+            create_state_machine(
+                name=f"express_statemachine_{short_uid()}",
+                definition=definition,
+                roleArn=snf_role_arn,
+                type=StateMachineType.EXPRESS,
+            )
+        sfn_snapshot.match("creation_error", ex.value.response)

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_express.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_express.py
@@ -1,0 +1,130 @@
+import json
+
+import pytest
+from localstack_snapshot.snapshots.transformer import RegexTransformer
+
+from localstack.aws.api.sqs import Message
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
+from tests.aws.services.stepfunctions.templates.services.services_templates import ServicesTemplates
+from tests.aws.services.stepfunctions.utils import (
+    await_on_sqs_message,
+    create_and_record_express_sync_execution,
+)
+
+
+@markers.snapshot.skip_snapshot_verify(
+    paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..billingDetails"]
+)
+class TestSfnApiExpress:
+    @markers.aws.validated
+    def test_create_describe_delete(
+        self,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+        aws_client,
+    ):
+        snf_role_arn = create_iam_role_for_sfn()
+        sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "snf_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition_str = json.dumps(definition)
+
+        creation_response = create_state_machine(
+            name=f"statemachine_{short_uid()}",
+            definition=definition_str,
+            roleArn=snf_role_arn,
+            type="EXPRESS",
+        )
+        sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_create_arn(creation_response, 0))
+        sfn_snapshot.match("creation_response", creation_response)
+
+        state_machine_arn = creation_response["stateMachineArn"]
+        describe_response = aws_client.stepfunctions.describe_state_machine(
+            stateMachineArn=state_machine_arn
+        )
+        sfn_snapshot.match("describe_response", describe_response)
+
+        deletion_response = aws_client.stepfunctions.delete_state_machine(
+            stateMachineArn=state_machine_arn
+        )
+        sfn_snapshot.match("deletion_response", deletion_response)
+
+    @markers.aws.validated
+    def test_start_describe_history_execution(
+        self,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sqs_create_queue,
+        sfn_snapshot,
+        aws_client,
+    ):
+        snf_role_arn = create_iam_role_for_sfn()
+        sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "snf_role_arn"))
+
+        queue_url = sqs_create_queue(QueueName=f"queue-{short_uid()}")
+        sfn_snapshot.add_transformer(RegexTransformer(queue_url, "sqs_queue_url"))
+
+        definition = ServicesTemplates.load_sfn_template(ServicesTemplates.SQS_SEND_MESSAGE)
+        definition_str = json.dumps(definition)
+
+        creation_response = create_state_machine(
+            name=f"statemachine_{short_uid()}",
+            definition=definition_str,
+            roleArn=snf_role_arn,
+            type="EXPRESS",
+        )
+        sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_create_arn(creation_response, 0))
+        sfn_snapshot.match("creation_response", creation_response)
+
+        state_machine_arn = creation_response["stateMachineArn"]
+
+        input_arguments = {
+            "QueueUrl": queue_url,
+            "MessageBody": "HelloWorld",
+        }
+        start_response = aws_client.stepfunctions.start_execution(
+            stateMachineArn=state_machine_arn, input=json.dumps(input_arguments)
+        )
+        sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_exec_arn(start_response, 0))
+        sfn_snapshot.match("start_response", start_response)
+        execution_arn = start_response["executionArn"]
+
+        message: Message = await_on_sqs_message(sqs_client=aws_client.sqs, queue_url=queue_url)
+        sfn_snapshot.match("message_body", message["Body"])
+
+        with pytest.raises(Exception) as ex:
+            aws_client.stepfunctions.list_executions(stateMachineArn=state_machine_arn)
+        sfn_snapshot.match("list_executions_error", ex.value.response)
+
+        with pytest.raises(Exception) as ex:
+            aws_client.stepfunctions.describe_execution(executionArn=execution_arn)
+        sfn_snapshot.match("describe_execution_error", ex.value.response)
+
+        with pytest.raises(Exception) as ex:
+            aws_client.stepfunctions.get_execution_history(executionArn=execution_arn)
+        sfn_snapshot.match("get_execution_history_error", ex.value.response)
+
+    @markers.aws.validated
+    def test_start_sync_execution(
+        self,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sqs_create_queue,
+        sfn_snapshot,
+        aws_client,
+    ):
+        template = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({})
+        create_and_record_express_sync_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_express.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_express.py
@@ -3,19 +3,25 @@ import json
 import pytest
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
-from localstack.aws.api.sqs import Message
+from localstack.aws.api.stepfunctions import StateMachineType
 from localstack.testing.pytest import markers
+from localstack.testing.pytest.stepfunctions.utils import (
+    create_and_record_express_async_execution,
+    create_and_record_express_sync_execution,
+)
 from localstack.utils.strings import short_uid
 from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
 from tests.aws.services.stepfunctions.templates.services.services_templates import ServicesTemplates
-from tests.aws.services.stepfunctions.utils import (
-    await_on_sqs_message,
-    create_and_record_express_sync_execution,
-)
 
 
 @markers.snapshot.skip_snapshot_verify(
-    paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..billingDetails"]
+    paths=[
+        "$..loggingConfiguration",
+        "$..tracingConfiguration",
+        "$..billingDetails",
+        "$..redrive_count",
+        "$..event_timestamp",
+    ]
 )
 class TestSfnApiExpress:
     @markers.aws.validated
@@ -36,7 +42,7 @@ class TestSfnApiExpress:
             name=f"statemachine_{short_uid()}",
             definition=definition_str,
             roleArn=snf_role_arn,
-            type="EXPRESS",
+            type=StateMachineType.EXPRESS,
         )
         sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_create_arn(creation_response, 0))
         sfn_snapshot.match("creation_response", creation_response)
@@ -53,47 +59,26 @@ class TestSfnApiExpress:
         sfn_snapshot.match("deletion_response", deletion_response)
 
     @markers.aws.validated
-    def test_start_describe_history_execution(
+    def test_start_async_describe_history_execution(
         self,
         create_iam_role_for_sfn,
         create_state_machine,
-        sqs_create_queue,
+        sfn_create_log_group,
         sfn_snapshot,
         aws_client,
     ):
-        snf_role_arn = create_iam_role_for_sfn()
-        sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "snf_role_arn"))
-
-        queue_url = sqs_create_queue(QueueName=f"queue-{short_uid()}")
-        sfn_snapshot.add_transformer(RegexTransformer(queue_url, "sqs_queue_url"))
-
-        definition = ServicesTemplates.load_sfn_template(ServicesTemplates.SQS_SEND_MESSAGE)
+        definition = ServicesTemplates.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
         definition_str = json.dumps(definition)
-
-        creation_response = create_state_machine(
-            name=f"statemachine_{short_uid()}",
-            definition=definition_str,
-            roleArn=snf_role_arn,
-            type="EXPRESS",
+        execution_input = json.dumps(dict())
+        state_machine_arn, execution_arn = create_and_record_express_async_execution(
+            aws_client,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_create_log_group,
+            sfn_snapshot,
+            definition_str,
+            execution_input,
         )
-        sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_create_arn(creation_response, 0))
-        sfn_snapshot.match("creation_response", creation_response)
-
-        state_machine_arn = creation_response["stateMachineArn"]
-
-        input_arguments = {
-            "QueueUrl": queue_url,
-            "MessageBody": "HelloWorld",
-        }
-        start_response = aws_client.stepfunctions.start_execution(
-            stateMachineArn=state_machine_arn, input=json.dumps(input_arguments)
-        )
-        sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_exec_arn(start_response, 0))
-        sfn_snapshot.match("start_response", start_response)
-        execution_arn = start_response["executionArn"]
-
-        message: Message = await_on_sqs_message(sqs_client=aws_client.sqs, queue_url=queue_url)
-        sfn_snapshot.match("message_body", message["Body"])
 
         with pytest.raises(Exception) as ex:
             aws_client.stepfunctions.list_executions(stateMachineArn=state_machine_arn)
@@ -102,6 +87,10 @@ class TestSfnApiExpress:
         with pytest.raises(Exception) as ex:
             aws_client.stepfunctions.describe_execution(executionArn=execution_arn)
         sfn_snapshot.match("describe_execution_error", ex.value.response)
+
+        with pytest.raises(Exception) as ex:
+            aws_client.stepfunctions.stop_execution(executionArn=execution_arn)
+        sfn_snapshot.match("stop_execution_error", ex.value.response)
 
         with pytest.raises(Exception) as ex:
             aws_client.stepfunctions.get_execution_history(executionArn=execution_arn)
@@ -114,14 +103,14 @@ class TestSfnApiExpress:
         create_state_machine,
         sqs_create_queue,
         sfn_snapshot,
-        aws_client,
+        stepfunctions_client_sync_executions,
     ):
         template = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
         definition = json.dumps(template)
 
         exec_input = json.dumps({})
         create_and_record_express_sync_execution(
-            aws_client.stepfunctions,
+            stepfunctions_client_sync_executions,
             create_iam_role_for_sfn,
             create_state_machine,
             sfn_snapshot,

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_express.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_express.py
@@ -3,7 +3,6 @@ import json
 import pytest
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
-from aws.services.stepfunctions.templates.activities.activity_templates import ActivityTemplate
 from localstack.aws.api.stepfunctions import StateMachineType
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.stepfunctions.utils import (
@@ -11,6 +10,9 @@ from localstack.testing.pytest.stepfunctions.utils import (
     create_and_record_express_sync_execution,
 )
 from localstack.utils.strings import short_uid
+from tests.aws.services.stepfunctions.templates.activities.activity_templates import (
+    ActivityTemplate,
+)
 from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
 from tests.aws.services.stepfunctions.templates.callbacks.callback_templates import (
     CallbackTemplates,

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_express.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_express.snapshot.json
@@ -1,0 +1,147 @@
+{
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_create_describe_delete": {
+    "recorded-date": "15-03-2024, 13:45:44",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_response": {
+        "creationDate": "datetime",
+        "definition": {
+          "Comment": "BASE_PASS_RESULT",
+          "StartAt": "State_1",
+          "States": {
+            "State_1": {
+              "Type": "Pass",
+              "Result": {
+                "Arg1": "argument1"
+              },
+              "End": true
+            }
+          }
+        },
+        "loggingConfiguration": {
+          "includeExecutionData": false,
+          "level": "OFF"
+        },
+        "name": "<ArnPart_0idx>",
+        "roleArn": "snf_role_arn",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "status": "ACTIVE",
+        "tracingConfiguration": {
+          "enabled": false
+        },
+        "type": "EXPRESS",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "deletion_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_start_describe_history_execution": {
+    "recorded-date": "05-04-2024, 19:51:28",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_response": {
+        "executionArn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:f3e4df91-8412-4a20-8054-fbe366c0e434:<ExecArnPart_0idx>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "message_body": "HelloWorld",
+      "list_executions_error": {
+        "Error": {
+          "Code": "StateMachineTypeNotSupported",
+          "Message": "This operation is not supported by this type of state machine"
+        },
+        "message": "This operation is not supported by this type of state machine",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "describe_execution_error": {
+        "Error": {
+          "Code": "InvalidArn",
+          "Message": "Invalid Arn: 'Resource type not valid in this context: express'"
+        },
+        "message": "Invalid Arn: 'Resource type not valid in this context: express'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get_execution_history_error": {
+        "Error": {
+          "Code": "InvalidArn",
+          "Message": "Invalid Arn: 'Resource type not valid in this context: express'"
+        },
+        "message": "Invalid Arn: 'Resource type not valid in this context: express'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_start_sync_execution": {
+    "recorded-date": "06-04-2024, 14:36:18",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_execution_sync_response": {
+        "billingDetails": {
+          "billedDurationInMilliseconds": 100,
+          "billedMemoryUsedInMB": 64
+        },
+        "executionArn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
+        "input": {},
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<SyncExecArn_Part1_0idx>",
+        "output": {
+          "Arg1": "argument1"
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_express.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_express.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_create_describe_delete": {
-    "recorded-date": "15-03-2024, 13:45:44",
+    "recorded-date": "26-06-2024, 19:06:21",
     "recorded-content": {
       "creation_response": {
         "creationDate": "datetime",
@@ -50,8 +50,8 @@
       }
     }
   },
-  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_start_describe_history_execution": {
-    "recorded-date": "05-04-2024, 19:51:28",
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_start_async_describe_history_execution": {
+    "recorded-date": "03-07-2024, 17:14:50",
     "recorded-content": {
       "creation_response": {
         "creationDate": "datetime",
@@ -61,15 +61,22 @@
           "HTTPStatusCode": 200
         }
       },
-      "start_response": {
-        "executionArn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:f3e4df91-8412-4a20-8054-fbe366c0e434:<ExecArnPart_0idx>",
-        "startDate": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
+      "end_event": {
+        "details": {
+          "output": {
+            "Arg1": "argument1"
+          },
+          "outputDetails": {
+            "truncated": false
+          }
+        },
+        "event_timestamp": "timestamp",
+        "execution_arn": "arn:aws:states:<region>:111111111111:express:<ArnPart_0idx>:<ExpressExecArn_Part1_0idx>:<ExpressExecArn_Part2_0idx>",
+        "id": "4",
+        "previous_event_id": "3",
+        "redrive_count": "0",
+        "type": "ExecutionSucceeded"
       },
-      "message_body": "HelloWorld",
       "list_executions_error": {
         "Error": {
           "Code": "StateMachineTypeNotSupported",
@@ -82,6 +89,17 @@
         }
       },
       "describe_execution_error": {
+        "Error": {
+          "Code": "InvalidArn",
+          "Message": "Invalid Arn: 'Resource type not valid in this context: express'"
+        },
+        "message": "Invalid Arn: 'Resource type not valid in this context: express'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "stop_execution_error": {
         "Error": {
           "Code": "InvalidArn",
           "Message": "Invalid Arn: 'Resource type not valid in this context: express'"
@@ -106,7 +124,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_start_sync_execution": {
-    "recorded-date": "06-04-2024, 14:36:18",
+    "recorded-date": "26-06-2024, 19:06:54",
     "recorded-content": {
       "creation_response": {
         "creationDate": "datetime",

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_express.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_express.snapshot.json
@@ -161,5 +161,61 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_illegal_callbacks[WAIT_FOR_TASK_TOKEN]": {
+    "recorded-date": "03-07-2024, 19:43:10",
+    "recorded-content": {
+      "creation_error": {
+        "Error": {
+          "Code": "InvalidDefinition",
+          "Message": "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: Express state machine does not support '.waitForTaskToken' service integration  at /States/Publish/Resource'"
+        },
+        "message": "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: Express state machine does not support '.waitForTaskToken' service integration  at /States/Publish/Resource'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_illegal_callbacks[SYNC]": {
+    "recorded-date": "03-07-2024, 19:43:23",
+    "recorded-content": {
+      "creation_error": {
+        "Error": {
+          "Code": "InvalidDefinition",
+          "Message": "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: Express state machine does not support '.sync' service integration at /States/StartExecution/Resource'"
+        },
+        "message": "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: Express state machine does not support '.sync' service integration at /States/StartExecution/Resource'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_illegal_activity_task": {
+    "recorded-date": "03-07-2024, 19:27:25",
+    "recorded-content": {
+      "create_activity_output": {
+        "activityArn": "activity_arn",
+        "creationDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "creation_error": {
+        "Error": {
+          "Code": "InvalidDefinition",
+          "Message": "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: Express state machine does not support Activity ARN at /States/ActivityTask/Resource'"
+        },
+        "message": "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: Express state machine does not support Activity ARN at /States/ActivityTask/Resource'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_express.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_express.validation.json
@@ -2,6 +2,15 @@
   "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_create_describe_delete": {
     "last_validated_date": "2024-06-26T19:06:21+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_illegal_activity_task": {
+    "last_validated_date": "2024-07-03T19:27:25+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_illegal_callbacks[SYNC]": {
+    "last_validated_date": "2024-07-03T19:43:23+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_illegal_callbacks[WAIT_FOR_TASK_TOKEN]": {
+    "last_validated_date": "2024-07-03T19:43:10+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_start_async_describe_history_execution": {
     "last_validated_date": "2024-07-03T17:14:50+00:00"
   },

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_express.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_express.validation.json
@@ -1,11 +1,11 @@
 {
   "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_create_describe_delete": {
-    "last_validated_date": "2024-03-15T13:45:44+00:00"
+    "last_validated_date": "2024-06-26T19:06:21+00:00"
   },
-  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_start_describe_history_execution": {
-    "last_validated_date": "2024-04-05T19:51:28+00:00"
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_start_async_describe_history_execution": {
+    "last_validated_date": "2024-07-03T17:14:50+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_start_sync_execution": {
-    "last_validated_date": "2024-04-06T14:36:18+00:00"
+    "last_validated_date": "2024-06-26T19:06:54+00:00"
   }
 }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_express.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_express.validation.json
@@ -1,0 +1,11 @@
+{
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_create_describe_delete": {
+    "last_validated_date": "2024-03-15T13:45:44+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_start_describe_history_execution": {
+    "last_validated_date": "2024-04-05T19:51:28+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_express.py::TestSfnApiExpress::test_start_sync_execution": {
+    "last_validated_date": "2024-04-06T14:36:18+00:00"
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py
@@ -38,6 +38,31 @@ class TestSnfApiVersioning:
         sfn_snapshot.match("creation_resp_1", creation_resp_1)
 
     @markers.aws.validated
+    def test_create_express_with_publish(
+        self,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+        aws_client,
+    ):
+        snf_role_arn = create_iam_role_for_sfn()
+        sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "snf_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition_str = json.dumps(definition)
+
+        sm_name = f"statemachine_{short_uid()}"
+        creation_resp_1 = create_state_machine(
+            name=sm_name,
+            definition=definition_str,
+            roleArn=snf_role_arn,
+            publish=True,
+            type="EXPRESS",
+        )
+        sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_create_arn(creation_resp_1, 0))
+        sfn_snapshot.match("creation_resp_1", creation_resp_1)
+
+    @markers.aws.validated
     def test_create_with_version_description_no_publish(
         self,
         create_iam_role_for_sfn,

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
+from localstack.aws.api.stepfunctions import StateMachineType
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.stepfunctions.utils import (
     await_execution_lists_terminated,
@@ -57,7 +58,7 @@ class TestSnfApiVersioning:
             definition=definition_str,
             roleArn=snf_role_arn,
             publish=True,
-            type="EXPRESS",
+            type=StateMachineType.EXPRESS,
         )
         sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_create_arn(creation_resp_1, 0))
         sfn_snapshot.match("creation_resp_1", creation_resp_1)

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.snapshot.json
@@ -809,6 +809,20 @@
       }
     }
   },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py::TestSnfApiVersioning::test_create_express_with_publish": {
+    "recorded-date": "05-04-2024, 19:53:29",
+    "recorded-content": {
+      "creation_resp_1": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "stateMachineVersionArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py::TestSnfApiVersioning::test_list_state_machine_versions_pagination": {
     "recorded-date": "01-07-2024, 12:20:00",
     "recorded-content": {

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py::TestSnfApiVersioning::test_create_express_with_publish": {
+    "last_validated_date": "2024-04-05T19:53:29+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py::TestSnfApiVersioning::test_create_publish_describe_no_version_description": {
     "last_validated_date": "2023-08-11T10:09:39+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, the StepFunctions v2 provider and interpreter offer no support for [Express Workflows](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-standard-vs-express.html). This PR addresses this by adding base support for Express Workflows.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added execution flavour logic to execution components, now STANDARD or EXPRESS
- Added sync execution components: Execution and ExecutionWorker
- Added static analyser to fail state machine creation that includes illegal callbacks or activities
- Added several validation exceptions concerning limitations of Express workflows
- Added support for [StartSyncExecution api action](https://docs.aws.amazon.com/cli/latest/reference/stepfunctions/start-sync-execution.html)
- Added several supporting utils for express testing
- Added base positive and negative api snapshot tests
- Added positive and negative snapshot tests for sync and async express workflow executions

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
