### PR TITLE
Clarify docker client volume API

### DIFF
--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -499,7 +499,7 @@ class DockerRunFlags:
     env_vars: Optional[Dict[str, str]]
     extra_hosts: Optional[Dict[str, str]]
     labels: Optional[Dict[str, str]]
-    mounts: Optional[List[SimpleVolumeBind]]
+    volumes: Optional[List[SimpleVolumeBind]]
     network: Optional[str]
     platform: Optional[DockerPlatform]
     privileged: Optional[bool]
@@ -835,7 +835,7 @@ class ContainerClient(metaclass=ABCMeta):
             interactive=container_config.interactive,
             tty=container_config.tty,
             command=container_config.command,
-            mount_volumes=container_config.volumes,
+            volumes=container_config.volumes,
             ports=container_config.ports,
             exposed_ports=container_config.exposed_ports,
             env_vars=container_config.env_vars,
@@ -866,7 +866,7 @@ class ContainerClient(metaclass=ABCMeta):
         tty: bool = False,
         detach: bool = False,
         command: Optional[Union[List[str], str]] = None,
-        mount_volumes: Optional[Union[VolumeMappings, List[SimpleVolumeBind]]] = None,
+        volumes: Optional[Union[VolumeMappings, List[SimpleVolumeBind]]] = None,
         ports: Optional[PortMappings] = None,
         exposed_ports: Optional[List[str]] = None,
         env_vars: Optional[Dict[str, str]] = None,
@@ -903,7 +903,7 @@ class ContainerClient(metaclass=ABCMeta):
         tty: bool = False,
         detach: bool = False,
         command: Optional[Union[List[str], str]] = None,
-        mount_volumes: Optional[Union[VolumeMappings, List[SimpleVolumeBind]]] = None,
+        volumes: Optional[Union[VolumeMappings, List[SimpleVolumeBind]]] = None,
         ports: Optional[PortMappings] = None,
         exposed_ports: Optional[List[str]] = None,
         env_vars: Optional[Dict[str, str]] = None,
@@ -942,7 +942,7 @@ class ContainerClient(metaclass=ABCMeta):
             tty=container_config.tty,
             detach=container_config.detach,
             command=container_config.command,
-            mount_volumes=container_config.volumes,
+            volumes=container_config.volumes,
             ports=container_config.ports,
             exposed_ports=container_config.exposed_ports,
             env_vars=container_config.env_vars,
@@ -1154,7 +1154,7 @@ class Util:
         additional_flags: str,
         env_vars: Optional[Dict[str, str]] = None,
         labels: Optional[Dict[str, str]] = None,
-        mounts: Optional[List[SimpleVolumeBind]] = None,
+        volumes: Optional[List[SimpleVolumeBind]] = None,
         network: Optional[str] = None,
         platform: Optional[DockerPlatform] = None,
         ports: Optional[PortMappings] = None,
@@ -1168,7 +1168,7 @@ class Util:
                                  https://docs.docker.com/engine/reference/commandline/run/
         :param env_vars: Dict with env vars. Will be modified in place.
         :param labels: Dict with labels. Will be modified in place.
-        :param mounts: List of mount tuples (host_path, container_path). Will be modified in place.
+        :param volumes: List of mount tuples (host_path, container_path). Will be modified in place.
         :param network: Existing network name (optional). Warning will be printed if network is overwritten in flags.
         :param platform: Platform to execute container. Warning will be printed if platform is overwritten in flags.
         :param ports: PortMapping object. Will be modified in place.
@@ -1343,7 +1343,7 @@ class Util:
             user = args.user
 
         if args.volumes:
-            mounts = mounts if mounts is not None else []
+            volumes = volumes if volumes is not None else []
             for volume in args.volumes:
                 match = re.match(
                     r"(?P<host>[\w\s\\\/:\-.]+?):(?P<container>[\w\s\/\-.]+)(?::(?P<arg>ro|rw|z|Z))?",
@@ -1357,7 +1357,7 @@ class Util:
                 rw_args = match.group("arg")
                 if rw_args:
                     LOG.info("Volume options like :ro or :rw are currently ignored.")
-                mounts.append((host_path, container_path))
+                volumes.append((host_path, container_path))
 
         dns = ensure_list(dns or [])
         if args.dns:
@@ -1370,7 +1370,7 @@ class Util:
             env_vars=env_vars,
             extra_hosts=extra_hosts,
             labels=labels,
-            mounts=mounts,
+            volumes=volumes,
             ports=ports,
             network=network,
             platform=platform,
@@ -1382,7 +1382,7 @@ class Util:
 
     @staticmethod
     def convert_mount_list_to_dict(
-        mount_volumes: Union[List[SimpleVolumeBind], VolumeMappings],
+        volumes: Union[List[SimpleVolumeBind], VolumeMappings],
     ) -> Dict[str, Dict[str, str]]:
         """Converts a List of (host_path, container_path) tuples to a Dict suitable as volume argument for docker sdk"""
 
@@ -1398,7 +1398,7 @@ class Util:
         return dict(
             map(
                 _map_to_dict,
-                mount_volumes,
+                volumes,
             )
         )
 

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -720,7 +720,7 @@ class CmdDockerClient(ContainerClient):
         tty: bool = False,
         detach: bool = False,
         command: Optional[Union[List[str], str]] = None,
-        mount_volumes: Optional[List[SimpleVolumeBind]] = None,
+        volumes: Optional[List[SimpleVolumeBind]] = None,
         ports: Optional[PortMappings] = None,
         exposed_ports: Optional[List[str]] = None,
         env_vars: Optional[Dict[str, str]] = None,
@@ -749,11 +749,9 @@ class CmdDockerClient(ContainerClient):
             cmd += ["--entrypoint", entrypoint]
         if privileged:
             cmd += ["--privileged"]
-        if mount_volumes:
+        if volumes:
             cmd += [
-                volume
-                for mount_volume in mount_volumes
-                for volume in ["-v", self._map_to_volume_param(mount_volume)]
+                param for volume in volumes for param in ["-v", self._map_to_volume_param(volume)]
             ]
         if interactive:
             cmd.append("--interactive")
@@ -809,7 +807,7 @@ class CmdDockerClient(ContainerClient):
         return cmd, env_file
 
     @staticmethod
-    def _map_to_volume_param(mount_volume: Union[SimpleVolumeBind, VolumeBind]) -> str:
+    def _map_to_volume_param(volume: Union[SimpleVolumeBind, VolumeBind]) -> str:
         """
         Maps the mount volume, to a parameter for the -v docker cli argument.
 
@@ -817,13 +815,13 @@ class CmdDockerClient(ContainerClient):
         (host_path, container_path) -> host_path:container_path
         VolumeBind(host_dir=host_path, container_dir=container_path, read_only=True) -> host_path:container_path:ro
 
-        :param mount_volume: Either a SimpleVolumeBind, in essence a tuple (host_dir, container_dir), or a VolumeBind object
+        :param volume: Either a SimpleVolumeBind, in essence a tuple (host_dir, container_dir), or a VolumeBind object
         :return: String which is passable as parameter to the docker cli -v option
         """
-        if isinstance(mount_volume, VolumeBind):
-            return mount_volume.to_str()
+        if isinstance(volume, VolumeBind):
+            return volume.to_str()
         else:
-            return f"{mount_volume[0]}:{mount_volume[1]}"
+            return f"{volume[0]}:{volume[1]}"
 
     def _check_and_raise_no_such_container_error(
         self, container_name_or_id: str, error: subprocess.CalledProcessError

--- a/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
@@ -611,7 +611,7 @@ class SdkDockerClient(ContainerClient):
         tty: bool = False,
         detach: bool = False,
         command: Optional[Union[List[str], str]] = None,
-        mount_volumes: Optional[List[SimpleVolumeBind]] = None,
+        volumes: Optional[List[SimpleVolumeBind]] = None,
         ports: Optional[PortMappings] = None,
         exposed_ports: Optional[List[str]] = None,
         env_vars: Optional[Dict[str, str]] = None,
@@ -636,7 +636,7 @@ class SdkDockerClient(ContainerClient):
             parsed_flags = Util.parse_additional_flags(
                 additional_flags,
                 env_vars=env_vars,
-                mounts=mount_volumes,
+                volumes=volumes,
                 network=network,
                 platform=platform,
                 privileged=privileged,
@@ -647,7 +647,7 @@ class SdkDockerClient(ContainerClient):
             )
             env_vars = parsed_flags.env_vars
             extra_hosts = parsed_flags.extra_hosts
-            mount_volumes = parsed_flags.mounts
+            volumes = parsed_flags.volumes
             labels = parsed_flags.labels
             network = parsed_flags.network
             platform = parsed_flags.platform
@@ -694,8 +694,8 @@ class SdkDockerClient(ContainerClient):
                     for ulimit in ulimits
                 ]
             mounts = None
-            if mount_volumes:
-                mounts = Util.convert_mount_list_to_dict(mount_volumes)
+            if volumes:
+                mounts = Util.convert_mount_list_to_dict(volumes)
 
             def create_container():
                 return self.client().containers.create(
@@ -740,7 +740,7 @@ class SdkDockerClient(ContainerClient):
         tty: bool = False,
         detach: bool = False,
         command: Optional[Union[List[str], str]] = None,
-        mount_volumes: Optional[List[SimpleVolumeBind]] = None,
+        volumes: Optional[List[SimpleVolumeBind]] = None,
         ports: Optional[PortMappings] = None,
         exposed_ports: Optional[List[str]] = None,
         env_vars: Optional[Dict[str, str]] = None,
@@ -771,7 +771,7 @@ class SdkDockerClient(ContainerClient):
                 detach=detach,
                 remove=remove and detach,
                 command=command,
-                mount_volumes=mount_volumes,
+                volumes=volumes,
                 ports=ports,
                 exposed_ports=exposed_ports,
                 env_vars=env_vars,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -220,7 +220,7 @@ class TestCliContainerLifecycle:
             remove=True,
             entrypoint="",
             command=["bin/localstack", "start", "-d"],
-            mount_volumes=[
+            volumes=[
                 ("/var/run/docker.sock", "/var/run/docker.sock"),
                 (MODULE_MAIN_PATH, "/opt/code/localstack/localstack"),
             ],

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -507,12 +507,12 @@ class TestDockerClient:
         condition=in_docker(), reason="cannot test volume mounts from host when in docker"
     )
     def test_create_with_volume(self, tmpdir, docker_client: ContainerClient, create_container):
-        mount_volumes = [(tmpdir.realpath(), "/tmp/mypath")]
+        volumes = [(tmpdir.realpath(), "/tmp/mypath")]
 
         c = create_container(
             "alpine",
             command=["sh", "-c", "echo 'foobar' > /tmp/mypath/foo.log"],
-            mount_volumes=mount_volumes,
+            volumes=volumes,
         )
         docker_client.start_container(c.container_id)
         assert tmpdir.join("foo.log").isfile(), "foo.log was not created in mounted dir"
@@ -524,7 +524,7 @@ class TestDockerClient:
     def test_inspect_container_volumes(
         self, tmpdir, docker_client: ContainerClient, create_container
     ):
-        mount_volumes = [
+        volumes = [
             (tmpdir.realpath() / "foo", "/tmp/mypath/foo"),
             ("some_named_volume", "/tmp/mypath/volume"),
         ]
@@ -532,7 +532,7 @@ class TestDockerClient:
         c = create_container(
             "alpine",
             command=["sh", "-c", "while true; do sleep 1; done"],
-            mount_volumes=mount_volumes,
+            volumes=volumes,
         )
         docker_client.start_container(c.container_id)
 

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -105,7 +105,7 @@ class TestArgumentParsing:
         flags = Util.parse_additional_flags(
             argument_string,
             env_vars=env_vars,
-            mounts=mounts,
+            volumes=mounts,
             network=network,
             platform=platform,
             privileged=privileged,
@@ -130,7 +130,7 @@ class TestArgumentParsing:
             "--add-host host.docker.internal:host-gateway --add-host arbitrary.host:127.0.0.1"
         )
         flags = Util.parse_additional_flags(
-            argument_string, env_vars=env_vars, ports=ports, mounts=mounts
+            argument_string, env_vars=env_vars, ports=ports, volumes=mounts
         )
         assert {
             "host.docker.internal": "host-gateway",
@@ -151,10 +151,10 @@ class TestArgumentParsing:
     def test_file_paths(self):
         argument_string = r'-v "/tmp/test.jar:/tmp/foo bar/test.jar"'
         flags = Util.parse_additional_flags(argument_string)
-        assert flags.mounts == [(r"/tmp/test.jar", "/tmp/foo bar/test.jar")]
+        assert flags.volumes == [(r"/tmp/test.jar", "/tmp/foo bar/test.jar")]
         argument_string = r'-v "/tmp/test-foo_bar.jar:/tmp/test-foo_bar2.jar"'
         flags = Util.parse_additional_flags(argument_string)
-        assert flags.mounts == [(r"/tmp/test-foo_bar.jar", "/tmp/test-foo_bar2.jar")]
+        assert flags.volumes == [(r"/tmp/test-foo_bar.jar", "/tmp/test-foo_bar2.jar")]
 
     def test_labels(self):
         argument_string = r"--label foo=bar.123"
@@ -220,16 +220,16 @@ class TestArgumentParsing:
     def test_windows_paths(self):
         argument_string = r'-v "C:\Users\SomeUser\SomePath:/var/task"'
         flags = Util.parse_additional_flags(argument_string)
-        assert flags.mounts == [(r"C:\Users\SomeUser\SomePath", "/var/task")]
+        assert flags.volumes == [(r"C:\Users\SomeUser\SomePath", "/var/task")]
         argument_string = r'-v "C:\Users\SomeUser\SomePath:/var/task:ro"'
         flags = Util.parse_additional_flags(argument_string)
-        assert flags.mounts == [(r"C:\Users\SomeUser\SomePath", "/var/task")]
+        assert flags.volumes == [(r"C:\Users\SomeUser\SomePath", "/var/task")]
         argument_string = r'-v "C:\Users\Some User\Some Path:/var/task:ro"'
         flags = Util.parse_additional_flags(argument_string)
-        assert flags.mounts == [(r"C:\Users\Some User\Some Path", "/var/task")]
+        assert flags.volumes == [(r"C:\Users\Some User\Some Path", "/var/task")]
         argument_string = r'-v "/var/test:/var/task:ro"'
         flags = Util.parse_additional_flags(argument_string)
-        assert flags.mounts == [("/var/test", "/var/task")]
+        assert flags.volumes == [("/var/test", "/var/task")]
 
     def test_random_ports(self):
         argument_string = r"-p 0:80"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Our current usage of bind mounts in docker utilizes the docker `volumes` API. However, this API has been superceded by the `mounts` API.
There was also one, so far unsuccessful, try to use `mounts` for everything in LocalStack, with #9887.

There are some drawbacks when using the mounts API for bind mounts, for example the fact that the host path is not automatically created.
However, it would also achieve many advantages, like being able to mount subpaths of named volumes into containers.

To prepare for the future use of mounts, for now in addition to volumes, this PR renames all current occurrences of `mounts` or `mount_volumes` to `volumes`, to make the differenciation clearer.
We can then start to implement the mounts API in the docker client, and step by step migrate usages of `volumes` to `mounts` - where possible, as well as enable new usecases, like using a named volume as mount point for `/var/lib/localstack`, or adding `tmpfs` file systems to compute containers.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* No userfacing changes
* Rename all occurrences of `mounts` or `mount_volumes` when using the docker client to `volumes`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
