### PR TITLE
update coverage config, remove obsolete dev run configurator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -670,8 +670,8 @@ jobs:
             pip install pycobertura
             coverage xml --data-file=.coverage -o all.coverage.report.xml --include="localstack-core/localstack/services/*/**" --omit="*/**/__init__.py"
             coverage xml --data-file=.coverage.acceptance -o acceptance.coverage.report.xml --include="localstack-core/localstack/services/*/**"  --omit="*/**/__init__.py"
-            pycobertura show --format html -s localstack-core/localstack acceptance.coverage.report.xml -o coverage-acceptance.html
-            bash -c "pycobertura diff --format html -s1 localstack-core/localstack/ -s2 localstack-core/localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html; if [[ \$? -eq 1 ]] ; then exit 1 ; else exit 0 ; fi"
+            pycobertura show --format html acceptance.coverage.report.xml -o coverage-acceptance.html
+            bash -c "pycobertura diff --format html all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html; if [[ \$? -eq 1 ]] ; then exit 1 ; else exit 0 ; fi"
       - run:
           name: Create Metric Coverage Diff (API Coverage)
           environment:

--- a/localstack-core/localstack/dev/run/__main__.py
+++ b/localstack-core/localstack/dev/run/__main__.py
@@ -21,7 +21,6 @@ from localstack.utils.strings import short_uid
 
 from .configurators import (
     ConfigEnvironmentConfigurator,
-    CoverageRunScriptConfigurator,
     DependencyMountConfigurator,
     EntryPointMountConfigurator,
     ImageConfigurator,
@@ -265,7 +264,6 @@ def run(
             PortConfigurator(randomize),
             ConfigEnvironmentConfigurator(pro),
             ContainerConfigurators.mount_localstack_volume(host_paths.volume_dir),
-            CoverageRunScriptConfigurator(host_paths=host_paths),
             ContainerConfigurators.config_env_vars,
         ]
 

--- a/localstack-core/localstack/dev/run/configurators.py
+++ b/localstack-core/localstack/dev/run/configurators.py
@@ -185,29 +185,6 @@ class SourceVolumeMountConfigurator:
             )
 
 
-class CoverageRunScriptConfigurator:
-    """
-    Adds the coverage-run.py script as read-only volume mount into /opt/code/localstack/bin/coverage-run.py
-    """
-
-    def __init__(self, *, host_paths: HostPaths = None):
-        self.host_paths = host_paths or HostPaths()
-        self.container_paths = ProContainerPaths()
-
-    def __call__(self, cfg: ContainerConfiguration):
-        # coverage script
-        source = self.host_paths.localstack_ext_project_dir / "bin" / "coverage-run.py"
-        target = f"{self.container_paths.project_dir}/bin/coverage-run.py"
-        if source.exists():
-            cfg.volumes.add(VolumeBind(str(source), target, read_only=True))
-
-        # and add the pyproject toml since it contains the coverage config
-        source = self.host_paths.localstack_ext_project_dir / "pyproject.toml"
-        target = f"{self.container_paths.project_dir}/pyproject.toml"
-        if source.exists():
-            cfg.volumes.add(VolumeBind(str(source), target, read_only=True))
-
-
 class EntryPointMountConfigurator:
     """
     Mounts ``entry_points.txt`` files of localstack and dependencies into the venv in the container.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,14 +207,19 @@ select = ["B", "C", "E", "F", "I", "W", "T", "B9"]
 [tool.coverage.run]
 relative_files = true
 source = [
-    "localstack-core/localstack"
+    "localstack",
 ]
 omit = [
-    "localstack-core/localstack/aws/api/*",
-    "localstack-core/localstack/extensions/api/*",
-    "localstack-core/localstack/services/stepfunctions/asl/antlr/runtime/*"
+    "*/aws/api/*",
+    "*/extensions/api/*",
+    "*/services/stepfunctions/asl/antlr/runtime/*"
 ]
 dynamic_context = "test_function"
+
+[tool.coverage.paths]
+source = [
+    "localstack-core"
+]
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
## Motivation
This PR serves two purposes. It (a) adjusts the coverage config a bit such that the package path and the source config are properly separated, and (b) removes an obsolete coverage-related dev container config which is not used anymore.

## Changes
- Removes the `CoverageRunScriptConfigurator` since the `run-coverage.py` is not used anymore.
- Slightly changes the `pyproject.toml` to properly separate between the configuration of the sources and the package lookup config.

## TODO
- [ ] Wait for the removal of the usage of `run-coverage.py` in our downstream dependency.