### PR TITLE
APIGW NG add AWS_PROXY integration

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1039,9 +1039,6 @@ OPENSEARCH_MULTI_CLUSTER = is_env_not_false("OPENSEARCH_MULTI_CLUSTER")
 # Whether to really publish to GCM while using SNS Platform Application (needs credentials)
 LEGACY_SNS_GCM_PUBLISHING = is_env_true("LEGACY_SNS_GCM_PUBLISHING")
 
-# TODO: remove
-os.environ["PROVIDER_OVERRIDE_APIGATEWAY"] = "next_gen"
-
 # Whether the Next Gen APIGW invocation logic is enabled (handler chain)
 APIGW_NEXT_GEN_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_APIGATEWAY", "") == "next_gen"
 

--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1040,7 +1040,7 @@ OPENSEARCH_MULTI_CLUSTER = is_env_not_false("OPENSEARCH_MULTI_CLUSTER")
 LEGACY_SNS_GCM_PUBLISHING = is_env_true("LEGACY_SNS_GCM_PUBLISHING")
 
 # TODO: remove
-# os.environ["PROVIDER_OVERRIDE_APIGATEWAY"] = "next_gen"
+os.environ["PROVIDER_OVERRIDE_APIGATEWAY"] = "next_gen"
 
 # Whether the Next Gen APIGW invocation logic is enabled (handler chain)
 APIGW_NEXT_GEN_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_APIGATEWAY", "") == "next_gen"

--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1039,6 +1039,9 @@ OPENSEARCH_MULTI_CLUSTER = is_env_not_false("OPENSEARCH_MULTI_CLUSTER")
 # Whether to really publish to GCM while using SNS Platform Application (needs credentials)
 LEGACY_SNS_GCM_PUBLISHING = is_env_true("LEGACY_SNS_GCM_PUBLISHING")
 
+# TODO: remove
+# os.environ["PROVIDER_OVERRIDE_APIGATEWAY"] = "next_gen"
+
 # Whether the Next Gen APIGW invocation logic is enabled (handler chain)
 APIGW_NEXT_GEN_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_APIGATEWAY", "") == "next_gen"
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/api_key_validation.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/api_key_validation.py
@@ -36,8 +36,7 @@ class ApiKeyValidationHandler(RestApiGatewayHandler):
         if not method.get("apiKeyRequired"):
             return
 
-        # If the Identity context was not created yet, instantiate it and attach it to the context variables
-        identity = context.context_variables.setdefault("identity", ContextVarsIdentity())
+        identity = context.context_variables.get("identity")
 
         # Look for the api key value in the request. If it is not found, raise an exception
         if not (api_key_value := self.get_request_api_key(rest_api, request, identity)):

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -9,13 +9,13 @@ from werkzeug.datastructures import Headers, MultiDict
 
 from localstack.http import Response
 from localstack.services.apigateway.helpers import REQUEST_TIME_DATE_FORMAT
-from localstack.utils.strings import short_uid
+from localstack.utils.strings import long_uid, short_uid
 from localstack.utils.time import timestamp
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import InvocationRequest, RestApiInvocationContext
 from ..moto_helpers import get_stage_variables
-from ..variables import ContextVariables
+from ..variables import ContextVariables, ContextVarsIdentity
 
 LOG = logging.getLogger(__name__)
 
@@ -138,10 +138,24 @@ class InvocationRequestParser(RestApiGatewayHandler):
             domainPrefix=domain_prefix,
             extendedRequestId=short_uid(),  # TODO: use snapshot tests to verify format
             httpMethod=invocation_request["http_method"],
+            identity=ContextVarsIdentity(
+                accountId=None,
+                accessKey=None,
+                caller=None,
+                cognitoAuthenticationProvider=None,
+                cognitoAuthenticationType=None,
+                cognitoIdentityId=None,
+                cognitoIdentityPoolId=None,
+                principalOrgId=None,
+                sourceIp="127.0.0.1",  # TODO: get the sourceIp from the Request
+                user=None,
+                userAgent=invocation_request["raw_headers"].get("User-Agent"),
+                userArn=None,
+            ),
             # TODO: check if we need the raw path? with forward slashes
             path=f"/{context.stage}{invocation_request['path']}",
             protocol="HTTP/1.1",
