### PR TITLE
Apigw ng add x header to gateway responses

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
@@ -58,25 +58,25 @@ class InternalServerError(Default5xxError):
 
 class AccessDeniedError(BaseGatewayException):
     type = GatewayResponseType.ACCESS_DENIED
-    # Header Untested
+    # TODO validate this header with aws validated tests
     x_header = "AccessDeniedException"
 
 
 class ApiConfigurationError(BaseGatewayException):
     type = GatewayResponseType.API_CONFIGURATION_ERROR
-    # Header Untested
+    # TODO validate this header with aws validated tests
     x_header = "ApiConfigurationException"
 
 
 class AuthorizerConfigurationError(BaseGatewayException):
     type = GatewayResponseType.AUTHORIZER_CONFIGURATION_ERROR
-    # Header Untested
+    # TODO validate this header with aws validated tests
     x_header = "AuthorizerConfigurationException"
 
 
 class AuthorizerFailureError(BaseGatewayException):
     type = GatewayResponseType.AUTHORIZER_FAILURE
-    # Header Untested
+    # TODO validate this header with aws validated tests
     x_header = "AuthorizerFailureException"
 
 
@@ -92,13 +92,13 @@ class BadRequestBodyError(BaseGatewayException):
 
 class ExpiredTokenError(BaseGatewayException):
     type = GatewayResponseType.EXPIRED_TOKEN
-    # Header Untested
+    # TODO validate this header with aws validated tests
     x_header = "ExpiredTokenException"
 
 
 class IntegrationFailureError(BaseGatewayException):
     type = GatewayResponseType.INTEGRATION_FAILURE
-    # Header Untested
+    # TODO validate this header with aws validated tests
     x_header = "IntegrationFailureException"
 
 
@@ -114,7 +114,7 @@ class InvalidAPIKeyError(BaseGatewayException):
 
 class InvalidSignatureError(BaseGatewayException):
     type = GatewayResponseType.INVALID_SIGNATURE
-    # Header Untested
+    # TODO validate this header with aws validated tests
     x_header = "InvalidSignatureException"
 
 
@@ -130,13 +130,13 @@ class QuotaExceededError(BaseGatewayException):
 
 class RequestTooLargeError(BaseGatewayException):
     type = GatewayResponseType.REQUEST_TOO_LARGE
-    # Header Untested
+    # TODO validate this header with aws validated tests
     x_header = "RequestTooLargeException"
 
 
 class ResourceNotFoundError(BaseGatewayException):
     type = GatewayResponseType.RESOURCE_NOT_FOUND
-    # Header Untested
+    # TODO validate this header with aws validated tests
     x_header = "ResourceNotFoundException"
 
 
@@ -157,7 +157,7 @@ class UnsupportedMediaTypeError(BaseGatewayException):
 
 class WafFilteredError(BaseGatewayException):
     type = GatewayResponseType.WAF_FILTERED
-    # Header Untested
+    # TODO validate this header with aws validated tests
     x_header = "WafFilteredException"
 
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
@@ -17,6 +17,7 @@ class BaseGatewayException(Exception):
     message: str = "Unimplemented Response"
     type: GatewayResponseType
     status_code: int | str = None
+    x_header: str = ""
 
     def __init__(self, message: str = None, status_code: int | str = None):
         if message is not None:
@@ -26,89 +27,138 @@ class BaseGatewayException(Exception):
 
 
 class Default4xxError(BaseGatewayException):
+    """Do not raise from this class directly.
+    Use one of the subclasses instead, as they contain the appropriate header
+    """
+
     type: GatewayResponseType.DEFAULT_4XX
     status_code = 400
 
 
 class Default5xxError(BaseGatewayException):
+    """Do not raise from this class directly.
+    Use one of the subclasses instead, as they contain the appropriate header
+    """
+
     type: GatewayResponseType.DEFAULT_5XX
     status_code = 500
 
 
