### PR TITLE
Apigw ng request template mapping

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -1,5 +1,4 @@
 import logging
-from http import HTTPMethod
 
 from localstack.aws.api.apigateway import Integration, IntegrationType
 from localstack.http import Response
@@ -79,13 +78,6 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
         if not (integration_method := integration["httpMethod"]) or integration_method == "ANY":
             # otherwise, fallback to the request's method
             integration_method = context.invocation_request["method"]
-        # AWS doesn't send a body for these methods. Mock needs the body to get the status code
-        # TODO this might need to be done in the integrations?
-        if (
-            integration_method in [HTTPMethod.GET, HTTPMethod.HEAD, HTTPMethod.OPTIONS]
-            and not integration_type == IntegrationType.MOCK
-        ):
-            body = b""
 
         integration_request = IntegrationRequest(
             http_method=integration_method,
@@ -116,7 +108,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
         template: str,
     ) -> tuple[bytes, ContextVarsRequestOverride]:
         request: InvocationRequest = context.invocation_request
-        body = request.get("body")
+        body = request["body"]
 
         if not template:
             return body, {}

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -1,13 +1,30 @@
 import logging
+from enum import Enum
 
 from localstack.aws.api.apigateway import Integration, IntegrationType
 from localstack.http import Response
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
-from ..context import IntegrationRequest, RestApiInvocationContext
+from ..context import IntegrationRequest, InvocationRequest, RestApiInvocationContext
+from ..gateway_response import UnsupportedMediaTypeError
 from ..parameters_mapping import ParametersMapper, RequestDataMapping
+from ..template_mapping import ApiGatewayVtlTemplate
+from ..variables import (
+    ContextVarsRequestOverride,
+    MappingTemplateInput,
+    MappingTemplateParams,
+    MappingTemplateVariables,
+)
 
 LOG = logging.getLogger(__name__)
+
+
+class PassthroughBehavior(Enum):
+    # TODO maybe this class should be moved where it can also be used for validation in
+    #  the provider when we switch out of moto
+    WHEN_NO_MATCH = "WHEN_NO_MATCH"
+    WHEN_NO_TEMPLATES = "WHEN_NO_TEMPLATES"
+    NEVER = "NEVER"
 
 
 class IntegrationRequestHandler(RestApiGatewayHandler):
@@ -18,6 +35,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
 
     def __init__(self):
         self._param_mapper = ParametersMapper()
+        self._vtl_template = ApiGatewayVtlTemplate()
 
     def __call__(
         self,
@@ -34,18 +52,20 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
             # See
             return
 
-        # TODO: maybe first do the `passthroughBehavior` and determine if there's a mapping template?
+        # find request template to raise UnsupportedMediaTypeError early
+        request_template = self.get_request_template(
+            integration=integration, request=context.invocation_request
+        )
 
-        # TODO: this handler might not be tested yet until `TemplateMappings` are implemented, as overall behavior will
-        #  change
         integration_request_parameters = integration["requestParameters"] or {}
         request_data_mapping = self.get_integration_request_data(
             context, integration_request_parameters
         )
 
-        # TODO: work on TemplateMappings with VTL to render the body of the request
-        #  it might populate the context requestOverride too, maybe deepcopy the ContextVariables because it will
-        #  get mutated, or pop it directly? might just be better!
+        body, request_override = self.render_request_template_mapping(
+            context=context, template=request_template
+        )
+        request_data_mapping.update(request_override)
 
         # TODO: extract the code under into its own method
 
@@ -63,7 +83,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
             uri=rendered_integration_uri,
             query_string_parameters=request_data_mapping["querystring"],
             headers=request_data_mapping["header"],
-            body=b"",  # TODO: from MappingTemplates or passthrough
+            body=body.encode(),
         )
         # TODO: log every override that happens afterwards
 
@@ -80,3 +100,63 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
             context_variables=context.context_variables,
             stage_variables=context.stage_variables,
         )
+
+    def render_request_template_mapping(
+        self,
+        context: RestApiInvocationContext,
+        template: str,
+    ) -> tuple[str, ContextVarsRequestOverride]:
+        request: InvocationRequest = context.invocation_request
+        body = str(request.get("body", ""))
+
+        if not template:
+            return body, {}
+
+        variables = MappingTemplateVariables(
+            context=context.context_variables,
+            stageVariables=context.stage_variables or {},
+            input=MappingTemplateInput(
+                body=body,
+                params=MappingTemplateParams(
+                    path=request.get("path_parameters"),
+                    querystring=request.get("query_string_parameters", {}),
+                    header=request.get("headers", {}),
+                ),
+            ),
+        )
+        result = self._vtl_template.render_vtl(template=template.strip(), variables=variables)
+        return result, variables.get("requestOverride")
+
+    def get_request_template(self, integration: Integration, request: InvocationRequest) -> str:
+        """
+        Attempts to return the request template.
+        Will raise UnsupportedMediaTypeError if there are no match according to passthrough behavior.
+        """
+        request_templates = integration.get("requestTemplates")
+        passthrough_behavior = integration.get("passthroughBehavior")
+        # If content-type is not provided aws assumes application/json
+        content_type = request["raw_headers"].get("Content-Type", "application/json")
+        # first look to for a template associated to the content-type, otherwise look for the $default template
+        request_template = request_templates.get(content_type) or request_templates.get("$default")
+
+        if request_template or passthrough_behavior == PassthroughBehavior.WHEN_NO_MATCH:
+            return request_template
+
+        match passthrough_behavior:
+            case PassthroughBehavior.NEVER:
+                LOG.debug(
+                    "No request template found for '%s' and passthrough behavior set to NEVER",
+                    content_type,
+                )
+                raise UnsupportedMediaTypeError("Unsupported Media Type")
+            case PassthroughBehavior.WHEN_NO_TEMPLATES:
+                if request_templates:
+                    LOG.debug(
+                        "No request template found for '%s' and passthrough behavior set to WHEN_NO_TEMPLATES",
+                        content_type,
+                    )
+                    raise UnsupportedMediaTypeError("Unsupported Media Type")
+            case _:
+                LOG.debug("Unknown passthrough behavior: '%s'", passthrough_behavior)
+
+        return request_template

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 from localstack.aws.api.apigateway import Integration, IntegrationType
 from localstack.http import Response
