### PR TITLE
abandon dev tag, directly push latest on acceptance test run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,9 +47,9 @@ commands:
              }
 
              if [[ "$only_acceptance_tests" == "true" ]]; then
-                 set_env_vars "true" "dev" "Only acceptance tests run, the default tag is 'dev'"
+                 set_env_vars "true" "latest" "Only acceptance tests run, the default tag is 'latest'"
              elif [[ "$git_branch" == "master" ]] && [[ "$trigger_source" == "webhook" ]]; then
-                 set_env_vars "true" "dev" "Regular push run to master means only acceptance test run, the default tag is 'dev'"
+                 set_env_vars "true" "latest" "Regular push run to master means only acceptance test run, the default tag is 'latest'"
              else
                  set_env_vars "false" "latest" "All tests run, the default tag is 'latest'"
              fi


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/11049 we switched our testing methodology such that we only run acceptance tests on `master`. In order to avoid any disturbance, we introduced an intermediary tag `dev` to make sure that we do not break the `latest` image (which is directly used by a lot of our users) too often.
We have now learned that the acceptance tests in combination with the PR tests are a good gate, and there is no known instance where a dev tag contained issues which would even have been caught by the full integration test suite.
This is why this PR removes the `dev` tag again, runs on master which only execute the acceptance tests will directly push the `latest` image tag.

## Changes
- Removes the selective usage of the `dev` tag when only the acceptance tests are executed.
  - Even if only the acceptance tests are executed, we will directly push the `latest` tag.

/cc @thrau @komarkovich @MarcelStranak