### PR TITLE
fix caching in tests-pro-integration after source move

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -249,7 +249,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            localstack/.filesystem/var/lib/localstack
+            localstack/localstack-core/.filesystem/var/lib/localstack
           # include the matrix group (to re-use the var-libs used in the specific test group)
           key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-libs-${{ hashFiles('**/packages.py', '**/packages/*') }}-${{steps.determine-companion-ref.outputs.result}}-group-${{ matrix.group }}
           restore-keys: |


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/10800 the main module in localstack/localstack has been moved from the root of the repository to the `localstack-core` folder.
Unfortunately, this silently killed the caching in the workflow which runs the Community tests against the LocalStack Pro code (since the `.filesystem` folder now is in `localstack/localstack-core/.filesystem`).
This PR addresses this issue which should hopefully lead to an increase in the pipeline stability.

## Changes
- Adjusts the path for the var lib cache in `tests-pro-integration.yml`