### PR TITLE
APIGW NG implement URI rendering

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -72,6 +72,9 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
 
         # looks like the stageVariables rendering part is done in the Integration part in AWS
         # but we can avoid duplication by doing it here for now
+        # TODO: if the integration if of AWS Lambda type and the Lambda is in another account, we cannot render
+        #  stageVariables. Work on that special case later (we can add a quick check for the URI region and set the
+        #  stage variables to an empty dict)
         rendered_integration_uri = self.render_integration_uri(
             uri=integration["uri"],
             path_parameters=request_data_mapping["path"],

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -8,6 +8,7 @@ from localstack.utils.strings import to_bytes, to_str
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import IntegrationRequest, InvocationRequest, RestApiInvocationContext
 from ..gateway_response import UnsupportedMediaTypeError
+from ..helpers import render_uri_with_path_parameters, render_uri_with_stage_variables
 from ..parameters_mapping import ParametersMapper, RequestDataMapping
 from ..template_mapping import (
     ApiGatewayVtlTemplate,
@@ -66,12 +67,16 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
         body, request_override = self.render_request_template_mapping(
             context=context, template=request_template
         )
+        # TODO: log every override that happens afterwards (in a loop on `request_override`)
         merge_recursive(request_override, request_data_mapping, overwrite=True)
 
-        # TODO: extract the code under into its own method
-
-        # TODO: create helper method to render the different URI with stageVariables and parameters
-        rendered_integration_uri = integration["uri"]  # use request_data_mapping["path"]
+        # looks like the stageVariables rendering part is done in the Integration part in AWS
+        # but we can avoid duplication by doing it here for now
+        rendered_integration_uri = self.render_integration_uri(
+            uri=integration["uri"],
+            path_parameters=request_data_mapping["path"],
+            stage_variables=context.stage_variables,
+        )
 
         # TODO: verify the assumptions about the method with an AWS validated test
         # if the integration method is defined and is not ANY, we can use it for the integration
@@ -86,7 +91,6 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
             headers=request_data_mapping["header"],
             body=body,
         )
-        # TODO: log every override that happens afterwards
 
         # This is the data that downstream integrations might use if they are not of `PROXY_` type
         # LOG.debug("Created integration request from xxx")
@@ -130,7 +134,8 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
         )
         return to_bytes(body), request_override
 
