### PR TITLE
APIGW NG add HTTP and HTTP_PROXY integration

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -41,14 +41,12 @@ class IntegrationRequest(TypedDict, total=False):
     """HTTP Method of the incoming request"""
     uri: Optional[str]
     """URI of the integration"""
-    query_string_parameters: Optional[dict[str, str]]
+    query_string_parameters: Optional[dict[str, str | list[str]]]
     """Query string parameters of the request"""
     headers: Optional[dict[str, str]]
+    # TODO: should this be Headers type? would maybe help access in the integrations if we need
+    #  currently, we support headers with same name and different casing, it's up to the integration to support it
     """Headers of the request"""
-    multi_value_query_string_parameters: Optional[dict[str, list[str]]]
-    """Multi value query string parameters of the request"""
-    multi_value_headers: Optional[dict[str, list[str]]]
-    """Multi value headers of the request"""
     body: Optional[bytes]
     """Body content of the request"""
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -12,7 +12,7 @@ from .variables import ContextVariables, LoggingContextVariables
 
 
 class InvocationRequest(TypedDict, total=False):
-    http_method: Optional[HTTPMethod]
+    http_method: HTTPMethod
     """HTTP Method of the incoming request"""
     raw_path: Optional[str]
     # TODO: verify if raw_path is needed
@@ -21,33 +21,33 @@ class InvocationRequest(TypedDict, total=False):
     """Path of the request with no URL decoding"""
     path_parameters: Optional[dict[str, str]]
     """Path parameters of the request"""
-    query_string_parameters: Optional[dict[str, str]]
+    query_string_parameters: dict[str, str]
     """Query string parameters of the request"""
     # TODO: need to check if we need the raw headers (as it's practical for casing reasons)
-    raw_headers: Optional[Headers]
+    raw_headers: Headers
     """Raw headers using the Headers datastructure which allows access with no regards to casing"""
-    headers: Optional[dict[str, str]]
+    headers: dict[str, str]
     """Headers of the request"""
-    multi_value_query_string_parameters: Optional[dict[str, list[str]]]
+    multi_value_query_string_parameters: dict[str, list[str]]
     """Multi value query string parameters of the request"""
-    multi_value_headers: Optional[dict[str, list[str]]]
+    multi_value_headers: dict[str, list[str]]
     """Multi value headers of the request"""
-    body: Optional[bytes]
+    body: bytes
     """Body content of the request"""
 
 
 class IntegrationRequest(TypedDict, total=False):
-    http_method: Optional[HTTPMethod]
+    http_method: HTTPMethod
     """HTTP Method of the incoming request"""
-    uri: Optional[str]
+    uri: str
     """URI of the integration"""
-    query_string_parameters: Optional[dict[str, str | list[str]]]
+    query_string_parameters: dict[str, str | list[str]]
     """Query string parameters of the request"""
-    headers: Optional[dict[str, str]]
+    headers: dict[str, str]
     # TODO: should this be Headers type? would maybe help access in the integrations if we need
     #  currently, we support headers with same name and different casing, it's up to the integration to support it
     """Headers of the request"""
-    body: Optional[bytes]
+    body: bytes
     """Body content of the request"""
 
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway.py
@@ -27,8 +27,6 @@ class RestApiGateway(Gateway):
                 handlers.method_request_handler,
                 handlers.integration_request_handler,
                 handlers.integration_handler,
-                # temporary legacy which executes the legacy logic for now
-                handlers.legacy_handler,
             ]
         )
         self.response_handlers.extend(

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -81,11 +81,10 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
             stage_variables=context.stage_variables,
         )
 
-        # TODO: verify the assumptions about the method with an AWS validated test
         # if the integration method is defined and is not ANY, we can use it for the integration
         if not (integration_method := integration["httpMethod"]) or integration_method == "ANY":
             # otherwise, fallback to the request's method
