### PR TITLE
Feature/eventbridge v2 use arn util for arns

### DIFF
--- a/localstack-core/localstack/services/events/models.py
+++ b/localstack-core/localstack/services/events/models.py
@@ -38,7 +38,12 @@ from localstack.services.stores import (
     CrossRegionAttribute,
     LocalAttribute,
 )
-from localstack.utils.aws.arns import events_archive_arn, events_replay_arn, events_rule_arn
+from localstack.utils.aws.arns import (
+    event_bus_arn,
+    events_archive_arn,
+    events_replay_arn,
+    events_rule_arn,
+)
 from localstack.utils.tagging import TaggingService
 
 TargetDict = dict[TargetId, Target]
@@ -198,18 +203,20 @@ class EventBus:
     tags: TagList = field(default_factory=list)
     policy: Optional[ResourcePolicy] = None
     rules: RuleDict = field(default_factory=dict)
-    arn: Arn = field(init=False)
     creation_time: Timestamp = field(init=False)
     last_modified_time: Timestamp = field(init=False)
 
     def __post_init__(self):
-        self.arn = f"arn:aws:events:{self.region}:{self.account_id}:event-bus/{self.name}"
         self.creation_time = datetime.now(timezone.utc)
         self.last_modified_time = datetime.now(timezone.utc)
         if self.rules is None:
             self.rules = {}
         if self.tags is None:
             self.tags = []
+
+    @property
+    def arn(self) -> Arn:
+        return event_bus_arn(self.name, self.account_id, self.region)
 
 
 EventBusDict = dict[EventBusName, EventBus]

--- a/localstack-core/localstack/services/events/models.py
+++ b/localstack-core/localstack/services/events/models.py
@@ -38,7 +38,7 @@ from localstack.services.stores import (
     CrossRegionAttribute,
     LocalAttribute,
 )
-from localstack.utils.aws.arns import events_archive_arn, events_replay_arn
+from localstack.utils.aws.arns import events_archive_arn, events_replay_arn, events_rule_arn
 from localstack.utils.tagging import TaggingService
 
 TargetDict = dict[TargetId, Target]
@@ -121,13 +121,8 @@ class Rule:
     targets: TargetDict = field(default_factory=dict)
     managed_by: Optional[ManagedBy] = None  # can only be set by AWS services
     created_by: CreatedBy = field(init=False)
-    arn: Arn = field(init=False)
 
     def __post_init__(self):
-        if self.event_bus_name == "default":
-            self.arn = f"arn:aws:events:{self.region}:{self.account_id}:rule/{self.name}"
-        else:
-            self.arn = f"arn:aws:events:{self.region}:{self.account_id}:rule/{self.event_bus_name}/{self.name}"
         self.created_by = self.account_id
         if self.tags is None:
             self.tags = []
@@ -135,6 +130,10 @@ class Rule:
             self.targets = {}
         if self.state is None:
             self.state = RuleState.ENABLED
+
+    @property
+    def arn(self) -> Arn:
+        return events_rule_arn(self.name, self.account_id, self.region, self.event_bus_name)
 
 
 RuleDict = dict[RuleName, Rule]

--- a/localstack-core/localstack/utils/aws/arns.py
+++ b/localstack-core/localstack/utils/aws/arns.py
@@ -196,8 +196,12 @@ def log_group_arn(group_name: str, account_id: str, region_name: str) -> str:
 #
 
 
-def events_rule_arn(rule_name: str, account_id: str, region_name: str) -> str:
+def events_rule_arn(
+    rule_name: str, account_id: str, region_name: str, event_bus_name: str = "default"
+) -> str:
     pattern = "arn:aws:events:%s:%s:rule/%s"
+    if event_bus_name != "default":
+        rule_name = f"{event_bus_name}/{rule_name}"
     return _resource_arn(rule_name, pattern, account_id=account_id, region_name=region_name)
 
 

--- a/localstack-core/localstack/utils/aws/arns.py
+++ b/localstack-core/localstack/utils/aws/arns.py
@@ -196,15 +196,6 @@ def log_group_arn(group_name: str, account_id: str, region_name: str) -> str:
 #
 
 
-def events_rule_arn(
-    rule_name: str, account_id: str, region_name: str, event_bus_name: str = "default"
-) -> str:
-    pattern = "arn:aws:events:%s:%s:rule/%s"
-    if event_bus_name != "default":
-        rule_name = f"{event_bus_name}/{rule_name}"
-    return _resource_arn(rule_name, pattern, account_id=account_id, region_name=region_name)
-
-
 def events_archive_arn(archive_name: str, account_id: str, region_name: str) -> str:
     pattern = "arn:aws:events:%s:%s:archive/%s"
     return _resource_arn(archive_name, pattern, account_id=account_id, region_name=region_name)
@@ -218,6 +209,15 @@ def event_bus_arn(bus_name: str, account_id: str, region_name: str) -> str:
 def events_replay_arn(replay_name: str, account_id: str, region_name: str) -> str:
     pattern = "arn:aws:events:%s:%s:replay/%s"
     return _resource_arn(replay_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def events_rule_arn(
+    rule_name: str, account_id: str, region_name: str, event_bus_name: str = "default"
+) -> str:
+    pattern = "arn:aws:events:%s:%s:rule/%s"
+    if event_bus_name != "default":
+        rule_name = f"{event_bus_name}/{rule_name}"
+    return _resource_arn(rule_name, pattern, account_id=account_id, region_name=region_name)
 
 
 #


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Using the arn util to define arns via and access them via a property of the dataclasses defined for each top-level entity of events (bus, rule, archive, replay) is preferable to having the logic of creating arns located in the model files of event bridge. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