-            requestId=short_uid(),  # TODO: use snapshot tests to verify format
+            requestId=long_uid(),
             requestTime=timestamp(time=now, format=REQUEST_TIME_DATE_FORMAT),
             requestTimeEpoch=int(now.timestamp() * 1000),
             stage=context.stage,

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
@@ -75,7 +75,7 @@ def get_lambda_function_arn_from_invocation_uri(uri: str) -> str:
     :param uri: the integration URI value for a lambda function
     :return: the lambda function ARN
     """
-    return uri.split(":lambda:path")[1].split("functions/")[1].removesuffix("/invocations")
+    return uri.split("functions/")[1].removesuffix("/invocations")
 
 
 def validate_sub_dict_of_typed_dict(typed_dict: Type[TypedDict], obj: dict) -> bool:

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -1,4 +1,53 @@
+import base64
+import json
+import logging
+from http import HTTPMethod
+from typing import Optional, TypedDict
+
+from botocore.exceptions import ClientError
+from werkzeug.datastructures import Headers
+
+from localstack.aws.api.apigateway import Integration
+from localstack.http import Response
+from localstack.services.apigateway.integration import get_service_factory
+from localstack.utils.aws.arns import extract_region_from_arn
+from localstack.utils.aws.client_types import ServicePrincipal
+from localstack.utils.collections import merge_dicts
+from localstack.utils.strings import to_bytes, to_str
+
+from ..context import InvocationRequest, RestApiInvocationContext
+from ..helpers import (
+    get_lambda_function_arn_from_invocation_uri,
+    get_source_arn,
+    validate_sub_dict_of_typed_dict,
+)
+from ..variables import ContextVariables
 from .core import RestApiIntegration
+
+LOG = logging.getLogger(__name__)
+
+
+class LambdaProxyResponse(TypedDict, total=False):
+    body: Optional[str]
+    statusCode: Optional[int]
+    headers: Optional[dict[str, str]]
+    isBase64Encoded: Optional[bool]
+    multiValueHeaders: Optional[dict[str, list[str]]]
+
+
+class LambdaInputEvent(TypedDict, total=False):
+    body: str
+    isBase64Encoded: bool
+    httpMethod: str | HTTPMethod
+    resource: str
+    path: str
+    headers: dict[str, str]
+    multiValueHeaders: dict[str, list[str]]
+    queryStringParameters: dict[str, str]
+    multiValueQueryStringParameters: dict[str, list[str]]
+    requestContext: ContextVariables
+    pathParameters: dict[str, str]
+    stageVariables: dict[str, str]
 
 
 class RestApiAwsIntegration(RestApiIntegration):
@@ -37,3 +86,143 @@ class RestApiAwsProxyIntegration(RestApiIntegration):
     """
 
     name = "AWS_PROXY"