-            integration_method = context.invocation_request["method"]
+            integration_method = context.invocation_request["http_method"]
 
         integration_request = IntegrationRequest(
             http_method=integration_method,

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -75,8 +75,8 @@ class InvocationRequestParser(RestApiGatewayHandler):
         if "_user_request_" in raw_uri:
             raw_uri = raw_uri.partition("_user_request_")[2]
 
-        # remove the stage from the path
-        raw_uri = raw_uri.replace(f"/{stage_name}", "")
+        # remove the stage from the path, only replace the first occurrence
+        raw_uri = raw_uri.replace(f"/{stage_name}", "", 1)
 
         if raw_uri.startswith("//"):
             # TODO: AWS validate this assumption

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
@@ -44,6 +44,10 @@ class BaseRestApiHttpIntegration(RestApiIntegration):
             "user-agent": f"AmazonAPIGateway_{context.api_id}",
         }
 
+    @staticmethod
+    def _get_integration_timeout(integration: Integration) -> float:
+        return int(integration.get("timeoutInMillis", 29000)) / 1000
+
 
 class RestApiHttpIntegration(BaseRestApiHttpIntegration):
     """
@@ -70,8 +74,9 @@ class RestApiHttpIntegration(BaseRestApiHttpIntegration):
         if method not in NO_BODY_METHODS:
             request_parameters["data"] = integration_req["body"]
 
-        # TODO: configurable timeout (29 by default)
-        # request_parameters["timeout"] = 29
+        # TODO: configurable timeout (29 by default) (check type and default value in provider)
+        # integration: Integration = context.resource_method["methodIntegration"]
+        # request_parameters["timeout"] = self._get_integration_timeout(integration)
         # TODO: check for redirects
         # request_parameters["allow_redirects"] = False
 
@@ -127,6 +132,9 @@ class RestApiHttpProxyIntegration(BaseRestApiHttpIntegration):
         # TODO: validate this for HTTP_PROXY
         if method not in NO_BODY_METHODS:
             request_parameters["data"] = invocation_req["body"]
+
+        # TODO: configurable timeout (29 by default) (check type and default value in provider)
+        # request_parameters["timeout"] = self._get_integration_timeout(integration)
 
         request_response = requests.request(**request_parameters)
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
@@ -1,4 +1,19 @@
+from http import HTTPMethod
+
+import requests
+from werkzeug.datastructures import Headers
+
+from localstack.http import Response
+
+from ..context import IntegrationRequest, InvocationRequest, RestApiInvocationContext
+from ..helpers import render_uri_with_path_parameters
 from .core import RestApiIntegration
+
+NO_BODY_METHODS = {
+    HTTPMethod.OPTIONS,
+    HTTPMethod.GET,
+    HTTPMethod.HEAD,
+}
 
 
 class RestApiHttpIntegration(RestApiIntegration):
@@ -9,6 +24,39 @@ class RestApiHttpIntegration(RestApiIntegration):
 
     name = "HTTP"
 
+    def invoke(self, context: RestApiInvocationContext) -> Response:
+        integration_req: IntegrationRequest = context.integration_request
+        method = integration_req["http_method"]
+
+        # TODO: get right casing in case we can override them with mappings/override?
+        default_apigw_headers = {
+            "x-amzn-apigateway-api-id": context.api_id,
+            "x-amzn-trace-id": "",  # TODO
+            "user-agent": f"AmazonAPIGateway_{context.api_id}",
+            "accept-encoding": "gzip,deflate",
+        }
+        default_apigw_headers.update(integration_req["headers"])
+
+        request_parameters = {
+            "method": method,
+            "url": integration_req["uri"],
+            "params": integration_req["query_string_parameters"],
+            "headers": default_apigw_headers,
+        }
+
+        if method not in NO_BODY_METHODS:
+            request_parameters["data"] = integration_req["body"]
+
+        request_response = requests.request(**request_parameters)
+
+        response = Response(
+            response=request_response.content,
+            status=request_response.status_code,
+            headers=Headers(dict(request_response.headers)),
+        )
+
+        return response
+
 
 class RestApiHttpProxyIntegration(RestApiIntegration):
     """
