### PR TITLE
fix aws_http_client_factory fixture to use TEST_AWS_REGION_NAME

### DIFF
--- a/localstack-core/localstack/testing/aws/util.py
+++ b/localstack-core/localstack/testing/aws/util.py
@@ -190,6 +190,7 @@ def base_aws_session() -> boto3.Session:
     session = boto3.Session(
         aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
         aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
+        region_name=TEST_AWS_REGION_NAME,
     )
     # make sure we consider our custom data paths for legacy specs (like SQS query protocol)
     session._loader.search_paths.append(LOCALSTACK_BUILTIN_DATA_PATH)

--- a/localstack-core/localstack/testing/aws/util.py
+++ b/localstack-core/localstack/testing/aws/util.py
@@ -190,7 +190,6 @@ def base_aws_session() -> boto3.Session:
     session = boto3.Session(
         aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
         aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
-        region_name=TEST_AWS_REGION_NAME,
     )
     # make sure we consider our custom data paths for legacy specs (like SQS query protocol)
     session._loader.search_paths.append(LOCALSTACK_BUILTIN_DATA_PATH)

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -22,9 +22,6 @@ from werkzeug import Request, Response
 
 from localstack import config
 from localstack.aws.connect import ServiceLevelClientFactory
-from localstack.constants import (
-    AWS_REGION_US_EAST_1,
-)
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
@@ -91,7 +88,7 @@ def aws_http_client_factory(aws_session):
         aws_access_key_id: str = None,
         aws_secret_access_key: str = None,
     ):
-        region = region or aws_session.region_name or AWS_REGION_US_EAST_1
+        region = region or TEST_AWS_REGION_NAME
 
         if aws_access_key_id or aws_secret_access_key:
             credentials = botocore.credentials.Credentials(


### PR DESCRIPTION
## Motivation
In our [latest scheduled run testing multi-account / multi-region capabilities of LocalStack](https://app.circleci.com/pipelines/github/localstack/localstack/26458/workflows/852a2bc9-8c02-497f-a314-9b4c048af228/jobs/225179/parallel-runs/1/steps/1-111), the Kinesis tests adjusted with https://github.com/localstack/localstack/pull/11133 and https://github.com/localstack/localstack/pull/11141 failed:
```
FAILED tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_cbor_at_timestamp - assert 200 == 500
 +  where 500 = <Response [500]>.status_code
FAILED tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_get_records - assert 200 == 400
 +  where 400 = <Response [400]>.status_code
FAILED tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_get_records_empty_stream - assert 200 == 400
 +  where 400 = <Response [400]>.status_code
```

It turns out that our `aws_http_client_factory` fixture did not yet take the `TEST_AWS_REGION_NAME` config into account.

## Changes
- Adjusts the `aws_http_client_factory` fixture to also set the region from `TEST_AWS_REGION_NAME`.

## Testing
- Set the following env vars when running the failing tests: `TEST_AWS_ACCOUNT_ID=123456789012;TEST_AWS_REGION_NAME=ap-southeast-2;TEST_AWS_ACCESS_KEY_ID=123456789012` 
- [Triggered Multi-Accounts / Multi-Region test run](https://app.circleci.com/pipelines/github/localstack/localstack/26468/workflows/f4663d57-5d04-4e76-9ae7-b4fb7a4012a7)