### PR TITLE
[SFN] Fix Parsing of Escape Sequences in Intrinsic Functions

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/parse/intrinsic/preprocessor.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/parse/intrinsic/preprocessor.py
@@ -61,6 +61,8 @@ class Preprocessor(ASLIntrinsicParserVisitor):
         if escaped_char.isalpha():
             replacements = {"n": "\n", "t": "\t", "r": "\r"}
             return replacements.get(escaped_char, escaped_char)
+        if escaped_char == '"':
+            return '"'
         else:
             return match.group(0)
 

--- a/localstack-core/localstack/services/stepfunctions/asl/parse/intrinsic/preprocessor.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/parse/intrinsic/preprocessor.py
@@ -61,7 +61,7 @@ class Preprocessor(ASLIntrinsicParserVisitor):
         if escaped_char.isalpha():
             replacements = {"n": "\n", "t": "\t", "r": "\r"}
             return replacements.get(escaped_char, escaped_char)
-        if escaped_char == '"':
+        elif escaped_char == '"':
             return '"'
         else:
             return match.group(0)

--- a/tests/aws/services/stepfunctions/templates/intrinsicfunctions/intrinsic_functions_templates.py
+++ b/tests/aws/services/stepfunctions/templates/intrinsicfunctions/intrinsic_functions_templates.py
@@ -37,6 +37,9 @@ class IntrinsicFunctionTemplate(TemplateLoader):
     JSON_MERGE: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/json_manipulation/json_merge.json5"
     )
+    JSON_MERGE_ESCAPED_ARGUMENT: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/json_manipulation/json_merge_escaped_argument.json5"
+    )
 
     # String Operations.
     STRING_SPLIT: Final[str] = os.path.join(

--- a/tests/aws/services/stepfunctions/templates/intrinsicfunctions/statemachines/json_manipulation/json_merge_escaped_argument.json5
+++ b/tests/aws/services/stepfunctions/templates/intrinsicfunctions/statemachines/json_manipulation/json_merge_escaped_argument.json5
@@ -1,0 +1,15 @@
+{
+  "Comment": "JSON_MERGE_ESCAPED_ARGUMENT",
+  "StartAt": "StartState",
+  "States": {
+    "StartState": {
+      "Type": "Pass",
+      "ResultPath": "$.result_path",
+      "Parameters": {
+        "merged.$": "States.JsonMerge(States.StringToJson('{\"constant_in_literal\": \"false\"}'), $$.Execution.Input.input_field, false)"
+      },
+      "OutputPath": "$.result_path.merged",
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
+++ b/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
@@ -181,3 +181,6 @@ class ScenariosTemplate(TemplateLoader):
     WAIT_TIMESTAMP_PATH: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/wait_timestamp_path.json5"
     )
+    DIRECT_ACCESS_CONTEXT_OBJECT_CHILD_FIELD: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/direct_access_context_object_child_field.json5"
+    )

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_json_manipulation.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_json_manipulation.py
@@ -1,6 +1,7 @@
 import json
 
 from localstack.testing.pytest import markers
+from localstack.testing.pytest.stepfunctions.utils import create_and_record_execution
 from tests.aws.services.stepfunctions.templates.intrinsicfunctions.intrinsic_functions_templates import (
     IntrinsicFunctionTemplate as IFT,
 )
@@ -77,4 +78,25 @@ class TestJsonManipulation:
             sfn_snapshot,
             IFT.JSON_MERGE,
             input_values,
+        )
+
+    @markers.aws.validated
+    def test_json_merge_escaped_argument(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+    ):
+        template = IFT.load_sfn_template(IFT.JSON_MERGE_ESCAPED_ARGUMENT)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"input_field": {"constant_input_field": "constant_value"}})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
         )

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_json_manipulation.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_json_manipulation.snapshot.json
@@ -1364,5 +1364,83 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/intrinsic_functions/test_json_manipulation.py::TestJsonManipulation::test_json_merge_escaped_argument": {
+    "recorded-date": "05-07-2024, 14:24:10",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "input_field": {
+                  "constant_input_field": "constant_value"
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "input_field": {
+                  "constant_input_field": "constant_value"
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "StartState"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "StartState",
+              "output": {
+                "constant_input_field": "constant_value",
+                "constant_in_literal": "false"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "constant_input_field": "constant_value",
+                "constant_in_literal": "false"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_json_manipulation.validation.json
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_json_manipulation.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/stepfunctions/v2/intrinsic_functions/test_json_manipulation.py::TestJsonManipulation::test_json_merge": {
     "last_validated_date": "2023-02-13T11:49:30+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/intrinsic_functions/test_json_manipulation.py::TestJsonManipulation::test_json_merge_escaped_argument": {
+    "last_validated_date": "2024-07-05T14:24:10+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/intrinsic_functions/test_json_manipulation.py::TestJsonManipulation::test_json_to_string": {
     "last_validated_date": "2023-02-09T09:21:51+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently the StepFunctions v2 interpreter is unable to accurately parse escaped quote sequences (eg. `'\"Hello\"'`), which can appear as String Literal arguments. This PR addresses such issue and added relevant snapshot test.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Add escape sequence override logic for quotes
- Relevant snapshot test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