@@ -18,3 +66,54 @@ class RestApiHttpProxyIntegration(RestApiIntegration):
     """
 
     name = "HTTP_PROXY"
+
+    def invoke(self, context: RestApiInvocationContext) -> Response:
+        invocation_req: InvocationRequest = context.invocation_request
+        integration_uri = context.resource_method["methodIntegration"]["uri"]
+        uri = render_uri_with_path_parameters(
+            integration_uri,
+            path_parameters=invocation_req["path_parameters"],
+        )
+
+        # TODO: get right casing in case we can override them with mappings/override?
+        default_apigw_headers = {
+            "x-amzn-apigateway-api-id": context.api_id,
+            "x-amzn-trace-id": "",  # TODO
+            "user-agent": f"AmazonAPIGateway_{context.api_id}",
+            "accept-encoding": "gzip,deflate",
+        }
+        headers = {
+            key: ",".join(value) for key, value in invocation_req["multi_value_headers"].items()
+        }
+        # TODO: check which headers to pop
+        headers.pop("Host", None)
+
+        default_apigw_headers.update(headers)
+
+        method = invocation_req["http_method"]
+        request_parameters = {
+            "method": invocation_req["http_method"],
+            "url": uri,
+            "params": invocation_req["multi_value_query_string_parameters"],
+            "headers": default_apigw_headers,
+        }
+
+        # TODO: validate this
+        if method not in NO_BODY_METHODS:
+            request_parameters["data"] = invocation_req["body"]
+
+        request_response = requests.request(**request_parameters)
+
+        response_headers = Headers(dict(request_response.headers))
+        remapped = ["connection", "content-length", "date", "x-amzn-requestid"]
+        for header in remapped:
+            if value := request_response.headers.get(header):
+                response_headers[f"x-amzn-remapped-{header}"] = value
+
+        response = Response(
+            response=request_response.content,
+            status=request_response.status_code,
+            headers=response_headers,
+        )
+
+        return response

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
@@ -1,4 +1,5 @@
 from http import HTTPMethod
+from typing import Optional, TypedDict
 
 import requests
 from werkzeug.datastructures import Headers
@@ -16,7 +17,35 @@ NO_BODY_METHODS = {
 }
 
 
-class RestApiHttpIntegration(RestApiIntegration):
+class SimpleHttpRequest(TypedDict, total=False):
+    method: HTTPMethod
+    url: str
+    params: Optional[dict[str, str | list[str]]]
+    data: bytes
+    headers: Optional[dict[str, str]]
+    cookies: Optional[dict[str, str]]
+    timeout: Optional[int]
+    allow_redirects: Optional[bool]
+    stream: Optional[bool]
+    verify: Optional[bool]
+    # TODO: check if there was a situation where we'd pass certs?
+    cert: Optional[str | tuple[str, str]]
+
+
+class BaseRestApiHttpIntegration(RestApiIntegration):
+    @staticmethod
+    def _get_default_headers(context: RestApiInvocationContext) -> dict[str, str]:
+        # passing full context as the trace-id will probably also come from it
+        # TODO: get right casing in case we can override them with mappings/override?
+        return {
+            "x-amzn-apigateway-api-id": context.api_id,
+            "x-amzn-trace-id": "",  # TODO
+            "user-agent": f"AmazonAPIGateway_{context.api_id}",
+            "accept-encoding": "gzip,deflate",
+        }
+
+
+class RestApiHttpIntegration(BaseRestApiHttpIntegration):
     """
     This is a REST API integration responsible to send a request to another HTTP API.
     https://docs.aws.amazon.com/apigateway/latest/developerguide/setup-http-integrations.html#api-gateway-set-up-http-proxy-integration-on-proxy-resource
@@ -28,16 +57,10 @@ class RestApiHttpIntegration(RestApiIntegration):
         integration_req: IntegrationRequest = context.integration_request
         method = integration_req["http_method"]
 
-        # TODO: get right casing in case we can override them with mappings/override?
-        default_apigw_headers = {
-            "x-amzn-apigateway-api-id": context.api_id,
-            "x-amzn-trace-id": "",  # TODO
-            "user-agent": f"AmazonAPIGateway_{context.api_id}",
-            "accept-encoding": "gzip,deflate",
-        }
+        default_apigw_headers = self._get_default_headers(context)
         default_apigw_headers.update(integration_req["headers"])
 