+
+    def invoke(self, context: RestApiInvocationContext) -> Response:
+        invocation_req: InvocationRequest = context.invocation_request
+        integration: Integration = context.resource_method["methodIntegration"]
+        # if the integration method is defined and is not ANY, we can use it for the integration
+        if not (method := integration["httpMethod"]) or method == "ANY":
+            # otherwise, fallback to the request's method
+            method = invocation_req["http_method"]
+
+        if method != HTTPMethod.POST:
+            raise Exception
+            # raise ApiGatewayIntegrationError("Internal server error", status_code=500)
+
+        input_event = self.create_lambda_input_event(context)
+        function_arn = get_lambda_function_arn_from_invocation_uri(integration["uri"])
+
+        try:
+            lambda_payload = self.call_lambda(
+                function_arn=function_arn,
+                event=to_bytes(json.dumps(input_event)),
+                context=context,
+            )
+        except ClientError:
+            # TODO
+            raise
+        except Exception:
+            # TODO
+            raise
+
+        lambda_response = self.parse_lambda_response(lambda_payload)
+
+        headers = merge_dicts(
+            {"Content-Type": "application/json"},
+            lambda_response.get("headers") or {},
+            lambda_response.get("multiValueHeaders") or {},
+        )
+
+        response = Response(
+            headers=Headers(headers),
+        )
+        response.data = lambda_response.get("body") or ""
+        response.status_code = lambda_response.get("statusCode") or 200
+
+        return response
+
+    @staticmethod
+    def call_lambda(
+        function_arn: str,
+        event: bytes,
+        context: RestApiInvocationContext,
+    ) -> bytes:
+        # TODO: properly get the value out
+        integration: Integration = context.resource_method["methodIntegration"]
+        raw_headers = context.invocation_request["raw_headers"]
+        is_invocation_asynchronous = raw_headers.get("X-Amz-Invocation-Type") == "'Event'"
+
+        lambda_client = get_service_factory(
+            region_name=extract_region_from_arn(function_arn),
+            role_arn=integration.get("credentials"),
+        ).lambda_
+        inv_result = lambda_client.request_metadata(
+            service_principal=ServicePrincipal.apigateway,
+            source_arn=get_source_arn(context),
+        ).invoke(
+            FunctionName=function_arn,
+            Payload=event,
+            InvocationType="Event" if is_invocation_asynchronous else "RequestResponse",
+        )
+        if payload := inv_result.get("Payload"):
+            return payload.read()
+        return b""
+
+    @staticmethod
+    def parse_lambda_response(payload: bytes) -> LambdaProxyResponse:
+        try:
+            lambda_response = json.loads(payload)
+
+        except json.JSONDecodeError:
+            raise
+
+        # none of the lambda response fields are mandatory, but you cannot return any other fields
+        if not validate_sub_dict_of_typed_dict(LambdaProxyResponse, lambda_response):
+            LOG.warning(
+                'Lambda output should follow the next JSON format: { "isBase64Encoded": true|false, "statusCode": httpStatusCode, "headers": { "headerName": "headerValue", ... },"body": "..."} but was: %s',
+                payload,
+            )
+            # status_code = 502
+            # {"message": "Internal server error"}
+            raise Exception
+
+        # TODO: validate type of each values?
+
+        return lambda_response
+
+    def create_lambda_input_event(self, context: RestApiInvocationContext) -> LambdaInputEvent:
+        # https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+        invocation_req: InvocationRequest = context.invocation_request
+
+        # TODO: binary support of APIGW
+        body, is_b64_encoded = self._format_body(invocation_req["body"])
+
+        input_event = LambdaInputEvent(
+            headers=self._format_headers(invocation_req["headers"]),
+            multiValueHeaders=self._format_headers(invocation_req["multi_value_headers"]),
+            body=body or None,
+            isBase64Encoded=is_b64_encoded,
+            requestContext=context.context_variables,
+            stageVariables=context.stage_variables,
+            queryStringParameters=invocation_req["query_string_parameters"] or None,
+            multiValueQueryStringParameters=invocation_req["multi_value_query_string_parameters"]
+            or None,
+            pathParameters=invocation_req["path_parameters"],
+            httpMethod=invocation_req["http_method"],
+            path=invocation_req["path"],
+            resource=context.resource["path"],
+        )
+
+        return input_event
+
+    @staticmethod
+    def _format_headers(headers: dict[str, str | list[str]]) -> dict[str, str | list[str]]:
+        # Some headers get capitalized like in CloudFront, see
+        # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html#add-origin-custom-headers-forward-authorization
+        # It seems AWS_PROXY lambda integrations are behind CloudFront, as seen by the returned headers in AWS
+        to_capitalize: list[str] = ["authorization"]  # some headers get capitalized
+        to_filter: list[str] = ["content-length", "connection"]
+        headers = {
+            k.capitalize() if k.lower() in to_capitalize else k: v
+            for k, v in headers.items()
+            if k.lower() not in to_filter
+        }
+
+        return headers
+
+    @staticmethod
+    def _format_body(body: bytes) -> tuple[str, bool]:
+        try:
+            return body.decode("utf-8"), False
+        except UnicodeDecodeError:
+            return to_str(base64.b64encode(body)), True

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -198,6 +198,9 @@ class RestApiAwsProxyIntegration(RestApiIntegration):
 
     @staticmethod
     def _is_lambda_response_valid(lambda_response: dict) -> bool:
+        if not isinstance(lambda_response, dict):
+            return False
+
         if not validate_sub_dict_of_typed_dict(LambdaProxyResponse, lambda_response):
             return False
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
@@ -31,6 +31,8 @@ class ContextVarsIdentity(TypedDict, total=False):
     # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
     accountId: Optional[str]
     """The AWS account ID associated with the request."""
+    accessKey: Optional[str]
+    """The AWS access key associated with the request."""
     apiKey: Optional[str]
     """For API methods that require an API key, this variable is the API key associated with the method request."""
     apiKeyId: Optional[str]

--- a/tests/aws/services/apigateway/test_apigateway_lambda.py
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.py
@@ -289,7 +289,12 @@ def test_lambda_aws_proxy_integration_non_post_method(
         credentials=role_arn,
     )
 
-    # TODO: comment
+    # Note: we are adding a GatewayResponse here to test a weird AWS bug: when the AWS_PROXY integration fails, it
+    # internally raises an IntegrationFailure error.
+    # However, in the documentation, it is written than this error should return 504. But like this test shows, when the
+    # user does not update the status code, it returns 500, unlike what the documentation and APIGW returns when calling
+    # `GetGatewayResponse`.
+    # TODO: in the future, write a specific test for this behavior
     aws_client.apigateway.put_gateway_response(
         restApiId=api_id,
         responseType="INTEGRATION_FAILURE",

--- a/tests/aws/services/apigateway/test_apigateway_lambda.py
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.py
@@ -31,24 +31,15 @@ REQUEST_TEMPLATE_VM = os.path.join(THIS_FOLDER, "../../files/request-template.vm
 RESPONSE_TEMPLATE_VM = os.path.join(THIS_FOLDER, "../../files/response-template.vm")
 
 CLOUDFRONT_SKIP_HEADERS = [
-    "$..headers.Via",
-    "$..headers.X-Amz-Cf-Id",
-    "$..headers.CloudFront-Forwarded-Proto",
-    "$..headers.CloudFront-Is-Desktop-Viewer",
-    "$..headers.CloudFront-Is-Mobile-Viewer",
-    "$..headers.CloudFront-Is-SmartTV-Viewer",
-    "$..headers.CloudFront-Is-Tablet-Viewer",
-    "$..headers.CloudFront-Viewer-ASN",
-    "$..headers.CloudFront-Viewer-Country",
-    "$..multiValueHeaders.Via",
-    "$..multiValueHeaders.X-Amz-Cf-Id",
-    "$..multiValueHeaders.CloudFront-Forwarded-Proto",
-    "$..multiValueHeaders.CloudFront-Is-Desktop-Viewer",
-    "$..multiValueHeaders.CloudFront-Is-Mobile-Viewer",
-    "$..multiValueHeaders.CloudFront-Is-SmartTV-Viewer",
-    "$..multiValueHeaders.CloudFront-Is-Tablet-Viewer",
-    "$..multiValueHeaders.CloudFront-Viewer-ASN",
-    "$..multiValueHeaders.CloudFront-Viewer-Country",
+    "$..Via",
+    "$..X-Amz-Cf-Id",
+    "$..CloudFront-Forwarded-Proto",
+    "$..CloudFront-Is-Desktop-Viewer",
+    "$..CloudFront-Is-Mobile-Viewer",
+    "$..CloudFront-Is-SmartTV-Viewer",
+    "$..CloudFront-Is-Tablet-Viewer",
+    "$..CloudFront-Viewer-ASN",
+    "$..CloudFront-Viewer-Country",
 ]
 
 
@@ -56,34 +47,23 @@ CLOUDFRONT_SKIP_HEADERS = [
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         *CLOUDFRONT_SKIP_HEADERS,
-        "$..headers.X-Amzn-Trace-Id",
-        "$..headers.X-Forwarded-For",
-        "$..headers.X-Forwarded-Port",
-        "$..headers.X-Forwarded-Proto",
-        "$..multiValueHeaders.X-Amzn-Trace-Id",
-        "$..multiValueHeaders.X-Forwarded-For",
-        "$..multiValueHeaders.X-Forwarded-Port",
-        "$..multiValueHeaders.X-Forwarded-Proto",
+        "$..X-Amzn-Trace-Id",
+        "$..X-Forwarded-For",
+        "$..X-Forwarded-Port",
+        "$..X-Forwarded-Proto",
     ]
 )
 @markers.snapshot.skip_snapshot_verify(
     condition=lambda: not is_next_gen_api(),
     paths=[
         "$..body",
-        "$..headers.Accept",
-        "$..headers.Content-Length",
-        "$..headers.Accept-Encoding",
-        "$..headers.Connection",
-        "$..headers.accept",
-        "$..headers.accept-encoding",
-        "$..headers.x-localstack-edge",
-        "$..multiValueHeaders.Content-Length",
-        "$..multiValueHeaders.Accept",
-        "$..multiValueHeaders.Accept-Encoding",
-        "$..multiValueHeaders.Connection",
-        "$..multiValueHeaders.accept",
-        "$..multiValueHeaders.accept-encoding",
-        "$..multiValueHeaders.x-localstack-edge",
+        "$..Accept",
+        "$..accept",
+        "$..Content-Length",
+        "$..Accept-Encoding",
+        "$..Connection",
+        "$..accept-encoding",
+        "$..x-localstack-edge",
         "$..pathParameters",
         "$..requestContext.authorizer",
         "$..requestContext.deploymentId",
@@ -308,8 +288,15 @@ def test_lambda_aws_proxy_integration_non_post_method(
         uri=f"arn:aws:apigateway:{aws_client.apigateway.meta.region_name}:lambda:path/2015-03-31/functions/{lambda_arn}/invocations",
         credentials=role_arn,
     )
-    aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
 
+    # TODO: comment
+    aws_client.apigateway.put_gateway_response(
+        restApiId=api_id,
+        responseType="INTEGRATION_FAILURE",
+        responseParameters={},
+    )
+
+    aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
     # invoke rest api
     invocation_url = api_invoke_url(
         api_id=api_id,
@@ -811,7 +798,7 @@ def test_lambda_aws_proxy_response_format(
         "wrong-format",
         "empty-response",
     ]
-
+    # TODO: refactor the test to use a lambda that returns whatever we pass it to instead of pre-defined responses
     for lambda_format_type in format_types:
         # invoke rest api
         invocation_url = api_invoke_url(

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
-    "recorded-date": "09-07-2024, 15:27:16",
+    "recorded-date": "10-07-2024, 12:28:36",
     "recorded-content": {
       "invocation-payload-without-trailing-slash": {
         "body": null,
@@ -649,7 +649,7 @@
           "CloudFront-Viewer-Country": "<cloudfront-country:1>",
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
-          "Via": "<via:6>",
+          "Via": "<via:2>",
           "X-Amz-Cf-Id": "<cf-id:6>",
           "X-Amzn-Trace-Id": "<trace-id:6>",
           "X-Forwarded-For": "<source-ip:1>, <ip>",
@@ -697,7 +697,7 @@
             "python-requests/testing"
           ],
           "Via": [
-            "<via:6>"
+            "<via:2>"
           ],
           "X-Amz-Cf-Id": [
             "<cf-id:6>"
@@ -802,7 +802,7 @@
           "Content-Type": "application/json;charset=utf-8",
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
-          "Via": "<via:7>",
+          "Via": "<via:6>",
           "X-Amz-Cf-Id": "<cf-id:7>",
           "X-Amzn-Trace-Id": "<trace-id:7>",
           "X-Forwarded-For": "<source-ip:1>, <ip>",
@@ -852,7 +852,7 @@
             "python-requests/testing"
           ],
           "Via": [
-            "<via:7>"
+            "<via:6>"
           ],
           "X-Amz-Cf-Id": [
             "<cf-id:7>"

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
-    "recorded-date": "20-03-2024, 14:44:59",
+    "recorded-date": "09-07-2024, 15:27:16",
     "recorded-content": {
       "invocation-payload-without-trailing-slash": {
         "body": null,
@@ -15,7 +15,7 @@
           "CloudFront-Is-Tablet-Viewer": "false",
           "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
           "CloudFront-Viewer-Country": "<cloudfront-country:1>",
-          "Host": "<api-id>.execute-api.<region>.amazonaws.com",
+          "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:1>",
           "X-Amz-Cf-Id": "<cf-id:1>",
@@ -59,7 +59,7 @@
             "<cloudfront-country:1>"
           ],
           "Host": [
-            "<api-id>.execute-api.<region>.amazonaws.com"
+            "<host:1>"
           ],
           "User-Agent": [
             "python-requests/testing"
@@ -96,7 +96,7 @@
           "accountId": "111111111111",
           "apiId": "<api-id>",
           "deploymentId": "<deployment-id:1>",
-          "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
+          "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:1>",
           "httpMethod": "GET",
@@ -139,7 +139,7 @@
           "CloudFront-Is-Tablet-Viewer": "false",
           "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
           "CloudFront-Viewer-Country": "<cloudfront-country:1>",
-          "Host": "<api-id>.execute-api.<region>.amazonaws.com",
+          "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:2>",
           "X-Amz-Cf-Id": "<cf-id:2>",
@@ -183,7 +183,7 @@
             "<cloudfront-country:1>"
           ],
           "Host": [
-            "<api-id>.execute-api.<region>.amazonaws.com"
+            "<host:1>"
           ],
           "User-Agent": [
             "python-requests/testing"
@@ -220,7 +220,7 @@
           "accountId": "111111111111",
           "apiId": "<api-id>",
           "deploymentId": "<deployment-id:1>",
-          "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
+          "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:2>",
           "httpMethod": "GET",
@@ -263,7 +263,7 @@
           "CloudFront-Is-Tablet-Viewer": "false",
           "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
           "CloudFront-Viewer-Country": "<cloudfront-country:1>",
-          "Host": "<api-id>.execute-api.<region>.amazonaws.com",
+          "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:3>",
           "X-Amz-Cf-Id": "<cf-id:3>",
@@ -307,7 +307,7 @@
             "<cloudfront-country:1>"
           ],
           "Host": [
-            "<api-id>.execute-api.<region>.amazonaws.com"
+            "<host:1>"
           ],
           "User-Agent": [
             "python-requests/testing"
@@ -350,7 +350,7 @@
           "accountId": "111111111111",
           "apiId": "<api-id>",
           "deploymentId": "<deployment-id:1>",
-          "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
+          "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:3>",
           "httpMethod": "GET",
@@ -393,7 +393,7 @@
           "CloudFront-Is-Tablet-Viewer": "false",
           "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
           "CloudFront-Viewer-Country": "<cloudfront-country:1>",
-          "Host": "<api-id>.execute-api.<region>.amazonaws.com",
+          "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:4>",
           "X-Amz-Cf-Id": "<cf-id:4>",
@@ -437,7 +437,7 @@
             "<cloudfront-country:1>"
           ],
           "Host": [
-            "<api-id>.execute-api.<region>.amazonaws.com"
+            "<host:1>"
           ],
           "User-Agent": [
             "python-requests/testing"
@@ -480,7 +480,7 @@
           "accountId": "111111111111",
           "apiId": "<api-id>",
           "deploymentId": "<deployment-id:1>",
-          "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
+          "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:4>",
           "httpMethod": "GET",
@@ -523,7 +523,7 @@
           "CloudFront-Is-Tablet-Viewer": "false",
           "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
           "CloudFront-Viewer-Country": "<cloudfront-country:1>",
-          "Host": "<api-id>.execute-api.<region>.amazonaws.com",
+          "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:5>",
           "X-Amz-Cf-Id": "<cf-id:5>",
@@ -567,7 +567,7 @@
             "<cloudfront-country:1>"
           ],
           "Host": [
-            "<api-id>.execute-api.<region>.amazonaws.com"
+            "<host:1>"
           ],
           "User-Agent": [
             "python-requests/testing"
@@ -604,7 +604,7 @@
           "accountId": "111111111111",
           "apiId": "<api-id>",
           "deploymentId": "<deployment-id:1>",
-          "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
+          "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:5>",
           "httpMethod": "GET",
@@ -647,7 +647,7 @@
           "CloudFront-Is-Tablet-Viewer": "false",
           "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
           "CloudFront-Viewer-Country": "<cloudfront-country:1>",
-          "Host": "<api-id>.execute-api.<region>.amazonaws.com",
+          "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:6>",
           "X-Amz-Cf-Id": "<cf-id:6>",
@@ -691,7 +691,7 @@
             "<cloudfront-country:1>"
           ],
           "Host": [
-            "<api-id>.execute-api.<region>.amazonaws.com"
+            "<host:1>"
           ],
           "User-Agent": [
             "python-requests/testing"
@@ -754,7 +754,7 @@
           "accountId": "111111111111",
           "apiId": "<api-id>",
           "deploymentId": "<deployment-id:1>",
-          "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
+          "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:6>",
           "httpMethod": "GET",
@@ -800,7 +800,7 @@
           "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
           "CloudFront-Viewer-Country": "<cloudfront-country:1>",
           "Content-Type": "application/json;charset=utf-8",
-          "Host": "<api-id>.execute-api.<region>.amazonaws.com",
+          "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:7>",
           "X-Amz-Cf-Id": "<cf-id:7>",
@@ -846,7 +846,7 @@
             "application/json;charset=utf-8"
           ],
           "Host": [
-            "<api-id>.execute-api.<region>.amazonaws.com"
+            "<host:1>"
           ],
           "User-Agent": [
             "python-requests/testing"
@@ -893,7 +893,7 @@
           "accountId": "111111111111",
           "apiId": "<api-id>",
           "deploymentId": "<deployment-id:1>",
-          "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
+          "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:7>",
           "httpMethod": "POST",

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -9,7 +9,7 @@
     "last_validated_date": "2023-05-31T21:09:38+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
-    "last_validated_date": "2024-03-20T14:44:59+00:00"
+    "last_validated_date": "2024-07-09T15:27:16+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration_non_post_method": {
     "last_validated_date": "2024-03-20T22:16:43+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -9,10 +9,10 @@
     "last_validated_date": "2023-05-31T21:09:38+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
-    "last_validated_date": "2024-07-09T15:27:16+00:00"
+    "last_validated_date": "2024-07-10T12:28:36+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration_non_post_method": {
-    "last_validated_date": "2024-03-20T22:16:43+00:00"
+    "last_validated_date": "2024-07-10T15:43:36+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_response_format": {
     "last_validated_date": "2024-02-23T18:39:48+00:00"

--- a/tests/unit/services/apigateway/test_handler_api_key_validation.py
+++ b/tests/unit/services/apigateway/test_handler_api_key_validation.py
@@ -70,10 +70,11 @@ def create_context():
         context.api_id = TEST_API_ID
         context.resource_method = method or Method()
         context.context_variables = ContextVariables()
+        context.context_variables["identity"] = ContextVarsIdentity()
 
         # Context populated by a Lambda Authorizer
         if api_key is not None:
-            context.context_variables["identity"] = ContextVarsIdentity(apiKey=api_key)
+            context.context_variables["identity"]["apiKey"] = api_key
         return context
 
     return _create_context


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR implements the `AWS_PROXY` API Gateway integration. 
https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html



<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- populate the `identity` field of the context with the default values for a method with no authorizer
- port a few utils needed for the lambda integration
- implement the `AWS_PROXY` integration, adding the utils to create the input payload and parsing the response from lambda and passing it down the chain

<!-- Optional section: How to test these changes? -->

## Testing
All the tests related to `AWS_PROXY` in `tests.aws.services.apigateway.test_apigateway_lambda` are passing when forcing the provider, with way less snapshot ignore than before 🥳 
(With `test_lambda_aws_proxy_integration_non_post_method` depending #11183 to be merged due to the gateway response default value issue).

<!-- Optional section: What's left to do before it can be merged? -->

## TODO

What's left to do:

- [ ] write maybe a bit of unit test
- [ ] manage all exceptions, do validation in console too
- [ ] ?