+from localstack.utils.collections import merge_recursive
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import IntegrationRequest, InvocationRequest, RestApiInvocationContext
@@ -65,7 +66,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
         body, request_override = self.render_request_template_mapping(
             context=context, template=request_template
         )
-        request_data_mapping.update(request_override)
+        merge_recursive(request_override, request_data_mapping)
 
         # TODO: extract the code under into its own method
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -1,0 +1,214 @@
+# > In API Gateway, an API's method request or response can take a payload in a different format from the integration
+# request or response.
+#
+# You can transform your data to:
+# - Match the payload to an API-specified format.
+# - Override an API's request and response parameters and status codes.
+# - Return client selected response headers.
+# - Associate path parameters, query string parameters, or header parameters in the method request of HTTP proxy
+#       or AWS service proxy. TODO: this is from the documentation. Can we use requestOverides for proxy integrations?
+# - Select which data to send using integration with AWS services, such as Amazon DynamoDB or Lambda functions,
+#       or HTTP endpoints.
+#
+# You can use mapping templates to transform your data. A mapping template is a script expressed in Velocity Template
+# Language (VTL) and applied to the payload using JSONPath .
+#
+# https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html
+import base64
+import copy
+import json
+import logging
+from typing import Any
+from urllib.parse import quote_plus, unquote_plus
+
+import xmltodict
+
+from localstack import config
+from localstack.services.apigateway.next_gen.execute_api.variables import (
+    ContextVarsRequestOverride,
+    ContextVarsResponseOverride,
+    MappingTemplateVariables,
+)
+from localstack.utils.aws.templating import VelocityUtil, VtlTemplate
+from localstack.utils.json import extract_jsonpath, json_safe
+
+LOG = logging.getLogger(__name__)
+
+
+class AttributeDict(dict):
+    """
+    Wrapper returned by VelocityUtilApiGateway.parseJson to allow access to dict values as attributes (dot notation),
+    e.g.: $util.parseJson('$.foo').bar
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(AttributeDict, self).__init__(*args, **kwargs)
+        for key, value in self.items():
+            if isinstance(value, dict):
+                self[key] = AttributeDict(value)
+
+    def __getattr__(self, name):
+        if name in self:
+            return self[name]
+        raise AttributeError(f"'AttributeDict' object has no attribute '{name}'")
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+    def __delattr__(self, name):
+        if name in self:
+            del self[name]
+        else:
+            raise AttributeError(f"'AttributeDict' object has no attribute '{name}'")
+
+
+class VelocityUtilApiGateway(VelocityUtil):
+    """
+    Simple class to mimic the behavior of variable '$util' in AWS API Gateway integration
+    velocity templates.
+    See: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+    """
+
+    def base64Encode(self, s):
+        if not isinstance(s, str):
+            s = json.dumps(s)
+        encoded_str = s.encode(config.DEFAULT_ENCODING)
+        encoded_b64_str = base64.b64encode(encoded_str)
+        return encoded_b64_str.decode(config.DEFAULT_ENCODING)
+
+    def base64Decode(self, s):
+        if not isinstance(s, str):
+            s = json.dumps(s)
+        return base64.b64decode(s)
+
+    def toJson(self, obj):
+        return obj and json.dumps(obj)
+
+    def urlEncode(self, s):
+        return quote_plus(s)
+
+    def urlDecode(self, s):
+        return unquote_plus(s)
+
+    def escapeJavaScript(self, obj: Any) -> str:
+        """
+        Converts the given object to a string and escapes any regular single quotes (') into escaped ones (\').
+        JSON dumps will escape the single quotes.
+        https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+        """
+        if obj is None:
+            return "null"
+        if isinstance(obj, str):
+            # empty string escapes to empty object
+            if len(obj.strip()) == 0:
+                return "{}"
+            return json.dumps(obj)[1:-1]
+        if obj in (True, False):
+            return str(obj).lower()
+        return str(obj)
+
+    def parseJson(self, s: str):
+        obj = json.loads(s)
+        return AttributeDict(obj) if isinstance(obj, dict) else obj
+
+
+class VelocityInput:
+    """
+    Simple class to mimic the behavior of variable '$input' in AWS API Gateway integration
+    velocity templates.
+    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+    """
+
+    def __init__(self, body, params):
+        self.parameters = params or {}
+        self.value = body
+
+    def path(self, path):
+        if not self.value:
+            return {}
+        value = self.value if isinstance(self.value, dict) else json.loads(self.value)
+        return extract_jsonpath(value, path)
+
+    def json(self, path):
+        path = path or "$"
+        matching = self.path(path)
+        if isinstance(matching, (list, dict)):
+            matching = json_safe(matching)
+        return json.dumps(matching)
+
+    @property
+    def body(self):
+        return self.value
+
+    def params(self, name=None):
+        if not name:
+            return self.parameters
+        for k in ["path", "querystring", "header"]:
+            if val := self.parameters.get(k).get(name):
+                return val
+        return ""
+
+    def __getattr__(self, name):
+        return self.value.get(name)
+
+    def __repr__(self):
+        return "$input"
+
+
+class ApiGatewayVtlTemplate(VtlTemplate):
+    """Util class for rendering VTL templates with API Gateway specific extensions"""
+
+    def prepare_namespace(self, variables) -> dict[str, Any]:
+        namespace = super().prepare_namespace(variables)
+        input_var = variables.get("input") or {}
+        variables = {
+            "input": VelocityInput(input_var.get("body"), input_var.get("params")),
+            "util": VelocityUtilApiGateway(),
+        }
+        namespace.update(variables)
+        return namespace
+
+    def render_request(
+        self, template: str, variables: MappingTemplateVariables
+    ) -> tuple[str, ContextVarsRequestOverride]:
+        vars: MappingTemplateVariables = copy.deepcopy(variables)
+        vars["requestOverride"] = ContextVarsRequestOverride()
+        result = self.render_vtl(template=template.strip(), variables=vars)
+        return result, vars["requestOverride"]
+
+    def render_response(
+        self, template: str, variables: MappingTemplateVariables
+    ) -> tuple[str, ContextVarsResponseOverride]:
+        pass
+
+    def _render_as_text(self, template: str, variables: dict[str, Any]) -> str:
+        """
+        Render the given Velocity template string + variables into a plain string.
+        :return: the template rendering result as a string
+        """
+        rendered_tpl = self.render_vtl(template, variables=variables)
+        return rendered_tpl.strip()
+
+    @staticmethod
+    def _validate_json(content: str):
+        """
+        Checks that the content received is a valid JSON.
+        :raise JSONDecodeError: if content is not valid JSON
+        """
+        try:
+            json.loads(content)
+        except Exception as e:
+            LOG.info("Unable to parse template result as JSON: %s - %s", e, content)
+            raise
+
+    @staticmethod
+    def _validate_xml(content: str):
+        """
+        Checks that the content received is a valid XML.
+        :raise xml.parsers.expat.ExpatError: if content is not valid XML
+        """
+        try:
+            xmltodict.parse(content)
+        except Exception as e:
+            LOG.info("Unable to parse template result as XML: %s - %s", e, content)
+            raise

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -172,15 +172,19 @@ class ApiGatewayVtlTemplate(VtlTemplate):
         self, template: str, variables: MappingTemplateVariables
     ) -> tuple[str, ContextVarsRequestOverride]:
         vars: MappingTemplateVariables = copy.deepcopy(variables)
-        vars["requestOverride"] = ContextVarsRequestOverride()
+        vars["context"]["requestOverride"] = ContextVarsRequestOverride(
+            querystring={}, header={}, path={}
+        )
         result = self.render_vtl(template=template.strip(), variables=vars)
-        return result, vars["requestOverride"]
+        return result, vars["context"]["requestOverride"]
 
     def render_response(
         self, template: str, variables: MappingTemplateVariables
     ) -> tuple[str, ContextVarsResponseOverride]:
         pass
 
+    # TODO Maybe we don't need those methods and they should belong on the integration response handler?
+    #  And we should raise the appropriate exception from the gateway responses.
     def _render_as_text(self, template: str, variables: dict[str, Any]) -> str:
         """
         Render the given Velocity template string + variables into a plain string.

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -18,21 +18,38 @@ import base64
 import copy
 import json
 import logging
-from typing import Any
+from typing import Any, TypedDict
 from urllib.parse import quote_plus, unquote_plus
 
 import xmltodict
 
 from localstack import config
 from localstack.services.apigateway.next_gen.execute_api.variables import (
+    ContextVariables,
     ContextVarsRequestOverride,
     ContextVarsResponseOverride,
-    MappingTemplateVariables,
 )
 from localstack.utils.aws.templating import VelocityUtil, VtlTemplate
 from localstack.utils.json import extract_jsonpath, json_safe
 
 LOG = logging.getLogger(__name__)
+
+
+class MappingTemplateParams(TypedDict, total=False):
+    path: dict[str, str]
+    querystring: dict[str, str]
+    header: dict[str, str]
+
+
+class MappingTemplateInput(TypedDict, total=False):
+    body: str
+    params: MappingTemplateParams
+
+
+class MappingTemplateVariables(TypedDict, total=False):
+    context: ContextVariables
+    input: MappingTemplateInput
+    stageVariables: dict[str, str]
 
 
 class AttributeDict(dict):

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
@@ -8,7 +8,7 @@ class ContextVarsAuthorizer(TypedDict, total=False):
     # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
     claims: Optional[dict[str, str]]
     """Claims returned from the Amazon Cognito user pool after the method caller is successfully authenticated"""
-    principal_id: Optional[str]
+    principalId: Optional[str]
     """The principal user identification associated with the token sent by the client and returned from an API Gateway Lambda authorizer"""
 
 
@@ -80,6 +80,8 @@ class ContextVariables(TypedDict, total=False):
     """The API owner's AWS account ID."""
     apiId: str
     """The identifier API Gateway assigns to your API."""
+    authorizer: Optional[ContextVarsAuthorizer]
+    """The principal user identification associated with the token."""
     awsEndpointRequestId: Optional[str]
     """The AWS endpoint's request ID."""
     deploymentId: str
@@ -101,6 +103,8 @@ class ContextVariables(TypedDict, total=False):
     """The request protocol"""
     requestId: str
     """An ID for the request. Clients can override this request ID. """
+    requestOverride: Optional[ContextVarsRequestOverride]
+    """Request override. Only exists for request mapping template"""
     requestTime: str
     """The CLF-formatted request time (dd/MMM/yyyy:HH:mm:ss +-hhmm)."""
     requestTimeEpoch: int
@@ -109,6 +113,8 @@ class ContextVariables(TypedDict, total=False):
     """The identifier that API Gateway assigns to your resource."""
     resourcePath: Optional[str]
     """The path to your resource"""
+    responseOverride: Optional[ContextVarsResponseOverride]
+    """Response override. Only exists for response mapping template"""
     stage: str
     """The deployment stage of the API request """
     wafResponseCode: Optional[str]
@@ -179,3 +185,20 @@ class LoggingContextVariables(TypedDict, total=False):
     status: Optional[str]
     waf: Optional[LoggingContextVarsWaf]
     xrayTraceId: Optional[str]
+
+
+class MappingTemplateParams(TypedDict, total=False):
+    path: dict[str, str]
+    querystring: dict[str, str]
+    header: dict[str, str]
+
+
+class MappingTemplateInput(TypedDict):
+    body: str
+    params: MappingTemplateParams
+
+
+class MappingTemplateVariables(TypedDict, total=False):
+    context: ContextVariables
+    input: MappingTemplateInput
+    stageVariables: dict[str, str]

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
@@ -185,20 +185,3 @@ class LoggingContextVariables(TypedDict, total=False):
     status: Optional[str]
     waf: Optional[LoggingContextVarsWaf]
     xrayTraceId: Optional[str]
-
-
-class MappingTemplateParams(TypedDict, total=False):
-    path: dict[str, str]
-    querystring: dict[str, str]
-    header: dict[str, str]
-
-
-class MappingTemplateInput(TypedDict):
-    body: str
-    params: MappingTemplateParams
-
-
-class MappingTemplateVariables(TypedDict, total=False):
-    context: ContextVariables
-    input: MappingTemplateInput
-    stageVariables: dict[str, str]

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -1,0 +1,265 @@
+from http import HTTPMethod
+
+import pytest
+from werkzeug.datastructures import Headers
+
+from localstack.aws.api.apigateway import Integration, IntegrationType, Method
+from localstack.http import Request, Response
+from localstack.services.apigateway.models import MergedRestApi, RestApiDeployment
+from localstack.services.apigateway.next_gen.execute_api.api import RestApiGatewayHandlerChain
+from localstack.services.apigateway.next_gen.execute_api.context import (
+    InvocationRequest,
+    RestApiInvocationContext,
+)
+from localstack.services.apigateway.next_gen.execute_api.gateway_response import (
+    UnsupportedMediaTypeError,
+)
+from localstack.services.apigateway.next_gen.execute_api.handlers import IntegrationRequestHandler
+from localstack.services.apigateway.next_gen.execute_api.handlers.integration_request import (
+    PassthroughBehavior,
+)
+from localstack.services.apigateway.next_gen.execute_api.variables import (
+    ContextVariables,
+    ContextVarsRequestOverride,
+)
+from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
+
+TEST_API_ID = "test-api"
+TEST_API_STAGE = "stage"
+
+
+@pytest.fixture
+def create_context():
+    """
+    Create a context populated with what we would expect to receive from the chain at runtime.
+    We assume that the parser and other handler have successfully populated the context to this point.
+    """
+
+    def _create_context(
+        method: Method = None,
+        request: InvocationRequest = None,
+    ):
+        context = RestApiInvocationContext(Request())
+
+        # The api key validator only relies on the raw headers from the invocation requests
+        context.invocation_request = request or InvocationRequest()
+
+        # Frozen deployment populated by the router
+        context.deployment = RestApiDeployment(
+            account_id=TEST_AWS_ACCOUNT_ID,
+            region=TEST_AWS_REGION_NAME,
+            rest_api=MergedRestApi(rest_api={}),
+        )
+
+        # Context populated by parser handler
+        context.region = TEST_AWS_REGION_NAME
+        context.account_id = TEST_AWS_ACCOUNT_ID
+        context.stage = TEST_API_STAGE
+        context.api_id = TEST_API_ID
+        context.resource_method = method or Method(
+            methodIntegration=Integration(
+                type=IntegrationType.HTTP,
+                requestParameters=None,
+                uri="https://example.com",
+                httpMethod="POST",
+            )
+        )
+        context.context_variables = ContextVariables(
+            resourceId="resource-id",
+            apiId=TEST_API_ID,
+            httpMethod="POST",
+            path="/stage/root/{path}",
+            requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
+            resourcePath="/root/{path}",
+            stage="stage",
+        )
+
+        return context
+
+    return _create_context
+
+
+@pytest.fixture
+def default_invocation_request() -> InvocationRequest:
+    header_dict = {"header": ["ignored-value", "test-header-value"]}
+    headers = Headers(header_dict)
+    return InvocationRequest(
+        http_method=HTTPMethod.POST,
+        raw_path="/test/test-path-value",
+        path="/test/test-path-value",
+        path_parameters={"path": "test-path-value"},
+        query_string_parameters={"qs": "test-qs-value"},
+        raw_headers=headers,
+        headers=dict(headers),
+        multi_value_query_string_parameters={"qs": ["ignored-value", "test-qs-value"]},
+        multi_value_headers=header_dict,
+        body=b"",
+    )
+
+
+@pytest.fixture
+def integration_request_handler():
+    """Returns a dummy integration request handler invoker for testing."""
+
+    def _handler_invoker(context: RestApiInvocationContext):
+        return IntegrationRequestHandler()(RestApiGatewayHandlerChain(), context, Response())
+
+    return _handler_invoker
+
+
+class TestHandlerIntegrationRequest:
+    def test_noop(self, integration_request_handler, default_invocation_request, create_context):
+        context = create_context(request=default_invocation_request)
+        integration_request_handler(context)
+        assert context.integration_request == {
+            "body": b"",
+            "headers": {},
+            "http_method": "POST",
+            "query_string_parameters": {},
+            "uri": "https://example.com",
+        }
+
+    def test_passthrough_never(
+        self, integration_request_handler, default_invocation_request, create_context
+    ):
+        context = create_context(request=default_invocation_request)
+        context.resource_method["methodIntegration"]["passthroughBehavior"] = (
+            PassthroughBehavior.NEVER
+        )
+
+        # With no template, it is expected to raise
+        with pytest.raises(UnsupportedMediaTypeError) as e:
+            integration_request_handler(context)
+        assert e.match("Unsupported Media Type")
+
+        # With a non-matching template it should raise
+        context.resource_method["methodIntegration"]["requestTemplates"] = {
+            "application/xml": "#Empty"
+        }
+        with pytest.raises(UnsupportedMediaTypeError) as e:
+            integration_request_handler(context)
+        assert e.match("Unsupported Media Type")
+
+        # With a matching template it should use it
+        context.resource_method["methodIntegration"]["requestTemplates"] = {
+            "application/json": '{"foo":"bar"}'
+        }
+        integration_request_handler(context)
+        assert context.integration_request["body"] == b'{"foo":"bar"}'
+
+    def test_passthrough_when_no_match(
+        self, integration_request_handler, default_invocation_request, create_context
+    ):
+        context = create_context(request=default_invocation_request)
+        context.resource_method["methodIntegration"]["passthroughBehavior"] = (
+            PassthroughBehavior.WHEN_NO_MATCH
+        )
+        # When no template are created it should passthrough
+        integration_request_handler(context)
+        assert context.integration_request["body"] == b""
+
+        # when a non matching template is found it should passthrough
+        context.resource_method["methodIntegration"]["requestTemplates"] = {
+            "application/xml": '{"foo":"bar"}'
+        }
+        integration_request_handler(context)
+        assert context.integration_request["body"] == b""
+
+        # when a matching template is found, it should use it
+        context.resource_method["methodIntegration"]["requestTemplates"] = {
+            "application/json": '{"foo":"bar"}'
+        }
+        integration_request_handler(context)
+        assert context.integration_request["body"] == b'{"foo":"bar"}'
+
+    def test_passthrough_when_no_templates(
+        self, integration_request_handler, default_invocation_request, create_context
+    ):
+        context = create_context(request=default_invocation_request)
+        context.resource_method["methodIntegration"]["passthroughBehavior"] = (
+            PassthroughBehavior.WHEN_NO_TEMPLATES
+        )
+        # If a non matching template is found, it should raise
+        context.resource_method["methodIntegration"]["requestTemplates"] = {"application/xml": ""}
+        with pytest.raises(UnsupportedMediaTypeError) as e:
+            integration_request_handler(context)
+        assert e.match("Unsupported Media Type")
+
+        # If a matching template is found, it should use it
+        context.resource_method["methodIntegration"]["requestTemplates"] = {
+            "application/json": '{"foo":"bar"}'
+        }
+        integration_request_handler(context)
+        assert context.integration_request["body"] == b'{"foo":"bar"}'
+
+        # If no template were created, it should passthrough
+        context.resource_method["methodIntegration"]["requestTemplates"] = {}
+        integration_request_handler(context)
+        assert context.integration_request["body"] == b""
+
+    def test_default_template(
+        self, integration_request_handler, default_invocation_request, create_context
+    ):
+        request = default_invocation_request
+        context = create_context(request=request)
+
+        # if no matching template, use the default
+        context.resource_method["methodIntegration"]["requestTemplates"] = {
+            "$default": '{"foo":"bar"}'
+        }
+        integration_request_handler(context)
+        assert context.integration_request["body"] == b'{"foo":"bar"}'
+
+        # If there is a matching template, use it instead
+        context.resource_method["methodIntegration"]["requestTemplates"] = {
+            "$default": '{"foo":"bar"}',
+            "application/json": "Matching Template",
+        }
+        integration_request_handler(context)
+        assert context.integration_request["body"] == b"Matching Template"
+
+    def test_request_parameters(
+        self, integration_request_handler, default_invocation_request, create_context
+    ):
+        context = create_context(request=default_invocation_request)
+        context.resource_method["methodIntegration"]["requestParameters"] = {
+            "integration.request.path.path": "method.request.path.path",
+            "integration.request.querystring.qs": "method.request.querystring.qs",
+            "integration.request.header.header": "method.request.header.header",
+        }
+        context.resource_method["methodIntegration"]["uri"] = "https://example.com/{path}"
+        integration_request_handler(context)
+        # TODO this test will fail when we implement uri mapping
+        assert context.integration_request["uri"] == "https://example.com/{path}"
+        assert context.integration_request["query_string_parameters"] == {"qs": "test-qs-value"}
+        assert context.integration_request["headers"] == {"header": "test-header-value"}
+
+    def test_request_override(
+        self, integration_request_handler, default_invocation_request, create_context
+    ):
+        context = create_context(request=default_invocation_request)
+        context.resource_method["methodIntegration"]["requestParameters"] = {
+            "integration.request.path.path": "method.request.path.path",
+            "integration.request.querystring.qs": "method.request.querystring.qs",
+            "integration.request.header.header": "method.request.header.header",
+        }
+        context.resource_method["methodIntegration"]["uri"] = "https://example.com/{path}"
+        context.resource_method["methodIntegration"]["requestTemplates"] = {
+            "application/json": REQUEST_OVERRIDE
+        }
+        integration_request_handler(context)
+        # TODO this test will fail when we implement uri mapping
+        assert context.integration_request["uri"] == "https://example.com/{path}"
+        assert context.integration_request["query_string_parameters"] == {"qs": "queryOverride"}
+        assert context.integration_request["headers"] == {
+            "header": "headerOverride",
+            "multivalue": ["1header", "2header"],
+        }
+
+
+REQUEST_OVERRIDE = """
+#set($context.requestOverride.header.header = "headerOverride")
+#set($context.requestOverride.header.multivalue = ["1header", "2header"])
+#set($context.requestOverride.path.path = "pathOverride")
+#set($context.requestOverride.querystring.qs = "queryOverride")
+"""

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -268,6 +268,18 @@ class TestHandlerIntegrationRequest:
         integration_request_handler(context)
         context.integration_request["body"] = b""
 
+    def test_multivalue_mapping(
+        self, integration_request_handler, default_invocation_request, create_context
+    ):
+        context = create_context(request=default_invocation_request)
+        context.resource_method["methodIntegration"]["requestParameters"] = {
+            "integration.request.header.multi": "method.request.multivalueheader.header",
+            "integration.request.querystring.multi": "method.request.multivaluequerystring.qs",
+        }
+        integration_request_handler(context)
+        assert context.integration_request["headers"]["multi"] == "header1,header2"
+        assert context.integration_request["query_string_parameters"]["multi"] == ["qs1", "qs2"]
+
 
 REQUEST_OVERRIDE = """
 #set($context.requestOverride.header.header = "headerOverride")

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -255,19 +255,6 @@ class TestHandlerIntegrationRequest:
             "multivalue": ["1header", "2header"],
         }
 
-    @pytest.mark.parametrize("method", [HTTPMethod.OPTIONS, HTTPMethod.GET, HTTPMethod.HEAD])
-    def test_no_body_for_method(
-        self, integration_request_handler, default_invocation_request, create_context, method
-    ):
-        requests = default_invocation_request
-        requests["http_method"] = method
-        context = create_context(request=requests)
-        context.resource_method["methodIntegration"]["requestTemplates"] = {
-            "application/json": '{"foo":"bar"}'
-        }
-        integration_request_handler(context)
-        context.integration_request["body"] = b""
-
     def test_multivalue_mapping(
         self, integration_request_handler, default_invocation_request, create_context
     ):

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -89,7 +89,6 @@ def default_invocation_request() -> InvocationRequest:
             headers={"header": ["header1", "header2"]},
             path=f"{TEST_API_STAGE}/resource/path",
             query_string="qs=qs1&qs=qs2",
-            body=b"",
         )
     )
     request["path_parameters"] = {"proxy": "path"}

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -239,7 +239,7 @@ class TestHandlerIntegrationRequest:
         context = create_context(request=default_invocation_request)
         context.resource_method["methodIntegration"]["requestParameters"] = {
             "integration.request.path.path": "method.request.path.path",
-            "integration.request.querystring.qs": "method.request.querystring.qs",
+            "integration.request.querystring.qs": "method.request.multivaluequerystring.qs",
             "integration.request.header.header": "method.request.header.header",
         }
         context.resource_method["methodIntegration"]["uri"] = "https://example.com/{path}"

--- a/tests/unit/services/apigateway/test_template_mapping.py
+++ b/tests/unit/services/apigateway/test_template_mapping.py
@@ -1,0 +1,323 @@
+import json
+from json import JSONDecodeError
+
+import pytest
+import xmltodict
+
+from localstack.constants import APPLICATION_JSON, APPLICATION_XML
+from localstack.services.apigateway.next_gen.execute_api.template_mapping import (
+    ApiGatewayVtlTemplate,
+    VelocityUtilApiGateway,
+)
+from localstack.services.apigateway.next_gen.execute_api.variables import (
+    ContextVariables,
+    ContextVarsAuthorizer,
+    ContextVarsIdentity,
+    MappingTemplateInput,
+    MappingTemplateParams,
+    MappingTemplateVariables,
+)
+
+
+class TestVelocityUtilApiGatewayFunctions:
+    def test_render_template_values(self):
+        util = VelocityUtilApiGateway()
+
+        encoded = util.urlEncode("x=a+b")
+        assert encoded == "x%3Da%2Bb"
+
+        decoded = util.urlDecode("x=a+b")
+        assert decoded == "x=a b"
+
+        escape_tests = (
+            ("it's", "it's"),
+            ("0010", "0010"),
+            ("true", "true"),
+            ("True", "True"),
+            ("1.021", "1.021"),
+            ('""', '\\"\\"'),
+            ('"""', '\\"\\"\\"'),
+            ('{"foo": 123}', '{\\"foo\\": 123}'),
+            ('{"foo"": 123}', '{\\"foo\\"\\": 123}'),
+            (1, "1"),
+            (None, "null"),
+        )
+        for string, expected in escape_tests:
+            escaped = util.escapeJavaScript(string)
+            assert escaped == expected
+
+    def test_parse_json(self):
+        util = VelocityUtilApiGateway()
+
+        # write table tests for the following input
+        a = {"array": "[1,2,3]"}
+        obj = util.parseJson(a["array"])
+        assert obj[0] == 1
+
+        o = {"object": '{"key1":"var1","key2":{"arr":[1,2,3]}}'}
+        obj = util.parseJson(o["object"])
+        assert obj.key2.arr[0] == 1
+
+        s = '"string"'
+        obj = util.parseJson(s)
+        assert obj == "string"
+
+        n = {"number": "1"}
+        obj = util.parseJson(n["number"])
+        assert obj == 1
+
+        b = {"boolean": "true"}
+        obj = util.parseJson(b["boolean"])
+        assert obj is True
+
+        z = {"zero_length_array": "[]"}
+        obj = util.parseJson(z["zero_length_array"])
+        assert obj == []
+
+
+class TestApiGatewayVtlTemplate:
+    def test_apply_template(self):
+        variables = MappingTemplateVariables(
+            input=MappingTemplateInput(body='{"action":"$default","message":"foobar"}')
+        )
+
+        template = "$util.escapeJavaScript($input.json('$.message'))"
+        rendered_request = ApiGatewayVtlTemplate().render_vtl(
+            template=template, variables=variables
+        )
+
+        assert '\\"foobar\\"' == rendered_request
+
+    def test_apply_template_no_json_payload(self):
+        variables = MappingTemplateVariables(input=MappingTemplateInput(body='"#foobar123"'))
+
+        template = "$util.escapeJavaScript($input.json('$.message'))"
+        rendered_request = ApiGatewayVtlTemplate().render_vtl(
+            template=template, variables=variables
+        )
+
+        assert "[]" == rendered_request
+
+    @pytest.mark.parametrize("format", [APPLICATION_JSON, APPLICATION_XML])
+    def test_render_custom_template(self, format):
+        variables = MappingTemplateVariables(
+            input=MappingTemplateInput(
+                body='{"spam": "eggs"}',
+                params=MappingTemplateParams(
+                    path={"proxy": "path"},
+                    querystring={"baz": "test"},
+                    header={"content-type": format, "accept": format},
+                ),
+            ),
+            context=ContextVariables(
+                httpMethod="POST",
+                stage="local",
+                authorizer=ContextVarsAuthorizer(principalId="12233"),
+                identity=ContextVarsIdentity(accountId="00000", apiKey="11111"),
+                resourcePath="/{proxy}",
+            ),
+            stageVariables={"stageVariable1": "value1", "stageVariable2": "value2"},
+        )
+
+        template = TEMPLATE_JSON if format == APPLICATION_JSON else TEMPLATE_XML
+        template += REQUEST_OVERRIDE
+
+        rendered_request, request_override = ApiGatewayVtlTemplate().render_request(
+            template=template, variables=variables
+        )
+        if format == APPLICATION_JSON:
+            rendered_request = json.loads(rendered_request)
+            assert rendered_request.get("body") == {"spam": "eggs"}
+            assert rendered_request.get("method") == "POST"
+            assert rendered_request.get("principalId") == "12233"
+        else:
+            rendered_request = xmltodict.parse(rendered_request).get("root", {})
+            # TODO Verify that those difference between xml and json are expected
+            assert rendered_request.get("body") == '{"spam": "eggs"}'
+            assert rendered_request.get("@method") == "POST"
+            assert rendered_request.get("@principalId") == "12233"
+
+        assert rendered_request.get("stage") == "local"
+        assert rendered_request.get("enhancedAuthContext") == {"principalId": "12233"}
+        assert rendered_request.get("identity") == {"accountId": "00000", "apiKey": "11111"}
+        assert rendered_request.get("headers") == {
+            "content-type": format,
+            "accept": format,
+        }
+        assert rendered_request.get("query") == {"baz": "test"}
+        assert rendered_request.get("path") == {"proxy": "path"}
+        assert rendered_request.get("stageVariables") == {
+            "stageVariable1": "value1",
+            "stageVariable2": "value2",
+        }
+
+        assert request_override == {
+            "header": {"multivalue": ["1header", "2header"], "oHeader": "1header"},
+            "path": {"proxy": "proxy"},
+            "querystring": {"query": "query"},
+        }
+
+    def test_render_valid_booleans_in_json(self):
+        template = ApiGatewayVtlTemplate()
+
+        # assert that boolean results of _render_json_result(..) are JSON-parseable
+        tstring = '{"mybool": $boolTrue}'
+        result = template._render_as_text(tstring, {"boolTrue": "true"})
+        assert json.loads(result) == {"mybool": True}
+        result = template._render_as_text(tstring, {"boolTrue": True})
+        assert json.loads(result) == {"mybool": True}
+
+        # older versions of `airspeed` were rendering booleans as False/True, which is no longer valid now
+        tstring = '{"mybool": False}'
+        with pytest.raises(JSONDecodeError):
+            result = template._render_as_text(tstring, {})
+            template._validate_json(result)
+
+    # TODO Update the following tests when updating the response params
+    # def test_error_when_render_invalid_json(self):
+    #     api_context = ApiInvocationContext(
+    #         method="POST",
+    #         path="/foo/bar?baz=test",
+    #         data=b"<root></root>",
+    #         headers={},
+    #     )
+    #     api_context.integration = {
+    #         "integrationResponses": {
+    #             "200": {"responseTemplates": {APPLICATION_JSON: RESPONSE_TEMPLATE_WRONG_JSON}}
+    #         },
+    #     }
+    #     api_context.response = requests_response({"spam": "eggs"})
+    #     api_context.context = {}
+    #     api_context.stage_variables = {}
+    #
+    #     template = ResponseTemplates()
+    #     with pytest.raises(JSONDecodeError):
+    #         template.render(api_context=api_context)
+    #
+
+
+#
+#     def test_error_when_render_invalid_xml(self):
+#         api_context = ApiInvocationContext(
+#             method="POST",
+#             path="/foo/bar?baz=test",
+#             data=b"<root></root>",
+#             headers={"content-type": APPLICATION_XML, "accept": APPLICATION_XML},
+#             stage="local",
+#         )
+#         api_context.integration = {
+#             "integrationResponses": {
+#                 "200": {"responseTemplates": {APPLICATION_XML: RESPONSE_TEMPLATE_WRONG_XML}}
+#             },
+#         }
+#         api_context.resource_path = "/{proxy+}"
+#         api_context.response = requests_response({"spam": "eggs"})
+#         api_context.context = {}
+#         api_context.stage_variables = {}
+#
+#         template = ResponseTemplates()
+#         with pytest.raises(xml.parsers.expat.ExpatError):
+#             template.render(api_context=api_context, template_key=APPLICATION_XML)
+
+TEMPLATE_JSON = """
+
+#set( $body = $input.json("$") )
+#define( $loop )
+{
+    #foreach($e in $map.keySet())
+       #set( $k = $e )
+       #set( $v = $map.get($k))
+       "$k": "$v"
+       #if( $foreach.hasNext ) , #end
+    #end
+}
+#end
+  {
+    "body": $body,
+    "method": "$context.httpMethod",
+    "principalId": "$context.authorizer.principalId",
+    "stage": "$context.stage",
+    "cognitoPoolClaims" : {
+       "sub": "$context.authorizer.claims.sub"
+    },
+    #set( $map = $context.authorizer )
+    "enhancedAuthContext": $loop,
+
+    #set( $map = $input.params().header )
+    "headers": $loop,
+
+    #set( $map = $input.params().querystring )
+    "query": $loop,
+
+    #set( $map = $input.params().path )
+    "path": $loop,
+
+    #set( $map = $context.identity )
+    "identity": $loop,
+
+    #set( $map = $stageVariables )
+    "stageVariables": $loop,
+
+    "requestPath": "$context.resourcePath"
+}
+"""
+
+TEMPLATE_WRONG_JSON = """
+#set( $body = $input.json("$") )
+  {
+    "body": $body,
+    "method": $context.httpMethod,
+  }
+"""
+
+TEMPLATE_XML = """
+
+#set( $body = $input.json("$") )
+    #define( $loop )
+        #foreach($e in $map.keySet())
+           #set( $k = $e )
+           #set( $v = $map.get($k))
+           <$k>$v</$k>
+    #end
+#end
+<root method="$context.httpMethod" principalId="$context.authorizer.principalId" requestPath="$context.resourcePath">
+    <body>$body</body>
+    <stage>$context.stage</stage>
+    <cognitoPoolClaims>
+       <sub>$context.authorizer.claims.sub</sub>
+    </cognitoPoolClaims>
+
+    #set( $map = $context.authorizer )
+    <enhancedAuthContext>$loop</enhancedAuthContext>
+
+    #set( $map = $input.params().header )
+    <headers>$loop</headers>
+
+    #set( $map = $input.params().querystring )
+    <query>$loop</query>
+
+    #set( $map = $input.params().path )
+    <path>$loop</path>
+
+    #set( $map = $context.identity )
+    <identity>$loop</identity>
+
+    #set( $map = $stageVariables )
+<stageVariables>$loop</stageVariables>
+</root>
+"""
+REQUEST_OVERRIDE = """
+
+#set($context.requestOverride.header.oHeader = "1header")
+#set($context.requestOverride.header.multivalue = ["1header", "2header"])
+#set($context.requestOverride.path.proxy = "proxy")
+#set($context.requestOverride.querystring.query = "query")
+"""
+
+TEMPLATE_WRONG_XML = """
+#set( $body = $input.json("$") )
+<root>
+  <body>$body</body>
+  <not-closed>$context.stage
+</root>
+"""

