### PR TITLE
Add missing log_config passing in create_container_from_config method

### DIFF
--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -852,6 +852,7 @@ class ContainerClient(metaclass=ABCMeta):
             labels=container_config.labels,
             ulimits=container_config.ulimits,
             init=container_config.init,
+            log_config=container_config.log_config,
         )
 
     @abstractmethod


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
In my original PR #11095 I forgot to forward the `log_config` from the container configuration to the actual docker create call in the `create_container_from_config` method, I only added it to `run_container_from_config`.

This PR fixes this mistake, but cannot be merged until some adaptions in `-ext` take place, due to a naming conflict in the ECS TaskContainerConfiguration.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Forward `log_config` parameter in `create_container_from_config` method

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
