### PR TITLE
Apigw ng implement mock integration

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/mock.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/mock.py
@@ -1,4 +1,15 @@
+import json
+import logging
+from json import JSONDecodeError
+
+from localstack.http import Response
+from localstack.utils.strings import to_str
+
+from ..context import IntegrationRequest, RestApiInvocationContext
+from ..gateway_response import InternalServerError
 from .core import RestApiIntegration
+
+LOG = logging.getLogger(__name__)
 
 
 class RestApiMockIntegration(RestApiIntegration):
@@ -12,3 +23,35 @@ class RestApiMockIntegration(RestApiIntegration):
     """
 
     name = "MOCK"
+
+    def invoke(self, context: RestApiInvocationContext) -> Response:
+        integration_req: IntegrationRequest = context.integration_request
+
+        status_code = self.get_status_code(integration_req)
+
+        if status_code is None:
+            LOG.debug(
+                "Execution failed due to configuration error: Unable to parse statusCode. "
+                "It should be an integer that is defined in the request template."
+            )
+            raise InternalServerError("Internal server error")
+
+        return Response(status=status_code)
+
+    @staticmethod
+    def get_status_code(integration_req: IntegrationRequest) -> int | None:
+        try:
+            body = json.loads(to_str(integration_req["body"]))
+        except JSONDecodeError as e:
+            LOG.debug(
+                "Exception while parsing integration request body: %s",
+                e,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
+            )
+            return
+
+        status_code = body.get("statusCode")
+        if not isinstance(status_code, int):
+            return
+
+        return status_code

--- a/tests/unit/services/apigateway/test_mock_integration.py
+++ b/tests/unit/services/apigateway/test_mock_integration.py
@@ -1,0 +1,51 @@
+import pytest
+
+from localstack.http import Request
+from localstack.services.apigateway.next_gen.execute_api.context import (
+    IntegrationRequest,
+    RestApiInvocationContext,
+)
+from localstack.services.apigateway.next_gen.execute_api.gateway_response import InternalServerError
+from localstack.services.apigateway.next_gen.execute_api.integrations import RestApiMockIntegration
+from localstack.utils.strings import to_bytes
+
+
+@pytest.fixture
+def create_default_context():
+    def _create_context(body: str) -> RestApiInvocationContext:
+        context = RestApiInvocationContext(request=Request())
+        context.integration_request = IntegrationRequest(body=to_bytes(body))
+        return context
+
+    return _create_context
+
+
+class TestMockIntegration:
+    def test_mock_integration(self, create_default_context):
+        mock_integration = RestApiMockIntegration()
+
+        ctx = create_default_context(body='{"statusCode": 200}')
+        response = mock_integration.invoke(ctx)
+        assert response.status_code == 200
+
+        # It needs to be an integer
+        ctx = create_default_context(body='{"statusCode": "200"}')
+        with pytest.raises(InternalServerError) as exc_info:
+            mock_integration.invoke(ctx)
+        assert exc_info.match("Internal server error")
+
+        # Any integer will do
+        ctx = create_default_context(body='{"statusCode": 0}')
+        response = mock_integration.invoke(ctx)
+        assert response.status_code == 0
+
+        # Literally any
+        ctx = create_default_context(body='{"statusCode": -1000}')
+        response = mock_integration.invoke(ctx)
+        assert response.status_code == -1000
+
+        # Malformed Json
+        ctx = create_default_context(body='{"statusCode": 200')
+        with pytest.raises(InternalServerError) as exc_info:
+            mock_integration.invoke(ctx)
+        assert exc_info.match("Internal server error")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Implements Mock integration. https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-mock-integration.html

Upon testing with the console, I confirmed that any integer, positive or negative will work. It will then get matched to the response as usual.

I didn't test much of the validated tests yet as #11143 and #11144 both bring fixes required to enable end to end integrations.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Mock integration
- Unit tests

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