-        request_parameters = {
+        request_parameters: SimpleHttpRequest = {
             "method": method,
             "url": integration_req["uri"],
             "params": integration_req["query_string_parameters"],
@@ -47,18 +70,21 @@ class RestApiHttpIntegration(RestApiIntegration):
         if method not in NO_BODY_METHODS:
             request_parameters["data"] = integration_req["body"]
 
+        # TODO: configurable timeout (29 by default)
+        # request_parameters["timeout"] = 29
+        # TODO: check for redirects
+        # request_parameters["allow_redirects"] = False
+
         request_response = requests.request(**request_parameters)
 
-        response = Response(
+        return Response(
             response=request_response.content,
             status=request_response.status_code,
             headers=Headers(dict(request_response.headers)),
         )
 
-        return response
 
-
-class RestApiHttpProxyIntegration(RestApiIntegration):
+class RestApiHttpProxyIntegration(BaseRestApiHttpIntegration):
     """
     This is a simplified REST API integration responsible to send a request to another HTTP API by proxying it almost
     directly.
@@ -69,36 +95,30 @@ class RestApiHttpProxyIntegration(RestApiIntegration):
 
     def invoke(self, context: RestApiInvocationContext) -> Response:
         invocation_req: InvocationRequest = context.invocation_request
+        method = invocation_req["http_method"]
         integration_uri = context.resource_method["methodIntegration"]["uri"]
         uri = render_uri_with_path_parameters(
             integration_uri,
             path_parameters=invocation_req["path_parameters"],
         )
 
-        # TODO: get right casing in case we can override them with mappings/override?
-        default_apigw_headers = {
-            "x-amzn-apigateway-api-id": context.api_id,
-            "x-amzn-trace-id": "",  # TODO
-            "user-agent": f"AmazonAPIGateway_{context.api_id}",
-            "accept-encoding": "gzip,deflate",
-        }
-        headers = {
+        default_apigw_headers = self._get_default_headers(context)
+
+        request_headers = {
             key: ",".join(value) for key, value in invocation_req["multi_value_headers"].items()
         }
         # TODO: check which headers to pop
-        headers.pop("Host", None)
+        request_headers.pop("Host", None)
+        default_apigw_headers.update(request_headers)
 
-        default_apigw_headers.update(headers)
-
-        method = invocation_req["http_method"]
-        request_parameters = {
-            "method": invocation_req["http_method"],
+        request_parameters: SimpleHttpRequest = {
+            "method": method,
             "url": uri,
             "params": invocation_req["multi_value_query_string_parameters"],
             "headers": default_apigw_headers,
         }
 
-        # TODO: validate this
+        # TODO: validate this for HTTP_PROXY
         if method not in NO_BODY_METHODS:
             request_parameters["data"] = invocation_req["body"]
 
@@ -110,10 +130,8 @@ class RestApiHttpProxyIntegration(RestApiIntegration):
             if value := request_response.headers.get(header):
                 response_headers[f"x-amzn-remapped-{header}"] = value
 
-        response = Response(
+        return Response(
             response=request_response.content,
             status=request_response.status_code,
             headers=response_headers,
         )
-
-        return response

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
@@ -48,6 +48,12 @@ class ParametersMapper:
             path={},
             querystring={},
         )
+        # default values, can be overridden with right casing
+        if content_type := invocation_request["raw_headers"].get("Content-Type"):
+            request_data_mapping["header"]["Content-Type"] = content_type
+
+        if accept := invocation_request["raw_headers"].get("Accept"):
+            request_data_mapping["header"]["Accept"] = accept
 
         for integration_mapping, request_mapping in request_parameters.items():
             integration_param_location, param_name = integration_mapping.removeprefix(

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
@@ -48,12 +48,11 @@ class ParametersMapper:
             path={},
             querystring={},
         )
-        # default values, can be overridden with right casing
-        if content_type := invocation_request["raw_headers"].get("Content-Type"):
-            request_data_mapping["header"]["Content-Type"] = content_type
 
-        if accept := invocation_request["raw_headers"].get("Accept"):
-            request_data_mapping["header"]["Accept"] = accept
+        # default values, can be overridden with right casing
+        for header in ("Content-Type", "Accept"):
+            if value := invocation_request["raw_headers"].get(header):
+                request_data_mapping["header"][header] = value
 
         for integration_mapping, request_mapping in request_parameters.items():
             integration_param_location, param_name = integration_mapping.removeprefix(

--- a/tests/aws/services/apigateway/conftest.py
+++ b/tests/aws/services/apigateway/conftest.py
@@ -83,6 +83,8 @@ def create_rest_api_with_integration(
         res_templates=None,
         integration_type=None,
         stage=DEFAULT_STAGE_NAME,
+        resource_method: str = "POST",
+        integration_method: str = "POST",
     ):
         name = f"test-apigw-{short_uid()}"
         api_id, name, root_id = create_rest_apigw(
@@ -100,7 +102,7 @@ def create_rest_api_with_integration(
             aws_client.apigateway,
             restApiId=api_id,
             resourceId=resource_id,
-            httpMethod="POST",
+            httpMethod=resource_method,
             authorizationType="NONE",
             apiKeyRequired=False,
             requestParameters={value: True for value in req_parameters.values()},
@@ -129,7 +131,7 @@ def create_rest_api_with_integration(
             restApiId=api_id,
             resourceId=resource_id,
             httpMethod=method,
-            integrationHttpMethod="POST",
+            integrationHttpMethod=integration_method,
             type=integration_type or "AWS",
             credentials=assume_role_arn,
             uri=integration_uri,
@@ -141,7 +143,7 @@ def create_rest_api_with_integration(
             aws_client.apigateway,
             restApiId=api_id,
             resourceId=resource_id,
-            httpMethod="POST",
+            httpMethod=resource_method,
             statusCode="200",
         )
 
@@ -150,7 +152,7 @@ def create_rest_api_with_integration(
             aws_client.apigateway,
             restApiId=api_id,
             resourceId=resource_id,
-            httpMethod="POST",
+            httpMethod=resource_method,
             statusCode="200",
             responseTemplates=res_templates,
         )

--- a/tests/aws/services/apigateway/test_apigateway_http.py
+++ b/tests/aws/services/apigateway/test_apigateway_http.py
@@ -46,18 +46,17 @@ def add_http_integration_transformers(snapshot):
         # TODO: shared between HTTP & HTTP_PROXY
         "$..content.headers.x-amzn-trace-id",
         "$..content.headers.x-forwarded-for",
+        "$..headers.x-amz-apigw-id",
+        "$..headers.x-amzn-trace-id",
         "$..content.origin",
         "$..headers.server",
+        # TODO: only missing for HTTP
+        "$..headers.x-amzn-requestid",
         # TODO: for HTTP integration only: requests (urllib3) automatically adds `Accept-Encoding` when sending the
         #  request, seems like we cannot remove it
         "$..headers.accept-encoding",
-        "$..headers.x-amz-apigw-id",
         # TODO: only missing for HTTP_PROXY
         "$..headers.x-amzn-remapped-x-amzn-requestid",
-        "$..headers.x-amzn-trace-id",
-        # TODO: only missing for HTTP
-        "$..headers.x-amzn-requestid",
-        "$..headers.x-amzn-trace-id",
     ]
 )
 @markers.snapshot.skip_snapshot_verify(

--- a/tests/aws/services/apigateway/test_apigateway_http.py
+++ b/tests/aws/services/apigateway/test_apigateway_http.py
@@ -48,6 +48,9 @@ def add_http_integration_transformers(snapshot):
         "$..content.headers.x-forwarded-for",
         "$..content.origin",
         "$..headers.server",
+        # TODO: for HTTP integration only: requests (urllib3) automatically adds `Accept-Encoding` when sending the
+        #  request, seems like we cannot remove it
+        "$..headers.accept-encoding",
         "$..headers.x-amz-apigw-id",
         # TODO: only missing for HTTP_PROXY
         "$..headers.x-amzn-remapped-x-amzn-requestid",
@@ -60,7 +63,6 @@ def add_http_integration_transformers(snapshot):
 @markers.snapshot.skip_snapshot_verify(
     condition=lambda: not is_next_gen_api(),
     paths=[
-        "$..content.headers.accept-encoding",  # TODO: We add an extra space when adding this header
         "$..content.headers.user-agent",  # TODO: We have to properly set that header on non proxied requests.
         # TODO: x-forwarded-for header is actually set when the request is sent to `requests.request`.
         # Custom servers receive the header, but lambda execution code receives an empty string.
@@ -158,3 +160,66 @@ def test_http_integration_invoke_status_code_passthrough(
     # invoke non matching response code
     invoke_response = retry(invoke_api, sleep=2, retries=10, url=f"{invocation_url}/400")
     snapshot.match("non-matching-response", invoke_response)
+
+
+@markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        # TODO: shared between HTTP & HTTP_PROXY
+        "$..origin",
+        # TODO: for HTTP integration only: requests (urllib3) automatically adds `Accept-Encoding` when sending the
+        #  request, seems like we cannot remove it
+        "$..accept-encoding",
+    ]
+)
+@markers.snapshot.skip_snapshot_verify(
+    condition=lambda: not is_next_gen_api(),
+    paths=[
+        "$..headers.user-agent",  # TODO: We have to properly set that header on non proxied requests.
+        "$..headers.x-localstack-edge",
+    ],
+)
+@pytest.mark.parametrize("integration_type", ["HTTP", "HTTP_PROXY"])
+def test_http_integration_method(
+    integration_type,
+    create_echo_http_server,
+    create_rest_api_with_integration,
+    snapshot,
+    add_http_integration_transformers,
+):
+    echo_server_url = create_echo_http_server(trim_x_headers=True)
+    # create api gateway
+    stage_name = "test"
+    api_id = create_rest_api_with_integration(
+        integration_uri=echo_server_url,
+        integration_type=integration_type,
+        stage=stage_name,
+        resource_method="ANY",
+        integration_method="POST",
+    )
+    snapshot.match("api_id", {"rest_api_id": api_id})
+    invocation_url = api_invoke_url(
+        api_id=api_id,
+        stage=stage_name,
+        path="/test",
+    )
+
+    def invoke_api(url: str, method: str) -> dict:
+        response = requests.request(
+            method=method,
+            url=url,
+            data=json.dumps({"message": "hello world"}),
+            headers={
+                "Content-Type": "application/json",
+                "accept": "application/json",
+                "user-Agent": "test/integration",
+            },
+            verify=False,
+        )
+        assert response.status_code == 200
+        return response.json()
+
+    # retry is necessary against AWS, probably IAM permission delay
+    for http_method in ("POST", "PUT", "GET"):
+        invoke_response = retry(invoke_api, sleep=2, retries=10, url=invocation_url, method="POST")
+        snapshot.match(f"http-invocation-lambda-url-{http_method.lower()}", invoke_response)

--- a/tests/aws/services/apigateway/test_apigateway_http.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_http.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_with_lambda[HTTP]": {
-    "recorded-date": "29-03-2024, 15:12:45",
+    "recorded-date": "05-07-2024, 17:32:48",
     "recorded-content": {
       "api_id": {
         "rest_api_id": "<rest_api_id:1>"
@@ -14,7 +14,6 @@
           "domain": "<domain:1>",
           "headers": {
             "accept": "application/json",
-            "accept-encoding": "gzip,deflate",
             "content-length": "26",
             "content-type": "application/json",
             "host": "<domain:1>",
@@ -45,7 +44,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_with_lambda[HTTP_PROXY]": {
-    "recorded-date": "29-03-2024, 15:13:24",
+    "recorded-date": "05-07-2024, 17:32:54",
     "recorded-content": {
       "api_id": {
         "rest_api_id": "<rest_api_id:1>"
@@ -128,6 +127,127 @@
           "status_code": 400
         },
         "status_code": 400
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_method[HTTP]": {
+    "recorded-date": "05-07-2024, 17:00:39",
+    "recorded-content": {
+      "api_id": {
+        "rest_api_id": "<rest_api_id:1>"
+      },
+      "http-invocation-lambda-url-post": {
+        "args": {},
+        "data": {
+          "message": "hello world"
+        },
+        "domain": "<domain:1>",
+        "headers": {
+          "accept": "application/json",
+          "content-length": "<content_length:1>",
+          "content-type": "application/json",
+          "host": "<domain:1>",
+          "user-agent": "AmazonAPIGateway_<rest_api_id:1>"
+        },
+        "method": "POST",
+        "origin": "<origin:1>",
+        "path": "/"
+      },
+      "http-invocation-lambda-url-put": {
+        "args": {},
+        "data": {
+          "message": "hello world"
+        },
+        "domain": "<domain:1>",
+        "headers": {
+          "accept": "application/json",
+          "content-length": "<content_length:1>",
+          "content-type": "application/json",
+          "host": "<domain:1>",
+          "user-agent": "AmazonAPIGateway_<rest_api_id:1>"
+        },
+        "method": "POST",
+        "origin": "<origin:2>",
+        "path": "/"
+      },
+      "http-invocation-lambda-url-get": {
+        "args": {},
+        "data": {
+          "message": "hello world"
+        },
+        "domain": "<domain:1>",
+        "headers": {
+          "accept": "application/json",
+          "content-length": "<content_length:1>",
+          "content-type": "application/json",
+          "host": "<domain:1>",
+          "user-agent": "AmazonAPIGateway_<rest_api_id:1>"
+        },
+        "method": "POST",
+        "origin": "<origin:3>",
+        "path": "/"
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_method[HTTP_PROXY]": {
+    "recorded-date": "05-07-2024, 17:00:46",
+    "recorded-content": {
+      "api_id": {
+        "rest_api_id": "<rest_api_id:1>"
+      },
+      "http-invocation-lambda-url-post": {
+        "args": {},
+        "data": {
+          "message": "hello world"
+        },
+        "domain": "<domain:1>",
+        "headers": {
+          "accept": "application/json",
+          "accept-encoding": "gzip, deflate",
+          "content-length": "<content_length:1>",
+          "content-type": "application/json",
+          "host": "<domain:1>",
+          "user-agent": "test/integration"
+        },
+        "method": "POST",
+        "origin": "<origin:1>",
+        "path": "/"
+      },
+      "http-invocation-lambda-url-put": {
+        "args": {},
+        "data": {
+          "message": "hello world"
+        },
+        "domain": "<domain:1>",
+        "headers": {
+          "accept": "application/json",
+          "accept-encoding": "gzip, deflate",
+          "content-length": "<content_length:1>",
+          "content-type": "application/json",
+          "host": "<domain:1>",
+          "user-agent": "test/integration"
+        },
+        "method": "POST",
+        "origin": "<origin:2>",
+        "path": "/"
+      },
+      "http-invocation-lambda-url-get": {
+        "args": {},
+        "data": {
+          "message": "hello world"
+        },
+        "domain": "<domain:1>",
+        "headers": {
+          "accept": "application/json",
+          "accept-encoding": "gzip, deflate",
+          "content-length": "<content_length:1>",
+          "content-type": "application/json",
+          "host": "<domain:1>",
+          "user-agent": "test/integration"
+        },
+        "method": "POST",
+        "origin": "<origin:3>",
+        "path": "/"
       }
     }
   }

--- a/tests/aws/services/apigateway/test_apigateway_http.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_http.validation.json
@@ -5,10 +5,16 @@
   "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_invoke_status_code_passthrough[HTTP_PROXY]": {
     "last_validated_date": "2024-04-01T21:46:23+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_method[HTTP]": {
+    "last_validated_date": "2024-07-05T17:00:39+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_method[HTTP_PROXY]": {
+    "last_validated_date": "2024-07-05T17:00:46+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_with_lambda[HTTP]": {
-    "last_validated_date": "2024-04-01T21:51:36+00:00"
+    "last_validated_date": "2024-07-05T17:32:48+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_with_lambda[HTTP_PROXY]": {
-    "last_validated_date": "2024-03-29T15:13:24+00:00"
+    "last_validated_date": "2024-07-05T17:32:54+00:00"
   }
 }

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -43,9 +43,6 @@ def default_context():
             query_string="qs=qs1&qs=qs2",
         )
     )
-    request = InvocationRequestParser().create_invocation_request(context)
-    request["path_parameters"] = {"proxy": "path"}
-    context.invocation_request = request
 
     # Frozen deployment populated by the router
     context.deployment = RestApiDeployment(
@@ -54,11 +51,18 @@ def default_context():
         rest_api=MergedRestApi(rest_api={}),
     )
 
-    # Context populated by parser handler
+    # Context populated by parser handler before creating the invocation request
     context.region = TEST_AWS_REGION_NAME
     context.account_id = TEST_AWS_ACCOUNT_ID
     context.stage = TEST_API_STAGE
     context.api_id = TEST_API_ID
+
+    request = InvocationRequestParser().create_invocation_request(context)
+    context.invocation_request = request
+
+    # add path_parameters from the router parser
+    request["path_parameters"] = {"proxy": "path"}
+
     context.resource_method = Method(
         methodIntegration=Integration(
             type=IntegrationType.HTTP,

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -220,6 +220,20 @@ class TestHandlerIntegrationRequest:
             "multivalue": ["1header", "2header"],
         }
 
+    def test_request_override_casing(self, integration_request_handler, default_context):
+        default_context.resource_method["methodIntegration"]["requestParameters"] = {
+            "integration.request.header.myHeader": "method.request.header.header",
+        }
+        default_context.resource_method["methodIntegration"]["requestTemplates"] = {
+            "application/json": '#set($context.requestOverride.header.myheader = "headerOverride")'
+        }
+        integration_request_handler(default_context)
+        # TODO: for now, it's up to the integration to properly merge headers (`requests` does it automatically)
+        assert default_context.integration_request["headers"] == {
+            "myHeader": "header2",
+            "myheader": "headerOverride",
+        }
+
     def test_multivalue_mapping(self, integration_request_handler, default_context):
         default_context.resource_method["methodIntegration"]["requestParameters"] = {
             "integration.request.header.multi": "method.request.multivalueheader.header",

--- a/tests/unit/services/apigateway/test_parameters_mapping.py
+++ b/tests/unit/services/apigateway/test_parameters_mapping.py
@@ -400,6 +400,56 @@ class TestApigatewayRequestParametersMapping:
             "querystring": {},
         }
 
+    def test_default_values_headers_request_mapping(
+        self, default_invocation_request, default_context_variables
+    ):
+        mapper = ParametersMapper()
+        default_invocation_request["raw_headers"].add("Content-Type", "application/json")
+        default_invocation_request["raw_headers"].add("Accept", "application/json")
+
+        mapping = mapper.map_integration_request(
+            request_parameters={},
+            invocation_request=default_invocation_request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+
+        assert mapping == {
+            "header": {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            "path": {},
+            "querystring": {},
+        }
+
+    def test_default_values_headers_request_mapping_override(
+        self, default_invocation_request, default_context_variables
+    ):
+        mapper = ParametersMapper()
+        request_parameters = {
+            "integration.request.header.Content-Type": "method.request.header.header_value",
+            "integration.request.header.accept": "method.request.header.header_value",
+        }
+        default_invocation_request["raw_headers"].add("Content-Type", "application/json")
+        default_invocation_request["raw_headers"].add("Accept", "application/json")
+
+        mapping = mapper.map_integration_request(
+            request_parameters=request_parameters,
+            invocation_request=default_invocation_request,
+            context_variables=default_context_variables,
+            stage_variables={},
+        )
+        assert mapping == {
+            "header": {
+                "Content-Type": "test-header-value",
+                "Accept": "application/json",
+                "accept": "test-header-value",
+            },
+            "path": {},
+            "querystring": {},
+        }
+
 
 class TestApigatewayResponseParametersMapping:
     """


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR implements the `HTTP` and `HTTP_PROXY` integrations. The previous work we have done make those extremely simple to implement and understand, and it shows how much the current work is going to simplify APIGW. 

The PR also contains a few changes across the board, because we can now test full end-to-end integration tests: the `tests/aws/services/apigateway/test_apigateway_http.py` test file is fully green with the new PR, with improved parity. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implemented the `HTTP` and `HTTP_PROXY` integrations
- change some typing around some existing contexts, as those were not really `Optional` and it helps with making sure we're not lacking data once we're in the integration
- remove the `legacy` handler as we can now enable full end-to-end tests
- remove the full clear of headers when receiving a response from an integration that is not of `_PROXY` type, but instead have a mechanism to keep some
- return the integration response/method response status code for the response
- fix the `path` value, as we would replace the `/<stage>` multiple times through, and if you had a path looking `/test/test` where `test` was your stage and `test` just a regular resource, we're replace everything
- add default values for `Accept` and `Content-Type`, behavior checked with AWS and add test for it
- remove some snapshot skips when running the HTTP integrations integration tests with the new provider
- update some unit tests to be a bit simpler and avoid mistakes

<!-- Optional section: How to test these changes? -->

## Testing
Set `PROVIDER_OVERRIDE_APIGATEWAY=next_gen` and run all tests in `tests/aws/services/apigateway/test_apigateway_http.py`, they now all run! 🥳 

<!-- Optional section: What's left to do before it can be merged? -->
## TODO

What's left to do:

- [x] PR description