+class BadRequestException(Default4xxError):
+    x_header = "BadRequestException"
+
+
+class InternalFailureException(Default5xxError):
+    x_header = "InternalFailureException"
+
+
+class InternalServerError(Default5xxError):
+    x_header = "InternalServerError"
+
+
 class AccessDeniedError(BaseGatewayException):
     type = GatewayResponseType.ACCESS_DENIED
+    # Header Untested
+    x_header = "AccessDeniedException"
 
 
 class ApiConfigurationError(BaseGatewayException):
     type = GatewayResponseType.API_CONFIGURATION_ERROR
+    # Header Untested
+    x_header = "ApiConfigurationException"
 
 
 class AuthorizerConfigurationError(BaseGatewayException):
     type = GatewayResponseType.AUTHORIZER_CONFIGURATION_ERROR
+    # Header Untested
+    x_header = "AuthorizerConfigurationException"
 
 
 class AuthorizerFailureError(BaseGatewayException):
     type = GatewayResponseType.AUTHORIZER_FAILURE
+    # Header Untested
+    x_header = "AuthorizerFailureException"
 
 
 class BadRequestParametersError(BaseGatewayException):
     type = GatewayResponseType.BAD_REQUEST_PARAMETERS
+    x_header = "BadRequestException"
 
 
 class BadRequestBodyError(BaseGatewayException):
     type = GatewayResponseType.BAD_REQUEST_BODY
+    x_header = "BadRequestException"
 
 
 class ExpiredTokenError(BaseGatewayException):
     type = GatewayResponseType.EXPIRED_TOKEN
+    # Header Untested
+    x_header = "ExpiredTokenException"
 
 
 class IntegrationFailureError(BaseGatewayException):
     type = GatewayResponseType.INTEGRATION_FAILURE
+    # Header Untested
+    x_header = "IntegrationFailureException"
 
 
 class IntegrationTimeoutError(BaseGatewayException):
     type = GatewayResponseType.INTEGRATION_TIMEOUT
+    x_header = "InternalServerErrorException"
 
 
 class InvalidAPIKeyError(BaseGatewayException):
     type = GatewayResponseType.INVALID_API_KEY
+    x_header = "ForbiddenException"
 
 
 class InvalidSignatureError(BaseGatewayException):
     type = GatewayResponseType.INVALID_SIGNATURE
+    # Header Untested
+    x_header = "InvalidSignatureException"
 
 
 class MissingAuthTokenError(BaseGatewayException):
     type = GatewayResponseType.MISSING_AUTHENTICATION_TOKEN
+    x_header = "MissingAuthenticationTokenException"
 
 
 class QuotaExceededError(BaseGatewayException):
     type = GatewayResponseType.QUOTA_EXCEEDED
+    x_header = "LimitExceededException"
 
 
 class RequestTooLargeError(BaseGatewayException):
     type = GatewayResponseType.REQUEST_TOO_LARGE
+    # Header Untested
+    x_header = "RequestTooLargeException"
 
 
 class ResourceNotFoundError(BaseGatewayException):
     type = GatewayResponseType.RESOURCE_NOT_FOUND
+    # Header Untested
+    x_header = "ResourceNotFoundException"
 
 
 class ThrottledError(BaseGatewayException):
     type = GatewayResponseType.THROTTLED
+    x_header = "TooManyRequestsException"
 
 
 class UnauthorizedError(BaseGatewayException):
     type = GatewayResponseType.UNAUTHORIZED
+    x_header = "UnauthorizedException"
 
 
 class UnsupportedMediaTypeError(BaseGatewayException):
     type = GatewayResponseType.UNSUPPORTED_MEDIA_TYPE
+    x_header = "BadRequestException"
 
 
 class WafFilteredError(BaseGatewayException):
     type = GatewayResponseType.WAF_FILTERED
+    # Header Untested
+    x_header = "WafFilteredException"
 
 
 class GatewayResponseCode(StatusCode, Enum):

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
@@ -53,7 +53,7 @@ class InternalFailureException(Default5xxError):
 
 
 class InternalServerError(Default5xxError):