-    def get_request_template(self, integration: Integration, request: InvocationRequest) -> str:
+    @staticmethod
+    def get_request_template(integration: Integration, request: InvocationRequest) -> str:
         """
         Attempts to return the request template.
         Will raise UnsupportedMediaTypeError if there are no match according to passthrough behavior.
@@ -163,3 +168,25 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
                 LOG.debug("Unknown passthrough behavior: '%s'", passthrough_behavior)
 
         return request_template
+
+    @staticmethod
+    def render_integration_uri(
+        uri: str, path_parameters: dict[str, str], stage_variables: dict[str, str]
+    ) -> str:
+        """
+        A URI can contain different value to interpolate / render
+        It will have path parameters substitutions with this shape (can also add a querystring).
+        URI=http://myhost.test/rootpath/{path}
+
+        It can also have another format, for stage variables, documented here:
+        https://docs.aws.amazon.com/apigateway/latest/developerguide/aws-api-gateway-stage-variables-reference.html#stage-variables-in-integration-HTTP-uris
+        URI=https://${stageVariables.<variable_name>}
+        This format is the same as VTL.
+
+        :param uri: the integration URI
+        :param path_parameters: the list of path parameters, coming from the parameters mapping and override
+        :param stage_variables: -
+        :return: the rendered URI
+        """
+        uri_with_path = render_uri_with_path_parameters(uri, path_parameters)
+        return render_uri_with_stage_variables(uri_with_path, stage_variables)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
@@ -1,10 +1,17 @@
 import copy
+import logging
 
+from airspeed.operators import TemplateSyntaxError
 from moto.apigateway.models import RestAPI as MotoRestAPI
 
 from localstack.services.apigateway.models import MergedRestApi, RestApiContainer, RestApiDeployment
+from localstack.utils.aws.templating import VtlTemplate
 
 from .moto_helpers import get_resources_from_moto_rest_api
+
+LOG = logging.getLogger(__name__)
+
+_vtl_template_renderer = VtlTemplate()
 
 
 def freeze_rest_api(
@@ -26,3 +33,27 @@ def freeze_rest_api(
         region=region,
         rest_api=copy.deepcopy(rest_api),
     )
+
+
+def render_uri_with_stage_variables(uri: str, stage_variables: dict[str, str]):
+    """
+    https://docs.aws.amazon.com/apigateway/latest/developerguide/aws-api-gateway-stage-variables-reference.html#stage-variables-in-integration-HTTP-uris
+    URI=https://${stageVariables.<variable_name>}
+    This format is the same as VTL, so we're using a simplified version. The provider should validate the input.
+    """
+    try:
+        return _vtl_template_renderer.render_vtl(uri, {"stageVariables": stage_variables})
+    except TemplateSyntaxError:
+        LOG.warning(
+            "The URI provided did not have the right format: the stageVariables could not be rendered: '%s'",
+            uri,
+            exc_info=LOG.isEnabledFor(logging.DEBUG),
+        )
+        return uri
+
+
+def render_uri_with_path_parameters(uri: str, path_parameters: dict[str, str]) -> str:
+    for key, value in path_parameters.items():
+        uri = uri.replace(f"{{{key}}}", value)
+
+    return uri

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
@@ -5,13 +5,11 @@ import re
 from moto.apigateway.models import RestAPI as MotoRestAPI
 
 from localstack.services.apigateway.models import MergedRestApi, RestApiContainer, RestApiDeployment
-from localstack.utils.aws.templating import VtlTemplate
 
 from .moto_helpers import get_resources_from_moto_rest_api
 
 LOG = logging.getLogger(__name__)
 
-_vtl_template_renderer = VtlTemplate()
 _stage_variable_pattern = re.compile(r"\${stageVariables\.(?P<varName>.*?)}")
 
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -188,12 +188,12 @@ class ApiGatewayVtlTemplate(VtlTemplate):
     def render_request(
         self, template: str, variables: MappingTemplateVariables
     ) -> tuple[str, ContextVarsRequestOverride]:
-        vars: MappingTemplateVariables = copy.deepcopy(variables)
-        vars["context"]["requestOverride"] = ContextVarsRequestOverride(
+        variables_copy: MappingTemplateVariables = copy.deepcopy(variables)
+        variables_copy["context"]["requestOverride"] = ContextVarsRequestOverride(
             querystring={}, header={}, path={}
         )
-        result = self.render_vtl(template=template.strip(), variables=vars)
-        return result, vars["context"]["requestOverride"]
+        result = self.render_vtl(template=template.strip(), variables=variables_copy)
+        return result, variables_copy["context"]["requestOverride"]
 
     def render_response(
         self, template: str, variables: MappingTemplateVariables

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -233,31 +233,27 @@ class TestHandlerIntegrationRequest:
         ]
 
     def test_integration_uri_path_params_undefined(
-        self, integration_request_handler, default_invocation_request, create_context
+        self, integration_request_handler, default_context
     ):
-        context = create_context(request=default_invocation_request)
-        context.resource_method["methodIntegration"]["requestParameters"] = {
+        default_context.resource_method["methodIntegration"]["requestParameters"] = {
             "integration.request.path.path": "method.request.path.wrongvalue",
         }
-        context.resource_method["methodIntegration"]["uri"] = "https://example.com/{path}"
-        integration_request_handler(context)
-        assert context.integration_request["uri"] == "https://example.com/{path}"
+        default_context.resource_method["methodIntegration"]["uri"] = "https://example.com/{path}"
+        integration_request_handler(default_context)
+        assert default_context.integration_request["uri"] == "https://example.com/{path}"
 
-    def test_integration_uri_stage_variables(
-        self, integration_request_handler, default_invocation_request, create_context
-    ):
-        context = create_context(request=default_invocation_request)
-        context.stage_variables = {
+    def test_integration_uri_stage_variables(self, integration_request_handler, default_context):
+        default_context.stage_variables = {
             "stageVar": "stageValue",
         }
-        context.resource_method["methodIntegration"]["requestParameters"] = {
+        default_context.resource_method["methodIntegration"]["requestParameters"] = {
             "integration.request.path.path": "method.request.path.proxy",
         }
-        context.resource_method["methodIntegration"]["uri"] = (
+        default_context.resource_method["methodIntegration"]["uri"] = (
             "https://example.com/{path}/${stageVariables.stageVar}"
         )
-        integration_request_handler(context)
-        assert context.integration_request["uri"] == "https://example.com/path/stageValue"
+        integration_request_handler(default_context)
+        assert default_context.integration_request["uri"] == "https://example.com/path/stageValue"
 
 
 REQUEST_OVERRIDE = """

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -21,7 +21,6 @@ from localstack.services.apigateway.next_gen.execute_api.handlers.integration_re
 )
 from localstack.services.apigateway.next_gen.execute_api.variables import (
     ContextVariables,
-    ContextVarsRequestOverride,
 )
 from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 