--- a/tests/unit/services/apigateway/test_template_mapping.py
+++ b/tests/unit/services/apigateway/test_template_mapping.py
@@ -7,15 +7,15 @@ import xmltodict
 from localstack.constants import APPLICATION_JSON, APPLICATION_XML
 from localstack.services.apigateway.next_gen.execute_api.template_mapping import (
     ApiGatewayVtlTemplate,
+    MappingTemplateInput,
+    MappingTemplateParams,
+    MappingTemplateVariables,
     VelocityUtilApiGateway,
 )
 from localstack.services.apigateway.next_gen.execute_api.variables import (
     ContextVariables,
     ContextVarsAuthorizer,
     ContextVarsIdentity,
-    MappingTemplateInput,
-    MappingTemplateParams,
-    MappingTemplateVariables,
 )
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Adding VTL Template Mapping to our Integration request handler and port `ApiGatewayVtlTemplate` class to NG provider.

The request template allows to create a request body based on the provided VTL template. You can also use it to `#set` requests override the path parameters, headers and query strings. See: https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html

When no templates are found based on content-type, an `UnsupportedMediaTypeError` can be raised depending on the set passthrough behaviour.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Implements `ApiGatewayVtlTemplate`, which is ported and simplified from legacy `templates.py`. 
- adds logic for and exception for passthrough behavior
- augments request template with the request overrides

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

## TODO

What's left to do:

- [x] Implement unit tests for `ApiGatewayVtlTemplate`. Port from legacy to prevent regressions as we move forward
- [x] Implement unit tests for `IntegrationRequestHandler`. There might be more tests needed as parameters mapping was not tested yet