-    code = "InternalServerError"
+    code = "InternalServerErrorException"
 
 
 class AccessDeniedError(BaseGatewayException):

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
@@ -17,7 +17,7 @@ class BaseGatewayException(Exception):
     message: str = "Unimplemented Response"
     type: GatewayResponseType
     status_code: int | str = None
-    x_header: str = ""
+    code: str = ""
 
     def __init__(self, message: str = None, status_code: int | str = None):
         if message is not None:
@@ -45,120 +45,120 @@ class Default5xxError(BaseGatewayException):
 
 
 class BadRequestException(Default4xxError):
-    x_header = "BadRequestException"
+    code = "BadRequestException"
 
 
 class InternalFailureException(Default5xxError):
-    x_header = "InternalFailureException"
+    code = "InternalFailureException"
 
 
 class InternalServerError(Default5xxError):
-    x_header = "InternalServerError"
+    code = "InternalServerError"
 
 
 class AccessDeniedError(BaseGatewayException):
     type = GatewayResponseType.ACCESS_DENIED
     # TODO validate this header with aws validated tests
-    x_header = "AccessDeniedException"
+    code = "AccessDeniedException"
 
 
 class ApiConfigurationError(BaseGatewayException):
     type = GatewayResponseType.API_CONFIGURATION_ERROR
     # TODO validate this header with aws validated tests
-    x_header = "ApiConfigurationException"
+    code = "ApiConfigurationException"
 
 
 class AuthorizerConfigurationError(BaseGatewayException):
     type = GatewayResponseType.AUTHORIZER_CONFIGURATION_ERROR
     # TODO validate this header with aws validated tests
-    x_header = "AuthorizerConfigurationException"
+    code = "AuthorizerConfigurationException"
 
 
 class AuthorizerFailureError(BaseGatewayException):
     type = GatewayResponseType.AUTHORIZER_FAILURE
     # TODO validate this header with aws validated tests
-    x_header = "AuthorizerFailureException"
+    code = "AuthorizerFailureException"
 
 
 class BadRequestParametersError(BaseGatewayException):
     type = GatewayResponseType.BAD_REQUEST_PARAMETERS
-    x_header = "BadRequestException"
+    code = "BadRequestException"
 
 
 class BadRequestBodyError(BaseGatewayException):
     type = GatewayResponseType.BAD_REQUEST_BODY
-    x_header = "BadRequestException"
+    code = "BadRequestException"
 
 
 class ExpiredTokenError(BaseGatewayException):
     type = GatewayResponseType.EXPIRED_TOKEN
     # TODO validate this header with aws validated tests
-    x_header = "ExpiredTokenException"
+    code = "ExpiredTokenException"
 
 
 class IntegrationFailureError(BaseGatewayException):
     type = GatewayResponseType.INTEGRATION_FAILURE
     # TODO validate this header with aws validated tests
-    x_header = "IntegrationFailureException"
+    code = "IntegrationFailureException"
 
 
 class IntegrationTimeoutError(BaseGatewayException):
     type = GatewayResponseType.INTEGRATION_TIMEOUT
-    x_header = "InternalServerErrorException"
+    code = "InternalServerErrorException"
 
 
 class InvalidAPIKeyError(BaseGatewayException):
     type = GatewayResponseType.INVALID_API_KEY
-    x_header = "ForbiddenException"
+    code = "ForbiddenException"
 
 
 class InvalidSignatureError(BaseGatewayException):
     type = GatewayResponseType.INVALID_SIGNATURE
     # TODO validate this header with aws validated tests
-    x_header = "InvalidSignatureException"
+    code = "InvalidSignatureException"
 
 
 class MissingAuthTokenError(BaseGatewayException):
     type = GatewayResponseType.MISSING_AUTHENTICATION_TOKEN
-    x_header = "MissingAuthenticationTokenException"
+    code = "MissingAuthenticationTokenException"
 
 
 class QuotaExceededError(BaseGatewayException):
     type = GatewayResponseType.QUOTA_EXCEEDED
-    x_header = "LimitExceededException"
+    code = "LimitExceededException"
 
 
 class RequestTooLargeError(BaseGatewayException):
     type = GatewayResponseType.REQUEST_TOO_LARGE
     # TODO validate this header with aws validated tests
