### PR TITLE
fix opensearch and kinesis test markers

### DIFF
--- a/tests/aws/services/kinesis/test_kinesis.validation.json
+++ b/tests/aws/services/kinesis/test_kinesis.validation.json
@@ -8,6 +8,12 @@
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_create_stream_without_stream_name_raises": {
     "last_validated_date": "2024-06-10T09:38:19+00:00"
   },
+  "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_get_records": {
+    "last_validated_date": "2024-07-04T14:57:38+00:00"
+  },
+  "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_get_records_empty_stream": {
+    "last_validated_date": "2024-07-04T14:59:11+00:00"
+  },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_record_lifecycle_data_integrity": {
     "last_validated_date": "2022-08-25T10:39:44+00:00"
   },

--- a/tests/aws/services/opensearch/test_opensearch.validation.json
+++ b/tests/aws/services/opensearch/test_opensearch.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_list_versions": {
+    "last_validated_date": "2024-07-04T15:26:07+00:00"
+  }
+}


### PR DESCRIPTION
## Motivation
While working on #11133, I saw that the test module contains a few tests with "needs fixing".
Also, @bentsku made me aware of the fact that the opensearch test module contains a lot of `markers.aws.unkown` which we try to get rid of with lots of PRs in the last few months. Just adding a few cross-links to connect these efforts a bit:
- https://github.com/localstack/localstack/pull/10994
- https://github.com/localstack/localstack/pull/10991
- https://github.com/localstack/localstack/pull/10987
- https://github.com/localstack/localstack/pull/10929
- https://github.com/localstack/localstack/pull/10920
- https://github.com/localstack/localstack/pull/10892
- https://github.com/localstack/localstack/pull/10653
- https://github.com/localstack/localstack/pull/9151
- https://github.com/localstack/localstack/pull/9141

## Changes
- Fixes all but one non-AWS validated kinesis test (the last one fails with an Internal Server Error / 500 by AWS).
- Basically marks most of the opensearch tests as `needs_fixing` (the domain creation fixture is not working against AWS yet), and some as `only_localstack` (there are a lot of tests for the different endpoint strategies).