@@ -73,7 +72,6 @@ def default_context():
         apiId=TEST_API_ID,
         httpMethod="POST",
         path=f"{TEST_API_STAGE}/resource/{{proxy}}",
-        requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
         resourcePath="/resource/{proxy}",
         stage=TEST_API_STAGE,
     )
@@ -191,14 +189,14 @@ class TestHandlerIntegrationRequest:
 
     def test_request_parameters(self, integration_request_handler, default_context):
         default_context.resource_method["methodIntegration"]["requestParameters"] = {
-            "integration.request.path.path": "method.request.path.path",
+            "integration.request.path.path": "method.request.path.proxy",
             "integration.request.querystring.qs": "method.request.querystring.qs",
             "integration.request.header.header": "method.request.header.header",
         }
         default_context.resource_method["methodIntegration"]["uri"] = "https://example.com/{path}"
         integration_request_handler(default_context)
         # TODO this test will fail when we implement uri mapping
-        assert default_context.integration_request["uri"] == "https://example.com/{path}"
+        assert default_context.integration_request["uri"] == "https://example.com/path"
         assert default_context.integration_request["query_string_parameters"] == {"qs": "qs2"}
         assert default_context.integration_request["headers"] == {"header": "header2"}
 
@@ -213,8 +211,7 @@ class TestHandlerIntegrationRequest:
             "application/json": REQUEST_OVERRIDE
         }
         integration_request_handler(default_context)
-        # TODO this test will fail when we implement uri mapping
-        assert default_context.integration_request["uri"] == "https://example.com/{path}"
+        assert default_context.integration_request["uri"] == "https://example.com/pathOverride"
         assert default_context.integration_request["query_string_parameters"] == {
             "qs": "queryOverride"
         }
@@ -234,6 +231,33 @@ class TestHandlerIntegrationRequest:
             "qs1",
             "qs2",
         ]