-    x_header = "RequestTooLargeException"
+    code = "RequestTooLargeException"
 
 
 class ResourceNotFoundError(BaseGatewayException):
     type = GatewayResponseType.RESOURCE_NOT_FOUND
     # TODO validate this header with aws validated tests
-    x_header = "ResourceNotFoundException"
+    code = "ResourceNotFoundException"
 
 
 class ThrottledError(BaseGatewayException):
     type = GatewayResponseType.THROTTLED
-    x_header = "TooManyRequestsException"
+    code = "TooManyRequestsException"
 
 
 class UnauthorizedError(BaseGatewayException):
     type = GatewayResponseType.UNAUTHORIZED
-    x_header = "UnauthorizedException"
+    code = "UnauthorizedException"
 
 
 class UnsupportedMediaTypeError(BaseGatewayException):
     type = GatewayResponseType.UNSUPPORTED_MEDIA_TYPE
-    x_header = "BadRequestException"
+    code = "BadRequestException"
 
 
 class WafFilteredError(BaseGatewayException):
     type = GatewayResponseType.WAF_FILTERED
     # TODO validate this header with aws validated tests
-    x_header = "WafFilteredException"
+    code = "WafFilteredException"
 
 
 class GatewayResponseCode(StatusCode, Enum):

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/gateway_exception.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/gateway_exception.py
@@ -67,4 +67,4 @@ class GatewayExceptionHandler(RestApiGatewayExceptionHandler):
 
     def _build_response_headers(self, exception: BaseGatewayException) -> dict:
         # TODO apply responseParameters to the headers and get content-type from the gateway_response
-        return {"content-type": "application/json", "x-amzn-errortype": exception.x_header}
+        return {"content-type": "application/json", "x-amzn-ErrorType": exception.code}

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/gateway_exception.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/gateway_exception.py
@@ -52,7 +52,7 @@ class GatewayExceptionHandler(RestApiGatewayExceptionHandler):
 
         content = self._build_response_content(exception)
 
-        headers = self._build_response_headers()
+        headers = self._build_response_headers(exception)
 
         status_code = gateway_response.get("statusCode")
         if not status_code:
@@ -65,6 +65,6 @@ class GatewayExceptionHandler(RestApiGatewayExceptionHandler):
         #  template body `{"message":$context.error.messageString}`
         return json.dumps({"message": exception.message})
 
-    def _build_response_headers(self) -> dict:
+    def _build_response_headers(self, exception: BaseGatewayException) -> dict:
         # TODO apply responseParameters to the headers and get content-type from the gateway_response
-        return {"content-type": "application/json"}
+        return {"content-type": "application/json", "x-amzn-errortype": exception.x_header}

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
@@ -15,7 +15,7 @@ from localstack.utils.json import extract_jsonpath
 from localstack.utils.strings import to_str
 
 from .context import InvocationRequest
-from .gateway_response import Default4xxError, Default5xxError
+from .gateway_response import BadRequestException, InternalFailureException
 from .variables import ContextVariables
 
 LOG = logging.getLogger(__name__)
@@ -150,8 +150,7 @@ class ParametersMapper:
             try:
                 decoded_body = self._json_load(body)
             except ValueError:
-                # x-amzn-errortype: InternalFailureException
-                raise Default5xxError(message="Internal server error")
+                raise InternalFailureException(message="Internal server error")
 
             if expr == "body":
                 return to_str(body)
@@ -205,7 +204,7 @@ class ParametersMapper:
             try:
                 decoded_body = self._json_load(body)
             except ValueError:
-                raise Default4xxError(message="Invalid JSON in request body")
+                raise BadRequestException(message="Invalid JSON in request body")
 
             if expr == "body":
                 return to_str(body)

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -7,7 +7,6 @@ from localstack.http import Request, Response
 from localstack.services.apigateway.models import MergedRestApi, RestApiDeployment
 from localstack.services.apigateway.next_gen.execute_api.api import RestApiGatewayHandlerChain
 from localstack.services.apigateway.next_gen.execute_api.context import (
-    InvocationRequest,
     RestApiInvocationContext,
 )
 from localstack.services.apigateway.next_gen.execute_api.gateway_response import (
@@ -31,59 +30,13 @@ TEST_API_STAGE = "stage"
 
 
 @pytest.fixture
-def create_context():
+def default_context():
     """
     Create a context populated with what we would expect to receive from the chain at runtime.
     We assume that the parser and other handler have successfully populated the context to this point.
     """
 
-    def _create_context(
-        method: Method = None,
-        request: InvocationRequest = None,
-    ):
-        context = RestApiInvocationContext(Request())
-
-        # The api key validator only relies on the raw headers from the invocation requests
-        context.invocation_request = request or InvocationRequest()
-
-        # Frozen deployment populated by the router
-        context.deployment = RestApiDeployment(
-            account_id=TEST_AWS_ACCOUNT_ID,
-            region=TEST_AWS_REGION_NAME,
-            rest_api=MergedRestApi(rest_api={}),
-        )
-
-        # Context populated by parser handler
-        context.region = TEST_AWS_REGION_NAME
-        context.account_id = TEST_AWS_ACCOUNT_ID
-        context.stage = TEST_API_STAGE
-        context.api_id = TEST_API_ID
-        context.resource_method = method or Method(
-            methodIntegration=Integration(
-                type=IntegrationType.HTTP,
-                requestParameters=None,
-                uri="https://example.com",
-                httpMethod="POST",
-            )
-        )
-        context.context_variables = ContextVariables(
-            resourceId="resource-id",
-            apiId=TEST_API_ID,
-            httpMethod="POST",
-            path=f"{TEST_API_STAGE}/resource/{{proxy}}",
-            requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
-            resourcePath="/resource/{proxy}",
-            stage=TEST_API_STAGE,
-        )
-
-        return context
-
-    return _create_context
-
-
-@pytest.fixture
-def default_invocation_request() -> InvocationRequest:
-    request = InvocationRequestParser().create_invocation_request(
+    context = RestApiInvocationContext(
         Request(
             method=HTTPMethod.POST,
             headers={"header": ["header1", "header2"]},
@@ -91,8 +44,41 @@ def default_invocation_request() -> InvocationRequest:
             query_string="qs=qs1&qs=qs2",
         )
     )
+    request = InvocationRequestParser().create_invocation_request(context)
     request["path_parameters"] = {"proxy": "path"}
-    return request
+    context.invocation_request = request
+
+    # Frozen deployment populated by the router
+    context.deployment = RestApiDeployment(
+        account_id=TEST_AWS_ACCOUNT_ID,
+        region=TEST_AWS_REGION_NAME,
+        rest_api=MergedRestApi(rest_api={}),
+    )
+
+    # Context populated by parser handler
+    context.region = TEST_AWS_REGION_NAME
+    context.account_id = TEST_AWS_ACCOUNT_ID
+    context.stage = TEST_API_STAGE
+    context.api_id = TEST_API_ID
+    context.resource_method = Method(
+        methodIntegration=Integration(
+            type=IntegrationType.HTTP,
+            requestParameters=None,
+            uri="https://example.com",
+            httpMethod="POST",
+        )
+    )
+    context.context_variables = ContextVariables(
+        resourceId="resource-id",
+        apiId=TEST_API_ID,
+        httpMethod="POST",
+        path=f"{TEST_API_STAGE}/resource/{{proxy}}",
+        requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
+        resourcePath="/resource/{proxy}",
+        stage=TEST_API_STAGE,
+    )
+
+    return context
 
 
 @pytest.fixture
@@ -106,10 +92,9 @@ def integration_request_handler():
 
 
 class TestHandlerIntegrationRequest:
-    def test_noop(self, integration_request_handler, default_invocation_request, create_context):
-        context = create_context(request=default_invocation_request)
-        integration_request_handler(context)
-        assert context.integration_request == {
+    def test_noop(self, integration_request_handler, default_context):
+        integration_request_handler(default_context)
+        assert default_context.integration_request == {
             "body": b"",
             "headers": {},
             "http_method": "POST",
@@ -117,154 +102,138 @@ class TestHandlerIntegrationRequest:
             "uri": "https://example.com",
         }
 
-    def test_passthrough_never(
-        self, integration_request_handler, default_invocation_request, create_context
-    ):
-        context = create_context(request=default_invocation_request)
-        context.resource_method["methodIntegration"]["passthroughBehavior"] = (
+    def test_passthrough_never(self, integration_request_handler, default_context):
+        default_context.resource_method["methodIntegration"]["passthroughBehavior"] = (
             PassthroughBehavior.NEVER
         )
 
         # With no template, it is expected to raise
         with pytest.raises(UnsupportedMediaTypeError) as e:
-            integration_request_handler(context)
+            integration_request_handler(default_context)
         assert e.match("Unsupported Media Type")
 
         # With a non-matching template it should raise
-        context.resource_method["methodIntegration"]["requestTemplates"] = {
+        default_context.resource_method["methodIntegration"]["requestTemplates"] = {
             "application/xml": "#Empty"
         }
         with pytest.raises(UnsupportedMediaTypeError) as e:
-            integration_request_handler(context)
+            integration_request_handler(default_context)
         assert e.match("Unsupported Media Type")
 
         # With a matching template it should use it
-        context.resource_method["methodIntegration"]["requestTemplates"] = {
+        default_context.resource_method["methodIntegration"]["requestTemplates"] = {
             "application/json": '{"foo":"bar"}'
         }
-        integration_request_handler(context)
-        assert context.integration_request["body"] == b'{"foo":"bar"}'
+        integration_request_handler(default_context)
+        assert default_context.integration_request["body"] == b'{"foo":"bar"}'
 
-    def test_passthrough_when_no_match(
-        self, integration_request_handler, default_invocation_request, create_context
-    ):
-        context = create_context(request=default_invocation_request)
-        context.resource_method["methodIntegration"]["passthroughBehavior"] = (
+    def test_passthrough_when_no_match(self, integration_request_handler, default_context):
+        default_context.resource_method["methodIntegration"]["passthroughBehavior"] = (
             PassthroughBehavior.WHEN_NO_MATCH
         )
         # When no template are created it should passthrough
-        integration_request_handler(context)
-        assert context.integration_request["body"] == b""
+        integration_request_handler(default_context)
+        assert default_context.integration_request["body"] == b""
 
         # when a non matching template is found it should passthrough
-        context.resource_method["methodIntegration"]["requestTemplates"] = {
+        default_context.resource_method["methodIntegration"]["requestTemplates"] = {
             "application/xml": '{"foo":"bar"}'
         }
-        integration_request_handler(context)
-        assert context.integration_request["body"] == b""
+        integration_request_handler(default_context)
+        assert default_context.integration_request["body"] == b""
 
         # when a matching template is found, it should use it
-        context.resource_method["methodIntegration"]["requestTemplates"] = {
+        default_context.resource_method["methodIntegration"]["requestTemplates"] = {
             "application/json": '{"foo":"bar"}'
         }
-        integration_request_handler(context)
-        assert context.integration_request["body"] == b'{"foo":"bar"}'
+        integration_request_handler(default_context)
+        assert default_context.integration_request["body"] == b'{"foo":"bar"}'
 
-    def test_passthrough_when_no_templates(
-        self, integration_request_handler, default_invocation_request, create_context
-    ):
-        context = create_context(request=default_invocation_request)
-        context.resource_method["methodIntegration"]["passthroughBehavior"] = (
+    def test_passthrough_when_no_templates(self, integration_request_handler, default_context):
+        default_context.resource_method["methodIntegration"]["passthroughBehavior"] = (
             PassthroughBehavior.WHEN_NO_TEMPLATES
         )
         # If a non matching template is found, it should raise
-        context.resource_method["methodIntegration"]["requestTemplates"] = {"application/xml": ""}
+        default_context.resource_method["methodIntegration"]["requestTemplates"] = {
+            "application/xml": ""
+        }
         with pytest.raises(UnsupportedMediaTypeError) as e:
-            integration_request_handler(context)
+            integration_request_handler(default_context)
         assert e.match("Unsupported Media Type")
 
         # If a matching template is found, it should use it
-        context.resource_method["methodIntegration"]["requestTemplates"] = {
+        default_context.resource_method["methodIntegration"]["requestTemplates"] = {
             "application/json": '{"foo":"bar"}'
         }
-        integration_request_handler(context)
-        assert context.integration_request["body"] == b'{"foo":"bar"}'
+        integration_request_handler(default_context)
+        assert default_context.integration_request["body"] == b'{"foo":"bar"}'
 
         # If no template were created, it should passthrough
-        context.resource_method["methodIntegration"]["requestTemplates"] = {}
-        integration_request_handler(context)
-        assert context.integration_request["body"] == b""
+        default_context.resource_method["methodIntegration"]["requestTemplates"] = {}
+        integration_request_handler(default_context)
+        assert default_context.integration_request["body"] == b""
 
-    def test_default_template(
-        self, integration_request_handler, default_invocation_request, create_context
-    ):
-        request = default_invocation_request
-        context = create_context(request=request)
-
+    def test_default_template(self, integration_request_handler, default_context):
         # if no matching template, use the default
-        context.resource_method["methodIntegration"]["requestTemplates"] = {
+        default_context.resource_method["methodIntegration"]["requestTemplates"] = {
             "$default": '{"foo":"bar"}'
         }
-        integration_request_handler(context)
-        assert context.integration_request["body"] == b'{"foo":"bar"}'
+        integration_request_handler(default_context)
+        assert default_context.integration_request["body"] == b'{"foo":"bar"}'
 
         # If there is a matching template, use it instead
-        context.resource_method["methodIntegration"]["requestTemplates"] = {
+        default_context.resource_method["methodIntegration"]["requestTemplates"] = {
             "$default": '{"foo":"bar"}',
             "application/json": "Matching Template",
         }
-        integration_request_handler(context)
-        assert context.integration_request["body"] == b"Matching Template"
+        integration_request_handler(default_context)
+        assert default_context.integration_request["body"] == b"Matching Template"
 
-    def test_request_parameters(
-        self, integration_request_handler, default_invocation_request, create_context
-    ):
-        context = create_context(request=default_invocation_request)
-        context.resource_method["methodIntegration"]["requestParameters"] = {
+    def test_request_parameters(self, integration_request_handler, default_context):
+        default_context.resource_method["methodIntegration"]["requestParameters"] = {
             "integration.request.path.path": "method.request.path.path",
             "integration.request.querystring.qs": "method.request.querystring.qs",
             "integration.request.header.header": "method.request.header.header",
         }
-        context.resource_method["methodIntegration"]["uri"] = "https://example.com/{path}"
-        integration_request_handler(context)
+        default_context.resource_method["methodIntegration"]["uri"] = "https://example.com/{path}"
+        integration_request_handler(default_context)
         # TODO this test will fail when we implement uri mapping
-        assert context.integration_request["uri"] == "https://example.com/{path}"
-        assert context.integration_request["query_string_parameters"] == {"qs": "qs2"}
-        assert context.integration_request["headers"] == {"header": "header2"}
+        assert default_context.integration_request["uri"] == "https://example.com/{path}"
+        assert default_context.integration_request["query_string_parameters"] == {"qs": "qs2"}
+        assert default_context.integration_request["headers"] == {"header": "header2"}
 
-    def test_request_override(
-        self, integration_request_handler, default_invocation_request, create_context
-    ):
-        context = create_context(request=default_invocation_request)
-        context.resource_method["methodIntegration"]["requestParameters"] = {
+    def test_request_override(self, integration_request_handler, default_context):
+        default_context.resource_method["methodIntegration"]["requestParameters"] = {
             "integration.request.path.path": "method.request.path.path",
             "integration.request.querystring.qs": "method.request.multivaluequerystring.qs",
             "integration.request.header.header": "method.request.header.header",
         }
-        context.resource_method["methodIntegration"]["uri"] = "https://example.com/{path}"
-        context.resource_method["methodIntegration"]["requestTemplates"] = {
+        default_context.resource_method["methodIntegration"]["uri"] = "https://example.com/{path}"
+        default_context.resource_method["methodIntegration"]["requestTemplates"] = {
             "application/json": REQUEST_OVERRIDE
         }
-        integration_request_handler(context)
+        integration_request_handler(default_context)
         # TODO this test will fail when we implement uri mapping
-        assert context.integration_request["uri"] == "https://example.com/{path}"
-        assert context.integration_request["query_string_parameters"] == {"qs": "queryOverride"}
-        assert context.integration_request["headers"] == {
+        assert default_context.integration_request["uri"] == "https://example.com/{path}"
+        assert default_context.integration_request["query_string_parameters"] == {
+            "qs": "queryOverride"
+        }
+        assert default_context.integration_request["headers"] == {
             "header": "headerOverride",
             "multivalue": ["1header", "2header"],
         }
 
-    def test_multivalue_mapping(
-        self, integration_request_handler, default_invocation_request, create_context
-    ):
-        context = create_context(request=default_invocation_request)
-        context.resource_method["methodIntegration"]["requestParameters"] = {
+    def test_multivalue_mapping(self, integration_request_handler, default_context):
+        default_context.resource_method["methodIntegration"]["requestParameters"] = {
             "integration.request.header.multi": "method.request.multivalueheader.header",
             "integration.request.querystring.multi": "method.request.multivaluequerystring.qs",
         }
-        integration_request_handler(context)
-        assert context.integration_request["headers"]["multi"] == "header1,header2"
-        assert context.integration_request["query_string_parameters"]["multi"] == ["qs1", "qs2"]
+        integration_request_handler(default_context)
+        assert default_context.integration_request["headers"]["multi"] == "header1,header2"
+        assert default_context.integration_request["query_string_parameters"]["multi"] == [
+            "qs1",
+            "qs2",
+        ]
 
 
 REQUEST_OVERRIDE = """

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -9,7 +9,7 @@ import boto3
 import pytest
 import xmltodict
 
-from localstack.aws.api.apigateway import GatewayResponseType, Model
+from localstack.aws.api.apigateway import Model
 from localstack.constants import (
     APPLICATION_JSON,
     APPLICATION_XML,
@@ -35,10 +35,6 @@ from localstack.services.apigateway.invocations import (
     RequestValidator,
 )
 from localstack.services.apigateway.models import ApiGatewayStore, RestApiContainer
-from localstack.services.apigateway.next_gen.execute_api.gateway_response import (
-    AccessDeniedError,
-    BaseGatewayException,
-)
 from localstack.services.apigateway.templates import (
     RequestTemplates,
     ResponseTemplates,
@@ -1296,16 +1292,3 @@ class TestModelResolver:
             resolved_model["$defs"]["House"]["properties"]["houses"]["items"]["$ref"]
             == "#/$defs/House"
         )
-
-
-class TestGatewayResponse:
-    def test_base_response(self):
-        with pytest.raises(BaseGatewayException) as e:
-            raise BaseGatewayException()
-        assert e.value.message == "Unimplemented Response"
-
-    def test_subclassed_response(self):
-        with pytest.raises(BaseGatewayException) as e:
-            raise AccessDeniedError("Access Denied")
-        assert e.value.message == "Access Denied"
-        assert e.value.type == GatewayResponseType.ACCESS_DENIED


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR adds `x-amzn-errortype` header to all gateway responses.

These are not documented and the value of the token isn't consistent from error to error. The `DEFAULT_XXX` errors appears to be raised with different header value depending on the cause of the error.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Add `x_header` to `BaseGatewayException`
- Add the header to the response in the Gateway Exception Handler
- Populate the value for all errors. Only some were validated using the console or curl. The others have been marked with a TODO so as to avoid confusion in the future. As we get more snapshot tests going, we should be able to populate more of them
- Some unit tests were moved out of `/unit/apigateway.py` to help separating the legacy tests with the NG tests.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
