### PR TITLE
fix coverage drops by skipping report step for `acceptance-only-run`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,9 +643,7 @@ jobs:
       - run:
           name: Upload test metrics and implemented coverage data to tinybird
           command: |
-            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
-              echo "Skipping parity reporting to tinybird because only acceptance tests ran"
-            elif [ -z "$CIRCLE_PR_REPONAME" ]  ; then
+            if [ -z "$CIRCLE_PR_REPONAME" ]  ; then
               # check if a fork-only env var is set (https://circleci.com/docs/variables/)
               source .venv/bin/activate
               mkdir parity_metrics && mv target/metric_reports/metric-report-raw-data-*amd64*.csv parity_metrics
@@ -668,16 +666,12 @@ jobs:
           #    2: the changes worsened the overall coverage
           #    3: the changes introduced uncovered statements but the overall coverage is still better than before
           command: |
-            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
-              echo "Skipping coverage diff because only acceptance tests ran"
-            else
-              source .venv/bin/activate
-              pip install pycobertura
-              coverage xml --data-file=.coverage -o all.coverage.report.xml --include="localstack-core/localstack/services/*/**" --omit="*/**/__init__.py"
-              coverage xml --data-file=.coverage.acceptance -o acceptance.coverage.report.xml --include="localstack-core/localstack/services/*/**"  --omit="*/**/__init__.py"
-              pycobertura show --format html -s localstack-core/localstack acceptance.coverage.report.xml -o coverage-acceptance.html
-              bash -c "pycobertura diff --format html -s1 localstack-core/localstack/ -s2 localstack-core/localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html; if [[ \$? -eq 1 ]] ; then exit 1 ; else exit 0 ; fi"
-            fi
+            source .venv/bin/activate
+            pip install pycobertura
+            coverage xml --data-file=.coverage -o all.coverage.report.xml --include="localstack-core/localstack/services/*/**" --omit="*/**/__init__.py"
+            coverage xml --data-file=.coverage.acceptance -o acceptance.coverage.report.xml --include="localstack-core/localstack/services/*/**"  --omit="*/**/__init__.py"
+            pycobertura show --format html -s localstack-core/localstack acceptance.coverage.report.xml -o coverage-acceptance.html
+            bash -c "pycobertura diff --format html -s1 localstack-core/localstack/ -s2 localstack-core/localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html; if [[ \$? -eq 1 ]] ; then exit 1 ; else exit 0 ; fi"
       - run:
           name: Create Metric Coverage Diff (API Coverage)
           environment:
@@ -685,13 +679,9 @@ jobs:
             COVERAGE_DIR_ACCEPTANCE: "acceptance_parity_metrics"
             OUTPUT_DIR: "api-coverage"
           command: |
-            if [[ $ONLY_ACCEPTANCE_TESTS == "true" ]]; then
-              echo "Skipping metric coverage diff because only acceptance tests ran"
-            else
-              source .venv/bin/activate
-              mkdir api-coverage
-              python -m scripts.metrics_coverage.diff_metrics_coverage
-            fi
+            source .venv/bin/activate
+            mkdir api-coverage
+            python -m scripts.metrics_coverage.diff_metrics_coverage
       - store_artifacts:
           path: api-coverage/
       - store_artifacts:
@@ -877,11 +867,6 @@ workflows:
           resource_class: medium
           requires:
             - docker-build-amd64
-      - report:
-          requires:
-            - acceptance-tests-amd64
-            - acceptance-tests-arm64
-            - unit-tests
       - push:
           filters:
             branches:


### PR DESCRIPTION
## Motivation
Since #11049 by default we only run the acceptance tests for commits on `master`.
While this PR skips pushing test results to our internal test analytics, it still pushes the coverage data, [which leads to the coverage metrics jumping between 47% (acceptance tests only) and 84% (full test suite)](https://coveralls.io/github/localstack/localstack).
![image](https://github.com/localstack/localstack/assets/2796604/bac208b4-396c-443c-997a-516c0f99ffe6)

## Changes
- Avoids the report step completely for the `acceptance-only-run` workflow in CircleCI.