+
+    def test_integration_uri_path_params_undefined(
+        self, integration_request_handler, default_invocation_request, create_context
+    ):
+        context = create_context(request=default_invocation_request)
+        context.resource_method["methodIntegration"]["requestParameters"] = {
+            "integration.request.path.path": "method.request.path.wrongvalue",
+        }
+        context.resource_method["methodIntegration"]["uri"] = "https://example.com/{path}"
+        integration_request_handler(context)
+        assert context.integration_request["uri"] == "https://example.com/{path}"
+
+    def test_integration_uri_stage_variables(
+        self, integration_request_handler, default_invocation_request, create_context
+    ):
+        context = create_context(request=default_invocation_request)
+        context.stage_variables = {
+            "stageVar": "stageValue",
+        }
+        context.resource_method["methodIntegration"]["requestParameters"] = {
+            "integration.request.path.path": "method.request.path.proxy",
+        }
+        context.resource_method["methodIntegration"]["uri"] = (
+            "https://example.com/{path}/${stageVariables.stageVar}"
+        )
+        integration_request_handler(context)
+        assert context.integration_request["uri"] == "https://example.com/path/stageValue"
 
 
 REQUEST_OVERRIDE = """

--- a/tests/unit/services/apigateway/test_uri_interpolation.py
+++ b/tests/unit/services/apigateway/test_uri_interpolation.py
@@ -82,12 +82,18 @@ class TestUriInterpolationStageVariables:
         assert "{path}" in rendered
 
     def test_uri_interpolating_with_no_variable(self):
-        uri_with_only_braces = "https://test.domain.example/root/${path}"
+        uri = "https://test.domain.example/root/${stageVariables.path}"
+        stage_variables = {}
+        rendered = render_uri_with_stage_variables(uri=uri, stage_variables=stage_variables)
+        assert rendered == "https://test.domain.example/root/"
+
+    def test_uri_interpolation_with_no_stage_var_prefix(self):
+        uri_with_no_prefix = "https://test.domain.example/root/${path}"
         stage_variables = {}
         rendered = render_uri_with_stage_variables(
-            uri=uri_with_only_braces, stage_variables=stage_variables
+            uri=uri_with_no_prefix, stage_variables=stage_variables
         )
-        assert rendered == "https://test.domain.example/root/"
+        assert rendered == "https://test.domain.example/root/${path}"
 
     def test_uri_interpolating_with_bad_format(self):
         # tested against AWS in an integration URI

--- a/tests/unit/services/apigateway/test_uri_interpolation.py
+++ b/tests/unit/services/apigateway/test_uri_interpolation.py
@@ -1,0 +1,128 @@
+import pytest
+
+from localstack.services.apigateway.next_gen.execute_api.helpers import (
+    render_uri_with_path_parameters,
+    render_uri_with_stage_variables,
+)
+
+
+class TestUriInterpolationStageVariables:
+    @pytest.mark.parametrize(
+        "uri,expected",
+        [
+            (
+                # A full URI without protocol
+                "https://${stageVariables.stageDomain}",
+                "https://example.com",
+            ),
+            (
+                # A full domain
+                "https://${stageVariables.stageDomain}/resource/operation",
+                "https://example.com/resource/operation",
+            ),
+            (
+                # A subdomain
+                "https://${stageVariables.stageVar}.example.com/resource/operation",
+                "https://stageValue.example.com/resource/operation",
+            ),
+            (
+                # A path
+                "https://example.com/${stageVariables.stageVar}/bar",
+                "https://example.com/stageValue/bar",
+            ),
+            (
+                # A query string
+                "https://example.com/foo?q=${stageVariables.stageVar}",
+                "https://example.com/foo?q=stageValue",
+            ),
+            (
+                # AWS URI action or path components
+                "arn:aws:apigateway:<region>:<service>:${stageVariables.stageVar}",
+                "arn:aws:apigateway:<region>:<service>:stageValue",
+            ),
+            (
+                # AWS integration Lambda function name
+                "arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/arn:aws:lambda:<region>:<account_id>:function:${stageVariables.stageVar}/invocations",
+                "arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/arn:aws:lambda:<region>:<account_id>:function:stageValue/invocations",
+            ),
+            (
+                # AWS integration Lambda function version/alias
+                "arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/arn:aws:lambda:<region>:<account_id>:function:<function_name>:${stageVariables.stageVar}/invocations",
+                "arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/arn:aws:lambda:<region>:<account_id>:function:<function_name>:stageValue/invocations",
+            ),
+            (
+                # Amazon Cognito user pool for a COGNITO_USER_POOLS authorizer.
+                "arn:aws:cognito-idp:<region>:<account_id>:userpool/${stageVariables.stageVar}",
+                "arn:aws:cognito-idp:<region>:<account_id>:userpool/stageValue",
+            ),
+            (
+                # AWS user/role integration credentials ARN
+                "arn:aws:iam::<account_id>:${stageVariables.stageVar}",
+                "arn:aws:iam::<account_id>:stageValue",
+            ),
+        ],
+    )
+    def test_uri_stage_variables_interpolation(self, uri, expected):
+        # test values taken from the documentation
+        # https://docs.aws.amazon.com/apigateway/latest/developerguide/aws-api-gateway-stage-variables-reference.html#stage-variables-in-integration-HTTP-uris
+        stage_variables = {
+            "stageVar": "stageValue",
+            "stageDomain": "example.com",
+            "moreVar": "var",
+        }
+        rendered = render_uri_with_stage_variables(uri=uri, stage_variables=stage_variables)
+        assert rendered == expected
+
+    def test_uri_interpolating_with_only_curly_braces(self):
+        uri_with_only_braces = "https://test.domain.example/root/{path}"
+        stage_variables = {"path": "value"}
+        rendered = render_uri_with_stage_variables(
+            uri=uri_with_only_braces, stage_variables=stage_variables
+        )
+        assert "{path}" in rendered
+
+    def test_uri_interpolating_with_no_variable(self):
+        uri_with_only_braces = "https://test.domain.example/root/${path}"
+        stage_variables = {}
+        rendered = render_uri_with_stage_variables(
+            uri=uri_with_only_braces, stage_variables=stage_variables
+        )
+        assert rendered == "https://test.domain.example/root/"
+
+    def test_uri_interpolating_with_bad_format(self):
+        # tested against AWS in an integration URI
+        uri_with_bad_format = r"https://test.domain.example/root/${path\}"
+        stage_variables = {"path": "value"}
+        rendered = render_uri_with_stage_variables(
+            uri=uri_with_bad_format, stage_variables=stage_variables
+        )
+        assert rendered == uri_with_bad_format
+
+
+class TestUriInterpolationPathParameters:
+    def test_uri_render_path_param(self):
+        uri_with_only_braces = "https://test.domain.example/root/{path}"
+        path_parameters = {"path": "value"}
+        rendered = render_uri_with_path_parameters(
+            uri=uri_with_only_braces,
+            path_parameters=path_parameters,
+        )
+        assert rendered == "https://test.domain.example/root/value"
+
+    def test_uri_render_missing_path_param(self):
+        uri_with_only_braces = "https://test.domain.example/root/{unknown}"
+        path_parameters = {"path": "value"}
+        rendered = render_uri_with_path_parameters(
+            uri=uri_with_only_braces,
+            path_parameters=path_parameters,
+        )
+        assert rendered == "https://test.domain.example/root/{unknown}"
+
+    def test_uri_render_partial_missing_path_param(self):
+        uri_with_only_braces = "https://test.domain.example/root/{unknown}/{path}"
+        path_parameters = {"path": "value"}
+        rendered = render_uri_with_path_parameters(
+            uri=uri_with_only_braces,
+            path_parameters=path_parameters,
+        )
+        assert rendered == "https://test.domain.example/root/{unknown}/value"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Throughout APIGW invocation, there are several places where you can use stageVariables inside some URI and ARN. 
We also need to interpolate path parameters inside the Integration URI

This PR implements 2 utils, to render stage variables following the VTL syntax, and another one to render path parameters, only in curly braces.
The Integration Request handler combines those 2 utils to render the Integration URI. 

More informations about stage variables here:
https://docs.aws.amazon.com/apigateway/latest/developerguide/aws-api-gateway-stage-variables-reference.html#stage-variables-in-integration-HTTP-uris

We will also use the utils inside the Integration for the credentials, and in the cognito authorizer to render the UserPool. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement stage variables rendering util
- implement path parameters rendering util
- add unit tests for the URI rendering
- renamed a variable inside the template mappings due to a PyCharm linting, as we were overriding the builtin `vars`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
