### PR TITLE
Feature/eventbridge v2 custom json encoder exporter

### DIFF
--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -117,12 +117,12 @@ from localstack.services.events.rule import RuleService, RuleServiceDict
 from localstack.services.events.scheduler import JobScheduler
 from localstack.services.events.target import TargetSender, TargetSenderDict, TargetSenderFactory
 from localstack.services.events.utils import (
-    EventJSONEncoder,
     extract_event_bus_name,
     format_event,
     get_resource_type,
     is_archive_arn,
     recursive_remove_none_values_from_dict,
+    to_json_str,
 )
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.common import truncate
@@ -1282,7 +1282,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             matching_rules = [rule for rule in event_bus.rules.values()]
             for rule in matching_rules:
                 event_pattern = rule.event_pattern
-                event_str = json.dumps(event_formatted, cls=EventJSONEncoder)
+                event_str = to_json_str(event_formatted)
                 if matches_rule(event_str, event_pattern):
                     for target in rule.targets.values():
                         target_arn = target["Arn"]

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -11,7 +11,7 @@ from botocore.client import BaseClient
 from localstack.aws.api.events import Arn, InputTransformer, RuleName, Target, TargetInputPath
 from localstack.aws.connect import connect_to
 from localstack.services.events.models import FormattedEvent, TransformedEvent, ValidationException
-from localstack.services.events.utils import EventJSONEncoder, event_time_to_time_string
+from localstack.services.events.utils import event_time_to_time_string, to_json_str
 from localstack.utils import collections
 from localstack.utils.aws.arns import (
     extract_account_id_from_arn,
@@ -76,7 +76,7 @@ def replace_template_placeholders(
         key = match.group(1)
         value = replacements.get(key, match.group(0))  # handle non defined placeholders
         if is_json:
-            return json.dumps(value, cls=EventJSONEncoder)
+            return to_json_str(value)
         if isinstance(value, datetime.datetime):
             return event_time_to_time_string(value)
         return value
@@ -312,7 +312,7 @@ class FirehoseTargetSender(TargetSender):
         delivery_stream_name = firehose_name(self.target["Arn"])
         self.client.put_record(
             DeliveryStreamName=delivery_stream_name,
-            Record={"Data": to_bytes(json.dumps(event, cls=EventJSONEncoder))},
+            Record={"Data": to_bytes(to_json_str(event))},
         )
 
 
@@ -323,7 +323,7 @@ class KinesisTargetSender(TargetSender):
         partition_key = event.get(partition_key_path, event["id"])
         self.client.put_record(
             StreamName=stream_name,
-            Data=to_bytes(json.dumps(event, cls=EventJSONEncoder)),
+            Data=to_bytes(to_json_str(event)),
             PartitionKey=partition_key,
         )
 
@@ -340,7 +340,7 @@ class LambdaTargetSender(TargetSender):
         asynchronous = True  # TODO clarify default behavior of AWS
         self.client.invoke(
             FunctionName=self.target["Arn"],
-            Payload=to_bytes(json.dumps(event, cls=EventJSONEncoder)),
+            Payload=to_bytes(to_json_str(event)),
             InvocationType="Event" if asynchronous else "RequestResponse",
         )
 
@@ -356,7 +356,7 @@ class LogsTargetSender(TargetSender):
             logEvents=[
                 {
                     "timestamp": now_utc(millis=True),
-                    "message": json.dumps(event, cls=EventJSONEncoder),
+                    "message": to_json_str(event),
                 }
             ],
         )
@@ -379,9 +379,7 @@ class SagemakerTargetSender(TargetSender):
 
 class SnsTargetSender(TargetSender):
     def send_event(self, event):
-        self.client.publish(
-            TopicArn=self.target["Arn"], Message=json.dumps(event, cls=EventJSONEncoder)
-        )
+        self.client.publish(TopicArn=self.target["Arn"], Message=to_json_str(event))
 
 
 class SqsTargetSender(TargetSender):
@@ -391,10 +389,9 @@ class SqsTargetSender(TargetSender):
         kwargs = {"MessageGroupId": msg_group_id} if msg_group_id else {}
         self.client.send_message(
             QueueUrl=queue_url,
-            MessageBody=json.dumps(
+            MessageBody=to_json_str(
                 event,
                 separators=(",", ":"),
-                cls=EventJSONEncoder,
             ),
             **kwargs,
         )
@@ -404,9 +401,7 @@ class StatesTargetSender(TargetSender):
     """Step Functions Target Sender"""
 
     def send_event(self, event):
-        self.client.start_execution(
-            stateMachineArn=self.target["Arn"], input=json.dumps(event, cls=EventJSONEncoder)
-        )
+        self.client.start_execution(stateMachineArn=self.target["Arn"], input=to_json_str(event))
 
     def _validate_input(self, target: Target):
         super()._validate_input(target)

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -2,7 +2,7 @@ import json
 import logging
 import re
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from localstack.aws.api.events import (
     ArchiveName,
@@ -36,6 +36,10 @@ class EventJSONEncoder(json.JSONEncoder):
         if isinstance(obj, datetime):
             return event_time_to_time_string(obj)
         return super().default(obj)
+
+
+def to_json_str(obj: Any, separators: Optional[tuple[str, str]] = None) -> str:
+    return json.dumps(obj, cls=EventJSONEncoder, separators=separators)
 
 
 def extract_event_bus_name(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Using a custom util function to dump json to strings utilizing the custom json encoder that handles exporting of time stamp to the correct string format removes the potential pitfall of forgetting to include the custom json class when using `json.dumps`. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
