### PR TITLE
Use `StrEnums` instead of `str` for generated constant classes in the ASF APIs

### DIFF
--- a/localstack-core/localstack/aws/api/acm/__init__.py
+++ b/localstack-core/localstack/aws/api/acm/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -22,7 +23,7 @@ TagValue = str
 ValidationExceptionMessage = str
 
 
-class CertificateStatus(str):
+class CertificateStatus(StrEnum):
     PENDING_VALIDATION = "PENDING_VALIDATION"
     ISSUED = "ISSUED"
     INACTIVE = "INACTIVE"
@@ -32,24 +33,24 @@ class CertificateStatus(str):
     FAILED = "FAILED"
 
 
-class CertificateTransparencyLoggingPreference(str):
+class CertificateTransparencyLoggingPreference(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
 
 
-class CertificateType(str):
+class CertificateType(StrEnum):
     IMPORTED = "IMPORTED"
     AMAZON_ISSUED = "AMAZON_ISSUED"
     PRIVATE = "PRIVATE"
 
 
-class DomainStatus(str):
+class DomainStatus(StrEnum):
     PENDING_VALIDATION = "PENDING_VALIDATION"
     SUCCESS = "SUCCESS"
     FAILED = "FAILED"
 
 
-class ExtendedKeyUsageName(str):
+class ExtendedKeyUsageName(StrEnum):
     TLS_WEB_SERVER_AUTHENTICATION = "TLS_WEB_SERVER_AUTHENTICATION"
     TLS_WEB_CLIENT_AUTHENTICATION = "TLS_WEB_CLIENT_AUTHENTICATION"
     CODE_SIGNING = "CODE_SIGNING"
@@ -64,7 +65,7 @@ class ExtendedKeyUsageName(str):
     CUSTOM = "CUSTOM"
 
 
-class FailureReason(str):
+class FailureReason(StrEnum):
     NO_AVAILABLE_CONTACTS = "NO_AVAILABLE_CONTACTS"
     ADDITIONAL_VERIFICATION_REQUIRED = "ADDITIONAL_VERIFICATION_REQUIRED"
     DOMAIN_NOT_ALLOWED = "DOMAIN_NOT_ALLOWED"
@@ -84,7 +85,7 @@ class FailureReason(str):
     OTHER = "OTHER"
 
 
-class KeyAlgorithm(str):
+class KeyAlgorithm(StrEnum):
     RSA_1024 = "RSA_1024"
     RSA_2048 = "RSA_2048"
     RSA_3072 = "RSA_3072"
@@ -94,7 +95,7 @@ class KeyAlgorithm(str):
     EC_secp521r1 = "EC_secp521r1"
 
 
-class KeyUsageName(str):
+class KeyUsageName(StrEnum):
     DIGITAL_SIGNATURE = "DIGITAL_SIGNATURE"
     NON_REPUDIATION = "NON_REPUDIATION"
     KEY_ENCIPHERMENT = "KEY_ENCIPHERMENT"
@@ -108,23 +109,23 @@ class KeyUsageName(str):
     CUSTOM = "CUSTOM"
 
 
-class RecordType(str):
+class RecordType(StrEnum):
     CNAME = "CNAME"
 
 
-class RenewalEligibility(str):
+class RenewalEligibility(StrEnum):
     ELIGIBLE = "ELIGIBLE"
     INELIGIBLE = "INELIGIBLE"
 
 
-class RenewalStatus(str):
+class RenewalStatus(StrEnum):
     PENDING_AUTO_RENEWAL = "PENDING_AUTO_RENEWAL"
     PENDING_VALIDATION = "PENDING_VALIDATION"
     SUCCESS = "SUCCESS"
     FAILED = "FAILED"
 
 
-class RevocationReason(str):
+class RevocationReason(StrEnum):
     UNSPECIFIED = "UNSPECIFIED"
     KEY_COMPROMISE = "KEY_COMPROMISE"
     CA_COMPROMISE = "CA_COMPROMISE"
@@ -137,16 +138,16 @@ class RevocationReason(str):
     A_A_COMPROMISE = "A_A_COMPROMISE"
 
 
-class SortBy(str):
+class SortBy(StrEnum):
     CREATED_AT = "CREATED_AT"
 
 
-class SortOrder(str):
+class SortOrder(StrEnum):
     ASCENDING = "ASCENDING"
     DESCENDING = "DESCENDING"
 
 
-class ValidationMethod(str):
+class ValidationMethod(StrEnum):
     EMAIL = "EMAIL"
     DNS = "DNS"
 

--- a/localstack-core/localstack/aws/api/apigateway/__init__.py
+++ b/localstack-core/localstack/aws/api/apigateway/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import IO, Dict, Iterable, List, Optional, TypedDict, Union
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -14,22 +15,22 @@ StatusCode = str
 String = str
 
 
-class ApiKeySourceType(str):
+class ApiKeySourceType(StrEnum):
     HEADER = "HEADER"
     AUTHORIZER = "AUTHORIZER"
 
 
-class ApiKeysFormat(str):
+class ApiKeysFormat(StrEnum):
     csv = "csv"
 
 
-class AuthorizerType(str):
+class AuthorizerType(StrEnum):
     TOKEN = "TOKEN"
     REQUEST = "REQUEST"
     COGNITO_USER_POOLS = "COGNITO_USER_POOLS"
 
 
-class CacheClusterSize(str):
+class CacheClusterSize(StrEnum):
     i_0_5 = "0.5"
     i_1_6 = "1.6"
     i_6_1 = "6.1"
@@ -40,7 +41,7 @@ class CacheClusterSize(str):
     i_237 = "237"
 
 
-class CacheClusterStatus(str):
+class CacheClusterStatus(StrEnum):
     CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
     AVAILABLE = "AVAILABLE"
     DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS"
@@ -48,17 +49,17 @@ class CacheClusterStatus(str):
     FLUSH_IN_PROGRESS = "FLUSH_IN_PROGRESS"
 
 
-class ConnectionType(str):
+class ConnectionType(StrEnum):
     INTERNET = "INTERNET"
     VPC_LINK = "VPC_LINK"
 
 
-class ContentHandlingStrategy(str):
+class ContentHandlingStrategy(StrEnum):
     CONVERT_TO_BINARY = "CONVERT_TO_BINARY"
     CONVERT_TO_TEXT = "CONVERT_TO_TEXT"
 
 
-class DocumentationPartType(str):
+class DocumentationPartType(StrEnum):
     API = "API"
     AUTHORIZER = "AUTHORIZER"
     MODEL = "MODEL"
@@ -73,7 +74,7 @@ class DocumentationPartType(str):
     RESPONSE_BODY = "RESPONSE_BODY"
 
 
-class DomainNameStatus(str):
+class DomainNameStatus(StrEnum):
     AVAILABLE = "AVAILABLE"
     UPDATING = "UPDATING"
     PENDING = "PENDING"
@@ -81,13 +82,13 @@ class DomainNameStatus(str):
     PENDING_OWNERSHIP_VERIFICATION = "PENDING_OWNERSHIP_VERIFICATION"
 
 
-class EndpointType(str):
+class EndpointType(StrEnum):
     REGIONAL = "REGIONAL"
     EDGE = "EDGE"
     PRIVATE = "PRIVATE"
 
 
-class GatewayResponseType(str):
+class GatewayResponseType(StrEnum):
     DEFAULT_4XX = "DEFAULT_4XX"
     DEFAULT_5XX = "DEFAULT_5XX"
     RESOURCE_NOT_FOUND = "RESOURCE_NOT_FOUND"
@@ -111,7 +112,7 @@ class GatewayResponseType(str):
     WAF_FILTERED = "WAF_FILTERED"
 
 
-class IntegrationType(str):
+class IntegrationType(StrEnum):
     HTTP = "HTTP"
     AWS = "AWS"
     MOCK = "MOCK"
@@ -119,12 +120,12 @@ class IntegrationType(str):
     AWS_PROXY = "AWS_PROXY"
 
 
-class LocationStatusType(str):
+class LocationStatusType(StrEnum):
     DOCUMENTED = "DOCUMENTED"
     UNDOCUMENTED = "UNDOCUMENTED"
 
 
-class Op(str):
+class Op(StrEnum):
     add = "add"
     remove = "remove"
     replace = "replace"
@@ -133,29 +134,29 @@ class Op(str):
     test = "test"
 
 
-class PutMode(str):
+class PutMode(StrEnum):
     merge = "merge"
     overwrite = "overwrite"
 
 
-class QuotaPeriodType(str):
+class QuotaPeriodType(StrEnum):
     DAY = "DAY"
     WEEK = "WEEK"
     MONTH = "MONTH"
 
 
-class SecurityPolicy(str):
+class SecurityPolicy(StrEnum):
     TLS_1_0 = "TLS_1_0"
     TLS_1_2 = "TLS_1_2"
 
 
-class UnauthorizedCacheControlHeaderStrategy(str):
+class UnauthorizedCacheControlHeaderStrategy(StrEnum):
     FAIL_WITH_403 = "FAIL_WITH_403"
     SUCCEED_WITH_RESPONSE_HEADER = "SUCCEED_WITH_RESPONSE_HEADER"
     SUCCEED_WITHOUT_RESPONSE_HEADER = "SUCCEED_WITHOUT_RESPONSE_HEADER"
 
 
-class VpcLinkStatus(str):
+class VpcLinkStatus(StrEnum):
     AVAILABLE = "AVAILABLE"
     PENDING = "PENDING"
     DELETING = "DELETING"

--- a/localstack-core/localstack/aws/api/cloudcontrol/__init__.py
+++ b/localstack-core/localstack/aws/api/cloudcontrol/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -18,7 +19,7 @@ TypeName = str
 TypeVersionId = str
 
 
-class HandlerErrorCode(str):
+class HandlerErrorCode(StrEnum):
     NotUpdatable = "NotUpdatable"
     InvalidRequest = "InvalidRequest"
     AccessDenied = "AccessDenied"
@@ -36,13 +37,13 @@ class HandlerErrorCode(str):
     InternalFailure = "InternalFailure"
 
 
-class Operation(str):
+class Operation(StrEnum):
     CREATE = "CREATE"
     DELETE = "DELETE"
     UPDATE = "UPDATE"
 
 
-class OperationStatus(str):
+class OperationStatus(StrEnum):
     PENDING = "PENDING"
     IN_PROGRESS = "IN_PROGRESS"
     SUCCESS = "SUCCESS"

--- a/localstack-core/localstack/aws/api/cloudformation/__init__.py
+++ b/localstack-core/localstack/aws/api/cloudformation/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -179,44 +180,44 @@ Value = str
 Version = str
 
 
-class AccountFilterType(str):
+class AccountFilterType(StrEnum):
     NONE = "NONE"
     INTERSECTION = "INTERSECTION"
     DIFFERENCE = "DIFFERENCE"
     UNION = "UNION"
 
 
-class AccountGateStatus(str):
+class AccountGateStatus(StrEnum):
     SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"
     SKIPPED = "SKIPPED"
 
 
-class AttributeChangeType(str):
+class AttributeChangeType(StrEnum):
     Add = "Add"
     Remove = "Remove"
     Modify = "Modify"
 
 
-class CallAs(str):
+class CallAs(StrEnum):
     SELF = "SELF"
     DELEGATED_ADMIN = "DELEGATED_ADMIN"
 
 
-class Capability(str):
+class Capability(StrEnum):
     CAPABILITY_IAM = "CAPABILITY_IAM"
     CAPABILITY_NAMED_IAM = "CAPABILITY_NAMED_IAM"
     CAPABILITY_AUTO_EXPAND = "CAPABILITY_AUTO_EXPAND"
 
 
-class Category(str):
+class Category(StrEnum):
     REGISTERED = "REGISTERED"
     ACTIVATED = "ACTIVATED"
     THIRD_PARTY = "THIRD_PARTY"
     AWS_TYPES = "AWS_TYPES"
 
 
-class ChangeAction(str):
+class ChangeAction(StrEnum):
     Add = "Add"
     Modify = "Modify"
     Remove = "Remove"
@@ -224,13 +225,13 @@ class ChangeAction(str):
     Dynamic = "Dynamic"
 
 
-class ChangeSetHooksStatus(str):
+class ChangeSetHooksStatus(StrEnum):
     PLANNING = "PLANNING"
     PLANNED = "PLANNED"
     UNAVAILABLE = "UNAVAILABLE"
 
 
-class ChangeSetStatus(str):
+class ChangeSetStatus(StrEnum):
     CREATE_PENDING = "CREATE_PENDING"
     CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
     CREATE_COMPLETE = "CREATE_COMPLETE"
@@ -241,13 +242,13 @@ class ChangeSetStatus(str):
     FAILED = "FAILED"
 
 
-class ChangeSetType(str):
+class ChangeSetType(StrEnum):
     CREATE = "CREATE"
     UPDATE = "UPDATE"
     IMPORT = "IMPORT"
 
 
-class ChangeSource(str):
+class ChangeSource(StrEnum):
     ResourceReference = "ResourceReference"
     ParameterReference = "ParameterReference"
     ResourceAttribute = "ResourceAttribute"
@@ -255,42 +256,42 @@ class ChangeSource(str):
     Automatic = "Automatic"
 
 
-class ChangeType(str):
+class ChangeType(StrEnum):
     Resource = "Resource"
 
 
-class ConcurrencyMode(str):
+class ConcurrencyMode(StrEnum):
     STRICT_FAILURE_TOLERANCE = "STRICT_FAILURE_TOLERANCE"
     SOFT_FAILURE_TOLERANCE = "SOFT_FAILURE_TOLERANCE"
 
 
-class DeletionMode(str):
+class DeletionMode(StrEnum):
     STANDARD = "STANDARD"
     FORCE_DELETE_STACK = "FORCE_DELETE_STACK"
 
 
-class DeprecatedStatus(str):
+class DeprecatedStatus(StrEnum):
     LIVE = "LIVE"
     DEPRECATED = "DEPRECATED"
 
 
-class DetailedStatus(str):
+class DetailedStatus(StrEnum):
     CONFIGURATION_COMPLETE = "CONFIGURATION_COMPLETE"
     VALIDATION_FAILED = "VALIDATION_FAILED"
 
 
-class DifferenceType(str):
+class DifferenceType(StrEnum):
     ADD = "ADD"
     REMOVE = "REMOVE"
     NOT_EQUAL = "NOT_EQUAL"
 
 
-class EvaluationType(str):
+class EvaluationType(StrEnum):
     Static = "Static"
     Dynamic = "Dynamic"
 
 
-class ExecutionStatus(str):
+class ExecutionStatus(StrEnum):
     UNAVAILABLE = "UNAVAILABLE"
     AVAILABLE = "AVAILABLE"
     EXECUTE_IN_PROGRESS = "EXECUTE_IN_PROGRESS"
@@ -299,19 +300,19 @@ class ExecutionStatus(str):
     OBSOLETE = "OBSOLETE"
 
 
-class GeneratedTemplateDeletionPolicy(str):
+class GeneratedTemplateDeletionPolicy(StrEnum):
     DELETE = "DELETE"
     RETAIN = "RETAIN"
 
 
-class GeneratedTemplateResourceStatus(str):
+class GeneratedTemplateResourceStatus(StrEnum):
     PENDING = "PENDING"
     IN_PROGRESS = "IN_PROGRESS"
     FAILED = "FAILED"
     COMPLETE = "COMPLETE"
 
 
-class GeneratedTemplateStatus(str):
+class GeneratedTemplateStatus(StrEnum):
     CREATE_PENDING = "CREATE_PENDING"
     UPDATE_PENDING = "UPDATE_PENDING"
     DELETE_PENDING = "DELETE_PENDING"
@@ -322,12 +323,12 @@ class GeneratedTemplateStatus(str):
     COMPLETE = "COMPLETE"
 
 
-class GeneratedTemplateUpdateReplacePolicy(str):
+class GeneratedTemplateUpdateReplacePolicy(StrEnum):
     DELETE = "DELETE"
     RETAIN = "RETAIN"
 
 
-class HandlerErrorCode(str):
+class HandlerErrorCode(StrEnum):
     NotUpdatable = "NotUpdatable"
     InvalidRequest = "InvalidRequest"
     AccessDenied = "AccessDenied"
@@ -349,67 +350,67 @@ class HandlerErrorCode(str):
     UnsupportedTarget = "UnsupportedTarget"
 
 
-class HookFailureMode(str):
+class HookFailureMode(StrEnum):
     FAIL = "FAIL"
     WARN = "WARN"
 
 
-class HookInvocationPoint(str):
+class HookInvocationPoint(StrEnum):
     PRE_PROVISION = "PRE_PROVISION"
 
 
-class HookStatus(str):
+class HookStatus(StrEnum):
     HOOK_IN_PROGRESS = "HOOK_IN_PROGRESS"
     HOOK_COMPLETE_SUCCEEDED = "HOOK_COMPLETE_SUCCEEDED"
     HOOK_COMPLETE_FAILED = "HOOK_COMPLETE_FAILED"
     HOOK_FAILED = "HOOK_FAILED"
 
 
-class HookTargetType(str):
+class HookTargetType(StrEnum):
     RESOURCE = "RESOURCE"
 
 
-class IdentityProvider(str):
+class IdentityProvider(StrEnum):
     AWS_Marketplace = "AWS_Marketplace"
     GitHub = "GitHub"
     Bitbucket = "Bitbucket"
 
 
-class OnFailure(str):
+class OnFailure(StrEnum):
     DO_NOTHING = "DO_NOTHING"
     ROLLBACK = "ROLLBACK"
     DELETE = "DELETE"
 
 
-class OnStackFailure(str):
+class OnStackFailure(StrEnum):
     DO_NOTHING = "DO_NOTHING"
     ROLLBACK = "ROLLBACK"
     DELETE = "DELETE"
 
 
-class OperationResultFilterName(str):
+class OperationResultFilterName(StrEnum):
     OPERATION_RESULT_STATUS = "OPERATION_RESULT_STATUS"
 
 
-class OperationStatus(str):
+class OperationStatus(StrEnum):
     PENDING = "PENDING"
     IN_PROGRESS = "IN_PROGRESS"
     SUCCESS = "SUCCESS"
     FAILED = "FAILED"
 
 
-class OrganizationStatus(str):
+class OrganizationStatus(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
     DISABLED_PERMANENTLY = "DISABLED_PERMANENTLY"
 
 
-class PermissionModels(str):
+class PermissionModels(StrEnum):
     SERVICE_MANAGED = "SERVICE_MANAGED"
     SELF_MANAGED = "SELF_MANAGED"
 
 
-class PolicyAction(str):
+class PolicyAction(StrEnum):
     Delete = "Delete"
     Retain = "Retain"
     Snapshot = "Snapshot"
@@ -418,47 +419,47 @@ class PolicyAction(str):
     ReplaceAndSnapshot = "ReplaceAndSnapshot"
 
 
-class ProvisioningType(str):
+class ProvisioningType(StrEnum):
     NON_PROVISIONABLE = "NON_PROVISIONABLE"
     IMMUTABLE = "IMMUTABLE"
     FULLY_MUTABLE = "FULLY_MUTABLE"
 
 
-class PublisherStatus(str):
+class PublisherStatus(StrEnum):
     VERIFIED = "VERIFIED"
     UNVERIFIED = "UNVERIFIED"
 
 
-class RegionConcurrencyType(str):
+class RegionConcurrencyType(StrEnum):
     SEQUENTIAL = "SEQUENTIAL"
     PARALLEL = "PARALLEL"
 
 
-class RegistrationStatus(str):
+class RegistrationStatus(StrEnum):
     COMPLETE = "COMPLETE"
     IN_PROGRESS = "IN_PROGRESS"
     FAILED = "FAILED"
 
 
-class RegistryType(str):
+class RegistryType(StrEnum):
     RESOURCE = "RESOURCE"
     MODULE = "MODULE"
     HOOK = "HOOK"
 
 
-class Replacement(str):
+class Replacement(StrEnum):
     True_ = "True"
     False_ = "False"
     Conditional = "Conditional"
 
 
-class RequiresRecreation(str):
+class RequiresRecreation(StrEnum):
     Never = "Never"
     Conditionally = "Conditionally"
     Always = "Always"
 
 
-class ResourceAttribute(str):
+class ResourceAttribute(StrEnum):
     Properties = "Properties"
     Metadata = "Metadata"
     CreationPolicy = "CreationPolicy"
@@ -468,19 +469,19 @@ class ResourceAttribute(str):
     Tags = "Tags"
 
 
-class ResourceScanStatus(str):
+class ResourceScanStatus(StrEnum):
     IN_PROGRESS = "IN_PROGRESS"
     FAILED = "FAILED"
     COMPLETE = "COMPLETE"
     EXPIRED = "EXPIRED"
 
 
-class ResourceSignalStatus(str):
+class ResourceSignalStatus(StrEnum):
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
 
 
-class ResourceStatus(str):
+class ResourceStatus(StrEnum):
     CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
     CREATE_FAILED = "CREATE_FAILED"
     CREATE_COMPLETE = "CREATE_COMPLETE"
@@ -505,20 +506,20 @@ class ResourceStatus(str):
     ROLLBACK_FAILED = "ROLLBACK_FAILED"
 
 
-class StackDriftDetectionStatus(str):
+class StackDriftDetectionStatus(StrEnum):
     DETECTION_IN_PROGRESS = "DETECTION_IN_PROGRESS"
     DETECTION_FAILED = "DETECTION_FAILED"
     DETECTION_COMPLETE = "DETECTION_COMPLETE"
 
 
-class StackDriftStatus(str):
+class StackDriftStatus(StrEnum):
     DRIFTED = "DRIFTED"
     IN_SYNC = "IN_SYNC"
     UNKNOWN = "UNKNOWN"
     NOT_CHECKED = "NOT_CHECKED"
 
 
-class StackInstanceDetailedStatus(str):
+class StackInstanceDetailedStatus(StrEnum):
     PENDING = "PENDING"
     RUNNING = "RUNNING"
     SUCCEEDED = "SUCCEEDED"
@@ -529,26 +530,26 @@ class StackInstanceDetailedStatus(str):
     FAILED_IMPORT = "FAILED_IMPORT"
 
 
-class StackInstanceFilterName(str):
+class StackInstanceFilterName(StrEnum):
     DETAILED_STATUS = "DETAILED_STATUS"
     LAST_OPERATION_ID = "LAST_OPERATION_ID"
     DRIFT_STATUS = "DRIFT_STATUS"
 
 
-class StackInstanceStatus(str):
+class StackInstanceStatus(StrEnum):
     CURRENT = "CURRENT"
     OUTDATED = "OUTDATED"
     INOPERABLE = "INOPERABLE"
 
 
-class StackResourceDriftStatus(str):
+class StackResourceDriftStatus(StrEnum):
     IN_SYNC = "IN_SYNC"
     MODIFIED = "MODIFIED"
     DELETED = "DELETED"
     NOT_CHECKED = "NOT_CHECKED"
 
 
-class StackSetDriftDetectionStatus(str):
+class StackSetDriftDetectionStatus(StrEnum):
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
     PARTIAL_SUCCESS = "PARTIAL_SUCCESS"
@@ -556,20 +557,20 @@ class StackSetDriftDetectionStatus(str):
     STOPPED = "STOPPED"
 
 
-class StackSetDriftStatus(str):
+class StackSetDriftStatus(StrEnum):
     DRIFTED = "DRIFTED"
     IN_SYNC = "IN_SYNC"
     NOT_CHECKED = "NOT_CHECKED"
 
 
-class StackSetOperationAction(str):
+class StackSetOperationAction(StrEnum):
     CREATE = "CREATE"
     UPDATE = "UPDATE"
     DELETE = "DELETE"
     DETECT_DRIFT = "DETECT_DRIFT"
 
 
-class StackSetOperationResultStatus(str):
+class StackSetOperationResultStatus(StrEnum):
     PENDING = "PENDING"
     RUNNING = "RUNNING"
     SUCCEEDED = "SUCCEEDED"
@@ -577,7 +578,7 @@ class StackSetOperationResultStatus(str):
     CANCELLED = "CANCELLED"
 
 
-class StackSetOperationStatus(str):
+class StackSetOperationStatus(StrEnum):
     RUNNING = "RUNNING"
     SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"
@@ -586,12 +587,12 @@ class StackSetOperationStatus(str):
     QUEUED = "QUEUED"
 
 
-class StackSetStatus(str):
+class StackSetStatus(StrEnum):
     ACTIVE = "ACTIVE"
     DELETED = "DELETED"
 
 
-class StackStatus(str):
+class StackStatus(StrEnum):
     CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
     CREATE_FAILED = "CREATE_FAILED"
     CREATE_COMPLETE = "CREATE_COMPLETE"
@@ -617,40 +618,40 @@ class StackStatus(str):
     IMPORT_ROLLBACK_COMPLETE = "IMPORT_ROLLBACK_COMPLETE"
 
 
-class TemplateFormat(str):
+class TemplateFormat(StrEnum):
     JSON = "JSON"
     YAML = "YAML"
 
 
-class TemplateStage(str):
+class TemplateStage(StrEnum):
     Original = "Original"
     Processed = "Processed"
 
 
-class ThirdPartyType(str):
+class ThirdPartyType(StrEnum):
     RESOURCE = "RESOURCE"
     MODULE = "MODULE"
     HOOK = "HOOK"
 
 
-class TypeTestsStatus(str):
+class TypeTestsStatus(StrEnum):
     PASSED = "PASSED"
     FAILED = "FAILED"
     IN_PROGRESS = "IN_PROGRESS"
     NOT_TESTED = "NOT_TESTED"
 
 
-class VersionBump(str):
+class VersionBump(StrEnum):
     MAJOR = "MAJOR"
     MINOR = "MINOR"
 
 
-class Visibility(str):
+class Visibility(StrEnum):
     PUBLIC = "PUBLIC"
     PRIVATE = "PRIVATE"
 
 
-class WarningType(str):
+class WarningType(StrEnum):
     MUTUALLY_EXCLUSIVE_PROPERTIES = "MUTUALLY_EXCLUSIVE_PROPERTIES"
     UNSUPPORTED_PROPERTIES = "UNSUPPORTED_PROPERTIES"
     MUTUALLY_EXCLUSIVE_TYPES = "MUTUALLY_EXCLUSIVE_TYPES"

--- a/localstack-core/localstack/aws/api/cloudwatch/__init__.py
+++ b/localstack-core/localstack/aws/api/cloudwatch/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -89,29 +90,29 @@ Threshold = float
 TreatMissingData = str
 
 
-class ActionsSuppressedBy(str):
+class ActionsSuppressedBy(StrEnum):
     WaitPeriod = "WaitPeriod"
     ExtensionPeriod = "ExtensionPeriod"
     Alarm = "Alarm"
 
 
-class AlarmType(str):
+class AlarmType(StrEnum):
     CompositeAlarm = "CompositeAlarm"
     MetricAlarm = "MetricAlarm"
 
 
-class AnomalyDetectorStateValue(str):
+class AnomalyDetectorStateValue(StrEnum):
     PENDING_TRAINING = "PENDING_TRAINING"
     TRAINED_INSUFFICIENT_DATA = "TRAINED_INSUFFICIENT_DATA"
     TRAINED = "TRAINED"
 
 
-class AnomalyDetectorType(str):
+class AnomalyDetectorType(StrEnum):
     SINGLE_METRIC = "SINGLE_METRIC"
     METRIC_MATH = "METRIC_MATH"
 
 
-class ComparisonOperator(str):
+class ComparisonOperator(StrEnum):
     GreaterThanOrEqualToThreshold = "GreaterThanOrEqualToThreshold"
     GreaterThanThreshold = "GreaterThanThreshold"
     LessThanThreshold = "LessThanThreshold"
@@ -121,32 +122,32 @@ class ComparisonOperator(str):
     GreaterThanUpperThreshold = "GreaterThanUpperThreshold"
 
 
-class EvaluationState(str):
+class EvaluationState(StrEnum):
     PARTIAL_DATA = "PARTIAL_DATA"
 
 
-class HistoryItemType(str):
+class HistoryItemType(StrEnum):
     ConfigurationUpdate = "ConfigurationUpdate"
     StateUpdate = "StateUpdate"
     Action = "Action"
 
 
-class MetricStreamOutputFormat(str):
+class MetricStreamOutputFormat(StrEnum):
     json = "json"
     opentelemetry0_7 = "opentelemetry0.7"
     opentelemetry1_0 = "opentelemetry1.0"
 
 
-class RecentlyActive(str):
+class RecentlyActive(StrEnum):
     PT3H = "PT3H"
 
 
-class ScanBy(str):
+class ScanBy(StrEnum):
     TimestampDescending = "TimestampDescending"
     TimestampAscending = "TimestampAscending"
 
 
-class StandardUnit(str):
+class StandardUnit(StrEnum):
     Seconds = "Seconds"
     Microseconds = "Microseconds"
     Milliseconds = "Milliseconds"
@@ -176,13 +177,13 @@ class StandardUnit(str):
     None_ = "None"
 
 
-class StateValue(str):
+class StateValue(StrEnum):
     OK = "OK"
     ALARM = "ALARM"
     INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
 
 
-class Statistic(str):
+class Statistic(StrEnum):
     SampleCount = "SampleCount"
     Average = "Average"
     Sum = "Sum"
@@ -190,7 +191,7 @@ class Statistic(str):
     Maximum = "Maximum"
 
 
-class StatusCode(str):
+class StatusCode(StrEnum):
     Complete = "Complete"
     InternalError = "InternalError"
     PartialData = "PartialData"

--- a/localstack-core/localstack/aws/api/config/__init__.py
+++ b/localstack-core/localstack/aws/api/config/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -92,47 +93,47 @@ Value = str
 Version = str
 
 
-class AggregateConformancePackComplianceSummaryGroupKey(str):
+class AggregateConformancePackComplianceSummaryGroupKey(StrEnum):
     ACCOUNT_ID = "ACCOUNT_ID"
     AWS_REGION = "AWS_REGION"
 
 
-class AggregatedSourceStatusType(str):
+class AggregatedSourceStatusType(StrEnum):
     FAILED = "FAILED"
     SUCCEEDED = "SUCCEEDED"
     OUTDATED = "OUTDATED"
 
 
-class AggregatedSourceType(str):
+class AggregatedSourceType(StrEnum):
     ACCOUNT = "ACCOUNT"
     ORGANIZATION = "ORGANIZATION"
 
 
-class ChronologicalOrder(str):
+class ChronologicalOrder(StrEnum):
     Reverse = "Reverse"
     Forward = "Forward"
 
 
-class ComplianceType(str):
+class ComplianceType(StrEnum):
     COMPLIANT = "COMPLIANT"
     NON_COMPLIANT = "NON_COMPLIANT"
     NOT_APPLICABLE = "NOT_APPLICABLE"
     INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
 
 
-class ConfigRuleComplianceSummaryGroupKey(str):
+class ConfigRuleComplianceSummaryGroupKey(StrEnum):
     ACCOUNT_ID = "ACCOUNT_ID"
     AWS_REGION = "AWS_REGION"
 
 
-class ConfigRuleState(str):
+class ConfigRuleState(StrEnum):
     ACTIVE = "ACTIVE"
     DELETING = "DELETING"
     DELETING_RESULTS = "DELETING_RESULTS"
     EVALUATING = "EVALUATING"
 
 
-class ConfigurationItemStatus(str):
+class ConfigurationItemStatus(StrEnum):
     OK = "OK"
     ResourceDiscovered = "ResourceDiscovered"
     ResourceNotRecorded = "ResourceNotRecorded"
@@ -140,13 +141,13 @@ class ConfigurationItemStatus(str):
     ResourceDeletedNotRecorded = "ResourceDeletedNotRecorded"
 
 
-class ConformancePackComplianceType(str):
+class ConformancePackComplianceType(StrEnum):
     COMPLIANT = "COMPLIANT"
     NON_COMPLIANT = "NON_COMPLIANT"
     INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
 
 
-class ConformancePackState(str):
+class ConformancePackState(StrEnum):
     CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
     CREATE_COMPLETE = "CREATE_COMPLETE"
     CREATE_FAILED = "CREATE_FAILED"
@@ -154,22 +155,22 @@ class ConformancePackState(str):
     DELETE_FAILED = "DELETE_FAILED"
 
 
-class DeliveryStatus(str):
+class DeliveryStatus(StrEnum):
     Success = "Success"
     Failure = "Failure"
     Not_Applicable = "Not_Applicable"
 
 
-class EvaluationMode(str):
+class EvaluationMode(StrEnum):
     DETECTIVE = "DETECTIVE"
     PROACTIVE = "PROACTIVE"
 
 
-class EventSource(str):
+class EventSource(StrEnum):
     aws_config = "aws.config"
 
 
-class MaximumExecutionFrequency(str):
+class MaximumExecutionFrequency(StrEnum):
     One_Hour = "One_Hour"
     Three_Hours = "Three_Hours"
     Six_Hours = "Six_Hours"
@@ -177,7 +178,7 @@ class MaximumExecutionFrequency(str):
     TwentyFour_Hours = "TwentyFour_Hours"
 
 
-class MemberAccountRuleStatus(str):
+class MemberAccountRuleStatus(StrEnum):
     CREATE_SUCCESSFUL = "CREATE_SUCCESSFUL"
     CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
     CREATE_FAILED = "CREATE_FAILED"
@@ -189,25 +190,25 @@ class MemberAccountRuleStatus(str):
     UPDATE_FAILED = "UPDATE_FAILED"
 
 
-class MessageType(str):
+class MessageType(StrEnum):
     ConfigurationItemChangeNotification = "ConfigurationItemChangeNotification"
     ConfigurationSnapshotDeliveryCompleted = "ConfigurationSnapshotDeliveryCompleted"
     ScheduledNotification = "ScheduledNotification"
     OversizedConfigurationItemChangeNotification = "OversizedConfigurationItemChangeNotification"
 
 
-class OrganizationConfigRuleTriggerType(str):
+class OrganizationConfigRuleTriggerType(StrEnum):
     ConfigurationItemChangeNotification = "ConfigurationItemChangeNotification"
     OversizedConfigurationItemChangeNotification = "OversizedConfigurationItemChangeNotification"
     ScheduledNotification = "ScheduledNotification"
 
 
-class OrganizationConfigRuleTriggerTypeNoSN(str):
+class OrganizationConfigRuleTriggerTypeNoSN(StrEnum):
     ConfigurationItemChangeNotification = "ConfigurationItemChangeNotification"
     OversizedConfigurationItemChangeNotification = "OversizedConfigurationItemChangeNotification"
 
 
-class OrganizationResourceDetailedStatus(str):
+class OrganizationResourceDetailedStatus(StrEnum):
     CREATE_SUCCESSFUL = "CREATE_SUCCESSFUL"
     CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
     CREATE_FAILED = "CREATE_FAILED"
@@ -219,7 +220,7 @@ class OrganizationResourceDetailedStatus(str):
     UPDATE_FAILED = "UPDATE_FAILED"
 
 
-class OrganizationResourceStatus(str):
+class OrganizationResourceStatus(StrEnum):
     CREATE_SUCCESSFUL = "CREATE_SUCCESSFUL"
     CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
     CREATE_FAILED = "CREATE_FAILED"
@@ -231,7 +232,7 @@ class OrganizationResourceStatus(str):
     UPDATE_FAILED = "UPDATE_FAILED"
 
 
-class OrganizationRuleStatus(str):
+class OrganizationRuleStatus(StrEnum):
     CREATE_SUCCESSFUL = "CREATE_SUCCESSFUL"
     CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
     CREATE_FAILED = "CREATE_FAILED"
@@ -243,63 +244,63 @@ class OrganizationRuleStatus(str):
     UPDATE_FAILED = "UPDATE_FAILED"
 
 
-class Owner(str):
+class Owner(StrEnum):
     CUSTOM_LAMBDA = "CUSTOM_LAMBDA"
     AWS = "AWS"
     CUSTOM_POLICY = "CUSTOM_POLICY"
 
 
-class RecorderStatus(str):
+class RecorderStatus(StrEnum):
     Pending = "Pending"
     Success = "Success"
     Failure = "Failure"
 
 
-class RecordingFrequency(str):
+class RecordingFrequency(StrEnum):
     CONTINUOUS = "CONTINUOUS"
     DAILY = "DAILY"
 
 
-class RecordingStrategyType(str):
+class RecordingStrategyType(StrEnum):
     ALL_SUPPORTED_RESOURCE_TYPES = "ALL_SUPPORTED_RESOURCE_TYPES"
     INCLUSION_BY_RESOURCE_TYPES = "INCLUSION_BY_RESOURCE_TYPES"
     EXCLUSION_BY_RESOURCE_TYPES = "EXCLUSION_BY_RESOURCE_TYPES"
 
 
-class RemediationExecutionState(str):
+class RemediationExecutionState(StrEnum):
     QUEUED = "QUEUED"
     IN_PROGRESS = "IN_PROGRESS"
     SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"
 
 
-class RemediationExecutionStepState(str):
+class RemediationExecutionStepState(StrEnum):
     SUCCEEDED = "SUCCEEDED"
     PENDING = "PENDING"
     FAILED = "FAILED"
 
 
-class RemediationTargetType(str):
+class RemediationTargetType(StrEnum):
     SSM_DOCUMENT = "SSM_DOCUMENT"
 
 
-class ResourceConfigurationSchemaType(str):
+class ResourceConfigurationSchemaType(StrEnum):
     CFN_RESOURCE_SCHEMA = "CFN_RESOURCE_SCHEMA"
 
 
-class ResourceCountGroupKey(str):
+class ResourceCountGroupKey(StrEnum):
     RESOURCE_TYPE = "RESOURCE_TYPE"
     ACCOUNT_ID = "ACCOUNT_ID"
     AWS_REGION = "AWS_REGION"
 
 
-class ResourceEvaluationStatus(str):
+class ResourceEvaluationStatus(StrEnum):
     IN_PROGRESS = "IN_PROGRESS"
     FAILED = "FAILED"
     SUCCEEDED = "SUCCEEDED"
 
 
-class ResourceType(str):
+class ResourceType(StrEnum):
     AWS_EC2_CustomerGateway = "AWS::EC2::CustomerGateway"
     AWS_EC2_EIP = "AWS::EC2::EIP"
     AWS_EC2_Host = "AWS::EC2::Host"
@@ -723,15 +724,15 @@ class ResourceType(str):
     AWS_SSM_Document = "AWS::SSM::Document"
 
 
-class ResourceValueType(str):
+class ResourceValueType(StrEnum):
     RESOURCE_ID = "RESOURCE_ID"
 
 
-class SortBy(str):
+class SortBy(StrEnum):
     SCORE = "SCORE"
 
 
-class SortOrder(str):
+class SortOrder(StrEnum):
     ASCENDING = "ASCENDING"
     DESCENDING = "DESCENDING"
 

--- a/localstack-core/localstack/aws/api/dynamodb/__init__.py
+++ b/localstack-core/localstack/aws/api/dynamodb/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -87,37 +88,37 @@ TimeToLiveEnabled = bool
 UpdateExpression = str
 
 
-class ApproximateCreationDateTimePrecision(str):
+class ApproximateCreationDateTimePrecision(StrEnum):
     MILLISECOND = "MILLISECOND"
     MICROSECOND = "MICROSECOND"
 
 
-class AttributeAction(str):
+class AttributeAction(StrEnum):
     ADD = "ADD"
     PUT = "PUT"
     DELETE = "DELETE"
 
 
-class BackupStatus(str):
+class BackupStatus(StrEnum):
     CREATING = "CREATING"
     DELETED = "DELETED"
     AVAILABLE = "AVAILABLE"
 
 
-class BackupType(str):
+class BackupType(StrEnum):
     USER = "USER"
     SYSTEM = "SYSTEM"
     AWS_BACKUP = "AWS_BACKUP"
 
 
-class BackupTypeFilter(str):
+class BackupTypeFilter(StrEnum):
     USER = "USER"
     SYSTEM = "SYSTEM"
     AWS_BACKUP = "AWS_BACKUP"
     ALL = "ALL"
 
 
-class BatchStatementErrorCodeEnum(str):
+class BatchStatementErrorCodeEnum(StrEnum):
     ConditionalCheckFailed = "ConditionalCheckFailed"
     ItemCollectionSizeLimitExceeded = "ItemCollectionSizeLimitExceeded"
     RequestLimitExceeded = "RequestLimitExceeded"
@@ -131,12 +132,12 @@ class BatchStatementErrorCodeEnum(str):
     DuplicateItem = "DuplicateItem"
 
 
-class BillingMode(str):
+class BillingMode(StrEnum):
     PROVISIONED = "PROVISIONED"
     PAY_PER_REQUEST = "PAY_PER_REQUEST"
 
 
-class ComparisonOperator(str):
+class ComparisonOperator(StrEnum):
     EQ = "EQ"
     NE = "NE"
     IN = "IN"
@@ -152,22 +153,22 @@ class ComparisonOperator(str):
     BEGINS_WITH = "BEGINS_WITH"
 
 
-class ConditionalOperator(str):
+class ConditionalOperator(StrEnum):
     AND = "AND"
     OR = "OR"
 
 
-class ContinuousBackupsStatus(str):
+class ContinuousBackupsStatus(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
 
 
-class ContributorInsightsAction(str):
+class ContributorInsightsAction(StrEnum):
     ENABLE = "ENABLE"
     DISABLE = "DISABLE"
 
 
-class ContributorInsightsStatus(str):
+class ContributorInsightsStatus(StrEnum):
     ENABLING = "ENABLING"
     ENABLED = "ENABLED"
     DISABLING = "DISABLING"
@@ -175,7 +176,7 @@ class ContributorInsightsStatus(str):
     FAILED = "FAILED"
 
 
-class DestinationStatus(str):
+class DestinationStatus(StrEnum):
     ENABLING = "ENABLING"
     ACTIVE = "ACTIVE"
     DISABLING = "DISABLING"
@@ -184,35 +185,35 @@ class DestinationStatus(str):
     UPDATING = "UPDATING"
 
 
-class ExportFormat(str):
+class ExportFormat(StrEnum):
     DYNAMODB_JSON = "DYNAMODB_JSON"
     ION = "ION"
 
 
-class ExportStatus(str):
+class ExportStatus(StrEnum):
     IN_PROGRESS = "IN_PROGRESS"
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
 
 
-class ExportType(str):
+class ExportType(StrEnum):
     FULL_EXPORT = "FULL_EXPORT"
     INCREMENTAL_EXPORT = "INCREMENTAL_EXPORT"
 
 
-class ExportViewType(str):
+class ExportViewType(StrEnum):
     NEW_IMAGE = "NEW_IMAGE"
     NEW_AND_OLD_IMAGES = "NEW_AND_OLD_IMAGES"
 
 
-class GlobalTableStatus(str):
+class GlobalTableStatus(StrEnum):
     CREATING = "CREATING"
     ACTIVE = "ACTIVE"
     DELETING = "DELETING"
     UPDATING = "UPDATING"
 
 
-class ImportStatus(str):
+class ImportStatus(StrEnum):
     IN_PROGRESS = "IN_PROGRESS"
     COMPLETED = "COMPLETED"
     CANCELLING = "CANCELLING"
@@ -220,42 +221,42 @@ class ImportStatus(str):
     FAILED = "FAILED"
 
 
-class IndexStatus(str):
+class IndexStatus(StrEnum):
     CREATING = "CREATING"
     UPDATING = "UPDATING"
     DELETING = "DELETING"
     ACTIVE = "ACTIVE"
 
 
-class InputCompressionType(str):
+class InputCompressionType(StrEnum):
     GZIP = "GZIP"
     ZSTD = "ZSTD"
     NONE = "NONE"
 
 
-class InputFormat(str):
+class InputFormat(StrEnum):
     DYNAMODB_JSON = "DYNAMODB_JSON"
     ION = "ION"
     CSV = "CSV"
 
 
-class KeyType(str):
+class KeyType(StrEnum):
     HASH = "HASH"
     RANGE = "RANGE"
 
 
-class PointInTimeRecoveryStatus(str):
+class PointInTimeRecoveryStatus(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
 
 
-class ProjectionType(str):
+class ProjectionType(StrEnum):
     ALL = "ALL"
     KEYS_ONLY = "KEYS_ONLY"
     INCLUDE = "INCLUDE"
 
 
-class ReplicaStatus(str):
+class ReplicaStatus(StrEnum):
     CREATING = "CREATING"
     CREATION_FAILED = "CREATION_FAILED"
     UPDATING = "UPDATING"
@@ -265,18 +266,18 @@ class ReplicaStatus(str):
     INACCESSIBLE_ENCRYPTION_CREDENTIALS = "INACCESSIBLE_ENCRYPTION_CREDENTIALS"
 
 
-class ReturnConsumedCapacity(str):
+class ReturnConsumedCapacity(StrEnum):
     INDEXES = "INDEXES"
     TOTAL = "TOTAL"
     NONE = "NONE"
 
 
-class ReturnItemCollectionMetrics(str):
+class ReturnItemCollectionMetrics(StrEnum):
     SIZE = "SIZE"
     NONE = "NONE"
 
 
-class ReturnValue(str):
+class ReturnValue(StrEnum):
     NONE = "NONE"
     ALL_OLD = "ALL_OLD"
     UPDATED_OLD = "UPDATED_OLD"
@@ -284,17 +285,17 @@ class ReturnValue(str):
     UPDATED_NEW = "UPDATED_NEW"
 
 
-class ReturnValuesOnConditionCheckFailure(str):
+class ReturnValuesOnConditionCheckFailure(StrEnum):
     ALL_OLD = "ALL_OLD"
     NONE = "NONE"
 
 
-class S3SseAlgorithm(str):
+class S3SseAlgorithm(StrEnum):
     AES256 = "AES256"
     KMS = "KMS"
 
 
-class SSEStatus(str):
+class SSEStatus(StrEnum):
     ENABLING = "ENABLING"
     ENABLED = "ENABLED"
     DISABLING = "DISABLING"
@@ -302,37 +303,37 @@ class SSEStatus(str):
     UPDATING = "UPDATING"
 
 
-class SSEType(str):
+class SSEType(StrEnum):
     AES256 = "AES256"
     KMS = "KMS"
 
 
-class ScalarAttributeType(str):
+class ScalarAttributeType(StrEnum):
     S = "S"
     N = "N"
     B = "B"
 
 
-class Select(str):
+class Select(StrEnum):
     ALL_ATTRIBUTES = "ALL_ATTRIBUTES"
     ALL_PROJECTED_ATTRIBUTES = "ALL_PROJECTED_ATTRIBUTES"
     SPECIFIC_ATTRIBUTES = "SPECIFIC_ATTRIBUTES"
     COUNT = "COUNT"
 
 
-class StreamViewType(str):
+class StreamViewType(StrEnum):
     NEW_IMAGE = "NEW_IMAGE"
     OLD_IMAGE = "OLD_IMAGE"
     NEW_AND_OLD_IMAGES = "NEW_AND_OLD_IMAGES"
     KEYS_ONLY = "KEYS_ONLY"
 
 
-class TableClass(str):
+class TableClass(StrEnum):
     STANDARD = "STANDARD"
     STANDARD_INFREQUENT_ACCESS = "STANDARD_INFREQUENT_ACCESS"
 
 
-class TableStatus(str):
+class TableStatus(StrEnum):
     CREATING = "CREATING"
     UPDATING = "UPDATING"
     DELETING = "DELETING"
@@ -342,7 +343,7 @@ class TableStatus(str):
     ARCHIVED = "ARCHIVED"
 
 
-class TimeToLiveStatus(str):
+class TimeToLiveStatus(StrEnum):
     ENABLING = "ENABLING"
     DISABLING = "DISABLING"
     ENABLED = "ENABLED"

--- a/localstack-core/localstack/aws/api/dynamodbstreams/__init__.py
+++ b/localstack-core/localstack/aws/api/dynamodbstreams/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -19,32 +20,32 @@ StringAttributeValue = str
 TableName = str
 
 
-class KeyType(str):
+class KeyType(StrEnum):
     HASH = "HASH"
     RANGE = "RANGE"
 
 
-class OperationType(str):
+class OperationType(StrEnum):
     INSERT = "INSERT"
     MODIFY = "MODIFY"
     REMOVE = "REMOVE"
 
 
-class ShardIteratorType(str):
+class ShardIteratorType(StrEnum):
     TRIM_HORIZON = "TRIM_HORIZON"
     LATEST = "LATEST"
     AT_SEQUENCE_NUMBER = "AT_SEQUENCE_NUMBER"
     AFTER_SEQUENCE_NUMBER = "AFTER_SEQUENCE_NUMBER"
 
 
-class StreamStatus(str):
+class StreamStatus(StrEnum):
     ENABLING = "ENABLING"
     ENABLED = "ENABLED"
     DISABLING = "DISABLING"
     DISABLED = "DISABLED"
 
 
-class StreamViewType(str):
+class StreamViewType(StrEnum):
     NEW_IMAGE = "NEW_IMAGE"
     OLD_IMAGE = "OLD_IMAGE"
     NEW_AND_OLD_IMAGES = "NEW_AND_OLD_IMAGES"

--- a/localstack-core/localstack/aws/api/ec2/__init__.py
+++ b/localstack-core/localstack/aws/api/ec2/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import List, Optional, TypedDict
 
 from localstack.aws.api import (
@@ -345,7 +346,7 @@ totalGpuMemory = int
 totalInferenceMemory = int
 
 
-class AcceleratorManufacturer(str):
+class AcceleratorManufacturer(StrEnum):
     amazon_web_services = "amazon-web-services"
     amd = "amd"
     nvidia = "nvidia"
@@ -353,7 +354,7 @@ class AcceleratorManufacturer(str):
     habana = "habana"
 
 
-class AcceleratorName(str):
+class AcceleratorName(StrEnum):
     a100 = "a100"
     inferentia = "inferentia"
     k520 = "k520"
@@ -368,45 +369,45 @@ class AcceleratorName(str):
     t4g = "t4g"
 
 
-class AcceleratorType(str):
+class AcceleratorType(StrEnum):
     gpu = "gpu"
     fpga = "fpga"
     inference = "inference"
 
 
-class AccountAttributeName(str):
+class AccountAttributeName(StrEnum):
     supported_platforms = "supported-platforms"
     default_vpc = "default-vpc"
 
 
-class ActivityStatus(str):
+class ActivityStatus(StrEnum):
     error = "error"
     pending_fulfillment = "pending_fulfillment"
     pending_termination = "pending_termination"
     fulfilled = "fulfilled"
 
 
-class AddressAttributeName(str):
+class AddressAttributeName(StrEnum):
     domain_name = "domain-name"
 
 
-class AddressFamily(str):
+class AddressFamily(StrEnum):
     ipv4 = "ipv4"
     ipv6 = "ipv6"
 
 
-class AddressTransferStatus(str):
+class AddressTransferStatus(StrEnum):
     pending = "pending"
     disabled = "disabled"
     accepted = "accepted"
 
 
-class Affinity(str):
+class Affinity(StrEnum):
     default = "default"
     host = "host"
 
 
-class AllocationState(str):
+class AllocationState(StrEnum):
     available = "available"
     under_assessment = "under-assessment"
     permanent_failure = "permanent-failure"
@@ -415,7 +416,7 @@ class AllocationState(str):
     pending = "pending"
 
 
-class AllocationStrategy(str):
+class AllocationStrategy(StrEnum):
     lowestPrice = "lowestPrice"
     diversified = "diversified"
     capacityOptimized = "capacityOptimized"
@@ -423,32 +424,32 @@ class AllocationStrategy(str):
     priceCapacityOptimized = "priceCapacityOptimized"
 
 
-class AllocationType(str):
+class AllocationType(StrEnum):
     used = "used"
 
 
-class AllowsMultipleInstanceTypes(str):
+class AllowsMultipleInstanceTypes(StrEnum):
     on = "on"
     off = "off"
 
 
-class AmdSevSnpSpecification(str):
+class AmdSevSnpSpecification(StrEnum):
     enabled = "enabled"
     disabled = "disabled"
 
 
-class AnalysisStatus(str):
+class AnalysisStatus(StrEnum):
     running = "running"
     succeeded = "succeeded"
     failed = "failed"
 
 
-class ApplianceModeSupportValue(str):
+class ApplianceModeSupportValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class ArchitectureType(str):
+class ArchitectureType(StrEnum):
     i386 = "i386"
     x86_64 = "x86_64"
     arm64 = "arm64"
@@ -456,7 +457,7 @@ class ArchitectureType(str):
     arm64_mac = "arm64_mac"
 
 
-class ArchitectureValues(str):
+class ArchitectureValues(StrEnum):
     i386 = "i386"
     x86_64 = "x86_64"
     arm64 = "arm64"
@@ -464,7 +465,7 @@ class ArchitectureValues(str):
     arm64_mac = "arm64_mac"
 
 
-class AsnAssociationState(str):
+class AsnAssociationState(StrEnum):
     disassociated = "disassociated"
     failed_disassociation = "failed-disassociation"
     failed_association = "failed-association"
@@ -473,7 +474,7 @@ class AsnAssociationState(str):
     associated = "associated"
 
 
-class AsnState(str):
+class AsnState(StrEnum):
     deprovisioned = "deprovisioned"
     failed_deprovision = "failed-deprovision"
     failed_provision = "failed-provision"
@@ -482,11 +483,11 @@ class AsnState(str):
     provisioned = "provisioned"
 
 
-class AssociatedNetworkType(str):
+class AssociatedNetworkType(StrEnum):
     vpc = "vpc"
 
 
-class AssociationStatusCode(str):
+class AssociationStatusCode(StrEnum):
     associating = "associating"
     associated = "associated"
     association_failed = "association-failed"
@@ -494,35 +495,35 @@ class AssociationStatusCode(str):
     disassociated = "disassociated"
 
 
-class AttachmentStatus(str):
+class AttachmentStatus(StrEnum):
     attaching = "attaching"
     attached = "attached"
     detaching = "detaching"
     detached = "detached"
 
 
-class AutoAcceptSharedAssociationsValue(str):
+class AutoAcceptSharedAssociationsValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class AutoAcceptSharedAttachmentsValue(str):
+class AutoAcceptSharedAttachmentsValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class AutoPlacement(str):
+class AutoPlacement(StrEnum):
     on = "on"
     off = "off"
 
 
-class AvailabilityZoneOptInStatus(str):
+class AvailabilityZoneOptInStatus(StrEnum):
     opt_in_not_required = "opt-in-not-required"
     opted_in = "opted-in"
     not_opted_in = "not-opted-in"
 
 
-class AvailabilityZoneState(str):
+class AvailabilityZoneState(StrEnum):
     available = "available"
     information = "information"
     impaired = "impaired"
@@ -530,13 +531,13 @@ class AvailabilityZoneState(str):
     constrained = "constrained"
 
 
-class BareMetal(str):
+class BareMetal(StrEnum):
     included = "included"
     required = "required"
     excluded = "excluded"
 
 
-class BatchState(str):
+class BatchState(StrEnum):
     submitted = "submitted"
     active = "active"
     cancelled = "cancelled"
@@ -546,23 +547,23 @@ class BatchState(str):
     modifying = "modifying"
 
 
-class BgpStatus(str):
+class BgpStatus(StrEnum):
     up = "up"
     down = "down"
 
 
-class BootModeType(str):
+class BootModeType(StrEnum):
     legacy_bios = "legacy-bios"
     uefi = "uefi"
 
 
-class BootModeValues(str):
+class BootModeValues(StrEnum):
     legacy_bios = "legacy-bios"
     uefi = "uefi"
     uefi_preferred = "uefi-preferred"
 
 
-class BundleTaskState(str):
+class BundleTaskState(StrEnum):
     pending = "pending"
     waiting_for_shutdown = "waiting-for-shutdown"
     bundling = "bundling"
@@ -572,13 +573,13 @@ class BundleTaskState(str):
     failed = "failed"
 
 
-class BurstablePerformance(str):
+class BurstablePerformance(StrEnum):
     included = "included"
     required = "required"
     excluded = "excluded"
 
 
-class ByoipCidrState(str):
+class ByoipCidrState(StrEnum):
     advertised = "advertised"
     deprovisioned = "deprovisioned"
     failed_deprovision = "failed-deprovision"
@@ -589,14 +590,14 @@ class ByoipCidrState(str):
     provisioned_not_publicly_advertisable = "provisioned-not-publicly-advertisable"
 
 
-class CancelBatchErrorCode(str):
+class CancelBatchErrorCode(StrEnum):
     fleetRequestIdDoesNotExist = "fleetRequestIdDoesNotExist"
     fleetRequestIdMalformed = "fleetRequestIdMalformed"
     fleetRequestNotInCancellableState = "fleetRequestNotInCancellableState"
     unexpectedError = "unexpectedError"
 
 
-class CancelSpotInstanceRequestState(str):
+class CancelSpotInstanceRequestState(StrEnum):
     active = "active"
     open = "open"
     closed = "closed"
@@ -604,7 +605,7 @@ class CancelSpotInstanceRequestState(str):
     completed = "completed"
 
 
-class CapacityReservationFleetState(str):
+class CapacityReservationFleetState(StrEnum):
     submitted = "submitted"
     modifying = "modifying"
     active = "active"
@@ -616,7 +617,7 @@ class CapacityReservationFleetState(str):
     failed = "failed"
 
 
-class CapacityReservationInstancePlatform(str):
+class CapacityReservationInstancePlatform(StrEnum):
     Linux_UNIX = "Linux/UNIX"
     Red_Hat_Enterprise_Linux = "Red Hat Enterprise Linux"
     SUSE_Linux = "SUSE Linux"
@@ -637,12 +638,12 @@ class CapacityReservationInstancePlatform(str):
     Ubuntu_Pro = "Ubuntu Pro"
 
 
-class CapacityReservationPreference(str):
+class CapacityReservationPreference(StrEnum):
     open = "open"
     none = "none"
 
 
-class CapacityReservationState(str):
+class CapacityReservationState(StrEnum):
     active = "active"
     expired = "expired"
     cancelled = "cancelled"
@@ -653,225 +654,225 @@ class CapacityReservationState(str):
     payment_failed = "payment-failed"
 
 
-class CapacityReservationTenancy(str):
+class CapacityReservationTenancy(StrEnum):
     default = "default"
     dedicated = "dedicated"
 
 
-class CapacityReservationType(str):
+class CapacityReservationType(StrEnum):
     default = "default"
     capacity_block = "capacity-block"
 
 
-class CarrierGatewayState(str):
+class CarrierGatewayState(StrEnum):
     pending = "pending"
     available = "available"
     deleting = "deleting"
     deleted = "deleted"
 
 
-class ClientCertificateRevocationListStatusCode(str):
+class ClientCertificateRevocationListStatusCode(StrEnum):
     pending = "pending"
     active = "active"
 
 
-class ClientVpnAuthenticationType(str):
+class ClientVpnAuthenticationType(StrEnum):
     certificate_authentication = "certificate-authentication"
     directory_service_authentication = "directory-service-authentication"
     federated_authentication = "federated-authentication"
 
 
-class ClientVpnAuthorizationRuleStatusCode(str):
+class ClientVpnAuthorizationRuleStatusCode(StrEnum):
     authorizing = "authorizing"
     active = "active"
     failed = "failed"
     revoking = "revoking"
 
 
-class ClientVpnConnectionStatusCode(str):
+class ClientVpnConnectionStatusCode(StrEnum):
     active = "active"
     failed_to_terminate = "failed-to-terminate"
     terminating = "terminating"
     terminated = "terminated"
 
 
-class ClientVpnEndpointAttributeStatusCode(str):
+class ClientVpnEndpointAttributeStatusCode(StrEnum):
     applying = "applying"
     applied = "applied"
 
 
-class ClientVpnEndpointStatusCode(str):
+class ClientVpnEndpointStatusCode(StrEnum):
     pending_associate = "pending-associate"
     available = "available"
     deleting = "deleting"
     deleted = "deleted"
 
 
-class ClientVpnRouteStatusCode(str):
+class ClientVpnRouteStatusCode(StrEnum):
     creating = "creating"
     active = "active"
     failed = "failed"
     deleting = "deleting"
 
 
-class ConnectionNotificationState(str):
+class ConnectionNotificationState(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class ConnectionNotificationType(str):
+class ConnectionNotificationType(StrEnum):
     Topic = "Topic"
 
 
-class ConnectivityType(str):
+class ConnectivityType(StrEnum):
     private = "private"
     public = "public"
 
 
-class ContainerFormat(str):
+class ContainerFormat(StrEnum):
     ova = "ova"
 
 
-class ConversionTaskState(str):
+class ConversionTaskState(StrEnum):
     active = "active"
     cancelling = "cancelling"
     cancelled = "cancelled"
     completed = "completed"
 
 
-class CopyTagsFromSource(str):
+class CopyTagsFromSource(StrEnum):
     volume = "volume"
 
 
-class CpuManufacturer(str):
+class CpuManufacturer(StrEnum):
     intel = "intel"
     amd = "amd"
     amazon_web_services = "amazon-web-services"
 
 
-class CurrencyCodeValues(str):
+class CurrencyCodeValues(StrEnum):
     USD = "USD"
 
 
-class DatafeedSubscriptionState(str):
+class DatafeedSubscriptionState(StrEnum):
     Active = "Active"
     Inactive = "Inactive"
 
 
-class DefaultInstanceMetadataEndpointState(str):
+class DefaultInstanceMetadataEndpointState(StrEnum):
     disabled = "disabled"
     enabled = "enabled"
     no_preference = "no-preference"
 
 
-class DefaultInstanceMetadataTagsState(str):
+class DefaultInstanceMetadataTagsState(StrEnum):
     disabled = "disabled"
     enabled = "enabled"
     no_preference = "no-preference"
 
 
-class DefaultRouteTableAssociationValue(str):
+class DefaultRouteTableAssociationValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class DefaultRouteTablePropagationValue(str):
+class DefaultRouteTablePropagationValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class DefaultTargetCapacityType(str):
+class DefaultTargetCapacityType(StrEnum):
     spot = "spot"
     on_demand = "on-demand"
     capacity_block = "capacity-block"
 
 
-class DeleteFleetErrorCode(str):
+class DeleteFleetErrorCode(StrEnum):
     fleetIdDoesNotExist = "fleetIdDoesNotExist"
     fleetIdMalformed = "fleetIdMalformed"
     fleetNotInDeletableState = "fleetNotInDeletableState"
     unexpectedError = "unexpectedError"
 
 
-class DeleteQueuedReservedInstancesErrorCode(str):
+class DeleteQueuedReservedInstancesErrorCode(StrEnum):
     reserved_instances_id_invalid = "reserved-instances-id-invalid"
     reserved_instances_not_in_queued_state = "reserved-instances-not-in-queued-state"
     unexpected_error = "unexpected-error"
 
 
-class DestinationFileFormat(str):
+class DestinationFileFormat(StrEnum):
     plain_text = "plain-text"
     parquet = "parquet"
 
 
-class DeviceTrustProviderType(str):
+class DeviceTrustProviderType(StrEnum):
     jamf = "jamf"
     crowdstrike = "crowdstrike"
     jumpcloud = "jumpcloud"
 
 
-class DeviceType(str):
+class DeviceType(StrEnum):
     ebs = "ebs"
     instance_store = "instance-store"
 
 
-class DiskImageFormat(str):
+class DiskImageFormat(StrEnum):
     VMDK = "VMDK"
     RAW = "RAW"
     VHD = "VHD"
 
 
-class DiskType(str):
+class DiskType(StrEnum):
     hdd = "hdd"
     ssd = "ssd"
 
 
-class DnsNameState(str):
+class DnsNameState(StrEnum):
     pendingVerification = "pendingVerification"
     verified = "verified"
     failed = "failed"
 
 
-class DnsRecordIpType(str):
+class DnsRecordIpType(StrEnum):
     ipv4 = "ipv4"
     dualstack = "dualstack"
     ipv6 = "ipv6"
     service_defined = "service-defined"
 
 
-class DnsSupportValue(str):
+class DnsSupportValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class DomainType(str):
+class DomainType(StrEnum):
     vpc = "vpc"
     standard = "standard"
 
 
-class DynamicRoutingValue(str):
+class DynamicRoutingValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class EbsEncryptionSupport(str):
+class EbsEncryptionSupport(StrEnum):
     unsupported = "unsupported"
     supported = "supported"
 
 
-class EbsNvmeSupport(str):
+class EbsNvmeSupport(StrEnum):
     unsupported = "unsupported"
     supported = "supported"
     required = "required"
 
 
-class EbsOptimizedSupport(str):
+class EbsOptimizedSupport(StrEnum):
     unsupported = "unsupported"
     supported = "supported"
     default = "default"
 
 
-class Ec2InstanceConnectEndpointState(str):
+class Ec2InstanceConnectEndpointState(StrEnum):
     create_in_progress = "create-in-progress"
     create_complete = "create-complete"
     create_failed = "create-failed"
@@ -880,43 +881,43 @@ class Ec2InstanceConnectEndpointState(str):
     delete_failed = "delete-failed"
 
 
-class EkPubKeyFormat(str):
+class EkPubKeyFormat(StrEnum):
     der = "der"
     tpmt = "tpmt"
 
 
-class EkPubKeyType(str):
+class EkPubKeyType(StrEnum):
     rsa_2048 = "rsa-2048"
     ecc_sec_p384 = "ecc-sec-p384"
 
 
-class ElasticGpuState(str):
+class ElasticGpuState(StrEnum):
     ATTACHED = "ATTACHED"
 
 
-class ElasticGpuStatus(str):
+class ElasticGpuStatus(StrEnum):
     OK = "OK"
     IMPAIRED = "IMPAIRED"
 
 
-class EnaSupport(str):
+class EnaSupport(StrEnum):
     unsupported = "unsupported"
     supported = "supported"
     required = "required"
 
 
-class EndDateType(str):
+class EndDateType(StrEnum):
     unlimited = "unlimited"
     limited = "limited"
 
 
-class EphemeralNvmeSupport(str):
+class EphemeralNvmeSupport(StrEnum):
     unsupported = "unsupported"
     supported = "supported"
     required = "required"
 
 
-class EventCode(str):
+class EventCode(StrEnum):
     instance_reboot = "instance-reboot"
     system_reboot = "system-reboot"
     system_maintenance = "system-maintenance"
@@ -924,36 +925,36 @@ class EventCode(str):
     instance_stop = "instance-stop"
 
 
-class EventType(str):
+class EventType(StrEnum):
     instanceChange = "instanceChange"
     fleetRequestChange = "fleetRequestChange"
     error = "error"
     information = "information"
 
 
-class ExcessCapacityTerminationPolicy(str):
+class ExcessCapacityTerminationPolicy(StrEnum):
     noTermination = "noTermination"
     default = "default"
 
 
-class ExportEnvironment(str):
+class ExportEnvironment(StrEnum):
     citrix = "citrix"
     vmware = "vmware"
     microsoft = "microsoft"
 
 
-class ExportTaskState(str):
+class ExportTaskState(StrEnum):
     active = "active"
     cancelling = "cancelling"
     cancelled = "cancelled"
     completed = "completed"
 
 
-class FastLaunchResourceType(str):
+class FastLaunchResourceType(StrEnum):
     snapshot = "snapshot"
 
 
-class FastLaunchStateCode(str):
+class FastLaunchStateCode(StrEnum):
     enabling = "enabling"
     enabling_failed = "enabling-failed"
     enabled = "enabled"
@@ -962,7 +963,7 @@ class FastLaunchStateCode(str):
     disabling_failed = "disabling-failed"
 
 
-class FastSnapshotRestoreStateCode(str):
+class FastSnapshotRestoreStateCode(StrEnum):
     enabling = "enabling"
     optimizing = "optimizing"
     enabled = "enabled"
@@ -970,53 +971,53 @@ class FastSnapshotRestoreStateCode(str):
     disabled = "disabled"
 
 
-class FindingsFound(str):
+class FindingsFound(StrEnum):
     true = "true"
     false = "false"
     unknown = "unknown"
 
 
-class FleetActivityStatus(str):
+class FleetActivityStatus(StrEnum):
     error = "error"
     pending_fulfillment = "pending_fulfillment"
     pending_termination = "pending_termination"
     fulfilled = "fulfilled"
 
 
-class FleetCapacityReservationTenancy(str):
+class FleetCapacityReservationTenancy(StrEnum):
     default = "default"
 
 
-class FleetCapacityReservationUsageStrategy(str):
+class FleetCapacityReservationUsageStrategy(StrEnum):
     use_capacity_reservations_first = "use-capacity-reservations-first"
 
 
-class FleetEventType(str):
+class FleetEventType(StrEnum):
     instance_change = "instance-change"
     fleet_change = "fleet-change"
     service_error = "service-error"
 
 
-class FleetExcessCapacityTerminationPolicy(str):
+class FleetExcessCapacityTerminationPolicy(StrEnum):
     no_termination = "no-termination"
     termination = "termination"
 
 
-class FleetInstanceMatchCriteria(str):
+class FleetInstanceMatchCriteria(StrEnum):
     open = "open"
 
 
-class FleetOnDemandAllocationStrategy(str):
+class FleetOnDemandAllocationStrategy(StrEnum):
     lowest_price = "lowest-price"
     prioritized = "prioritized"
 
 
-class FleetReplacementStrategy(str):
+class FleetReplacementStrategy(StrEnum):
     launch = "launch"
     launch_before_terminate = "launch-before-terminate"
 
 
-class FleetStateCode(str):
+class FleetStateCode(StrEnum):
     submitted = "submitted"
     active = "active"
     deleted = "deleted"
@@ -1026,13 +1027,13 @@ class FleetStateCode(str):
     modifying = "modifying"
 
 
-class FleetType(str):
+class FleetType(StrEnum):
     request = "request"
     maintain = "maintain"
     instant = "instant"
 
 
-class FlowLogsResourceType(str):
+class FlowLogsResourceType(StrEnum):
     VPC = "VPC"
     Subnet = "Subnet"
     NetworkInterface = "NetworkInterface"
@@ -1040,75 +1041,75 @@ class FlowLogsResourceType(str):
     TransitGatewayAttachment = "TransitGatewayAttachment"
 
 
-class FpgaImageAttributeName(str):
+class FpgaImageAttributeName(StrEnum):
     description = "description"
     name = "name"
     loadPermission = "loadPermission"
     productCodes = "productCodes"
 
 
-class FpgaImageStateCode(str):
+class FpgaImageStateCode(StrEnum):
     pending = "pending"
     failed = "failed"
     available = "available"
     unavailable = "unavailable"
 
 
-class GatewayAssociationState(str):
+class GatewayAssociationState(StrEnum):
     associated = "associated"
     not_associated = "not-associated"
     associating = "associating"
     disassociating = "disassociating"
 
 
-class GatewayType(str):
+class GatewayType(StrEnum):
     ipsec_1 = "ipsec.1"
 
 
-class HostMaintenance(str):
+class HostMaintenance(StrEnum):
     on = "on"
     off = "off"
 
 
-class HostRecovery(str):
+class HostRecovery(StrEnum):
     on = "on"
     off = "off"
 
 
-class HostTenancy(str):
+class HostTenancy(StrEnum):
     default = "default"
     dedicated = "dedicated"
     host = "host"
 
 
-class HostnameType(str):
+class HostnameType(StrEnum):
     ip_name = "ip-name"
     resource_name = "resource-name"
 
 
-class HttpTokensState(str):
+class HttpTokensState(StrEnum):
     optional = "optional"
     required = "required"
 
 
-class HypervisorType(str):
+class HypervisorType(StrEnum):
     ovm = "ovm"
     xen = "xen"
 
 
-class IamInstanceProfileAssociationState(str):
+class IamInstanceProfileAssociationState(StrEnum):
     associating = "associating"
     associated = "associated"
     disassociating = "disassociating"
     disassociated = "disassociated"
 
 
-class Igmpv2SupportValue(str):
+class Igmpv2SupportValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class ImageAttributeName(str):
+class ImageAttributeName(StrEnum):
     description = "description"
     kernel = "kernel"
     ramdisk = "ramdisk"
@@ -1124,15 +1125,15 @@ class ImageAttributeName(str):
     deregistrationProtection = "deregistrationProtection"
 
 
-class ImageBlockPublicAccessDisabledState(str):
+class ImageBlockPublicAccessDisabledState(StrEnum):
     unblocked = "unblocked"
 
 
-class ImageBlockPublicAccessEnabledState(str):
+class ImageBlockPublicAccessEnabledState(StrEnum):
     block_new_sharing = "block-new-sharing"
 
 
-class ImageState(str):
+class ImageState(StrEnum):
     pending = "pending"
     available = "available"
     invalid = "invalid"
@@ -1143,17 +1144,17 @@ class ImageState(str):
     disabled = "disabled"
 
 
-class ImageTypeValues(str):
+class ImageTypeValues(StrEnum):
     machine = "machine"
     kernel = "kernel"
     ramdisk = "ramdisk"
 
 
-class ImdsSupportValues(str):
+class ImdsSupportValues(StrEnum):
     v2_0 = "v2.0"
 
 
-class InstanceAttributeName(str):
+class InstanceAttributeName(StrEnum):
     instanceType = "instanceType"
     kernel = "kernel"
     ramdisk = "ramdisk"
@@ -1172,76 +1173,76 @@ class InstanceAttributeName(str):
     disableApiStop = "disableApiStop"
 
 
-class InstanceAutoRecoveryState(str):
+class InstanceAutoRecoveryState(StrEnum):
     disabled = "disabled"
     default = "default"
 
 
-class InstanceBootModeValues(str):
+class InstanceBootModeValues(StrEnum):
     legacy_bios = "legacy-bios"
     uefi = "uefi"
 
 
-class InstanceEventWindowState(str):
+class InstanceEventWindowState(StrEnum):
     creating = "creating"
     deleting = "deleting"
     active = "active"
     deleted = "deleted"
 
 
-class InstanceGeneration(str):
+class InstanceGeneration(StrEnum):
     current = "current"
     previous = "previous"
 
 
-class InstanceHealthStatus(str):
+class InstanceHealthStatus(StrEnum):
     healthy = "healthy"
     unhealthy = "unhealthy"
 
 
-class InstanceInterruptionBehavior(str):
+class InstanceInterruptionBehavior(StrEnum):
     hibernate = "hibernate"
     stop = "stop"
     terminate = "terminate"
 
 
-class InstanceLifecycle(str):
+class InstanceLifecycle(StrEnum):
     spot = "spot"
     on_demand = "on-demand"
 
 
-class InstanceLifecycleType(str):
+class InstanceLifecycleType(StrEnum):
     spot = "spot"
     scheduled = "scheduled"
     capacity_block = "capacity-block"
 
 
-class InstanceMatchCriteria(str):
+class InstanceMatchCriteria(StrEnum):
     open = "open"
     targeted = "targeted"
 
 
-class InstanceMetadataEndpointState(str):
+class InstanceMetadataEndpointState(StrEnum):
     disabled = "disabled"
     enabled = "enabled"
 
 
-class InstanceMetadataOptionsState(str):
+class InstanceMetadataOptionsState(StrEnum):
     pending = "pending"
     applied = "applied"
 
 
-class InstanceMetadataProtocolState(str):
+class InstanceMetadataProtocolState(StrEnum):
     disabled = "disabled"
     enabled = "enabled"
 
 
-class InstanceMetadataTagsState(str):
+class InstanceMetadataTagsState(StrEnum):
     disabled = "disabled"
     enabled = "enabled"
 
 
-class InstanceStateName(str):
+class InstanceStateName(StrEnum):
     pending = "pending"
     running = "running"
     shutting_down = "shutting-down"
@@ -1250,12 +1251,12 @@ class InstanceStateName(str):
     stopped = "stopped"
 
 
-class InstanceStorageEncryptionSupport(str):
+class InstanceStorageEncryptionSupport(StrEnum):
     unsupported = "unsupported"
     required = "required"
 
 
-class InstanceType(str):
+class InstanceType(StrEnum):
     a1_medium = "a1.medium"
     a1_large = "a1.large"
     a1_xlarge = "a1.xlarge"
@@ -2078,28 +2079,28 @@ class InstanceType(str):
     mac2_m1ultra_metal = "mac2-m1ultra.metal"
 
 
-class InstanceTypeHypervisor(str):
+class InstanceTypeHypervisor(StrEnum):
     nitro = "nitro"
     xen = "xen"
 
 
-class InterfacePermissionType(str):
+class InterfacePermissionType(StrEnum):
     INSTANCE_ATTACH = "INSTANCE-ATTACH"
     EIP_ASSOCIATE = "EIP-ASSOCIATE"
 
 
-class InterfaceProtocolType(str):
+class InterfaceProtocolType(StrEnum):
     VLAN = "VLAN"
     GRE = "GRE"
 
 
-class IpAddressType(str):
+class IpAddressType(StrEnum):
     ipv4 = "ipv4"
     dualstack = "dualstack"
     ipv6 = "ipv6"
 
 
-class IpamAddressHistoryResourceType(str):
+class IpamAddressHistoryResourceType(StrEnum):
     eip = "eip"
     vpc = "vpc"
     subnet = "subnet"
@@ -2107,37 +2108,37 @@ class IpamAddressHistoryResourceType(str):
     instance = "instance"
 
 
-class IpamAssociatedResourceDiscoveryStatus(str):
+class IpamAssociatedResourceDiscoveryStatus(StrEnum):
     active = "active"
     not_found = "not-found"
 
 
-class IpamComplianceStatus(str):
+class IpamComplianceStatus(StrEnum):
     compliant = "compliant"
     noncompliant = "noncompliant"
     unmanaged = "unmanaged"
     ignored = "ignored"
 
 
-class IpamDiscoveryFailureCode(str):
+class IpamDiscoveryFailureCode(StrEnum):
     assume_role_failure = "assume-role-failure"
     throttling_failure = "throttling-failure"
     unauthorized_failure = "unauthorized-failure"
 
 
-class IpamManagementState(str):
+class IpamManagementState(StrEnum):
     managed = "managed"
     unmanaged = "unmanaged"
     ignored = "ignored"
 
 
-class IpamOverlapStatus(str):
+class IpamOverlapStatus(StrEnum):
     overlapping = "overlapping"
     nonoverlapping = "nonoverlapping"
     ignored = "ignored"
 
 
-class IpamPoolAllocationResourceType(str):
+class IpamPoolAllocationResourceType(StrEnum):
     ipam_pool = "ipam-pool"
     vpc = "vpc"
     ec2_public_ipv4_pool = "ec2-public-ipv4-pool"
@@ -2145,16 +2146,16 @@ class IpamPoolAllocationResourceType(str):
     subnet = "subnet"
 
 
-class IpamPoolAwsService(str):
+class IpamPoolAwsService(StrEnum):
     ec2 = "ec2"
 
 
-class IpamPoolCidrFailureCode(str):
+class IpamPoolCidrFailureCode(StrEnum):
     cidr_not_available = "cidr-not-available"
     limit_exceeded = "limit-exceeded"
 
 
-class IpamPoolCidrState(str):
+class IpamPoolCidrState(StrEnum):
     pending_provision = "pending-provision"
     provisioned = "provisioned"
     failed_provision = "failed-provision"
@@ -2165,16 +2166,16 @@ class IpamPoolCidrState(str):
     failed_import = "failed-import"
 
 
-class IpamPoolPublicIpSource(str):
+class IpamPoolPublicIpSource(StrEnum):
     amazon = "amazon"
     byoip = "byoip"
 
 
-class IpamPoolSourceResourceType(str):
+class IpamPoolSourceResourceType(StrEnum):
     vpc = "vpc"
 
 
-class IpamPoolState(str):
+class IpamPoolState(StrEnum):
     create_in_progress = "create-in-progress"
     create_complete = "create-complete"
     create_failed = "create-failed"
@@ -2189,12 +2190,12 @@ class IpamPoolState(str):
     restore_in_progress = "restore-in-progress"
 
 
-class IpamPublicAddressAssociationStatus(str):
+class IpamPublicAddressAssociationStatus(StrEnum):
     associated = "associated"
     disassociated = "disassociated"
 
 
-class IpamPublicAddressAwsService(str):
+class IpamPublicAddressAwsService(StrEnum):
     nat_gateway = "nat-gateway"
     database_migration_service = "database-migration-service"
     redshift = "redshift"
@@ -2206,7 +2207,7 @@ class IpamPublicAddressAwsService(str):
     other = "other"
 
 
-class IpamPublicAddressType(str):
+class IpamPublicAddressType(StrEnum):
     service_managed_ip = "service-managed-ip"
     service_managed_byoip = "service-managed-byoip"
     amazon_owned_eip = "amazon-owned-eip"
@@ -2214,7 +2215,7 @@ class IpamPublicAddressType(str):
     ec2_public_ip = "ec2-public-ip"
 
 
-class IpamResourceDiscoveryAssociationState(str):
+class IpamResourceDiscoveryAssociationState(StrEnum):
     associate_in_progress = "associate-in-progress"
     associate_complete = "associate-complete"
     associate_failed = "associate-failed"
@@ -2226,7 +2227,7 @@ class IpamResourceDiscoveryAssociationState(str):
     restore_in_progress = "restore-in-progress"
 
 
-class IpamResourceDiscoveryState(str):
+class IpamResourceDiscoveryState(StrEnum):
     create_in_progress = "create-in-progress"
     create_complete = "create-complete"
     create_failed = "create-failed"
@@ -2241,7 +2242,7 @@ class IpamResourceDiscoveryState(str):
     restore_in_progress = "restore-in-progress"
 
 
-class IpamResourceType(str):
+class IpamResourceType(StrEnum):
     vpc = "vpc"
     subnet = "subnet"
     eip = "eip"
@@ -2250,7 +2251,7 @@ class IpamResourceType(str):
     eni = "eni"
 
 
-class IpamScopeState(str):
+class IpamScopeState(StrEnum):
     create_in_progress = "create-in-progress"
     create_complete = "create-complete"
     create_failed = "create-failed"
@@ -2265,12 +2266,12 @@ class IpamScopeState(str):
     restore_in_progress = "restore-in-progress"
 
 
-class IpamScopeType(str):
+class IpamScopeType(StrEnum):
     public = "public"
     private = "private"
 
 
-class IpamState(str):
+class IpamState(StrEnum):
     create_in_progress = "create-in-progress"
     create_complete = "create-complete"
     create_failed = "create-failed"
@@ -2285,32 +2286,32 @@ class IpamState(str):
     restore_in_progress = "restore-in-progress"
 
 
-class IpamTier(str):
+class IpamTier(StrEnum):
     free = "free"
     advanced = "advanced"
 
 
-class Ipv6SupportValue(str):
+class Ipv6SupportValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class KeyFormat(str):
+class KeyFormat(StrEnum):
     pem = "pem"
     ppk = "ppk"
 
 
-class KeyType(str):
+class KeyType(StrEnum):
     rsa = "rsa"
     ed25519 = "ed25519"
 
 
-class LaunchTemplateAutoRecoveryState(str):
+class LaunchTemplateAutoRecoveryState(StrEnum):
     default = "default"
     disabled = "disabled"
 
 
-class LaunchTemplateErrorCode(str):
+class LaunchTemplateErrorCode(StrEnum):
     launchTemplateIdDoesNotExist = "launchTemplateIdDoesNotExist"
     launchTemplateIdMalformed = "launchTemplateIdMalformed"
     launchTemplateNameDoesNotExist = "launchTemplateNameDoesNotExist"
@@ -2319,46 +2320,46 @@ class LaunchTemplateErrorCode(str):
     unexpectedError = "unexpectedError"
 
 
-class LaunchTemplateHttpTokensState(str):
+class LaunchTemplateHttpTokensState(StrEnum):
     optional = "optional"
     required = "required"
 
 
-class LaunchTemplateInstanceMetadataEndpointState(str):
+class LaunchTemplateInstanceMetadataEndpointState(StrEnum):
     disabled = "disabled"
     enabled = "enabled"
 
 
-class LaunchTemplateInstanceMetadataOptionsState(str):
+class LaunchTemplateInstanceMetadataOptionsState(StrEnum):
     pending = "pending"
     applied = "applied"
 
 
-class LaunchTemplateInstanceMetadataProtocolIpv6(str):
+class LaunchTemplateInstanceMetadataProtocolIpv6(StrEnum):
     disabled = "disabled"
     enabled = "enabled"
 
 
-class LaunchTemplateInstanceMetadataTagsState(str):
+class LaunchTemplateInstanceMetadataTagsState(StrEnum):
     disabled = "disabled"
     enabled = "enabled"
 
 
-class ListingState(str):
+class ListingState(StrEnum):
     available = "available"
     sold = "sold"
     cancelled = "cancelled"
     pending = "pending"
 
 
-class ListingStatus(str):
+class ListingStatus(StrEnum):
     active = "active"
     pending = "pending"
     cancelled = "cancelled"
     closed = "closed"
 
 
-class LocalGatewayRouteState(str):
+class LocalGatewayRouteState(StrEnum):
     pending = "pending"
     active = "active"
     blackhole = "blackhole"
@@ -2366,95 +2367,95 @@ class LocalGatewayRouteState(str):
     deleted = "deleted"
 
 
-class LocalGatewayRouteTableMode(str):
+class LocalGatewayRouteTableMode(StrEnum):
     direct_vpc_routing = "direct-vpc-routing"
     coip = "coip"
 
 
-class LocalGatewayRouteType(str):
+class LocalGatewayRouteType(StrEnum):
     static = "static"
     propagated = "propagated"
 
 
-class LocalStorage(str):
+class LocalStorage(StrEnum):
     included = "included"
     required = "required"
     excluded = "excluded"
 
 
-class LocalStorageType(str):
+class LocalStorageType(StrEnum):
     hdd = "hdd"
     ssd = "ssd"
 
 
-class LocationType(str):
+class LocationType(StrEnum):
     region = "region"
     availability_zone = "availability-zone"
     availability_zone_id = "availability-zone-id"
     outpost = "outpost"
 
 
-class LockMode(str):
+class LockMode(StrEnum):
     compliance = "compliance"
     governance = "governance"
 
 
-class LockState(str):
+class LockState(StrEnum):
     compliance = "compliance"
     governance = "governance"
     compliance_cooloff = "compliance-cooloff"
     expired = "expired"
 
 
-class LogDestinationType(str):
+class LogDestinationType(StrEnum):
     cloud_watch_logs = "cloud-watch-logs"
     s3 = "s3"
     kinesis_data_firehose = "kinesis-data-firehose"
 
 
-class MarketType(str):
+class MarketType(StrEnum):
     spot = "spot"
     capacity_block = "capacity-block"
 
 
-class MembershipType(str):
+class MembershipType(StrEnum):
     static = "static"
     igmp = "igmp"
 
 
-class MetadataDefaultHttpTokensState(str):
+class MetadataDefaultHttpTokensState(StrEnum):
     optional = "optional"
     required = "required"
     no_preference = "no-preference"
 
 
-class MetricType(str):
+class MetricType(StrEnum):
     aggregate_latency = "aggregate-latency"
 
 
-class ModifyAvailabilityZoneOptInStatus(str):
+class ModifyAvailabilityZoneOptInStatus(StrEnum):
     opted_in = "opted-in"
     not_opted_in = "not-opted-in"
 
 
-class MonitoringState(str):
+class MonitoringState(StrEnum):
     disabled = "disabled"
     disabling = "disabling"
     enabled = "enabled"
     pending = "pending"
 
 
-class MoveStatus(str):
+class MoveStatus(StrEnum):
     movingToVpc = "movingToVpc"
     restoringToClassic = "restoringToClassic"
 
 
-class MulticastSupportValue(str):
+class MulticastSupportValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class NatGatewayAddressStatus(str):
+class NatGatewayAddressStatus(StrEnum):
     assigning = "assigning"
     unassigning = "unassigning"
     associating = "associating"
@@ -2463,7 +2464,7 @@ class NatGatewayAddressStatus(str):
     failed = "failed"
 
 
-class NatGatewayState(str):
+class NatGatewayState(StrEnum):
     pending = "pending"
     failed = "failed"
     available = "available"
@@ -2471,7 +2472,7 @@ class NatGatewayState(str):
     deleted = "deleted"
 
 
-class NetworkInterfaceAttribute(str):
+class NetworkInterfaceAttribute(StrEnum):
     description = "description"
     groupSet = "groupSet"
     sourceDestCheck = "sourceDestCheck"
@@ -2479,20 +2480,20 @@ class NetworkInterfaceAttribute(str):
     associatePublicIpAddress = "associatePublicIpAddress"
 
 
-class NetworkInterfaceCreationType(str):
+class NetworkInterfaceCreationType(StrEnum):
     efa = "efa"
     branch = "branch"
     trunk = "trunk"
 
 
-class NetworkInterfacePermissionStateCode(str):
+class NetworkInterfacePermissionStateCode(StrEnum):
     pending = "pending"
     granted = "granted"
     revoking = "revoking"
     revoked = "revoked"
 
 
-class NetworkInterfaceStatus(str):
+class NetworkInterfaceStatus(StrEnum):
     available = "available"
     associated = "associated"
     attaching = "attaching"
@@ -2500,7 +2501,7 @@ class NetworkInterfaceStatus(str):
     detaching = "detaching"
 
 
-class NetworkInterfaceType(str):
+class NetworkInterfaceType(StrEnum):
     interface = "interface"
     natGateway = "natGateway"
     efa = "efa"
@@ -2520,22 +2521,22 @@ class NetworkInterfaceType(str):
     aws_codestar_connections_managed = "aws_codestar_connections_managed"
 
 
-class NitroEnclavesSupport(str):
+class NitroEnclavesSupport(StrEnum):
     unsupported = "unsupported"
     supported = "supported"
 
 
-class NitroTpmSupport(str):
+class NitroTpmSupport(StrEnum):
     unsupported = "unsupported"
     supported = "supported"
 
 
-class OfferingClassType(str):
+class OfferingClassType(StrEnum):
     standard = "standard"
     convertible = "convertible"
 
 
-class OfferingTypeValues(str):
+class OfferingTypeValues(StrEnum):
     Heavy_Utilization = "Heavy Utilization"
     Medium_Utilization = "Medium Utilization"
     Light_Utilization = "Light Utilization"
@@ -2544,34 +2545,34 @@ class OfferingTypeValues(str):
     All_Upfront = "All Upfront"
 
 
-class OnDemandAllocationStrategy(str):
+class OnDemandAllocationStrategy(StrEnum):
     lowestPrice = "lowestPrice"
     prioritized = "prioritized"
 
 
-class OperationType(str):
+class OperationType(StrEnum):
     add = "add"
     remove = "remove"
 
 
-class PartitionLoadFrequency(str):
+class PartitionLoadFrequency(StrEnum):
     none = "none"
     daily = "daily"
     weekly = "weekly"
     monthly = "monthly"
 
 
-class PayerResponsibility(str):
+class PayerResponsibility(StrEnum):
     ServiceOwner = "ServiceOwner"
 
 
-class PaymentOption(str):
+class PaymentOption(StrEnum):
     AllUpfront = "AllUpfront"
     PartialUpfront = "PartialUpfront"
     NoUpfront = "NoUpfront"
 
 
-class PeriodType(str):
+class PeriodType(StrEnum):
     five_minutes = "five-minutes"
     fifteen_minutes = "fifteen-minutes"
     one_hour = "one-hour"
@@ -2580,39 +2581,39 @@ class PeriodType(str):
     one_week = "one-week"
 
 
-class PermissionGroup(str):
+class PermissionGroup(StrEnum):
     all = "all"
 
 
-class PhcSupport(str):
+class PhcSupport(StrEnum):
     unsupported = "unsupported"
     supported = "supported"
 
 
-class PlacementGroupState(str):
+class PlacementGroupState(StrEnum):
     pending = "pending"
     available = "available"
     deleting = "deleting"
     deleted = "deleted"
 
 
-class PlacementGroupStrategy(str):
+class PlacementGroupStrategy(StrEnum):
     cluster = "cluster"
     partition = "partition"
     spread = "spread"
 
 
-class PlacementStrategy(str):
+class PlacementStrategy(StrEnum):
     cluster = "cluster"
     spread = "spread"
     partition = "partition"
 
 
-class PlatformValues(str):
+class PlatformValues(StrEnum):
     Windows = "Windows"
 
 
-class PrefixListState(str):
+class PrefixListState(StrEnum):
     create_in_progress = "create-in-progress"
     create_complete = "create-complete"
     create_failed = "create-failed"
@@ -2627,7 +2628,7 @@ class PrefixListState(str):
     delete_failed = "delete-failed"
 
 
-class PrincipalType(str):
+class PrincipalType(StrEnum):
     All = "All"
     Service = "Service"
     OrganizationUnit = "OrganizationUnit"
@@ -2636,32 +2637,32 @@ class PrincipalType(str):
     Role = "Role"
 
 
-class ProductCodeValues(str):
+class ProductCodeValues(StrEnum):
     devpay = "devpay"
     marketplace = "marketplace"
 
 
-class Protocol(str):
+class Protocol(StrEnum):
     tcp = "tcp"
     udp = "udp"
 
 
-class ProtocolValue(str):
+class ProtocolValue(StrEnum):
     gre = "gre"
 
 
-class RIProductDescription(str):
+class RIProductDescription(StrEnum):
     Linux_UNIX = "Linux/UNIX"
     Linux_UNIX_Amazon_VPC_ = "Linux/UNIX (Amazon VPC)"
     Windows = "Windows"
     Windows_Amazon_VPC_ = "Windows (Amazon VPC)"
 
 
-class RecurringChargeFrequency(str):
+class RecurringChargeFrequency(StrEnum):
     Hourly = "Hourly"
 
 
-class ReplaceRootVolumeTaskState(str):
+class ReplaceRootVolumeTaskState(StrEnum):
     pending = "pending"
     in_progress = "in-progress"
     failing = "failing"
@@ -2670,12 +2671,12 @@ class ReplaceRootVolumeTaskState(str):
     failed_detached = "failed-detached"
 
 
-class ReplacementStrategy(str):
+class ReplacementStrategy(StrEnum):
     launch = "launch"
     launch_before_terminate = "launch-before-terminate"
 
 
-class ReportInstanceReasonCodes(str):
+class ReportInstanceReasonCodes(StrEnum):
     instance_stuck_in_state = "instance-stuck-in-state"
     unresponsive = "unresponsive"
     not_accepting_credentials = "not-accepting-credentials"
@@ -2687,19 +2688,19 @@ class ReportInstanceReasonCodes(str):
     other = "other"
 
 
-class ReportStatusType(str):
+class ReportStatusType(StrEnum):
     ok = "ok"
     impaired = "impaired"
 
 
-class ReservationState(str):
+class ReservationState(StrEnum):
     payment_pending = "payment-pending"
     payment_failed = "payment-failed"
     active = "active"
     retired = "retired"
 
 
-class ReservedInstanceState(str):
+class ReservedInstanceState(StrEnum):
     payment_pending = "payment-pending"
     active = "active"
     payment_failed = "payment-failed"
@@ -2708,15 +2709,15 @@ class ReservedInstanceState(str):
     queued_deleted = "queued-deleted"
 
 
-class ResetFpgaImageAttributeName(str):
+class ResetFpgaImageAttributeName(StrEnum):
     loadPermission = "loadPermission"
 
 
-class ResetImageAttributeName(str):
+class ResetImageAttributeName(StrEnum):
     launchPermission = "launchPermission"
 
 
-class ResourceType(str):
+class ResourceType(StrEnum):
     capacity_reservation = "capacity-reservation"
     client_vpn_endpoint = "client-vpn-endpoint"
     customer_gateway = "customer-gateway"
@@ -2808,23 +2809,23 @@ class ResourceType(str):
     instance_connect_endpoint = "instance-connect-endpoint"
 
 
-class RootDeviceType(str):
+class RootDeviceType(StrEnum):
     ebs = "ebs"
     instance_store = "instance-store"
 
 
-class RouteOrigin(str):
+class RouteOrigin(StrEnum):
     CreateRouteTable = "CreateRouteTable"
     CreateRoute = "CreateRoute"
     EnableVgwRoutePropagation = "EnableVgwRoutePropagation"
 
 
-class RouteState(str):
+class RouteState(StrEnum):
     active = "active"
     blackhole = "blackhole"
 
 
-class RouteTableAssociationStateCode(str):
+class RouteTableAssociationStateCode(StrEnum):
     associating = "associating"
     associated = "associated"
     disassociating = "disassociating"
@@ -2832,33 +2833,33 @@ class RouteTableAssociationStateCode(str):
     failed = "failed"
 
 
-class RuleAction(str):
+class RuleAction(StrEnum):
     allow = "allow"
     deny = "deny"
 
 
-class SSEType(str):
+class SSEType(StrEnum):
     sse_ebs = "sse-ebs"
     sse_kms = "sse-kms"
     none = "none"
 
 
-class SecurityGroupReferencingSupportValue(str):
+class SecurityGroupReferencingSupportValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class SelfServicePortal(str):
+class SelfServicePortal(StrEnum):
     enabled = "enabled"
     disabled = "disabled"
 
 
-class ServiceConnectivityType(str):
+class ServiceConnectivityType(StrEnum):
     ipv4 = "ipv4"
     ipv6 = "ipv6"
 
 
-class ServiceState(str):
+class ServiceState(StrEnum):
     Pending = "Pending"
     Available = "Available"
     Deleting = "Deleting"
@@ -2866,29 +2867,29 @@ class ServiceState(str):
     Failed = "Failed"
 
 
-class ServiceType(str):
+class ServiceType(StrEnum):
     Interface = "Interface"
     Gateway = "Gateway"
     GatewayLoadBalancer = "GatewayLoadBalancer"
 
 
-class ShutdownBehavior(str):
+class ShutdownBehavior(StrEnum):
     stop = "stop"
     terminate = "terminate"
 
 
-class SnapshotAttributeName(str):
+class SnapshotAttributeName(StrEnum):
     productCodes = "productCodes"
     createVolumePermission = "createVolumePermission"
 
 
-class SnapshotBlockPublicAccessState(str):
+class SnapshotBlockPublicAccessState(StrEnum):
     block_all_sharing = "block-all-sharing"
     block_new_sharing = "block-new-sharing"
     unblocked = "unblocked"
 
 
-class SnapshotState(str):
+class SnapshotState(StrEnum):
     pending = "pending"
     completed = "completed"
     error = "error"
@@ -2896,7 +2897,7 @@ class SnapshotState(str):
     recovering = "recovering"
 
 
-class SpotAllocationStrategy(str):
+class SpotAllocationStrategy(StrEnum):
     lowest_price = "lowest-price"
     diversified = "diversified"
     capacity_optimized = "capacity-optimized"
@@ -2904,13 +2905,13 @@ class SpotAllocationStrategy(str):
     price_capacity_optimized = "price-capacity-optimized"
 
 
-class SpotInstanceInterruptionBehavior(str):
+class SpotInstanceInterruptionBehavior(StrEnum):
     hibernate = "hibernate"
     stop = "stop"
     terminate = "terminate"
 
 
-class SpotInstanceState(str):
+class SpotInstanceState(StrEnum):
     open = "open"
     active = "active"
     closed = "closed"
@@ -2919,17 +2920,17 @@ class SpotInstanceState(str):
     disabled = "disabled"
 
 
-class SpotInstanceType(str):
+class SpotInstanceType(StrEnum):
     one_time = "one-time"
     persistent = "persistent"
 
 
-class SpreadLevel(str):
+class SpreadLevel(StrEnum):
     host = "host"
     rack = "rack"
 
 
-class State(str):
+class State(StrEnum):
     PendingAcceptance = "PendingAcceptance"
     Pending = "Pending"
     Available = "Available"
@@ -2940,38 +2941,38 @@ class State(str):
     Expired = "Expired"
 
 
-class StaticSourcesSupportValue(str):
+class StaticSourcesSupportValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class StatisticType(str):
+class StatisticType(StrEnum):
     p50 = "p50"
 
 
-class Status(str):
+class Status(StrEnum):
     MoveInProgress = "MoveInProgress"
     InVpc = "InVpc"
     InClassic = "InClassic"
 
 
-class StatusName(str):
+class StatusName(StrEnum):
     reachability = "reachability"
 
 
-class StatusType(str):
+class StatusType(StrEnum):
     passed = "passed"
     failed = "failed"
     insufficient_data = "insufficient-data"
     initializing = "initializing"
 
 
-class StorageTier(str):
+class StorageTier(StrEnum):
     archive = "archive"
     standard = "standard"
 
 
-class SubnetCidrBlockStateCode(str):
+class SubnetCidrBlockStateCode(StrEnum):
     associating = "associating"
     associated = "associated"
     disassociating = "disassociating"
@@ -2980,18 +2981,18 @@ class SubnetCidrBlockStateCode(str):
     failed = "failed"
 
 
-class SubnetCidrReservationType(str):
+class SubnetCidrReservationType(StrEnum):
     prefix = "prefix"
     explicit = "explicit"
 
 
-class SubnetState(str):
+class SubnetState(StrEnum):
     pending = "pending"
     available = "available"
     unavailable = "unavailable"
 
 
-class SummaryStatus(str):
+class SummaryStatus(StrEnum):
     ok = "ok"
     impaired = "impaired"
     insufficient_data = "insufficient-data"
@@ -2999,32 +3000,32 @@ class SummaryStatus(str):
     initializing = "initializing"
 
 
-class SupportedAdditionalProcessorFeature(str):
+class SupportedAdditionalProcessorFeature(StrEnum):
     amd_sev_snp = "amd-sev-snp"
 
 
-class TargetCapacityUnitType(str):
+class TargetCapacityUnitType(StrEnum):
     vcpu = "vcpu"
     memory_mib = "memory-mib"
     units = "units"
 
 
-class TargetStorageTier(str):
+class TargetStorageTier(StrEnum):
     archive = "archive"
 
 
-class TelemetryStatus(str):
+class TelemetryStatus(StrEnum):
     UP = "UP"
     DOWN = "DOWN"
 
 
-class Tenancy(str):
+class Tenancy(StrEnum):
     default = "default"
     dedicated = "dedicated"
     host = "host"
 
 
-class TieringOperationStatus(str):
+class TieringOperationStatus(StrEnum):
     archival_in_progress = "archival-in-progress"
     archival_completed = "archival-completed"
     archival_failed = "archival-failed"
@@ -3036,57 +3037,57 @@ class TieringOperationStatus(str):
     permanent_restore_failed = "permanent-restore-failed"
 
 
-class TpmSupportValues(str):
+class TpmSupportValues(StrEnum):
     v2_0 = "v2.0"
 
 
-class TrafficDirection(str):
+class TrafficDirection(StrEnum):
     ingress = "ingress"
     egress = "egress"
 
 
-class TrafficMirrorFilterRuleField(str):
+class TrafficMirrorFilterRuleField(StrEnum):
     destination_port_range = "destination-port-range"
     source_port_range = "source-port-range"
     protocol = "protocol"
     description = "description"
 
 
-class TrafficMirrorNetworkService(str):
+class TrafficMirrorNetworkService(StrEnum):
     amazon_dns = "amazon-dns"
 
 
-class TrafficMirrorRuleAction(str):
+class TrafficMirrorRuleAction(StrEnum):
     accept = "accept"
     reject = "reject"
 
 
-class TrafficMirrorSessionField(str):
+class TrafficMirrorSessionField(StrEnum):
     packet_length = "packet-length"
     description = "description"
     virtual_network_id = "virtual-network-id"
 
 
-class TrafficMirrorTargetType(str):
+class TrafficMirrorTargetType(StrEnum):
     network_interface = "network-interface"
     network_load_balancer = "network-load-balancer"
     gateway_load_balancer_endpoint = "gateway-load-balancer-endpoint"
 
 
-class TrafficType(str):
+class TrafficType(StrEnum):
     ACCEPT = "ACCEPT"
     REJECT = "REJECT"
     ALL = "ALL"
 
 
-class TransitGatewayAssociationState(str):
+class TransitGatewayAssociationState(StrEnum):
     associating = "associating"
     associated = "associated"
     disassociating = "disassociating"
     disassociated = "disassociated"
 
 
-class TransitGatewayAttachmentResourceType(str):
+class TransitGatewayAttachmentResourceType(StrEnum):
     vpc = "vpc"
     vpn = "vpn"
     direct_connect_gateway = "direct-connect-gateway"
@@ -3095,7 +3096,7 @@ class TransitGatewayAttachmentResourceType(str):
     tgw_peering = "tgw-peering"
 
 
-class TransitGatewayAttachmentState(str):
+class TransitGatewayAttachmentState(StrEnum):
     initiating = "initiating"
     initiatingRequest = "initiatingRequest"
     pendingAcceptance = "pendingAcceptance"
@@ -3111,14 +3112,14 @@ class TransitGatewayAttachmentState(str):
     failing = "failing"
 
 
-class TransitGatewayConnectPeerState(str):
+class TransitGatewayConnectPeerState(StrEnum):
     pending = "pending"
     available = "available"
     deleting = "deleting"
     deleted = "deleted"
 
 
-class TransitGatewayMulitcastDomainAssociationState(str):
+class TransitGatewayMulitcastDomainAssociationState(StrEnum):
     pendingAcceptance = "pendingAcceptance"
     associating = "associating"
     associated = "associated"
@@ -3128,35 +3129,35 @@ class TransitGatewayMulitcastDomainAssociationState(str):
     failed = "failed"
 
 
-class TransitGatewayMulticastDomainState(str):
+class TransitGatewayMulticastDomainState(StrEnum):
     pending = "pending"
     available = "available"
     deleting = "deleting"
     deleted = "deleted"
 
 
-class TransitGatewayPolicyTableState(str):
+class TransitGatewayPolicyTableState(StrEnum):
     pending = "pending"
     available = "available"
     deleting = "deleting"
     deleted = "deleted"
 
 
-class TransitGatewayPrefixListReferenceState(str):
+class TransitGatewayPrefixListReferenceState(StrEnum):
     pending = "pending"
     available = "available"
     modifying = "modifying"
     deleting = "deleting"
 
 
-class TransitGatewayPropagationState(str):
+class TransitGatewayPropagationState(StrEnum):
     enabling = "enabling"
     enabled = "enabled"
     disabling = "disabling"
     disabled = "disabled"
 
 
-class TransitGatewayRouteState(str):
+class TransitGatewayRouteState(StrEnum):
     pending = "pending"
     active = "active"
     blackhole = "blackhole"
@@ -3164,12 +3165,12 @@ class TransitGatewayRouteState(str):
     deleted = "deleted"
 
 
-class TransitGatewayRouteTableAnnouncementDirection(str):
+class TransitGatewayRouteTableAnnouncementDirection(StrEnum):
     outgoing = "outgoing"
     incoming = "incoming"
 
 
-class TransitGatewayRouteTableAnnouncementState(str):
+class TransitGatewayRouteTableAnnouncementState(StrEnum):
     available = "available"
     pending = "pending"
     failing = "failing"
@@ -3178,19 +3179,19 @@ class TransitGatewayRouteTableAnnouncementState(str):
     deleted = "deleted"
 
 
-class TransitGatewayRouteTableState(str):
+class TransitGatewayRouteTableState(StrEnum):
     pending = "pending"
     available = "available"
     deleting = "deleting"
     deleted = "deleted"
 
 
-class TransitGatewayRouteType(str):
+class TransitGatewayRouteType(StrEnum):
     static = "static"
     propagated = "propagated"
 
 
-class TransitGatewayState(str):
+class TransitGatewayState(StrEnum):
     pending = "pending"
     available = "available"
     modifying = "modifying"
@@ -3198,56 +3199,56 @@ class TransitGatewayState(str):
     deleted = "deleted"
 
 
-class TransportProtocol(str):
+class TransportProtocol(StrEnum):
     tcp = "tcp"
     udp = "udp"
 
 
-class TrustProviderType(str):
+class TrustProviderType(StrEnum):
     user = "user"
     device = "device"
 
 
-class TunnelInsideIpVersion(str):
+class TunnelInsideIpVersion(StrEnum):
     ipv4 = "ipv4"
     ipv6 = "ipv6"
 
 
-class UnlimitedSupportedInstanceFamily(str):
+class UnlimitedSupportedInstanceFamily(StrEnum):
     t2 = "t2"
     t3 = "t3"
     t3a = "t3a"
     t4g = "t4g"
 
 
-class UnsuccessfulInstanceCreditSpecificationErrorCode(str):
+class UnsuccessfulInstanceCreditSpecificationErrorCode(StrEnum):
     InvalidInstanceID_Malformed = "InvalidInstanceID.Malformed"
     InvalidInstanceID_NotFound = "InvalidInstanceID.NotFound"
     IncorrectInstanceState = "IncorrectInstanceState"
     InstanceCreditSpecification_NotSupported = "InstanceCreditSpecification.NotSupported"
 
 
-class UsageClassType(str):
+class UsageClassType(StrEnum):
     spot = "spot"
     on_demand = "on-demand"
     capacity_block = "capacity-block"
 
 
-class UserTrustProviderType(str):
+class UserTrustProviderType(StrEnum):
     iam_identity_center = "iam-identity-center"
     oidc = "oidc"
 
 
-class VerifiedAccessEndpointAttachmentType(str):
+class VerifiedAccessEndpointAttachmentType(StrEnum):
     vpc = "vpc"
 
 
-class VerifiedAccessEndpointProtocol(str):
+class VerifiedAccessEndpointProtocol(StrEnum):
     http = "http"
     https = "https"
 
 
-class VerifiedAccessEndpointStatusCode(str):
+class VerifiedAccessEndpointStatusCode(StrEnum):
     pending = "pending"
     active = "active"
     updating = "updating"
@@ -3255,22 +3256,22 @@ class VerifiedAccessEndpointStatusCode(str):
     deleted = "deleted"
 
 
-class VerifiedAccessEndpointType(str):
+class VerifiedAccessEndpointType(StrEnum):
     load_balancer = "load-balancer"
     network_interface = "network-interface"
 
 
-class VerifiedAccessLogDeliveryStatusCode(str):
+class VerifiedAccessLogDeliveryStatusCode(StrEnum):
     success = "success"
     failed = "failed"
 
 
-class VirtualizationType(str):
+class VirtualizationType(StrEnum):
     hvm = "hvm"
     paravirtual = "paravirtual"
 
 
-class VolumeAttachmentState(str):
+class VolumeAttachmentState(StrEnum):
     attaching = "attaching"
     attached = "attached"
     detaching = "detaching"
@@ -3278,19 +3279,19 @@ class VolumeAttachmentState(str):
     busy = "busy"
 
 
-class VolumeAttributeName(str):
+class VolumeAttributeName(StrEnum):
     autoEnableIO = "autoEnableIO"
     productCodes = "productCodes"
 
 
-class VolumeModificationState(str):
+class VolumeModificationState(StrEnum):
     modifying = "modifying"
     optimizing = "optimizing"
     completed = "completed"
     failed = "failed"
 
 
-class VolumeState(str):
+class VolumeState(StrEnum):
     creating = "creating"
     available = "available"
     in_use = "in-use"
@@ -3299,18 +3300,18 @@ class VolumeState(str):
     error = "error"
 
 
-class VolumeStatusInfoStatus(str):
+class VolumeStatusInfoStatus(StrEnum):
     ok = "ok"
     impaired = "impaired"
     insufficient_data = "insufficient-data"
 
 
-class VolumeStatusName(str):
+class VolumeStatusName(StrEnum):
     io_enabled = "io-enabled"
     io_performance = "io-performance"
 
 
-class VolumeType(str):
+class VolumeType(StrEnum):
     standard = "standard"
     io1 = "io1"
     io2 = "io2"
@@ -3320,13 +3321,13 @@ class VolumeType(str):
     gp3 = "gp3"
 
 
-class VpcAttributeName(str):
+class VpcAttributeName(StrEnum):
     enableDnsSupport = "enableDnsSupport"
     enableDnsHostnames = "enableDnsHostnames"
     enableNetworkAddressUsageMetrics = "enableNetworkAddressUsageMetrics"
 
 
-class VpcCidrBlockStateCode(str):
+class VpcCidrBlockStateCode(StrEnum):
     associating = "associating"
     associated = "associated"
     disassociating = "disassociating"
@@ -3335,13 +3336,13 @@ class VpcCidrBlockStateCode(str):
     failed = "failed"
 
 
-class VpcEndpointType(str):
+class VpcEndpointType(StrEnum):
     Interface = "Interface"
     Gateway = "Gateway"
     GatewayLoadBalancer = "GatewayLoadBalancer"
 
 
-class VpcPeeringConnectionStateReasonCode(str):
+class VpcPeeringConnectionStateReasonCode(StrEnum):
     initiating_request = "initiating-request"
     pending_acceptance = "pending-acceptance"
     active = "active"
@@ -3353,36 +3354,36 @@ class VpcPeeringConnectionStateReasonCode(str):
     deleting = "deleting"
 
 
-class VpcState(str):
+class VpcState(StrEnum):
     pending = "pending"
     available = "available"
 
 
-class VpcTenancy(str):
+class VpcTenancy(StrEnum):
     default = "default"
 
 
-class VpnEcmpSupportValue(str):
+class VpnEcmpSupportValue(StrEnum):
     enable = "enable"
     disable = "disable"
 
 
-class VpnProtocol(str):
+class VpnProtocol(StrEnum):
     openvpn = "openvpn"
 
 
-class VpnState(str):
+class VpnState(StrEnum):
     pending = "pending"
     available = "available"
     deleting = "deleting"
     deleted = "deleted"
 
 
-class VpnStaticRouteSource(str):
+class VpnStaticRouteSource(StrEnum):
     Static = "Static"
 
 
-class WeekDay(str):
+class WeekDay(StrEnum):
     sunday = "sunday"
     monday = "monday"
     tuesday = "tuesday"
@@ -3392,7 +3393,7 @@ class WeekDay(str):
     saturday = "saturday"
 
 
-class scope(str):
+class scope(StrEnum):
     Availability_Zone = "Availability Zone"
     Region = "Region"
 

--- a/localstack-core/localstack/aws/api/es/__init__.py
+++ b/localstack-core/localstack/aws/api/es/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -74,12 +75,12 @@ Username = str
 VpcEndpointId = str
 
 
-class AutoTuneDesiredState(str):
+class AutoTuneDesiredState(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
 
 
-class AutoTuneState(str):
+class AutoTuneState(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
     ENABLE_IN_PROGRESS = "ENABLE_IN_PROGRESS"
@@ -91,11 +92,11 @@ class AutoTuneState(str):
     ERROR = "ERROR"
 
 
-class AutoTuneType(str):
+class AutoTuneType(StrEnum):
     SCHEDULED_ACTION = "SCHEDULED_ACTION"
 
 
-class ConfigChangeStatus(str):
+class ConfigChangeStatus(StrEnum):
     Pending = "Pending"
     Initializing = "Initializing"
     Validating = "Validating"
@@ -106,7 +107,7 @@ class ConfigChangeStatus(str):
     Cancelled = "Cancelled"
 
 
-class DeploymentStatus(str):
+class DeploymentStatus(StrEnum):
     PENDING_UPDATE = "PENDING_UPDATE"
     IN_PROGRESS = "IN_PROGRESS"
     COMPLETED = "COMPLETED"
@@ -114,13 +115,13 @@ class DeploymentStatus(str):
     ELIGIBLE = "ELIGIBLE"
 
 
-class DescribePackagesFilterName(str):
+class DescribePackagesFilterName(StrEnum):
     PackageID = "PackageID"
     PackageName = "PackageName"
     PackageStatus = "PackageStatus"
 
 
-class DomainPackageStatus(str):
+class DomainPackageStatus(StrEnum):
     ASSOCIATING = "ASSOCIATING"
     ASSOCIATION_FAILED = "ASSOCIATION_FAILED"
     ACTIVE = "ACTIVE"
@@ -128,7 +129,7 @@ class DomainPackageStatus(str):
     DISSOCIATION_FAILED = "DISSOCIATION_FAILED"
 
 
-class DomainProcessingStatusType(str):
+class DomainProcessingStatusType(StrEnum):
     Creating = "Creating"
     Active = "Active"
     Modifying = "Modifying"
@@ -138,7 +139,7 @@ class DomainProcessingStatusType(str):
     Deleting = "Deleting"
 
 
-class ESPartitionInstanceType(str):
+class ESPartitionInstanceType(StrEnum):
     m3_medium_elasticsearch = "m3.medium.elasticsearch"
     m3_large_elasticsearch = "m3.large.elasticsearch"
     m3_xlarge_elasticsearch = "m3.xlarge.elasticsearch"
@@ -199,17 +200,17 @@ class ESPartitionInstanceType(str):
     i3_16xlarge_elasticsearch = "i3.16xlarge.elasticsearch"
 
 
-class ESWarmPartitionInstanceType(str):
+class ESWarmPartitionInstanceType(StrEnum):
     ultrawarm1_medium_elasticsearch = "ultrawarm1.medium.elasticsearch"
     ultrawarm1_large_elasticsearch = "ultrawarm1.large.elasticsearch"
 
 
-class EngineType(str):
+class EngineType(StrEnum):
     OpenSearch = "OpenSearch"
     Elasticsearch = "Elasticsearch"
 
 
-class InboundCrossClusterSearchConnectionStatusCode(str):
+class InboundCrossClusterSearchConnectionStatusCode(StrEnum):
     PENDING_ACCEPTANCE = "PENDING_ACCEPTANCE"
     APPROVED = "APPROVED"
     REJECTING = "REJECTING"
@@ -218,25 +219,25 @@ class InboundCrossClusterSearchConnectionStatusCode(str):
     DELETED = "DELETED"
 
 
-class InitiatedBy(str):
+class InitiatedBy(StrEnum):
     CUSTOMER = "CUSTOMER"
     SERVICE = "SERVICE"
 
 
-class LogType(str):
+class LogType(StrEnum):
     INDEX_SLOW_LOGS = "INDEX_SLOW_LOGS"
     SEARCH_SLOW_LOGS = "SEARCH_SLOW_LOGS"
     ES_APPLICATION_LOGS = "ES_APPLICATION_LOGS"
     AUDIT_LOGS = "AUDIT_LOGS"
 
 
-class OptionState(str):
+class OptionState(StrEnum):
     RequiresIndexDocuments = "RequiresIndexDocuments"
     Processing = "Processing"
     Active = "Active"
 
 
-class OutboundCrossClusterSearchConnectionStatusCode(str):
+class OutboundCrossClusterSearchConnectionStatusCode(StrEnum):
     PENDING_ACCEPTANCE = "PENDING_ACCEPTANCE"
     VALIDATING = "VALIDATING"
     VALIDATION_FAILED = "VALIDATION_FAILED"
@@ -247,14 +248,14 @@ class OutboundCrossClusterSearchConnectionStatusCode(str):
     DELETED = "DELETED"
 
 
-class OverallChangeStatus(str):
+class OverallChangeStatus(StrEnum):
     PENDING = "PENDING"
     PROCESSING = "PROCESSING"
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
 
 
-class PackageStatus(str):
+class PackageStatus(StrEnum):
     COPYING = "COPYING"
     COPY_FAILED = "COPY_FAILED"
     VALIDATING = "VALIDATING"
@@ -265,78 +266,78 @@ class PackageStatus(str):
     DELETE_FAILED = "DELETE_FAILED"
 
 
-class PackageType(str):
+class PackageType(StrEnum):
     TXT_DICTIONARY = "TXT-DICTIONARY"
 
 
-class PrincipalType(str):
+class PrincipalType(StrEnum):
     AWS_ACCOUNT = "AWS_ACCOUNT"
     AWS_SERVICE = "AWS_SERVICE"
 
 
-class PropertyValueType(str):
+class PropertyValueType(StrEnum):
     PLAIN_TEXT = "PLAIN_TEXT"
     STRINGIFIED_JSON = "STRINGIFIED_JSON"
 
 
-class ReservedElasticsearchInstancePaymentOption(str):
+class ReservedElasticsearchInstancePaymentOption(StrEnum):
     ALL_UPFRONT = "ALL_UPFRONT"
     PARTIAL_UPFRONT = "PARTIAL_UPFRONT"
     NO_UPFRONT = "NO_UPFRONT"
 
 
-class RollbackOnDisable(str):
+class RollbackOnDisable(StrEnum):
     NO_ROLLBACK = "NO_ROLLBACK"
     DEFAULT_ROLLBACK = "DEFAULT_ROLLBACK"
 
 
-class ScheduledAutoTuneActionType(str):
+class ScheduledAutoTuneActionType(StrEnum):
     JVM_HEAP_SIZE_TUNING = "JVM_HEAP_SIZE_TUNING"
     JVM_YOUNG_GEN_TUNING = "JVM_YOUNG_GEN_TUNING"
 
 
-class ScheduledAutoTuneSeverityType(str):
+class ScheduledAutoTuneSeverityType(StrEnum):
     LOW = "LOW"
     MEDIUM = "MEDIUM"
     HIGH = "HIGH"
 
 
-class TLSSecurityPolicy(str):
+class TLSSecurityPolicy(StrEnum):
     Policy_Min_TLS_1_0_2019_07 = "Policy-Min-TLS-1-0-2019-07"
     Policy_Min_TLS_1_2_2019_07 = "Policy-Min-TLS-1-2-2019-07"
     Policy_Min_TLS_1_2_PFS_2023_10 = "Policy-Min-TLS-1-2-PFS-2023-10"
 
 
-class TimeUnit(str):
+class TimeUnit(StrEnum):
     HOURS = "HOURS"
 
 
-class UpgradeStatus(str):
+class UpgradeStatus(StrEnum):
     IN_PROGRESS = "IN_PROGRESS"
     SUCCEEDED = "SUCCEEDED"
     SUCCEEDED_WITH_ISSUES = "SUCCEEDED_WITH_ISSUES"
     FAILED = "FAILED"
 
 
-class UpgradeStep(str):
+class UpgradeStep(StrEnum):
     PRE_UPGRADE_CHECK = "PRE_UPGRADE_CHECK"
     SNAPSHOT = "SNAPSHOT"
     UPGRADE = "UPGRADE"
 
 
-class VolumeType(str):
+class VolumeType(StrEnum):
     standard = "standard"
     gp2 = "gp2"
     io1 = "io1"
     gp3 = "gp3"
 
 
-class VpcEndpointErrorCode(str):
+class VpcEndpointErrorCode(StrEnum):
     ENDPOINT_NOT_FOUND = "ENDPOINT_NOT_FOUND"
     SERVER_ERROR = "SERVER_ERROR"
 
 
-class VpcEndpointStatus(str):
+class VpcEndpointStatus(StrEnum):
     CREATING = "CREATING"
     CREATE_FAILED = "CREATE_FAILED"
     ACTIVE = "ACTIVE"

--- a/localstack-core/localstack/aws/api/events/__init__.py
+++ b/localstack-core/localstack/aws/api/events/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -107,7 +108,7 @@ TraceHeader = str
 TransformerInput = str
 
 
-class ApiDestinationHttpMethod(str):
+class ApiDestinationHttpMethod(StrEnum):
     POST = "POST"
     GET = "GET"
     HEAD = "HEAD"
@@ -117,12 +118,12 @@ class ApiDestinationHttpMethod(str):
     DELETE = "DELETE"
 
 
-class ApiDestinationState(str):
+class ApiDestinationState(StrEnum):
     ACTIVE = "ACTIVE"
     INACTIVE = "INACTIVE"
 
 
-class ArchiveState(str):
+class ArchiveState(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
     CREATING = "CREATING"
@@ -131,24 +132,24 @@ class ArchiveState(str):
     UPDATE_FAILED = "UPDATE_FAILED"
 
 
-class AssignPublicIp(str):
+class AssignPublicIp(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
 
 
-class ConnectionAuthorizationType(str):
+class ConnectionAuthorizationType(StrEnum):
     BASIC = "BASIC"
     OAUTH_CLIENT_CREDENTIALS = "OAUTH_CLIENT_CREDENTIALS"
     API_KEY = "API_KEY"
 
 
-class ConnectionOAuthHttpMethod(str):
+class ConnectionOAuthHttpMethod(StrEnum):
     GET = "GET"
     POST = "POST"
     PUT = "PUT"
 
 
-class ConnectionState(str):
+class ConnectionState(StrEnum):
     CREATING = "CREATING"
     UPDATING = "UPDATING"
     DELETING = "DELETING"
@@ -158,7 +159,7 @@ class ConnectionState(str):
     DEAUTHORIZING = "DEAUTHORIZING"
 
 
-class EndpointState(str):
+class EndpointState(StrEnum):
     ACTIVE = "ACTIVE"
     CREATING = "CREATING"
     UPDATING = "UPDATING"
@@ -168,34 +169,34 @@ class EndpointState(str):
     DELETE_FAILED = "DELETE_FAILED"
 
 
-class EventSourceState(str):
+class EventSourceState(StrEnum):
     PENDING = "PENDING"
     ACTIVE = "ACTIVE"
     DELETED = "DELETED"
 
 
-class LaunchType(str):
+class LaunchType(StrEnum):
     EC2 = "EC2"
     FARGATE = "FARGATE"
     EXTERNAL = "EXTERNAL"
 
 
-class PlacementConstraintType(str):
+class PlacementConstraintType(StrEnum):
     distinctInstance = "distinctInstance"
     memberOf = "memberOf"
 
 
-class PlacementStrategyType(str):
+class PlacementStrategyType(StrEnum):
     random = "random"
     spread = "spread"
     binpack = "binpack"
 
 
-class PropagateTags(str):
+class PropagateTags(StrEnum):
     TASK_DEFINITION = "TASK_DEFINITION"
 
 
-class ReplayState(str):
+class ReplayState(StrEnum):
     STARTING = "STARTING"
     RUNNING = "RUNNING"
     CANCELLING = "CANCELLING"
@@ -204,12 +205,12 @@ class ReplayState(str):
     FAILED = "FAILED"
 
 
-class ReplicationState(str):
+class ReplicationState(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
 
 
-class RuleState(str):
+class RuleState(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
     ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS = "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS"

--- a/localstack-core/localstack/aws/api/firehose/__init__.py
+++ b/localstack-core/localstack/aws/api/firehose/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -95,12 +96,12 @@ TopicName = str
 Username = str
 
 
-class AmazonOpenSearchServerlessS3BackupMode(str):
+class AmazonOpenSearchServerlessS3BackupMode(StrEnum):
     FailedDocumentsOnly = "FailedDocumentsOnly"
     AllDocuments = "AllDocuments"
 
 
-class AmazonopensearchserviceIndexRotationPeriod(str):
+class AmazonopensearchserviceIndexRotationPeriod(StrEnum):
     NoRotation = "NoRotation"
     OneHour = "OneHour"
     OneDay = "OneDay"
@@ -108,12 +109,12 @@ class AmazonopensearchserviceIndexRotationPeriod(str):
     OneMonth = "OneMonth"
 
 
-class AmazonopensearchserviceS3BackupMode(str):
+class AmazonopensearchserviceS3BackupMode(StrEnum):
     FailedDocumentsOnly = "FailedDocumentsOnly"
     AllDocuments = "AllDocuments"
 
 
-class CompressionFormat(str):
+class CompressionFormat(StrEnum):
     UNCOMPRESSED = "UNCOMPRESSED"
     GZIP = "GZIP"
     ZIP = "ZIP"
@@ -121,22 +122,22 @@ class CompressionFormat(str):
     HADOOP_SNAPPY = "HADOOP_SNAPPY"
 
 
-class Connectivity(str):
+class Connectivity(StrEnum):
     PUBLIC = "PUBLIC"
     PRIVATE = "PRIVATE"
 
 
-class ContentEncoding(str):
+class ContentEncoding(StrEnum):
     NONE = "NONE"
     GZIP = "GZIP"
 
 
-class DefaultDocumentIdFormat(str):
+class DefaultDocumentIdFormat(StrEnum):
     FIREHOSE_DEFAULT = "FIREHOSE_DEFAULT"
     NO_DOCUMENT_ID = "NO_DOCUMENT_ID"
 
 
-class DeliveryStreamEncryptionStatus(str):
+class DeliveryStreamEncryptionStatus(StrEnum):
     ENABLED = "ENABLED"
     ENABLING = "ENABLING"
     ENABLING_FAILED = "ENABLING_FAILED"
@@ -145,7 +146,7 @@ class DeliveryStreamEncryptionStatus(str):
     DISABLING_FAILED = "DISABLING_FAILED"
 
 
-class DeliveryStreamFailureType(str):
+class DeliveryStreamFailureType(StrEnum):
     RETIRE_KMS_GRANT_FAILED = "RETIRE_KMS_GRANT_FAILED"
     CREATE_KMS_GRANT_FAILED = "CREATE_KMS_GRANT_FAILED"
     KMS_ACCESS_DENIED = "KMS_ACCESS_DENIED"
@@ -163,7 +164,7 @@ class DeliveryStreamFailureType(str):
     UNKNOWN_ERROR = "UNKNOWN_ERROR"
 
 
-class DeliveryStreamStatus(str):
+class DeliveryStreamStatus(StrEnum):
     CREATING = "CREATING"
     CREATING_FAILED = "CREATING_FAILED"
     DELETING = "DELETING"
@@ -171,13 +172,13 @@ class DeliveryStreamStatus(str):
     ACTIVE = "ACTIVE"
 
 
-class DeliveryStreamType(str):
+class DeliveryStreamType(StrEnum):
     DirectPut = "DirectPut"
     KinesisStreamAsSource = "KinesisStreamAsSource"
     MSKAsSource = "MSKAsSource"
 
 
-class ElasticsearchIndexRotationPeriod(str):
+class ElasticsearchIndexRotationPeriod(StrEnum):
     NoRotation = "NoRotation"
     OneHour = "OneHour"
     OneDay = "OneDay"
@@ -185,53 +186,53 @@ class ElasticsearchIndexRotationPeriod(str):
     OneMonth = "OneMonth"
 
 
-class ElasticsearchS3BackupMode(str):
+class ElasticsearchS3BackupMode(StrEnum):
     FailedDocumentsOnly = "FailedDocumentsOnly"
     AllDocuments = "AllDocuments"
 
 
-class HECEndpointType(str):
+class HECEndpointType(StrEnum):
     Raw = "Raw"
     Event = "Event"
 
 
-class HttpEndpointS3BackupMode(str):
+class HttpEndpointS3BackupMode(StrEnum):
     FailedDataOnly = "FailedDataOnly"
     AllData = "AllData"
 
 
-class KeyType(str):
+class KeyType(StrEnum):
     AWS_OWNED_CMK = "AWS_OWNED_CMK"
     CUSTOMER_MANAGED_CMK = "CUSTOMER_MANAGED_CMK"
 
 
-class NoEncryptionConfig(str):
+class NoEncryptionConfig(StrEnum):
     NoEncryption = "NoEncryption"
 
 
-class OrcCompression(str):
+class OrcCompression(StrEnum):
     NONE = "NONE"
     ZLIB = "ZLIB"
     SNAPPY = "SNAPPY"
 
 
-class OrcFormatVersion(str):
+class OrcFormatVersion(StrEnum):
     V0_11 = "V0_11"
     V0_12 = "V0_12"
 
 
-class ParquetCompression(str):
+class ParquetCompression(StrEnum):
     UNCOMPRESSED = "UNCOMPRESSED"
     GZIP = "GZIP"
     SNAPPY = "SNAPPY"
 
 
-class ParquetWriterVersion(str):
+class ParquetWriterVersion(StrEnum):
     V1 = "V1"
     V2 = "V2"
 
 
-class ProcessorParameterName(str):
+class ProcessorParameterName(StrEnum):
     LambdaArn = "LambdaArn"
     NumberOfRetries = "NumberOfRetries"
     MetadataExtractionQuery = "MetadataExtractionQuery"
@@ -245,7 +246,7 @@ class ProcessorParameterName(str):
     DataMessageExtraction = "DataMessageExtraction"
 
 
-class ProcessorType(str):
+class ProcessorType(StrEnum):
     RecordDeAggregation = "RecordDeAggregation"
     Decompression = "Decompression"
     CloudWatchLogProcessing = "CloudWatchLogProcessing"
@@ -254,28 +255,28 @@ class ProcessorType(str):
     AppendDelimiterToRecord = "AppendDelimiterToRecord"
 
 
-class RedshiftS3BackupMode(str):
+class RedshiftS3BackupMode(StrEnum):
     Disabled = "Disabled"
     Enabled = "Enabled"
 
 
-class S3BackupMode(str):
+class S3BackupMode(StrEnum):
     Disabled = "Disabled"
     Enabled = "Enabled"
 
 
-class SnowflakeDataLoadingOption(str):
+class SnowflakeDataLoadingOption(StrEnum):
     JSON_MAPPING = "JSON_MAPPING"
     VARIANT_CONTENT_MAPPING = "VARIANT_CONTENT_MAPPING"
     VARIANT_CONTENT_AND_METADATA_MAPPING = "VARIANT_CONTENT_AND_METADATA_MAPPING"
 
 
-class SnowflakeS3BackupMode(str):
+class SnowflakeS3BackupMode(StrEnum):
     FailedDataOnly = "FailedDataOnly"
     AllData = "AllData"
 
 
-class SplunkS3BackupMode(str):
+class SplunkS3BackupMode(StrEnum):
     FailedEventsOnly = "FailedEventsOnly"
     AllEvents = "AllEvents"
 

--- a/localstack-core/localstack/aws/api/iam/__init__.py
+++ b/localstack-core/localstack/aws/api/iam/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -109,12 +110,12 @@ userNameType = str
 virtualMFADeviceName = str
 
 
-class AccessAdvisorUsageGranularityType(str):
+class AccessAdvisorUsageGranularityType(StrEnum):
     SERVICE_LEVEL = "SERVICE_LEVEL"
     ACTION_LEVEL = "ACTION_LEVEL"
 
 
-class ContextKeyTypeEnum(str):
+class ContextKeyTypeEnum(StrEnum):
     string = "string"
     stringList = "stringList"
     numeric = "numeric"
@@ -129,14 +130,14 @@ class ContextKeyTypeEnum(str):
     dateList = "dateList"
 
 
-class DeletionTaskStatusType(str):
+class DeletionTaskStatusType(StrEnum):
     SUCCEEDED = "SUCCEEDED"
     IN_PROGRESS = "IN_PROGRESS"
     FAILED = "FAILED"
     NOT_STARTED = "NOT_STARTED"
 
 
-class EntityType(str):
+class EntityType(StrEnum):
     User = "User"
     Role = "Role"
     Group = "Group"
@@ -144,17 +145,17 @@ class EntityType(str):
     AWSManagedPolicy = "AWSManagedPolicy"
 
 
-class PermissionsBoundaryAttachmentType(str):
+class PermissionsBoundaryAttachmentType(StrEnum):
     PermissionsBoundaryPolicy = "PermissionsBoundaryPolicy"
 
 
-class PolicyEvaluationDecisionType(str):
+class PolicyEvaluationDecisionType(StrEnum):
     allowed = "allowed"
     explicitDeny = "explicitDeny"
     implicitDeny = "implicitDeny"
 
 
-class PolicySourceType(str):
+class PolicySourceType(StrEnum):
     user = "user"
     group = "group"
     role = "role"
@@ -164,73 +165,73 @@ class PolicySourceType(str):
     none = "none"
 
 
-class PolicyUsageType(str):
+class PolicyUsageType(StrEnum):
     PermissionsPolicy = "PermissionsPolicy"
     PermissionsBoundary = "PermissionsBoundary"
 
 
-class ReportFormatType(str):
+class ReportFormatType(StrEnum):
     text_csv = "text/csv"
 
 
-class ReportStateType(str):
+class ReportStateType(StrEnum):
     STARTED = "STARTED"
     INPROGRESS = "INPROGRESS"
     COMPLETE = "COMPLETE"
 
 
-class assignmentStatusType(str):
+class assignmentStatusType(StrEnum):
     Assigned = "Assigned"
     Unassigned = "Unassigned"
     Any = "Any"
 
 
-class encodingType(str):
+class encodingType(StrEnum):
     SSH = "SSH"
     PEM = "PEM"
 
 
-class globalEndpointTokenVersion(str):
+class globalEndpointTokenVersion(StrEnum):
     v1Token = "v1Token"
     v2Token = "v2Token"
 
 
-class jobStatusType(str):
+class jobStatusType(StrEnum):
     IN_PROGRESS = "IN_PROGRESS"
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
 
 
-class policyOwnerEntityType(str):
+class policyOwnerEntityType(StrEnum):
     USER = "USER"
     ROLE = "ROLE"
     GROUP = "GROUP"
 
 
-class policyScopeType(str):
+class policyScopeType(StrEnum):
     All = "All"
     AWS = "AWS"
     Local = "Local"
 
 
-class policyType(str):
+class policyType(StrEnum):
     INLINE = "INLINE"
     MANAGED = "MANAGED"
 
 
-class sortKeyType(str):
+class sortKeyType(StrEnum):
     SERVICE_NAMESPACE_ASCENDING = "SERVICE_NAMESPACE_ASCENDING"
     SERVICE_NAMESPACE_DESCENDING = "SERVICE_NAMESPACE_DESCENDING"
     LAST_AUTHENTICATED_TIME_ASCENDING = "LAST_AUTHENTICATED_TIME_ASCENDING"
     LAST_AUTHENTICATED_TIME_DESCENDING = "LAST_AUTHENTICATED_TIME_DESCENDING"
 
 
-class statusType(str):
+class statusType(StrEnum):
     Active = "Active"
     Inactive = "Inactive"
 
 
-class summaryKeyType(str):
+class summaryKeyType(StrEnum):
     Users = "Users"
     UsersQuota = "UsersQuota"
     Groups = "Groups"

--- a/localstack-core/localstack/aws/api/kinesis/__init__.py
+++ b/localstack-core/localstack/aws/api/kinesis/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, Iterator, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -35,18 +36,18 @@ TagKey = str
 TagValue = str
 
 
-class ConsumerStatus(str):
+class ConsumerStatus(StrEnum):
     CREATING = "CREATING"
     DELETING = "DELETING"
     ACTIVE = "ACTIVE"
 
 
-class EncryptionType(str):
+class EncryptionType(StrEnum):
     NONE = "NONE"
     KMS = "KMS"
 
 
-class MetricsName(str):
+class MetricsName(StrEnum):
     IncomingBytes = "IncomingBytes"
     IncomingRecords = "IncomingRecords"
     OutgoingBytes = "OutgoingBytes"
@@ -57,11 +58,11 @@ class MetricsName(str):
     ALL = "ALL"
 
 
-class ScalingType(str):
+class ScalingType(StrEnum):
     UNIFORM_SCALING = "UNIFORM_SCALING"
 
 
-class ShardFilterType(str):
+class ShardFilterType(StrEnum):
     AFTER_SHARD_ID = "AFTER_SHARD_ID"
     AT_TRIM_HORIZON = "AT_TRIM_HORIZON"
     FROM_TRIM_HORIZON = "FROM_TRIM_HORIZON"
@@ -70,7 +71,7 @@ class ShardFilterType(str):
     FROM_TIMESTAMP = "FROM_TIMESTAMP"
 
 
-class ShardIteratorType(str):
+class ShardIteratorType(StrEnum):
     AT_SEQUENCE_NUMBER = "AT_SEQUENCE_NUMBER"
     AFTER_SEQUENCE_NUMBER = "AFTER_SEQUENCE_NUMBER"
     TRIM_HORIZON = "TRIM_HORIZON"
@@ -78,12 +79,12 @@ class ShardIteratorType(str):
     AT_TIMESTAMP = "AT_TIMESTAMP"
 
 
-class StreamMode(str):
+class StreamMode(StrEnum):
     PROVISIONED = "PROVISIONED"
     ON_DEMAND = "ON_DEMAND"
 
 
-class StreamStatus(str):
+class StreamStatus(StrEnum):
     CREATING = "CREATING"
     DELETING = "DELETING"
     ACTIVE = "ACTIVE"

--- a/localstack-core/localstack/aws/api/kms/__init__.py
+++ b/localstack-core/localstack/aws/api/kms/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -40,7 +41,7 @@ XksProxyUriPathType = str
 XksProxyVpcEndpointServiceNameType = str
 
 
-class AlgorithmSpec(str):
+class AlgorithmSpec(StrEnum):
     RSAES_PKCS1_V1_5 = "RSAES_PKCS1_V1_5"
     RSAES_OAEP_SHA_1 = "RSAES_OAEP_SHA_1"
     RSAES_OAEP_SHA_256 = "RSAES_OAEP_SHA_256"
@@ -49,7 +50,7 @@ class AlgorithmSpec(str):
     SM2PKE = "SM2PKE"
 
 
-class ConnectionErrorCodeType(str):
+class ConnectionErrorCodeType(StrEnum):
     INVALID_CREDENTIALS = "INVALID_CREDENTIALS"
     CLUSTER_NOT_FOUND = "CLUSTER_NOT_FOUND"
     NETWORK_ERRORS = "NETWORK_ERRORS"
@@ -72,7 +73,7 @@ class ConnectionErrorCodeType(str):
     XKS_PROXY_INVALID_TLS_CONFIGURATION = "XKS_PROXY_INVALID_TLS_CONFIGURATION"
 
 
-class ConnectionStateType(str):
+class ConnectionStateType(StrEnum):
     CONNECTED = "CONNECTED"
     CONNECTING = "CONNECTING"
     FAILED = "FAILED"
@@ -80,12 +81,12 @@ class ConnectionStateType(str):
     DISCONNECTING = "DISCONNECTING"
 
 
-class CustomKeyStoreType(str):
+class CustomKeyStoreType(StrEnum):
     AWS_CLOUDHSM = "AWS_CLOUDHSM"
     EXTERNAL_KEY_STORE = "EXTERNAL_KEY_STORE"
 
 
-class CustomerMasterKeySpec(str):
+class CustomerMasterKeySpec(StrEnum):
     RSA_2048 = "RSA_2048"
     RSA_3072 = "RSA_3072"
     RSA_4096 = "RSA_4096"
@@ -101,7 +102,7 @@ class CustomerMasterKeySpec(str):
     SM2 = "SM2"
 
 
-class DataKeyPairSpec(str):
+class DataKeyPairSpec(StrEnum):
     RSA_2048 = "RSA_2048"
     RSA_3072 = "RSA_3072"
     RSA_4096 = "RSA_4096"
@@ -112,24 +113,24 @@ class DataKeyPairSpec(str):
     SM2 = "SM2"
 
 
-class DataKeySpec(str):
+class DataKeySpec(StrEnum):
     AES_256 = "AES_256"
     AES_128 = "AES_128"
 
 
-class EncryptionAlgorithmSpec(str):
+class EncryptionAlgorithmSpec(StrEnum):
     SYMMETRIC_DEFAULT = "SYMMETRIC_DEFAULT"
     RSAES_OAEP_SHA_1 = "RSAES_OAEP_SHA_1"
     RSAES_OAEP_SHA_256 = "RSAES_OAEP_SHA_256"
     SM2PKE = "SM2PKE"
 
 
-class ExpirationModelType(str):
+class ExpirationModelType(StrEnum):
     KEY_MATERIAL_EXPIRES = "KEY_MATERIAL_EXPIRES"
     KEY_MATERIAL_DOES_NOT_EXPIRE = "KEY_MATERIAL_DOES_NOT_EXPIRE"
 
 
-class GrantOperation(str):
+class GrantOperation(StrEnum):
     Decrypt = "Decrypt"
     Encrypt = "Encrypt"
     GenerateDataKey = "GenerateDataKey"
@@ -149,20 +150,20 @@ class GrantOperation(str):
     DeriveSharedSecret = "DeriveSharedSecret"
 
 
-class KeyAgreementAlgorithmSpec(str):
+class KeyAgreementAlgorithmSpec(StrEnum):
     ECDH = "ECDH"
 
 
-class KeyEncryptionMechanism(str):
+class KeyEncryptionMechanism(StrEnum):
     RSAES_OAEP_SHA_256 = "RSAES_OAEP_SHA_256"
 
 
-class KeyManagerType(str):
+class KeyManagerType(StrEnum):
     AWS = "AWS"
     CUSTOMER = "CUSTOMER"
 
 
-class KeySpec(str):
+class KeySpec(StrEnum):
     RSA_2048 = "RSA_2048"
     RSA_3072 = "RSA_3072"
     RSA_4096 = "RSA_4096"
@@ -178,7 +179,7 @@ class KeySpec(str):
     SM2 = "SM2"
 
 
-class KeyState(str):
+class KeyState(StrEnum):
     Creating = "Creating"
     Enabled = "Enabled"
     Disabled = "Disabled"
@@ -189,43 +190,43 @@ class KeyState(str):
     Updating = "Updating"
 
 
-class KeyUsageType(str):
+class KeyUsageType(StrEnum):
     SIGN_VERIFY = "SIGN_VERIFY"
     ENCRYPT_DECRYPT = "ENCRYPT_DECRYPT"
     GENERATE_VERIFY_MAC = "GENERATE_VERIFY_MAC"
     KEY_AGREEMENT = "KEY_AGREEMENT"
 
 
-class MacAlgorithmSpec(str):
+class MacAlgorithmSpec(StrEnum):
     HMAC_SHA_224 = "HMAC_SHA_224"
     HMAC_SHA_256 = "HMAC_SHA_256"
     HMAC_SHA_384 = "HMAC_SHA_384"
     HMAC_SHA_512 = "HMAC_SHA_512"
 
 
-class MessageType(str):
+class MessageType(StrEnum):
     RAW = "RAW"
     DIGEST = "DIGEST"
 
 
-class MultiRegionKeyType(str):
+class MultiRegionKeyType(StrEnum):
     PRIMARY = "PRIMARY"
     REPLICA = "REPLICA"
 
 
-class OriginType(str):
+class OriginType(StrEnum):
     AWS_KMS = "AWS_KMS"
     EXTERNAL = "EXTERNAL"
     AWS_CLOUDHSM = "AWS_CLOUDHSM"
     EXTERNAL_KEY_STORE = "EXTERNAL_KEY_STORE"
 
 
-class RotationType(str):
+class RotationType(StrEnum):
     AUTOMATIC = "AUTOMATIC"
     ON_DEMAND = "ON_DEMAND"
 
 
-class SigningAlgorithmSpec(str):
+class SigningAlgorithmSpec(StrEnum):
     RSASSA_PSS_SHA_256 = "RSASSA_PSS_SHA_256"
     RSASSA_PSS_SHA_384 = "RSASSA_PSS_SHA_384"
     RSASSA_PSS_SHA_512 = "RSASSA_PSS_SHA_512"
@@ -238,14 +239,14 @@ class SigningAlgorithmSpec(str):
     SM2DSA = "SM2DSA"
 
 
-class WrappingKeySpec(str):
+class WrappingKeySpec(StrEnum):
     RSA_2048 = "RSA_2048"
     RSA_3072 = "RSA_3072"
     RSA_4096 = "RSA_4096"
     SM2 = "SM2"
 
 
-class XksProxyConnectivityType(str):
+class XksProxyConnectivityType(StrEnum):
     PUBLIC_ENDPOINT = "PUBLIC_ENDPOINT"
     VPC_ENDPOINT_SERVICE = "VPC_ENDPOINT_SERVICE"
 

--- a/localstack-core/localstack/aws/api/lambda_/__init__.py
+++ b/localstack-core/localstack/aws/api/lambda_/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import IO, Dict, Iterable, Iterator, List, Optional, TypedDict, Union
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -99,7 +100,7 @@ Weight = float
 WorkingDirectory = str
 
 
-class ApplicationLogLevel(str):
+class ApplicationLogLevel(StrEnum):
     TRACE = "TRACE"
     DEBUG = "DEBUG"
     INFO = "INFO"
@@ -108,62 +109,62 @@ class ApplicationLogLevel(str):
     FATAL = "FATAL"
 
 
-class Architecture(str):
+class Architecture(StrEnum):
     x86_64 = "x86_64"
     arm64 = "arm64"
 
 
-class CodeSigningPolicy(str):
+class CodeSigningPolicy(StrEnum):
     Warn = "Warn"
     Enforce = "Enforce"
 
 
-class EndPointType(str):
+class EndPointType(StrEnum):
     KAFKA_BOOTSTRAP_SERVERS = "KAFKA_BOOTSTRAP_SERVERS"
 
 
-class EventSourcePosition(str):
+class EventSourcePosition(StrEnum):
     TRIM_HORIZON = "TRIM_HORIZON"
     LATEST = "LATEST"
     AT_TIMESTAMP = "AT_TIMESTAMP"
 
 
-class FullDocument(str):
+class FullDocument(StrEnum):
     UpdateLookup = "UpdateLookup"
     Default = "Default"
 
 
-class FunctionResponseType(str):
+class FunctionResponseType(StrEnum):
     ReportBatchItemFailures = "ReportBatchItemFailures"
 
 
-class FunctionUrlAuthType(str):
+class FunctionUrlAuthType(StrEnum):
     NONE = "NONE"
     AWS_IAM = "AWS_IAM"
 
 
-class FunctionVersion(str):
+class FunctionVersion(StrEnum):
     ALL = "ALL"
 
 
-class InvocationType(str):
+class InvocationType(StrEnum):
     Event = "Event"
     RequestResponse = "RequestResponse"
     DryRun = "DryRun"
 
 
-class InvokeMode(str):
+class InvokeMode(StrEnum):
     BUFFERED = "BUFFERED"
     RESPONSE_STREAM = "RESPONSE_STREAM"
 
 
-class LastUpdateStatus(str):
+class LastUpdateStatus(StrEnum):
     Successful = "Successful"
     Failed = "Failed"
     InProgress = "InProgress"
 
 
-class LastUpdateStatusReasonCode(str):
+class LastUpdateStatusReasonCode(StrEnum):
     EniLimitExceeded = "EniLimitExceeded"
     InsufficientRolePermissions = "InsufficientRolePermissions"
     InvalidConfiguration = "InvalidConfiguration"
@@ -187,33 +188,33 @@ class LastUpdateStatusReasonCode(str):
     FunctionError = "FunctionError"
 
 
-class LogFormat(str):
+class LogFormat(StrEnum):
     JSON = "JSON"
     Text = "Text"
 
 
-class LogType(str):
+class LogType(StrEnum):
     None_ = "None"
     Tail = "Tail"
 
 
-class PackageType(str):
+class PackageType(StrEnum):
     Zip = "Zip"
     Image = "Image"
 
 
-class ProvisionedConcurrencyStatusEnum(str):
+class ProvisionedConcurrencyStatusEnum(StrEnum):
     IN_PROGRESS = "IN_PROGRESS"
     READY = "READY"
     FAILED = "FAILED"
 
 
-class ResponseStreamingInvocationType(str):
+class ResponseStreamingInvocationType(StrEnum):
     RequestResponse = "RequestResponse"
     DryRun = "DryRun"
 
 
-class Runtime(str):
+class Runtime(StrEnum):
     nodejs = "nodejs"
     nodejs4_3 = "nodejs4.3"
     nodejs6_10 = "nodejs6.10"
@@ -254,17 +255,17 @@ class Runtime(str):
     java21 = "java21"
 
 
-class SnapStartApplyOn(str):
+class SnapStartApplyOn(StrEnum):
     PublishedVersions = "PublishedVersions"
     None_ = "None"
 
 
-class SnapStartOptimizationStatus(str):
+class SnapStartOptimizationStatus(StrEnum):
     On = "On"
     Off = "Off"
 
 
-class SourceAccessType(str):
+class SourceAccessType(StrEnum):
     BASIC_AUTH = "BASIC_AUTH"
     VPC_SUBNET = "VPC_SUBNET"
     VPC_SECURITY_GROUP = "VPC_SECURITY_GROUP"
@@ -275,14 +276,14 @@ class SourceAccessType(str):
     SERVER_ROOT_CA_CERTIFICATE = "SERVER_ROOT_CA_CERTIFICATE"
 
 
-class State(str):
+class State(StrEnum):
     Pending = "Pending"
     Active = "Active"
     Inactive = "Inactive"
     Failed = "Failed"
 
 
-class StateReasonCode(str):
+class StateReasonCode(StrEnum):
     Idle = "Idle"
     Creating = "Creating"
     Restoring = "Restoring"
@@ -309,13 +310,13 @@ class StateReasonCode(str):
     FunctionError = "FunctionError"
 
 
-class SystemLogLevel(str):
+class SystemLogLevel(StrEnum):
     DEBUG = "DEBUG"
     INFO = "INFO"
     WARN = "WARN"
 
 
-class ThrottleReason(str):
+class ThrottleReason(StrEnum):
     ConcurrentInvocationLimitExceeded = "ConcurrentInvocationLimitExceeded"
     FunctionInvocationRateLimitExceeded = "FunctionInvocationRateLimitExceeded"
     ReservedFunctionConcurrentInvocationLimitExceeded = (
@@ -326,12 +327,12 @@ class ThrottleReason(str):
     ConcurrentSnapshotCreateLimitExceeded = "ConcurrentSnapshotCreateLimitExceeded"
 
 
-class TracingMode(str):
+class TracingMode(StrEnum):
     Active = "Active"
     PassThrough = "PassThrough"
 
 
-class UpdateRuntimeOn(str):
+class UpdateRuntimeOn(StrEnum):
     Auto = "Auto"
     Manual = "Manual"
     FunctionUpdate = "FunctionUpdate"

--- a/localstack-core/localstack/aws/api/logs/__init__.py
+++ b/localstack-core/localstack/aws/api/logs/__init__.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import Dict, Iterator, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -96,7 +97,7 @@ Unmask = bool
 Value = str
 
 
-class AnomalyDetectorStatus(str):
+class AnomalyDetectorStatus(StrEnum):
     INITIALIZING = "INITIALIZING"
     TRAINING = "TRAINING"
     ANALYZING = "ANALYZING"
@@ -105,25 +106,25 @@ class AnomalyDetectorStatus(str):
     PAUSED = "PAUSED"
 
 
-class DataProtectionStatus(str):
+class DataProtectionStatus(StrEnum):
     ACTIVATED = "ACTIVATED"
     DELETED = "DELETED"
     ARCHIVED = "ARCHIVED"
     DISABLED = "DISABLED"
 
 
-class DeliveryDestinationType(str):
+class DeliveryDestinationType(StrEnum):
     S3 = "S3"
     CWL = "CWL"
     FH = "FH"
 
 
-class Distribution(str):
+class Distribution(StrEnum):
     Random = "Random"
     ByLogStream = "ByLogStream"
 
 
-class EvaluationFrequency(str):
+class EvaluationFrequency(StrEnum):
     ONE_MIN = "ONE_MIN"
     FIVE_MIN = "FIVE_MIN"
     TEN_MIN = "TEN_MIN"
@@ -132,7 +133,7 @@ class EvaluationFrequency(str):
     ONE_HOUR = "ONE_HOUR"
 
 
-class ExportTaskStatusCode(str):
+class ExportTaskStatusCode(StrEnum):
     CANCELLED = "CANCELLED"
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
@@ -141,21 +142,21 @@ class ExportTaskStatusCode(str):
     RUNNING = "RUNNING"
 
 
-class InheritedProperty(str):
+class InheritedProperty(StrEnum):
     ACCOUNT_DATA_PROTECTION = "ACCOUNT_DATA_PROTECTION"
 
 
-class LogGroupClass(str):
+class LogGroupClass(StrEnum):
     STANDARD = "STANDARD"
     INFREQUENT_ACCESS = "INFREQUENT_ACCESS"
 
 
-class OrderBy(str):
+class OrderBy(StrEnum):
     LogStreamName = "LogStreamName"
     LastEventTime = "LastEventTime"
 
 
-class OutputFormat(str):
+class OutputFormat(StrEnum):
     json = "json"
     plain = "plain"
     w3c = "w3c"
@@ -163,12 +164,12 @@ class OutputFormat(str):
     parquet = "parquet"
 
 
-class PolicyType(str):
+class PolicyType(StrEnum):
     DATA_PROTECTION_POLICY = "DATA_PROTECTION_POLICY"
     SUBSCRIPTION_FILTER_POLICY = "SUBSCRIPTION_FILTER_POLICY"
 
 
-class QueryStatus(str):
+class QueryStatus(StrEnum):
     Scheduled = "Scheduled"
     Running = "Running"
     Complete = "Complete"
@@ -178,11 +179,11 @@ class QueryStatus(str):
     Unknown = "Unknown"
 
 
-class Scope(str):
+class Scope(StrEnum):
     ALL = "ALL"
 
 
-class StandardUnit(str):
+class StandardUnit(StrEnum):
     Seconds = "Seconds"
     Microseconds = "Microseconds"
     Milliseconds = "Milliseconds"
@@ -212,23 +213,23 @@ class StandardUnit(str):
     None_ = "None"
 
 
-class State(str):
+class State(StrEnum):
     Active = "Active"
     Suppressed = "Suppressed"
     Baseline = "Baseline"
 
 
-class SuppressionState(str):
+class SuppressionState(StrEnum):
     SUPPRESSED = "SUPPRESSED"
     UNSUPPRESSED = "UNSUPPRESSED"
 
 
-class SuppressionType(str):
+class SuppressionType(StrEnum):
     LIMITED = "LIMITED"
     INFINITE = "INFINITE"
 
 
-class SuppressionUnit(str):
+class SuppressionUnit(StrEnum):
     SECONDS = "SECONDS"
     MINUTES = "MINUTES"
     HOURS = "HOURS"

--- a/localstack-core/localstack/aws/api/opensearch/__init__.py
+++ b/localstack-core/localstack/aws/api/opensearch/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -93,13 +94,13 @@ VolumeSize = str
 VpcEndpointId = str
 
 
-class ActionSeverity(str):
+class ActionSeverity(StrEnum):
     HIGH = "HIGH"
     MEDIUM = "MEDIUM"
     LOW = "LOW"
 
 
-class ActionStatus(str):
+class ActionStatus(StrEnum):
     PENDING_UPDATE = "PENDING_UPDATE"
     IN_PROGRESS = "IN_PROGRESS"
     FAILED = "FAILED"
@@ -108,18 +109,18 @@ class ActionStatus(str):
     ELIGIBLE = "ELIGIBLE"
 
 
-class ActionType(str):
+class ActionType(StrEnum):
     SERVICE_SOFTWARE_UPDATE = "SERVICE_SOFTWARE_UPDATE"
     JVM_HEAP_SIZE_TUNING = "JVM_HEAP_SIZE_TUNING"
     JVM_YOUNG_GEN_TUNING = "JVM_YOUNG_GEN_TUNING"
 
 
-class AutoTuneDesiredState(str):
+class AutoTuneDesiredState(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
 
 
-class AutoTuneState(str):
+class AutoTuneState(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
     ENABLE_IN_PROGRESS = "ENABLE_IN_PROGRESS"
@@ -131,11 +132,11 @@ class AutoTuneState(str):
     ERROR = "ERROR"
 
 
-class AutoTuneType(str):
+class AutoTuneType(StrEnum):
     SCHEDULED_ACTION = "SCHEDULED_ACTION"
 
 
-class ConfigChangeStatus(str):
+class ConfigChangeStatus(StrEnum):
     Pending = "Pending"
     Initializing = "Initializing"
     Validating = "Validating"
@@ -146,17 +147,17 @@ class ConfigChangeStatus(str):
     Cancelled = "Cancelled"
 
 
-class ConnectionMode(str):
+class ConnectionMode(StrEnum):
     DIRECT = "DIRECT"
     VPC_ENDPOINT = "VPC_ENDPOINT"
 
 
-class DataSourceStatus(str):
+class DataSourceStatus(StrEnum):
     ACTIVE = "ACTIVE"
     DISABLED = "DISABLED"
 
 
-class DeploymentStatus(str):
+class DeploymentStatus(StrEnum):
     PENDING_UPDATE = "PENDING_UPDATE"
     IN_PROGRESS = "IN_PROGRESS"
     COMPLETED = "COMPLETED"
@@ -164,7 +165,7 @@ class DeploymentStatus(str):
     ELIGIBLE = "ELIGIBLE"
 
 
-class DescribePackagesFilterName(str):
+class DescribePackagesFilterName(StrEnum):
     PackageID = "PackageID"
     PackageName = "PackageName"
     PackageStatus = "PackageStatus"
@@ -172,14 +173,14 @@ class DescribePackagesFilterName(str):
     EngineVersion = "EngineVersion"
 
 
-class DomainHealth(str):
+class DomainHealth(StrEnum):
     Red = "Red"
     Yellow = "Yellow"
     Green = "Green"
     NotAvailable = "NotAvailable"
 
 
-class DomainPackageStatus(str):
+class DomainPackageStatus(StrEnum):
     ASSOCIATING = "ASSOCIATING"
     ASSOCIATION_FAILED = "ASSOCIATION_FAILED"
     ACTIVE = "ACTIVE"
@@ -187,7 +188,7 @@ class DomainPackageStatus(str):
     DISSOCIATION_FAILED = "DISSOCIATION_FAILED"
 
 
-class DomainProcessingStatusType(str):
+class DomainProcessingStatusType(StrEnum):
     Creating = "Creating"
     Active = "Active"
     Modifying = "Modifying"
@@ -197,28 +198,28 @@ class DomainProcessingStatusType(str):
     Deleting = "Deleting"
 
 
-class DomainState(str):
+class DomainState(StrEnum):
     Active = "Active"
     Processing = "Processing"
     NotAvailable = "NotAvailable"
 
 
-class DryRunMode(str):
+class DryRunMode(StrEnum):
     Basic = "Basic"
     Verbose = "Verbose"
 
 
-class EngineType(str):
+class EngineType(StrEnum):
     OpenSearch = "OpenSearch"
     Elasticsearch = "Elasticsearch"
 
 
-class IPAddressType(str):
+class IPAddressType(StrEnum):
     ipv4 = "ipv4"
     dualstack = "dualstack"
 
 
-class InboundConnectionStatusCode(str):
+class InboundConnectionStatusCode(StrEnum):
     PENDING_ACCEPTANCE = "PENDING_ACCEPTANCE"
     APPROVED = "APPROVED"
     PROVISIONING = "PROVISIONING"
@@ -229,19 +230,19 @@ class InboundConnectionStatusCode(str):
     DELETED = "DELETED"
 
 
-class InitiatedBy(str):
+class InitiatedBy(StrEnum):
     CUSTOMER = "CUSTOMER"
     SERVICE = "SERVICE"
 
 
-class LogType(str):
+class LogType(StrEnum):
     INDEX_SLOW_LOGS = "INDEX_SLOW_LOGS"
     SEARCH_SLOW_LOGS = "SEARCH_SLOW_LOGS"
     ES_APPLICATION_LOGS = "ES_APPLICATION_LOGS"
     AUDIT_LOGS = "AUDIT_LOGS"
 
 
-class MaintenanceStatus(str):
+class MaintenanceStatus(StrEnum):
     PENDING = "PENDING"
     IN_PROGRESS = "IN_PROGRESS"
     COMPLETED = "COMPLETED"
@@ -249,30 +250,30 @@ class MaintenanceStatus(str):
     TIMED_OUT = "TIMED_OUT"
 
 
-class MaintenanceType(str):
+class MaintenanceType(StrEnum):
     REBOOT_NODE = "REBOOT_NODE"
     RESTART_SEARCH_PROCESS = "RESTART_SEARCH_PROCESS"
     RESTART_DASHBOARD = "RESTART_DASHBOARD"
 
 
-class MasterNodeStatus(str):
+class MasterNodeStatus(StrEnum):
     Available = "Available"
     UnAvailable = "UnAvailable"
 
 
-class NodeStatus(str):
+class NodeStatus(StrEnum):
     Active = "Active"
     StandBy = "StandBy"
     NotAvailable = "NotAvailable"
 
 
-class NodeType(str):
+class NodeType(StrEnum):
     Data = "Data"
     Ultrawarm = "Ultrawarm"
     Master = "Master"
 
 
-class OpenSearchPartitionInstanceType(str):
+class OpenSearchPartitionInstanceType(StrEnum):
     m3_medium_search = "m3.medium.search"
     m3_large_search = "m3.large.search"
     m3_xlarge_search = "m3.xlarge.search"
@@ -378,19 +379,19 @@ class OpenSearchPartitionInstanceType(str):
     t4g_medium_search = "t4g.medium.search"
 
 
-class OpenSearchWarmPartitionInstanceType(str):
+class OpenSearchWarmPartitionInstanceType(StrEnum):
     ultrawarm1_medium_search = "ultrawarm1.medium.search"
     ultrawarm1_large_search = "ultrawarm1.large.search"
     ultrawarm1_xlarge_search = "ultrawarm1.xlarge.search"
 
 
-class OptionState(str):
+class OptionState(StrEnum):
     RequiresIndexDocuments = "RequiresIndexDocuments"
     Processing = "Processing"
     Active = "Active"
 
 
-class OutboundConnectionStatusCode(str):
+class OutboundConnectionStatusCode(StrEnum):
     VALIDATING = "VALIDATING"
     VALIDATION_FAILED = "VALIDATION_FAILED"
     PENDING_ACCEPTANCE = "PENDING_ACCEPTANCE"
@@ -403,14 +404,14 @@ class OutboundConnectionStatusCode(str):
     DELETED = "DELETED"
 
 
-class OverallChangeStatus(str):
+class OverallChangeStatus(StrEnum):
     PENDING = "PENDING"
     PROCESSING = "PROCESSING"
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
 
 
-class PackageStatus(str):
+class PackageStatus(StrEnum):
     COPYING = "COPYING"
     COPY_FAILED = "COPY_FAILED"
     VALIDATING = "VALIDATING"
@@ -421,95 +422,95 @@ class PackageStatus(str):
     DELETE_FAILED = "DELETE_FAILED"
 
 
-class PackageType(str):
+class PackageType(StrEnum):
     TXT_DICTIONARY = "TXT-DICTIONARY"
     ZIP_PLUGIN = "ZIP-PLUGIN"
 
 
-class PrincipalType(str):
+class PrincipalType(StrEnum):
     AWS_ACCOUNT = "AWS_ACCOUNT"
     AWS_SERVICE = "AWS_SERVICE"
 
 
-class PropertyValueType(str):
+class PropertyValueType(StrEnum):
     PLAIN_TEXT = "PLAIN_TEXT"
     STRINGIFIED_JSON = "STRINGIFIED_JSON"
 
 
-class ReservedInstancePaymentOption(str):
+class ReservedInstancePaymentOption(StrEnum):
     ALL_UPFRONT = "ALL_UPFRONT"
     PARTIAL_UPFRONT = "PARTIAL_UPFRONT"
     NO_UPFRONT = "NO_UPFRONT"
 
 
-class RollbackOnDisable(str):
+class RollbackOnDisable(StrEnum):
     NO_ROLLBACK = "NO_ROLLBACK"
     DEFAULT_ROLLBACK = "DEFAULT_ROLLBACK"
 
 
-class ScheduleAt(str):
+class ScheduleAt(StrEnum):
     NOW = "NOW"
     TIMESTAMP = "TIMESTAMP"
     OFF_PEAK_WINDOW = "OFF_PEAK_WINDOW"
 
 
-class ScheduledAutoTuneActionType(str):
+class ScheduledAutoTuneActionType(StrEnum):
     JVM_HEAP_SIZE_TUNING = "JVM_HEAP_SIZE_TUNING"
     JVM_YOUNG_GEN_TUNING = "JVM_YOUNG_GEN_TUNING"
 
 
-class ScheduledAutoTuneSeverityType(str):
+class ScheduledAutoTuneSeverityType(StrEnum):
     LOW = "LOW"
     MEDIUM = "MEDIUM"
     HIGH = "HIGH"
 
 
-class ScheduledBy(str):
+class ScheduledBy(StrEnum):
     CUSTOMER = "CUSTOMER"
     SYSTEM = "SYSTEM"
 
 
-class SkipUnavailableStatus(str):
+class SkipUnavailableStatus(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
 
 
-class TLSSecurityPolicy(str):
+class TLSSecurityPolicy(StrEnum):
     Policy_Min_TLS_1_0_2019_07 = "Policy-Min-TLS-1-0-2019-07"
     Policy_Min_TLS_1_2_2019_07 = "Policy-Min-TLS-1-2-2019-07"
     Policy_Min_TLS_1_2_PFS_2023_10 = "Policy-Min-TLS-1-2-PFS-2023-10"
 
 
-class TimeUnit(str):
+class TimeUnit(StrEnum):
     HOURS = "HOURS"
 
 
-class UpgradeStatus(str):
+class UpgradeStatus(StrEnum):
     IN_PROGRESS = "IN_PROGRESS"
     SUCCEEDED = "SUCCEEDED"
     SUCCEEDED_WITH_ISSUES = "SUCCEEDED_WITH_ISSUES"
     FAILED = "FAILED"
 
 
-class UpgradeStep(str):
+class UpgradeStep(StrEnum):
     PRE_UPGRADE_CHECK = "PRE_UPGRADE_CHECK"
     SNAPSHOT = "SNAPSHOT"
     UPGRADE = "UPGRADE"
 
 
-class VolumeType(str):
+class VolumeType(StrEnum):
     standard = "standard"
     gp2 = "gp2"
     io1 = "io1"
     gp3 = "gp3"
 
 
-class VpcEndpointErrorCode(str):
+class VpcEndpointErrorCode(StrEnum):
     ENDPOINT_NOT_FOUND = "ENDPOINT_NOT_FOUND"
     SERVER_ERROR = "SERVER_ERROR"
 
 
-class VpcEndpointStatus(str):
+class VpcEndpointStatus(StrEnum):
     CREATING = "CREATING"
     CREATE_FAILED = "CREATE_FAILED"
     ACTIVE = "ACTIVE"
@@ -519,7 +520,7 @@ class VpcEndpointStatus(str):
     DELETE_FAILED = "DELETE_FAILED"
 
 
-class ZoneStatus(str):
+class ZoneStatus(StrEnum):
     Active = "Active"
     StandBy = "StandBy"
     NotAvailable = "NotAvailable"

--- a/localstack-core/localstack/aws/api/redshift/__init__.py
+++ b/localstack-core/localstack/aws/api/redshift/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -24,30 +25,30 @@ SensitiveString = str
 String = str
 
 
-class ActionType(str):
+class ActionType(StrEnum):
     restore_cluster = "restore-cluster"
     recommend_node_config = "recommend-node-config"
     resize_cluster = "resize-cluster"
 
 
-class AquaConfigurationStatus(str):
+class AquaConfigurationStatus(StrEnum):
     enabled = "enabled"
     disabled = "disabled"
     auto = "auto"
 
 
-class AquaStatus(str):
+class AquaStatus(StrEnum):
     enabled = "enabled"
     disabled = "disabled"
     applying = "applying"
 
 
-class AuthorizationStatus(str):
+class AuthorizationStatus(StrEnum):
     Authorized = "Authorized"
     Revoking = "Revoking"
 
 
-class DataShareStatus(str):
+class DataShareStatus(StrEnum):
     ACTIVE = "ACTIVE"
     PENDING_AUTHORIZATION = "PENDING_AUTHORIZATION"
     AUTHORIZED = "AUTHORIZED"
@@ -56,12 +57,12 @@ class DataShareStatus(str):
     AVAILABLE = "AVAILABLE"
 
 
-class DataShareStatusForConsumer(str):
+class DataShareStatusForConsumer(StrEnum):
     ACTIVE = "ACTIVE"
     AVAILABLE = "AVAILABLE"
 
 
-class DataShareStatusForProducer(str):
+class DataShareStatusForProducer(StrEnum):
     ACTIVE = "ACTIVE"
     AUTHORIZED = "AUTHORIZED"
     PENDING_AUTHORIZATION = "PENDING_AUTHORIZATION"
@@ -69,30 +70,30 @@ class DataShareStatusForProducer(str):
     REJECTED = "REJECTED"
 
 
-class ImpactRankingType(str):
+class ImpactRankingType(StrEnum):
     HIGH = "HIGH"
     MEDIUM = "MEDIUM"
     LOW = "LOW"
 
 
-class LogDestinationType(str):
+class LogDestinationType(StrEnum):
     s3 = "s3"
     cloudwatch = "cloudwatch"
 
 
-class Mode(str):
+class Mode(StrEnum):
     standard = "standard"
     high_performance = "high-performance"
 
 
-class NodeConfigurationOptionsFilterName(str):
+class NodeConfigurationOptionsFilterName(StrEnum):
     NodeType = "NodeType"
     NumberOfNodes = "NumberOfNodes"
     EstimatedDiskUtilizationPercent = "EstimatedDiskUtilizationPercent"
     Mode = "Mode"
 
 
-class OperatorType(str):
+class OperatorType(StrEnum):
     eq = "eq"
     lt = "lt"
     gt = "gt"
@@ -102,29 +103,29 @@ class OperatorType(str):
     between = "between"
 
 
-class ParameterApplyType(str):
+class ParameterApplyType(StrEnum):
     static = "static"
     dynamic = "dynamic"
 
 
-class PartnerIntegrationStatus(str):
+class PartnerIntegrationStatus(StrEnum):
     Active = "Active"
     Inactive = "Inactive"
     RuntimeFailure = "RuntimeFailure"
     ConnectionFailure = "ConnectionFailure"
 
 
-class RecommendedActionType(str):
+class RecommendedActionType(StrEnum):
     SQL = "SQL"
     CLI = "CLI"
 
 
-class ReservedNodeExchangeActionType(str):
+class ReservedNodeExchangeActionType(StrEnum):
     restore_cluster = "restore-cluster"
     resize_cluster = "resize-cluster"
 
 
-class ReservedNodeExchangeStatusType(str):
+class ReservedNodeExchangeStatusType(StrEnum):
     REQUESTED = "REQUESTED"
     PENDING = "PENDING"
     IN_PROGRESS = "IN_PROGRESS"
@@ -133,50 +134,50 @@ class ReservedNodeExchangeStatusType(str):
     FAILED = "FAILED"
 
 
-class ReservedNodeOfferingType(str):
+class ReservedNodeOfferingType(StrEnum):
     Regular = "Regular"
     Upgradable = "Upgradable"
 
 
-class ScheduleState(str):
+class ScheduleState(StrEnum):
     MODIFYING = "MODIFYING"
     ACTIVE = "ACTIVE"
     FAILED = "FAILED"
 
 
-class ScheduledActionFilterName(str):
+class ScheduledActionFilterName(StrEnum):
     cluster_identifier = "cluster-identifier"
     iam_role = "iam-role"
 
 
-class ScheduledActionState(str):
+class ScheduledActionState(StrEnum):
     ACTIVE = "ACTIVE"
     DISABLED = "DISABLED"
 
 
-class ScheduledActionTypeValues(str):
+class ScheduledActionTypeValues(StrEnum):
     ResizeCluster = "ResizeCluster"
     PauseCluster = "PauseCluster"
     ResumeCluster = "ResumeCluster"
 
 
-class ServiceAuthorization(str):
+class ServiceAuthorization(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class SnapshotAttributeToSortBy(str):
+class SnapshotAttributeToSortBy(StrEnum):
     SOURCE_TYPE = "SOURCE_TYPE"
     TOTAL_SIZE = "TOTAL_SIZE"
     CREATE_TIME = "CREATE_TIME"
 
 
-class SortByOrder(str):
+class SortByOrder(StrEnum):
     ASC = "ASC"
     DESC = "DESC"
 
 
-class SourceType(str):
+class SourceType(StrEnum):
     cluster = "cluster"
     cluster_parameter_group = "cluster-parameter-group"
     cluster_security_group = "cluster-security-group"
@@ -184,7 +185,7 @@ class SourceType(str):
     scheduled_action = "scheduled-action"
 
 
-class TableRestoreStatusType(str):
+class TableRestoreStatusType(StrEnum):
     PENDING = "PENDING"
     IN_PROGRESS = "IN_PROGRESS"
     SUCCEEDED = "SUCCEEDED"
@@ -192,30 +193,30 @@ class TableRestoreStatusType(str):
     CANCELED = "CANCELED"
 
 
-class UsageLimitBreachAction(str):
+class UsageLimitBreachAction(StrEnum):
     log = "log"
     emit_metric = "emit-metric"
     disable = "disable"
 
 
-class UsageLimitFeatureType(str):
+class UsageLimitFeatureType(StrEnum):
     spectrum = "spectrum"
     concurrency_scaling = "concurrency-scaling"
     cross_region_datasharing = "cross-region-datasharing"
 
 
-class UsageLimitLimitType(str):
+class UsageLimitLimitType(StrEnum):
     time = "time"
     data_scanned = "data-scanned"
 
 
-class UsageLimitPeriod(str):
+class UsageLimitPeriod(StrEnum):
     daily = "daily"
     weekly = "weekly"
     monthly = "monthly"
 
 
-class ZeroETLIntegrationStatus(str):
+class ZeroETLIntegrationStatus(StrEnum):
     creating = "creating"
     active = "active"
     modifying = "modifying"

--- a/localstack-core/localstack/aws/api/resource_groups/__init__.py
+++ b/localstack-core/localstack/aws/api/resource_groups/__init__.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -25,46 +26,46 @@ TagKey = str
 TagValue = str
 
 
-class GroupConfigurationStatus(str):
+class GroupConfigurationStatus(StrEnum):
     UPDATING = "UPDATING"
     UPDATE_COMPLETE = "UPDATE_COMPLETE"
     UPDATE_FAILED = "UPDATE_FAILED"
 
 
-class GroupFilterName(str):
+class GroupFilterName(StrEnum):
     resource_type = "resource-type"
     configuration_type = "configuration-type"
 
 
-class GroupLifecycleEventsDesiredStatus(str):
+class GroupLifecycleEventsDesiredStatus(StrEnum):
     ACTIVE = "ACTIVE"
     INACTIVE = "INACTIVE"
 
 
-class GroupLifecycleEventsStatus(str):
+class GroupLifecycleEventsStatus(StrEnum):
     ACTIVE = "ACTIVE"
     INACTIVE = "INACTIVE"
     IN_PROGRESS = "IN_PROGRESS"
     ERROR = "ERROR"
 
 
-class QueryErrorCode(str):
+class QueryErrorCode(StrEnum):
     CLOUDFORMATION_STACK_INACTIVE = "CLOUDFORMATION_STACK_INACTIVE"
     CLOUDFORMATION_STACK_NOT_EXISTING = "CLOUDFORMATION_STACK_NOT_EXISTING"
     CLOUDFORMATION_STACK_UNASSUMABLE_ROLE = "CLOUDFORMATION_STACK_UNASSUMABLE_ROLE"
     RESOURCE_TYPE_NOT_SUPPORTED = "RESOURCE_TYPE_NOT_SUPPORTED"
 
 
-class QueryType(str):
+class QueryType(StrEnum):
     TAG_FILTERS_1_0 = "TAG_FILTERS_1_0"
     CLOUDFORMATION_STACK_1_0 = "CLOUDFORMATION_STACK_1_0"
 
 
-class ResourceFilterName(str):
+class ResourceFilterName(StrEnum):
     resource_type = "resource-type"
 
 
-class ResourceStatusValue(str):
+class ResourceStatusValue(StrEnum):
     PENDING = "PENDING"
 
 

--- a/localstack-core/localstack/aws/api/resourcegroupstaggingapi/__init__.py
+++ b/localstack-core/localstack/aws/api/resourcegroupstaggingapi/__init__.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -24,18 +25,18 @@ TagsPerPage = int
 TargetId = str
 
 
-class ErrorCode(str):
+class ErrorCode(StrEnum):
     InternalServiceException = "InternalServiceException"
     InvalidParameterException = "InvalidParameterException"
 
 
-class GroupByAttribute(str):
+class GroupByAttribute(StrEnum):
     TARGET_ID = "TARGET_ID"
     REGION = "REGION"
     RESOURCE_TYPE = "RESOURCE_TYPE"
 
 
-class TargetIdType(str):
+class TargetIdType(StrEnum):
     ACCOUNT = "ACCOUNT"
     OU = "OU"
     ROOT = "ROOT"

--- a/localstack-core/localstack/aws/api/route53/__init__.py
+++ b/localstack-core/localstack/aws/api/route53/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -97,7 +98,7 @@ UUID = str
 VPCId = str
 
 
-class AccountLimitType(str):
+class AccountLimitType(StrEnum):
     MAX_HEALTH_CHECKS_BY_OWNER = "MAX_HEALTH_CHECKS_BY_OWNER"
     MAX_HOSTED_ZONES_BY_OWNER = "MAX_HOSTED_ZONES_BY_OWNER"
     MAX_TRAFFIC_POLICY_INSTANCES_BY_OWNER = "MAX_TRAFFIC_POLICY_INSTANCES_BY_OWNER"
@@ -105,23 +106,23 @@ class AccountLimitType(str):
     MAX_TRAFFIC_POLICIES_BY_OWNER = "MAX_TRAFFIC_POLICIES_BY_OWNER"
 
 
-class ChangeAction(str):
+class ChangeAction(StrEnum):
     CREATE = "CREATE"
     DELETE = "DELETE"
     UPSERT = "UPSERT"
 
 
-class ChangeStatus(str):
+class ChangeStatus(StrEnum):
     PENDING = "PENDING"
     INSYNC = "INSYNC"
 
 
-class CidrCollectionChangeAction(str):
+class CidrCollectionChangeAction(StrEnum):
     PUT = "PUT"
     DELETE_IF_EXISTS = "DELETE_IF_EXISTS"
 
 
-class CloudWatchRegion(str):
+class CloudWatchRegion(StrEnum):
     us_east_1 = "us-east-1"
     us_east_2 = "us-east-2"
     us_west_1 = "us-west-1"
@@ -160,14 +161,14 @@ class CloudWatchRegion(str):
     ca_west_1 = "ca-west-1"
 
 
-class ComparisonOperator(str):
+class ComparisonOperator(StrEnum):
     GreaterThanOrEqualToThreshold = "GreaterThanOrEqualToThreshold"
     GreaterThanThreshold = "GreaterThanThreshold"
     LessThanThreshold = "LessThanThreshold"
     LessThanOrEqualToThreshold = "LessThanOrEqualToThreshold"
 
 
-class HealthCheckRegion(str):
+class HealthCheckRegion(StrEnum):
     us_east_1 = "us-east-1"
     us_west_1 = "us-west-1"
     us_west_2 = "us-west-2"
@@ -178,7 +179,7 @@ class HealthCheckRegion(str):
     sa_east_1 = "sa-east-1"
 
 
-class HealthCheckType(str):
+class HealthCheckType(StrEnum):
     HTTP = "HTTP"
     HTTPS = "HTTPS"
     HTTP_STR_MATCH = "HTTP_STR_MATCH"
@@ -189,22 +190,22 @@ class HealthCheckType(str):
     RECOVERY_CONTROL = "RECOVERY_CONTROL"
 
 
-class HostedZoneLimitType(str):
+class HostedZoneLimitType(StrEnum):
     MAX_RRSETS_BY_ZONE = "MAX_RRSETS_BY_ZONE"
     MAX_VPCS_ASSOCIATED_BY_ZONE = "MAX_VPCS_ASSOCIATED_BY_ZONE"
 
 
-class HostedZoneType(str):
+class HostedZoneType(StrEnum):
     PrivateHostedZone = "PrivateHostedZone"
 
 
-class InsufficientDataHealthStatus(str):
+class InsufficientDataHealthStatus(StrEnum):
     Healthy = "Healthy"
     Unhealthy = "Unhealthy"
     LastKnownStatus = "LastKnownStatus"
 
 
-class RRType(str):
+class RRType(StrEnum):
     SOA = "SOA"
     A = "A"
     TXT = "TXT"
@@ -220,19 +221,19 @@ class RRType(str):
     DS = "DS"
 
 
-class ResettableElementName(str):
+class ResettableElementName(StrEnum):
     FullyQualifiedDomainName = "FullyQualifiedDomainName"
     Regions = "Regions"
     ResourcePath = "ResourcePath"
     ChildHealthChecks = "ChildHealthChecks"
 
 
-class ResourceRecordSetFailover(str):
+class ResourceRecordSetFailover(StrEnum):
     PRIMARY = "PRIMARY"
     SECONDARY = "SECONDARY"
 
 
-class ResourceRecordSetRegion(str):
+class ResourceRecordSetRegion(StrEnum):
     us_east_1 = "us-east-1"
     us_east_2 = "us-east-2"
     us_west_1 = "us-west-1"
@@ -266,11 +267,11 @@ class ResourceRecordSetRegion(str):
     ca_west_1 = "ca-west-1"
 
 
-class ReusableDelegationSetLimitType(str):
+class ReusableDelegationSetLimitType(StrEnum):
     MAX_ZONES_BY_REUSABLE_DELEGATION_SET = "MAX_ZONES_BY_REUSABLE_DELEGATION_SET"
 
 
-class Statistic(str):
+class Statistic(StrEnum):
     Average = "Average"
     Sum = "Sum"
     SampleCount = "SampleCount"
@@ -278,12 +279,12 @@ class Statistic(str):
     Minimum = "Minimum"
 
 
-class TagResourceType(str):
+class TagResourceType(StrEnum):
     healthcheck = "healthcheck"
     hostedzone = "hostedzone"
 
 
-class VPCRegion(str):
+class VPCRegion(StrEnum):
     us_east_1 = "us-east-1"
     us_east_2 = "us-east-2"
     us_west_1 = "us-west-1"

--- a/localstack-core/localstack/aws/api/route53resolver/__init__.py
+++ b/localstack-core/localstack/aws/api/route53resolver/__init__.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -50,33 +51,33 @@ TagValue = str
 Unsigned = int
 
 
-class Action(str):
+class Action(StrEnum):
     ALLOW = "ALLOW"
     BLOCK = "BLOCK"
     ALERT = "ALERT"
 
 
-class AutodefinedReverseFlag(str):
+class AutodefinedReverseFlag(StrEnum):
     ENABLE = "ENABLE"
     DISABLE = "DISABLE"
     USE_LOCAL_RESOURCE_SETTING = "USE_LOCAL_RESOURCE_SETTING"
 
 
-class BlockOverrideDnsType(str):
+class BlockOverrideDnsType(StrEnum):
     CNAME = "CNAME"
 
 
-class BlockResponse(str):
+class BlockResponse(StrEnum):
     NODATA = "NODATA"
     NXDOMAIN = "NXDOMAIN"
     OVERRIDE = "OVERRIDE"
 
 
-class FirewallDomainImportOperation(str):
+class FirewallDomainImportOperation(StrEnum):
     REPLACE = "REPLACE"
 
 
-class FirewallDomainListStatus(str):
+class FirewallDomainListStatus(StrEnum):
     COMPLETE = "COMPLETE"
     COMPLETE_IMPORT_FAILED = "COMPLETE_IMPORT_FAILED"
     IMPORTING = "IMPORTING"
@@ -84,36 +85,36 @@ class FirewallDomainListStatus(str):
     UPDATING = "UPDATING"
 
 
-class FirewallDomainRedirectionAction(str):
+class FirewallDomainRedirectionAction(StrEnum):
     INSPECT_REDIRECTION_DOMAIN = "INSPECT_REDIRECTION_DOMAIN"
     TRUST_REDIRECTION_DOMAIN = "TRUST_REDIRECTION_DOMAIN"
 
 
-class FirewallDomainUpdateOperation(str):
+class FirewallDomainUpdateOperation(StrEnum):
     ADD = "ADD"
     REMOVE = "REMOVE"
     REPLACE = "REPLACE"
 
 
-class FirewallFailOpenStatus(str):
+class FirewallFailOpenStatus(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
     USE_LOCAL_RESOURCE_SETTING = "USE_LOCAL_RESOURCE_SETTING"
 
 
-class FirewallRuleGroupAssociationStatus(str):
+class FirewallRuleGroupAssociationStatus(StrEnum):
     COMPLETE = "COMPLETE"
     DELETING = "DELETING"
     UPDATING = "UPDATING"
 
 
-class FirewallRuleGroupStatus(str):
+class FirewallRuleGroupStatus(StrEnum):
     COMPLETE = "COMPLETE"
     DELETING = "DELETING"
     UPDATING = "UPDATING"
 
 
-class IpAddressStatus(str):
+class IpAddressStatus(StrEnum):
     CREATING = "CREATING"
     FAILED_CREATION = "FAILED_CREATION"
     ATTACHING = "ATTACHING"
@@ -128,12 +129,12 @@ class IpAddressStatus(str):
     UPDATE_FAILED = "UPDATE_FAILED"
 
 
-class MutationProtectionStatus(str):
+class MutationProtectionStatus(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
 
 
-class OutpostResolverStatus(str):
+class OutpostResolverStatus(StrEnum):
     CREATING = "CREATING"
     OPERATIONAL = "OPERATIONAL"
     UPDATING = "UPDATING"
@@ -143,13 +144,13 @@ class OutpostResolverStatus(str):
     FAILED_DELETION = "FAILED_DELETION"
 
 
-class Protocol(str):
+class Protocol(StrEnum):
     DoH = "DoH"
     Do53 = "Do53"
     DoH_FIPS = "DoH-FIPS"
 
 
-class ResolverAutodefinedReverseStatus(str):
+class ResolverAutodefinedReverseStatus(StrEnum):
     ENABLING = "ENABLING"
     ENABLED = "ENABLED"
     DISABLING = "DISABLING"
@@ -158,7 +159,7 @@ class ResolverAutodefinedReverseStatus(str):
     USE_LOCAL_RESOURCE_SETTING = "USE_LOCAL_RESOURCE_SETTING"
 
 
-class ResolverDNSSECValidationStatus(str):
+class ResolverDNSSECValidationStatus(StrEnum):
     ENABLING = "ENABLING"
     ENABLED = "ENABLED"
     DISABLING = "DISABLING"
@@ -167,12 +168,12 @@ class ResolverDNSSECValidationStatus(str):
     USE_LOCAL_RESOURCE_SETTING = "USE_LOCAL_RESOURCE_SETTING"
 
 
-class ResolverEndpointDirection(str):
+class ResolverEndpointDirection(StrEnum):
     INBOUND = "INBOUND"
     OUTBOUND = "OUTBOUND"
 
 
-class ResolverEndpointStatus(str):
+class ResolverEndpointStatus(StrEnum):
     CREATING = "CREATING"
     OPERATIONAL = "OPERATIONAL"
     UPDATING = "UPDATING"
@@ -181,20 +182,20 @@ class ResolverEndpointStatus(str):
     DELETING = "DELETING"
 
 
-class ResolverEndpointType(str):
+class ResolverEndpointType(StrEnum):
     IPV6 = "IPV6"
     IPV4 = "IPV4"
     DUALSTACK = "DUALSTACK"
 
 
-class ResolverQueryLogConfigAssociationError(str):
+class ResolverQueryLogConfigAssociationError(StrEnum):
     NONE = "NONE"
     DESTINATION_NOT_FOUND = "DESTINATION_NOT_FOUND"
     ACCESS_DENIED = "ACCESS_DENIED"
     INTERNAL_SERVICE_ERROR = "INTERNAL_SERVICE_ERROR"
 
 
-class ResolverQueryLogConfigAssociationStatus(str):
+class ResolverQueryLogConfigAssociationStatus(StrEnum):
     CREATING = "CREATING"
     ACTIVE = "ACTIVE"
     ACTION_NEEDED = "ACTION_NEEDED"
@@ -202,14 +203,14 @@ class ResolverQueryLogConfigAssociationStatus(str):
     FAILED = "FAILED"
 
 
-class ResolverQueryLogConfigStatus(str):
+class ResolverQueryLogConfigStatus(StrEnum):
     CREATING = "CREATING"
     CREATED = "CREATED"
     DELETING = "DELETING"
     FAILED = "FAILED"
 
 
-class ResolverRuleAssociationStatus(str):
+class ResolverRuleAssociationStatus(StrEnum):
     CREATING = "CREATING"
     COMPLETE = "COMPLETE"
     DELETING = "DELETING"
@@ -217,31 +218,31 @@ class ResolverRuleAssociationStatus(str):
     OVERRIDDEN = "OVERRIDDEN"
 
 
-class ResolverRuleStatus(str):
+class ResolverRuleStatus(StrEnum):
     COMPLETE = "COMPLETE"
     DELETING = "DELETING"
     UPDATING = "UPDATING"
     FAILED = "FAILED"
 
 
-class RuleTypeOption(str):
+class RuleTypeOption(StrEnum):
     FORWARD = "FORWARD"
     SYSTEM = "SYSTEM"
     RECURSIVE = "RECURSIVE"
 
 
-class ShareStatus(str):
+class ShareStatus(StrEnum):
     NOT_SHARED = "NOT_SHARED"
     SHARED_WITH_ME = "SHARED_WITH_ME"
     SHARED_BY_ME = "SHARED_BY_ME"
 
 
-class SortOrder(str):
+class SortOrder(StrEnum):
     ASCENDING = "ASCENDING"
     DESCENDING = "DESCENDING"
 
 
-class Validation(str):
+class Validation(StrEnum):
     ENABLE = "ENABLE"
     DISABLE = "DISABLE"
     USE_LOCAL_RESOURCE_SETTING = "USE_LOCAL_RESOURCE_SETTING"

--- a/localstack-core/localstack/aws/api/s3/__init__.py
+++ b/localstack-core/localstack/aws/api/s3/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import IO, Dict, Iterable, Iterator, List, Optional, TypedDict, Union
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -185,21 +186,21 @@ MissingHeaderName = str
 KeyLength = str
 
 
-class AnalyticsS3ExportFileFormat(str):
+class AnalyticsS3ExportFileFormat(StrEnum):
     CSV = "CSV"
 
 
-class ArchiveStatus(str):
+class ArchiveStatus(StrEnum):
     ARCHIVE_ACCESS = "ARCHIVE_ACCESS"
     DEEP_ARCHIVE_ACCESS = "DEEP_ARCHIVE_ACCESS"
 
 
-class BucketAccelerateStatus(str):
+class BucketAccelerateStatus(StrEnum):
     Enabled = "Enabled"
     Suspended = "Suspended"
 
 
-class BucketCannedACL(str):
+class BucketCannedACL(StrEnum):
     private = "private"
     public_read = "public-read"
     public_read_write = "public-read-write"
@@ -207,7 +208,7 @@ class BucketCannedACL(str):
     log_delivery_write = "log-delivery-write"
 
 
-class BucketLocationConstraint(str):
+class BucketLocationConstraint(StrEnum):
     af_south_1 = "af-south-1"
     ap_east_1 = "ap-east-1"
     ap_northeast_1 = "ap-northeast-1"
@@ -238,52 +239,52 @@ class BucketLocationConstraint(str):
     us_west_2 = "us-west-2"
 
 
-class BucketLogsPermission(str):
+class BucketLogsPermission(StrEnum):
     FULL_CONTROL = "FULL_CONTROL"
     READ = "READ"
     WRITE = "WRITE"
 
 
-class BucketType(str):
+class BucketType(StrEnum):
     Directory = "Directory"
 
 
-class BucketVersioningStatus(str):
+class BucketVersioningStatus(StrEnum):
     Enabled = "Enabled"
     Suspended = "Suspended"
 
 
-class ChecksumAlgorithm(str):
+class ChecksumAlgorithm(StrEnum):
     CRC32 = "CRC32"
     CRC32C = "CRC32C"
     SHA1 = "SHA1"
     SHA256 = "SHA256"
 
 
-class ChecksumMode(str):
+class ChecksumMode(StrEnum):
     ENABLED = "ENABLED"
 
 
-class CompressionType(str):
+class CompressionType(StrEnum):
     NONE = "NONE"
     GZIP = "GZIP"
     BZIP2 = "BZIP2"
 
 
-class DataRedundancy(str):
+class DataRedundancy(StrEnum):
     SingleAvailabilityZone = "SingleAvailabilityZone"
 
 
-class DeleteMarkerReplicationStatus(str):
+class DeleteMarkerReplicationStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class EncodingType(str):
+class EncodingType(StrEnum):
     url = "url"
 
 
-class Event(str):
+class Event(StrEnum):
     s3_ReducedRedundancyLostObject = "s3:ReducedRedundancyLostObject"
     s3_ObjectCreated_ = "s3:ObjectCreated:*"
     s3_ObjectCreated_Put = "s3:ObjectCreated:Put"
@@ -315,58 +316,58 @@ class Event(str):
     s3_ObjectTagging_Delete = "s3:ObjectTagging:Delete"
 
 
-class ExistingObjectReplicationStatus(str):
+class ExistingObjectReplicationStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class ExpirationStatus(str):
+class ExpirationStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class ExpressionType(str):
+class ExpressionType(StrEnum):
     SQL = "SQL"
 
 
-class FileHeaderInfo(str):
+class FileHeaderInfo(StrEnum):
     USE = "USE"
     IGNORE = "IGNORE"
     NONE = "NONE"
 
 
-class FilterRuleName(str):
+class FilterRuleName(StrEnum):
     prefix = "prefix"
     suffix = "suffix"
 
 
-class IntelligentTieringAccessTier(str):
+class IntelligentTieringAccessTier(StrEnum):
     ARCHIVE_ACCESS = "ARCHIVE_ACCESS"
     DEEP_ARCHIVE_ACCESS = "DEEP_ARCHIVE_ACCESS"
 
 
-class IntelligentTieringStatus(str):
+class IntelligentTieringStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class InventoryFormat(str):
+class InventoryFormat(StrEnum):
     CSV = "CSV"
     ORC = "ORC"
     Parquet = "Parquet"
 
 
-class InventoryFrequency(str):
+class InventoryFrequency(StrEnum):
     Daily = "Daily"
     Weekly = "Weekly"
 
 
-class InventoryIncludedObjectVersions(str):
+class InventoryIncludedObjectVersions(StrEnum):
     All = "All"
     Current = "Current"
 
 
-class InventoryOptionalField(str):
+class InventoryOptionalField(StrEnum):
     Size = "Size"
     LastModifiedDate = "LastModifiedDate"
     StorageClass = "StorageClass"
@@ -384,36 +385,36 @@ class InventoryOptionalField(str):
     ObjectOwner = "ObjectOwner"
 
 
-class JSONType(str):
+class JSONType(StrEnum):
     DOCUMENT = "DOCUMENT"
     LINES = "LINES"
 
 
-class LocationType(str):
+class LocationType(StrEnum):
     AvailabilityZone = "AvailabilityZone"
 
 
-class MFADelete(str):
+class MFADelete(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class MFADeleteStatus(str):
+class MFADeleteStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class MetadataDirective(str):
+class MetadataDirective(StrEnum):
     COPY = "COPY"
     REPLACE = "REPLACE"
 
 
-class MetricsStatus(str):
+class MetricsStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class ObjectAttributes(str):
+class ObjectAttributes(StrEnum):
     ETag = "ETag"
     Checksum = "Checksum"
     ObjectParts = "ObjectParts"
@@ -421,7 +422,7 @@ class ObjectAttributes(str):
     ObjectSize = "ObjectSize"
 
 
-class ObjectCannedACL(str):
+class ObjectCannedACL(StrEnum):
     private = "private"
     public_read = "public-read"
     public_read_write = "public-read-write"
@@ -431,32 +432,32 @@ class ObjectCannedACL(str):
     bucket_owner_full_control = "bucket-owner-full-control"
 
 
-class ObjectLockEnabled(str):
+class ObjectLockEnabled(StrEnum):
     Enabled = "Enabled"
 
 
-class ObjectLockLegalHoldStatus(str):
+class ObjectLockLegalHoldStatus(StrEnum):
     ON = "ON"
     OFF = "OFF"
 
 
-class ObjectLockMode(str):
+class ObjectLockMode(StrEnum):
     GOVERNANCE = "GOVERNANCE"
     COMPLIANCE = "COMPLIANCE"
 
 
-class ObjectLockRetentionMode(str):
+class ObjectLockRetentionMode(StrEnum):
     GOVERNANCE = "GOVERNANCE"
     COMPLIANCE = "COMPLIANCE"
 
 
-class ObjectOwnership(str):
+class ObjectOwnership(StrEnum):
     BucketOwnerPreferred = "BucketOwnerPreferred"
     ObjectWriter = "ObjectWriter"
     BucketOwnerEnforced = "BucketOwnerEnforced"
 
 
-class ObjectStorageClass(str):
+class ObjectStorageClass(StrEnum):
     STANDARD = "STANDARD"
     REDUCED_REDUNDANCY = "REDUCED_REDUNDANCY"
     GLACIER = "GLACIER"
@@ -470,29 +471,29 @@ class ObjectStorageClass(str):
     EXPRESS_ONEZONE = "EXPRESS_ONEZONE"
 
 
-class ObjectVersionStorageClass(str):
+class ObjectVersionStorageClass(StrEnum):
     STANDARD = "STANDARD"
 
 
-class OptionalObjectAttributes(str):
+class OptionalObjectAttributes(StrEnum):
     RestoreStatus = "RestoreStatus"
 
 
-class OwnerOverride(str):
+class OwnerOverride(StrEnum):
     Destination = "Destination"
 
 
-class PartitionDateSource(str):
+class PartitionDateSource(StrEnum):
     EventTime = "EventTime"
     DeliveryTime = "DeliveryTime"
 
 
-class Payer(str):
+class Payer(StrEnum):
     Requester = "Requester"
     BucketOwner = "BucketOwner"
 
 
-class Permission(str):
+class Permission(StrEnum):
     FULL_CONTROL = "FULL_CONTROL"
     WRITE = "WRITE"
     WRITE_ACP = "WRITE_ACP"
@@ -500,27 +501,27 @@ class Permission(str):
     READ_ACP = "READ_ACP"
 
 
-class Protocol(str):
+class Protocol(StrEnum):
     http = "http"
     https = "https"
 
 
-class QuoteFields(str):
+class QuoteFields(StrEnum):
     ALWAYS = "ALWAYS"
     ASNEEDED = "ASNEEDED"
 
 
-class ReplicaModificationsStatus(str):
+class ReplicaModificationsStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class ReplicationRuleStatus(str):
+class ReplicationRuleStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class ReplicationStatus(str):
+class ReplicationStatus(StrEnum):
     COMPLETE = "COMPLETE"
     PENDING = "PENDING"
     FAILED = "FAILED"
@@ -528,40 +529,40 @@ class ReplicationStatus(str):
     COMPLETED = "COMPLETED"
 
 
-class ReplicationTimeStatus(str):
+class ReplicationTimeStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class RequestCharged(str):
+class RequestCharged(StrEnum):
     requester = "requester"
 
 
-class RequestPayer(str):
+class RequestPayer(StrEnum):
     requester = "requester"
 
 
-class RestoreRequestType(str):
+class RestoreRequestType(StrEnum):
     SELECT = "SELECT"
 
 
-class ServerSideEncryption(str):
+class ServerSideEncryption(StrEnum):
     AES256 = "AES256"
     aws_kms = "aws:kms"
     aws_kms_dsse = "aws:kms:dsse"
 
 
-class SessionMode(str):
+class SessionMode(StrEnum):
     ReadOnly = "ReadOnly"
     ReadWrite = "ReadWrite"
 
 
-class SseKmsEncryptedObjectsStatus(str):
+class SseKmsEncryptedObjectsStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class StorageClass(str):
+class StorageClass(StrEnum):
     STANDARD = "STANDARD"
     REDUCED_REDUNDANCY = "REDUCED_REDUNDANCY"
     STANDARD_IA = "STANDARD_IA"
@@ -575,22 +576,22 @@ class StorageClass(str):
     EXPRESS_ONEZONE = "EXPRESS_ONEZONE"
 
 
-class StorageClassAnalysisSchemaVersion(str):
+class StorageClassAnalysisSchemaVersion(StrEnum):
     V_1 = "V_1"
 
 
-class TaggingDirective(str):
+class TaggingDirective(StrEnum):
     COPY = "COPY"
     REPLACE = "REPLACE"
 
 
-class Tier(str):
+class Tier(StrEnum):
     Standard = "Standard"
     Bulk = "Bulk"
     Expedited = "Expedited"
 
 
-class TransitionStorageClass(str):
+class TransitionStorageClass(StrEnum):
     GLACIER = "GLACIER"
     STANDARD_IA = "STANDARD_IA"
     ONEZONE_IA = "ONEZONE_IA"
@@ -599,7 +600,7 @@ class TransitionStorageClass(str):
     GLACIER_IR = "GLACIER_IR"
 
 
-class Type(str):
+class Type(StrEnum):
     CanonicalUser = "CanonicalUser"
     AmazonCustomerByEmail = "AmazonCustomerByEmail"
     Group = "Group"

--- a/localstack-core/localstack/aws/api/s3control/__init__.py
+++ b/localstack-core/localstack/aws/api/s3control/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -111,20 +112,20 @@ TrafficDialPercentage = int
 VpcId = str
 
 
-class AsyncOperationName(str):
+class AsyncOperationName(StrEnum):
     CreateMultiRegionAccessPoint = "CreateMultiRegionAccessPoint"
     DeleteMultiRegionAccessPoint = "DeleteMultiRegionAccessPoint"
     PutMultiRegionAccessPointPolicy = "PutMultiRegionAccessPointPolicy"
 
 
-class BucketCannedACL(str):
+class BucketCannedACL(StrEnum):
     private = "private"
     public_read = "public-read"
     public_read_write = "public-read-write"
     authenticated_read = "authenticated-read"
 
 
-class BucketLocationConstraint(str):
+class BucketLocationConstraint(StrEnum):
     EU = "EU"
     eu_west_1 = "eu-west-1"
     us_west_1 = "us-west-1"
@@ -138,63 +139,63 @@ class BucketLocationConstraint(str):
     eu_central_1 = "eu-central-1"
 
 
-class BucketVersioningStatus(str):
+class BucketVersioningStatus(StrEnum):
     Enabled = "Enabled"
     Suspended = "Suspended"
 
 
-class DeleteMarkerReplicationStatus(str):
+class DeleteMarkerReplicationStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class ExistingObjectReplicationStatus(str):
+class ExistingObjectReplicationStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class ExpirationStatus(str):
+class ExpirationStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class Format(str):
+class Format(StrEnum):
     CSV = "CSV"
     Parquet = "Parquet"
 
 
-class GeneratedManifestFormat(str):
+class GeneratedManifestFormat(StrEnum):
     S3InventoryReport_CSV_20211130 = "S3InventoryReport_CSV_20211130"
 
 
-class GranteeType(str):
+class GranteeType(StrEnum):
     DIRECTORY_USER = "DIRECTORY_USER"
     DIRECTORY_GROUP = "DIRECTORY_GROUP"
     IAM = "IAM"
 
 
-class JobManifestFieldName(str):
+class JobManifestFieldName(StrEnum):
     Ignore = "Ignore"
     Bucket = "Bucket"
     Key = "Key"
     VersionId = "VersionId"
 
 
-class JobManifestFormat(str):
+class JobManifestFormat(StrEnum):
     S3BatchOperations_CSV_20180820 = "S3BatchOperations_CSV_20180820"
     S3InventoryReport_CSV_20161130 = "S3InventoryReport_CSV_20161130"
 
 
-class JobReportFormat(str):
+class JobReportFormat(StrEnum):
     Report_CSV_20180820 = "Report_CSV_20180820"
 
 
-class JobReportScope(str):
+class JobReportScope(StrEnum):
     AllTasks = "AllTasks"
     FailedTasksOnly = "FailedTasksOnly"
 
 
-class JobStatus(str):
+class JobStatus(StrEnum):
     Active = "Active"
     Cancelled = "Cancelled"
     Cancelling = "Cancelling"
@@ -210,22 +211,22 @@ class JobStatus(str):
     Suspended = "Suspended"
 
 
-class MFADelete(str):
+class MFADelete(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class MFADeleteStatus(str):
+class MFADeleteStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class MetricsStatus(str):
+class MetricsStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class MultiRegionAccessPointStatus(str):
+class MultiRegionAccessPointStatus(StrEnum):
     READY = "READY"
     INCONSISTENT_ACROSS_REGIONS = "INCONSISTENT_ACROSS_REGIONS"
     CREATING = "CREATING"
@@ -234,31 +235,31 @@ class MultiRegionAccessPointStatus(str):
     DELETING = "DELETING"
 
 
-class NetworkOrigin(str):
+class NetworkOrigin(StrEnum):
     Internet = "Internet"
     VPC = "VPC"
 
 
-class ObjectLambdaAccessPointAliasStatus(str):
+class ObjectLambdaAccessPointAliasStatus(StrEnum):
     PROVISIONING = "PROVISIONING"
     READY = "READY"
 
 
-class ObjectLambdaAllowedFeature(str):
+class ObjectLambdaAllowedFeature(StrEnum):
     GetObject_Range = "GetObject-Range"
     GetObject_PartNumber = "GetObject-PartNumber"
     HeadObject_Range = "HeadObject-Range"
     HeadObject_PartNumber = "HeadObject-PartNumber"
 
 
-class ObjectLambdaTransformationConfigurationAction(str):
+class ObjectLambdaTransformationConfigurationAction(StrEnum):
     GetObject = "GetObject"
     HeadObject = "HeadObject"
     ListObjects = "ListObjects"
     ListObjectsV2 = "ListObjectsV2"
 
 
-class OperationName(str):
+class OperationName(StrEnum):
     LambdaInvoke = "LambdaInvoke"
     S3PutObjectCopy = "S3PutObjectCopy"
     S3PutObjectAcl = "S3PutObjectAcl"
@@ -270,43 +271,43 @@ class OperationName(str):
     S3ReplicateObject = "S3ReplicateObject"
 
 
-class OutputSchemaVersion(str):
+class OutputSchemaVersion(StrEnum):
     V_1 = "V_1"
 
 
-class OwnerOverride(str):
+class OwnerOverride(StrEnum):
     Destination = "Destination"
 
 
-class Permission(str):
+class Permission(StrEnum):
     READ = "READ"
     WRITE = "WRITE"
     READWRITE = "READWRITE"
 
 
-class Privilege(str):
+class Privilege(StrEnum):
     Minimal = "Minimal"
     Default = "Default"
 
 
-class ReplicaModificationsStatus(str):
+class ReplicaModificationsStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class ReplicationRuleStatus(str):
+class ReplicationRuleStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class ReplicationStatus(str):
+class ReplicationStatus(StrEnum):
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
     REPLICA = "REPLICA"
     NONE = "NONE"
 
 
-class ReplicationStorageClass(str):
+class ReplicationStorageClass(StrEnum):
     STANDARD = "STANDARD"
     REDUCED_REDUNDANCY = "REDUCED_REDUNDANCY"
     STANDARD_IA = "STANDARD_IA"
@@ -318,17 +319,17 @@ class ReplicationStorageClass(str):
     GLACIER_IR = "GLACIER_IR"
 
 
-class ReplicationTimeStatus(str):
+class ReplicationTimeStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class RequestedJobStatus(str):
+class RequestedJobStatus(StrEnum):
     Cancelled = "Cancelled"
     Ready = "Ready"
 
 
-class S3CannedAccessControlList(str):
+class S3CannedAccessControlList(StrEnum):
     private = "private"
     public_read = "public-read"
     public_read_write = "public-read-write"
@@ -338,45 +339,45 @@ class S3CannedAccessControlList(str):
     bucket_owner_full_control = "bucket-owner-full-control"
 
 
-class S3ChecksumAlgorithm(str):
+class S3ChecksumAlgorithm(StrEnum):
     CRC32 = "CRC32"
     CRC32C = "CRC32C"
     SHA1 = "SHA1"
     SHA256 = "SHA256"
 
 
-class S3GlacierJobTier(str):
+class S3GlacierJobTier(StrEnum):
     BULK = "BULK"
     STANDARD = "STANDARD"
 
 
-class S3GranteeTypeIdentifier(str):
+class S3GranteeTypeIdentifier(StrEnum):
     id = "id"
     emailAddress = "emailAddress"
     uri = "uri"
 
 
-class S3MetadataDirective(str):
+class S3MetadataDirective(StrEnum):
     COPY = "COPY"
     REPLACE = "REPLACE"
 
 
-class S3ObjectLockLegalHoldStatus(str):
+class S3ObjectLockLegalHoldStatus(StrEnum):
     OFF = "OFF"
     ON = "ON"
 
 
-class S3ObjectLockMode(str):
+class S3ObjectLockMode(StrEnum):
     COMPLIANCE = "COMPLIANCE"
     GOVERNANCE = "GOVERNANCE"
 
 
-class S3ObjectLockRetentionMode(str):
+class S3ObjectLockRetentionMode(StrEnum):
     COMPLIANCE = "COMPLIANCE"
     GOVERNANCE = "GOVERNANCE"
 
 
-class S3Permission(str):
+class S3Permission(StrEnum):
     FULL_CONTROL = "FULL_CONTROL"
     READ = "READ"
     WRITE = "WRITE"
@@ -384,16 +385,16 @@ class S3Permission(str):
     WRITE_ACP = "WRITE_ACP"
 
 
-class S3PrefixType(str):
+class S3PrefixType(StrEnum):
     Object = "Object"
 
 
-class S3SSEAlgorithm(str):
+class S3SSEAlgorithm(StrEnum):
     AES256 = "AES256"
     KMS = "KMS"
 
 
-class S3StorageClass(str):
+class S3StorageClass(StrEnum):
     STANDARD = "STANDARD"
     STANDARD_IA = "STANDARD_IA"
     ONEZONE_IA = "ONEZONE_IA"
@@ -403,12 +404,12 @@ class S3StorageClass(str):
     GLACIER_IR = "GLACIER_IR"
 
 
-class SseKmsEncryptedObjectsStatus(str):
+class SseKmsEncryptedObjectsStatus(StrEnum):
     Enabled = "Enabled"
     Disabled = "Disabled"
 
 
-class TransitionStorageClass(str):
+class TransitionStorageClass(StrEnum):
     GLACIER = "GLACIER"
     STANDARD_IA = "STANDARD_IA"
     ONEZONE_IA = "ONEZONE_IA"

--- a/localstack-core/localstack/aws/api/scheduler/__init__.py
+++ b/localstack-core/localstack/aws/api/scheduler/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -49,48 +50,48 @@ TaskCount = int
 TaskDefinitionArn = str
 
 
-class ActionAfterCompletion(str):
+class ActionAfterCompletion(StrEnum):
     NONE = "NONE"
     DELETE = "DELETE"
 
 
-class AssignPublicIp(str):
+class AssignPublicIp(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
 
 
-class FlexibleTimeWindowMode(str):
+class FlexibleTimeWindowMode(StrEnum):
     OFF = "OFF"
     FLEXIBLE = "FLEXIBLE"
 
 
-class LaunchType(str):
+class LaunchType(StrEnum):
     EC2 = "EC2"
     FARGATE = "FARGATE"
     EXTERNAL = "EXTERNAL"
 
 
-class PlacementConstraintType(str):
+class PlacementConstraintType(StrEnum):
     distinctInstance = "distinctInstance"
     memberOf = "memberOf"
 
 
-class PlacementStrategyType(str):
+class PlacementStrategyType(StrEnum):
     random = "random"
     spread = "spread"
     binpack = "binpack"
 
 
-class PropagateTags(str):
+class PropagateTags(StrEnum):
     TASK_DEFINITION = "TASK_DEFINITION"
 
 
-class ScheduleGroupState(str):
+class ScheduleGroupState(StrEnum):
     ACTIVE = "ACTIVE"
     DELETING = "DELETING"
 
 
-class ScheduleState(str):
+class ScheduleState(StrEnum):
     ENABLED = "ENABLED"
     DISABLED = "DISABLED"
 

--- a/localstack-core/localstack/aws/api/secretsmanager/__init__.py
+++ b/localstack-core/localstack/aws/api/secretsmanager/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -41,7 +42,7 @@ TagKeyType = str
 TagValueType = str
 
 
-class FilterNameStringType(str):
+class FilterNameStringType(StrEnum):
     description = "description"
     name = "name"
     tag_key = "tag-key"
@@ -51,12 +52,12 @@ class FilterNameStringType(str):
     all = "all"
 
 
-class SortOrderType(str):
+class SortOrderType(StrEnum):
     asc = "asc"
     desc = "desc"
 
 
-class StatusType(str):
+class StatusType(StrEnum):
     InSync = "InSync"
     Failed = "Failed"
     InProgress = "InProgress"

--- a/localstack-core/localstack/aws/api/ses/__init__.py
+++ b/localstack-core/localstack/aws/api/ses/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -63,12 +64,12 @@ TextPart = str
 VerificationToken = str
 
 
-class BehaviorOnMXFailure(str):
+class BehaviorOnMXFailure(StrEnum):
     UseDefaultValue = "UseDefaultValue"
     RejectMessage = "RejectMessage"
 
 
-class BounceType(str):
+class BounceType(StrEnum):
     DoesNotExist = "DoesNotExist"
     MessageTooLarge = "MessageTooLarge"
     ExceededQuota = "ExceededQuota"
@@ -77,7 +78,7 @@ class BounceType(str):
     TemporaryFailure = "TemporaryFailure"
 
 
-class BulkEmailStatus(str):
+class BulkEmailStatus(StrEnum):
     Success = "Success"
     MessageRejected = "MessageRejected"
     MailFromDomainNotVerified = "MailFromDomainNotVerified"
@@ -94,27 +95,27 @@ class BulkEmailStatus(str):
     Failed = "Failed"
 
 
-class ConfigurationSetAttribute(str):
+class ConfigurationSetAttribute(StrEnum):
     eventDestinations = "eventDestinations"
     trackingOptions = "trackingOptions"
     deliveryOptions = "deliveryOptions"
     reputationOptions = "reputationOptions"
 
 
-class CustomMailFromStatus(str):
+class CustomMailFromStatus(StrEnum):
     Pending = "Pending"
     Success = "Success"
     Failed = "Failed"
     TemporaryFailure = "TemporaryFailure"
 
 
-class DimensionValueSource(str):
+class DimensionValueSource(StrEnum):
     messageTag = "messageTag"
     emailHeader = "emailHeader"
     linkTag = "linkTag"
 
 
-class DsnAction(str):
+class DsnAction(StrEnum):
     failed = "failed"
     delayed = "delayed"
     delivered = "delivered"
@@ -122,7 +123,7 @@ class DsnAction(str):
     expanded = "expanded"
 
 
-class EventType(str):
+class EventType(StrEnum):
     send = "send"
     reject = "reject"
     bounce = "bounce"
@@ -133,42 +134,42 @@ class EventType(str):
     renderingFailure = "renderingFailure"
 
 
-class IdentityType(str):
+class IdentityType(StrEnum):
     EmailAddress = "EmailAddress"
     Domain = "Domain"
 
 
-class InvocationType(str):
+class InvocationType(StrEnum):
     Event = "Event"
     RequestResponse = "RequestResponse"
 
 
-class NotificationType(str):
+class NotificationType(StrEnum):
     Bounce = "Bounce"
     Complaint = "Complaint"
     Delivery = "Delivery"
 
 
-class ReceiptFilterPolicy(str):
+class ReceiptFilterPolicy(StrEnum):
     Block = "Block"
     Allow = "Allow"
 
 
-class SNSActionEncoding(str):
+class SNSActionEncoding(StrEnum):
     UTF_8 = "UTF-8"
     Base64 = "Base64"
 
 
-class StopScope(str):
+class StopScope(StrEnum):
     RuleSet = "RuleSet"
 
 
-class TlsPolicy(str):
+class TlsPolicy(StrEnum):
     Require = "Require"
     Optional_ = "Optional"
 
 
-class VerificationStatus(str):
+class VerificationStatus(StrEnum):
     Pending = "Pending"
     Success = "Success"
     Failed = "Failed"

--- a/localstack-core/localstack/aws/api/sns/__init__.py
+++ b/localstack-core/localstack/aws/api/sns/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -35,7 +36,7 @@ topicARN = str
 topicName = str
 
 
-class LanguageCodeString(str):
+class LanguageCodeString(StrEnum):
     en_US = "en-US"
     en_GB = "en-GB"
     es_419 = "es-419"
@@ -51,19 +52,19 @@ class LanguageCodeString(str):
     zh_TW = "zh-TW"
 
 
-class NumberCapability(str):
+class NumberCapability(StrEnum):
     SMS = "SMS"
     MMS = "MMS"
     VOICE = "VOICE"
 
 
-class RouteType(str):
+class RouteType(StrEnum):
     Transactional = "Transactional"
     Promotional = "Promotional"
     Premium = "Premium"
 
 
-class SMSSandboxPhoneNumberVerificationStatus(str):
+class SMSSandboxPhoneNumberVerificationStatus(StrEnum):
     Pending = "Pending"
     Verified = "Verified"
 

--- a/localstack-core/localstack/aws/api/sqs/__init__.py
+++ b/localstack-core/localstack/aws/api/sqs/__init__.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -13,7 +14,7 @@ TagValue = str
 Token = str
 
 
-class MessageSystemAttributeName(str):
+class MessageSystemAttributeName(StrEnum):
     All = "All"
     SenderId = "SenderId"
     SentTimestamp = "SentTimestamp"
@@ -26,11 +27,11 @@ class MessageSystemAttributeName(str):
     DeadLetterQueueSourceArn = "DeadLetterQueueSourceArn"
 
 
-class MessageSystemAttributeNameForSends(str):
+class MessageSystemAttributeNameForSends(StrEnum):
     AWSTraceHeader = "AWSTraceHeader"
 
 
-class QueueAttributeName(str):
+class QueueAttributeName(StrEnum):
     All = "All"
     Policy = "Policy"
     VisibilityTimeout = "VisibilityTimeout"

--- a/localstack-core/localstack/aws/api/ssm/__init__.py
+++ b/localstack-core/localstack/aws/api/ssm/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -366,7 +367,7 @@ ValidNextStep = str
 Version = str
 
 
-class AssociationComplianceSeverity(str):
+class AssociationComplianceSeverity(StrEnum):
     CRITICAL = "CRITICAL"
     HIGH = "HIGH"
     MEDIUM = "MEDIUM"
@@ -374,19 +375,19 @@ class AssociationComplianceSeverity(str):
     UNSPECIFIED = "UNSPECIFIED"
 
 
-class AssociationExecutionFilterKey(str):
+class AssociationExecutionFilterKey(StrEnum):
     ExecutionId = "ExecutionId"
     Status = "Status"
     CreatedTime = "CreatedTime"
 
 
-class AssociationExecutionTargetsFilterKey(str):
+class AssociationExecutionTargetsFilterKey(StrEnum):
     Status = "Status"
     ResourceId = "ResourceId"
     ResourceType = "ResourceType"
 
 
-class AssociationFilterKey(str):
+class AssociationFilterKey(StrEnum):
     InstanceId = "InstanceId"
     Name = "Name"
     AssociationId = "AssociationId"
@@ -397,34 +398,34 @@ class AssociationFilterKey(str):
     ResourceGroupName = "ResourceGroupName"
 
 
-class AssociationFilterOperatorType(str):
+class AssociationFilterOperatorType(StrEnum):
     EQUAL = "EQUAL"
     LESS_THAN = "LESS_THAN"
     GREATER_THAN = "GREATER_THAN"
 
 
-class AssociationStatusName(str):
+class AssociationStatusName(StrEnum):
     Pending = "Pending"
     Success = "Success"
     Failed = "Failed"
 
 
-class AssociationSyncCompliance(str):
+class AssociationSyncCompliance(StrEnum):
     AUTO = "AUTO"
     MANUAL = "MANUAL"
 
 
-class AttachmentHashType(str):
+class AttachmentHashType(StrEnum):
     Sha256 = "Sha256"
 
 
-class AttachmentsSourceKey(str):
+class AttachmentsSourceKey(StrEnum):
     SourceUrl = "SourceUrl"
     S3FileUrl = "S3FileUrl"
     AttachmentReference = "AttachmentReference"
 
 
-class AutomationExecutionFilterKey(str):
+class AutomationExecutionFilterKey(StrEnum):
     DocumentNamePrefix = "DocumentNamePrefix"
     ExecutionStatus = "ExecutionStatus"
     ExecutionId = "ExecutionId"
@@ -439,7 +440,7 @@ class AutomationExecutionFilterKey(str):
     OpsItemId = "OpsItemId"
 
 
-class AutomationExecutionStatus(str):
+class AutomationExecutionStatus(StrEnum):
     Pending = "Pending"
     InProgress = "InProgress"
     Waiting = "Waiting"
@@ -461,21 +462,21 @@ class AutomationExecutionStatus(str):
     Exited = "Exited"
 
 
-class AutomationSubtype(str):
+class AutomationSubtype(StrEnum):
     ChangeRequest = "ChangeRequest"
 
 
-class AutomationType(str):
+class AutomationType(StrEnum):
     CrossAccount = "CrossAccount"
     Local = "Local"
 
 
-class CalendarState(str):
+class CalendarState(StrEnum):
     OPEN = "OPEN"
     CLOSED = "CLOSED"
 
 
-class CommandFilterKey(str):
+class CommandFilterKey(StrEnum):
     InvokedAfter = "InvokedAfter"
     InvokedBefore = "InvokedBefore"
     Status = "Status"
@@ -483,7 +484,7 @@ class CommandFilterKey(str):
     DocumentName = "DocumentName"
 
 
-class CommandInvocationStatus(str):
+class CommandInvocationStatus(StrEnum):
     Pending = "Pending"
     InProgress = "InProgress"
     Delayed = "Delayed"
@@ -494,7 +495,7 @@ class CommandInvocationStatus(str):
     Cancelling = "Cancelling"
 
 
-class CommandPluginStatus(str):
+class CommandPluginStatus(StrEnum):
     Pending = "Pending"
     InProgress = "InProgress"
     Success = "Success"
@@ -503,7 +504,7 @@ class CommandPluginStatus(str):
     Failed = "Failed"
 
 
-class CommandStatus(str):
+class CommandStatus(StrEnum):
     Pending = "Pending"
     InProgress = "InProgress"
     Success = "Success"
@@ -513,7 +514,7 @@ class CommandStatus(str):
     Cancelling = "Cancelling"
 
 
-class ComplianceQueryOperatorType(str):
+class ComplianceQueryOperatorType(StrEnum):
     EQUAL = "EQUAL"
     NOT_EQUAL = "NOT_EQUAL"
     BEGIN_WITH = "BEGIN_WITH"
@@ -521,7 +522,7 @@ class ComplianceQueryOperatorType(str):
     GREATER_THAN = "GREATER_THAN"
 
 
-class ComplianceSeverity(str):
+class ComplianceSeverity(StrEnum):
     CRITICAL = "CRITICAL"
     HIGH = "HIGH"
     MEDIUM = "MEDIUM"
@@ -530,70 +531,70 @@ class ComplianceSeverity(str):
     UNSPECIFIED = "UNSPECIFIED"
 
 
-class ComplianceStatus(str):
+class ComplianceStatus(StrEnum):
     COMPLIANT = "COMPLIANT"
     NON_COMPLIANT = "NON_COMPLIANT"
 
 
-class ComplianceUploadType(str):
+class ComplianceUploadType(StrEnum):
     COMPLETE = "COMPLETE"
     PARTIAL = "PARTIAL"
 
 
-class ConnectionStatus(str):
+class ConnectionStatus(StrEnum):
     connected = "connected"
     notconnected = "notconnected"
 
 
-class DescribeActivationsFilterKeys(str):
+class DescribeActivationsFilterKeys(StrEnum):
     ActivationIds = "ActivationIds"
     DefaultInstanceName = "DefaultInstanceName"
     IamRole = "IamRole"
 
 
-class DocumentFilterKey(str):
+class DocumentFilterKey(StrEnum):
     Name = "Name"
     Owner = "Owner"
     PlatformTypes = "PlatformTypes"
     DocumentType = "DocumentType"
 
 
-class DocumentFormat(str):
+class DocumentFormat(StrEnum):
     YAML = "YAML"
     JSON = "JSON"
     TEXT = "TEXT"
 
 
-class DocumentHashType(str):
+class DocumentHashType(StrEnum):
     Sha256 = "Sha256"
     Sha1 = "Sha1"
 
 
-class DocumentMetadataEnum(str):
+class DocumentMetadataEnum(StrEnum):
     DocumentReviews = "DocumentReviews"
 
 
-class DocumentParameterType(str):
+class DocumentParameterType(StrEnum):
     String = "String"
     StringList = "StringList"
 
 
-class DocumentPermissionType(str):
+class DocumentPermissionType(StrEnum):
     Share = "Share"
 
 
-class DocumentReviewAction(str):
+class DocumentReviewAction(StrEnum):
     SendForReview = "SendForReview"
     UpdateReview = "UpdateReview"
     Approve = "Approve"
     Reject = "Reject"
 
 
-class DocumentReviewCommentType(str):
+class DocumentReviewCommentType(StrEnum):
     Comment = "Comment"
 
 
-class DocumentStatus(str):
+class DocumentStatus(StrEnum):
     Creating = "Creating"
     Active = "Active"
     Updating = "Updating"
@@ -601,7 +602,7 @@ class DocumentStatus(str):
     Failed = "Failed"
 
 
-class DocumentType(str):
+class DocumentType(StrEnum):
     Command = "Command"
     Policy = "Policy"
     Automation = "Automation"
@@ -619,23 +620,23 @@ class DocumentType(str):
     QuickSetup = "QuickSetup"
 
 
-class ExecutionMode(str):
+class ExecutionMode(StrEnum):
     Auto = "Auto"
     Interactive = "Interactive"
 
 
-class ExternalAlarmState(str):
+class ExternalAlarmState(StrEnum):
     UNKNOWN = "UNKNOWN"
     ALARM = "ALARM"
 
 
-class Fault(str):
+class Fault(StrEnum):
     Client = "Client"
     Server = "Server"
     Unknown = "Unknown"
 
 
-class InstanceInformationFilterKey(str):
+class InstanceInformationFilterKey(StrEnum):
     InstanceIds = "InstanceIds"
     AgentVersion = "AgentVersion"
     PingStatus = "PingStatus"
@@ -646,14 +647,14 @@ class InstanceInformationFilterKey(str):
     AssociationStatus = "AssociationStatus"
 
 
-class InstancePatchStateOperatorType(str):
+class InstancePatchStateOperatorType(StrEnum):
     Equal = "Equal"
     NotEqual = "NotEqual"
     LessThan = "LessThan"
     GreaterThan = "GreaterThan"
 
 
-class InstancePropertyFilterKey(str):
+class InstancePropertyFilterKey(StrEnum):
     InstanceIds = "InstanceIds"
     AgentVersion = "AgentVersion"
     PingStatus = "PingStatus"
@@ -665,7 +666,7 @@ class InstancePropertyFilterKey(str):
     AssociationStatus = "AssociationStatus"
 
 
-class InstancePropertyFilterOperator(str):
+class InstancePropertyFilterOperator(StrEnum):
     Equal = "Equal"
     NotEqual = "NotEqual"
     BeginWith = "BeginWith"
@@ -673,17 +674,17 @@ class InstancePropertyFilterOperator(str):
     GreaterThan = "GreaterThan"
 
 
-class InventoryAttributeDataType(str):
+class InventoryAttributeDataType(StrEnum):
     string = "string"
     number = "number"
 
 
-class InventoryDeletionStatus(str):
+class InventoryDeletionStatus(StrEnum):
     InProgress = "InProgress"
     Complete = "Complete"
 
 
-class InventoryQueryOperatorType(str):
+class InventoryQueryOperatorType(StrEnum):
     Equal = "Equal"
     NotEqual = "NotEqual"
     BeginWith = "BeginWith"
@@ -692,18 +693,18 @@ class InventoryQueryOperatorType(str):
     Exists = "Exists"
 
 
-class InventorySchemaDeleteOption(str):
+class InventorySchemaDeleteOption(StrEnum):
     DisableSchema = "DisableSchema"
     DeleteSchema = "DeleteSchema"
 
 
-class LastResourceDataSyncStatus(str):
+class LastResourceDataSyncStatus(StrEnum):
     Successful = "Successful"
     Failed = "Failed"
     InProgress = "InProgress"
 
 
-class MaintenanceWindowExecutionStatus(str):
+class MaintenanceWindowExecutionStatus(StrEnum):
     PENDING = "PENDING"
     IN_PROGRESS = "IN_PROGRESS"
     SUCCESS = "SUCCESS"
@@ -714,24 +715,24 @@ class MaintenanceWindowExecutionStatus(str):
     SKIPPED_OVERLAPPING = "SKIPPED_OVERLAPPING"
 
 
-class MaintenanceWindowResourceType(str):
+class MaintenanceWindowResourceType(StrEnum):
     INSTANCE = "INSTANCE"
     RESOURCE_GROUP = "RESOURCE_GROUP"
 
 
-class MaintenanceWindowTaskCutoffBehavior(str):
+class MaintenanceWindowTaskCutoffBehavior(StrEnum):
     CONTINUE_TASK = "CONTINUE_TASK"
     CANCEL_TASK = "CANCEL_TASK"
 
 
-class MaintenanceWindowTaskType(str):
+class MaintenanceWindowTaskType(StrEnum):
     RUN_COMMAND = "RUN_COMMAND"
     AUTOMATION = "AUTOMATION"
     STEP_FUNCTIONS = "STEP_FUNCTIONS"
     LAMBDA = "LAMBDA"
 
 
-class NotificationEvent(str):
+class NotificationEvent(StrEnum):
     All = "All"
     InProgress = "InProgress"
     Success = "Success"
@@ -740,12 +741,12 @@ class NotificationEvent(str):
     Failed = "Failed"
 
 
-class NotificationType(str):
+class NotificationType(StrEnum):
     Command = "Command"
     Invocation = "Invocation"
 
 
-class OperatingSystem(str):
+class OperatingSystem(StrEnum):
     WINDOWS = "WINDOWS"
     AMAZON_LINUX = "AMAZON_LINUX"
     AMAZON_LINUX_2 = "AMAZON_LINUX_2"
@@ -763,7 +764,7 @@ class OperatingSystem(str):
     AMAZON_LINUX_2023 = "AMAZON_LINUX_2023"
 
 
-class OpsFilterOperatorType(str):
+class OpsFilterOperatorType(StrEnum):
     Equal = "Equal"
     NotEqual = "NotEqual"
     BeginWith = "BeginWith"
@@ -772,20 +773,20 @@ class OpsFilterOperatorType(str):
     Exists = "Exists"
 
 
-class OpsItemDataType(str):
+class OpsItemDataType(StrEnum):
     SearchableString = "SearchableString"
     String = "String"
 
 
-class OpsItemEventFilterKey(str):
+class OpsItemEventFilterKey(StrEnum):
     OpsItemId = "OpsItemId"
 
 
-class OpsItemEventFilterOperator(str):
+class OpsItemEventFilterOperator(StrEnum):
     Equal = "Equal"
 
 
-class OpsItemFilterKey(str):
+class OpsItemFilterKey(StrEnum):
     Status = "Status"
     CreatedBy = "CreatedBy"
     Source = "Source"
@@ -816,24 +817,24 @@ class OpsItemFilterKey(str):
     AccountId = "AccountId"
 
 
-class OpsItemFilterOperator(str):
+class OpsItemFilterOperator(StrEnum):
     Equal = "Equal"
     Contains = "Contains"
     GreaterThan = "GreaterThan"
     LessThan = "LessThan"
 
 
-class OpsItemRelatedItemsFilterKey(str):
+class OpsItemRelatedItemsFilterKey(StrEnum):
     ResourceType = "ResourceType"
     AssociationId = "AssociationId"
     ResourceUri = "ResourceUri"
 
 
-class OpsItemRelatedItemsFilterOperator(str):
+class OpsItemRelatedItemsFilterOperator(StrEnum):
     Equal = "Equal"
 
 
-class OpsItemStatus(str):
+class OpsItemStatus(StrEnum):
     Open = "Open"
     InProgress = "InProgress"
     Resolved = "Resolved"
@@ -855,30 +856,30 @@ class OpsItemStatus(str):
     Closed = "Closed"
 
 
-class ParameterTier(str):
+class ParameterTier(StrEnum):
     Standard = "Standard"
     Advanced = "Advanced"
     Intelligent_Tiering = "Intelligent-Tiering"
 
 
-class ParameterType(str):
+class ParameterType(StrEnum):
     String = "String"
     StringList = "StringList"
     SecureString = "SecureString"
 
 
-class ParametersFilterKey(str):
+class ParametersFilterKey(StrEnum):
     Name = "Name"
     Type = "Type"
     KeyId = "KeyId"
 
 
-class PatchAction(str):
+class PatchAction(StrEnum):
     ALLOW_AS_DEPENDENCY = "ALLOW_AS_DEPENDENCY"
     BLOCK = "BLOCK"
 
 
-class PatchComplianceDataState(str):
+class PatchComplianceDataState(StrEnum):
     INSTALLED = "INSTALLED"
     INSTALLED_OTHER = "INSTALLED_OTHER"
     INSTALLED_PENDING_REBOOT = "INSTALLED_PENDING_REBOOT"
@@ -888,7 +889,7 @@ class PatchComplianceDataState(str):
     FAILED = "FAILED"
 
 
-class PatchComplianceLevel(str):
+class PatchComplianceLevel(StrEnum):
     CRITICAL = "CRITICAL"
     HIGH = "HIGH"
     MEDIUM = "MEDIUM"
@@ -897,14 +898,14 @@ class PatchComplianceLevel(str):
     UNSPECIFIED = "UNSPECIFIED"
 
 
-class PatchDeploymentStatus(str):
+class PatchDeploymentStatus(StrEnum):
     APPROVED = "APPROVED"
     PENDING_APPROVAL = "PENDING_APPROVAL"
     EXPLICIT_APPROVED = "EXPLICIT_APPROVED"
     EXPLICIT_REJECTED = "EXPLICIT_REJECTED"
 
 
-class PatchFilterKey(str):
+class PatchFilterKey(StrEnum):
     ARCH = "ARCH"
     ADVISORY_ID = "ADVISORY_ID"
     BUGZILLA_ID = "BUGZILLA_ID"
@@ -926,12 +927,12 @@ class PatchFilterKey(str):
     VERSION = "VERSION"
 
 
-class PatchOperationType(str):
+class PatchOperationType(StrEnum):
     Scan = "Scan"
     Install = "Install"
 
 
-class PatchProperty(str):
+class PatchProperty(StrEnum):
     PRODUCT = "PRODUCT"
     PRODUCT_FAMILY = "PRODUCT_FAMILY"
     CLASSIFICATION = "CLASSIFICATION"
@@ -940,38 +941,38 @@ class PatchProperty(str):
     SEVERITY = "SEVERITY"
 
 
-class PatchSet(str):
+class PatchSet(StrEnum):
     OS = "OS"
     APPLICATION = "APPLICATION"
 
 
-class PingStatus(str):
+class PingStatus(StrEnum):
     Online = "Online"
     ConnectionLost = "ConnectionLost"
     Inactive = "Inactive"
 
 
-class PlatformType(str):
+class PlatformType(StrEnum):
     Windows = "Windows"
     Linux = "Linux"
     MacOS = "MacOS"
 
 
-class RebootOption(str):
+class RebootOption(StrEnum):
     RebootIfNeeded = "RebootIfNeeded"
     NoReboot = "NoReboot"
 
 
-class ResourceDataSyncS3Format(str):
+class ResourceDataSyncS3Format(StrEnum):
     JsonSerDe = "JsonSerDe"
 
 
-class ResourceType(str):
+class ResourceType(StrEnum):
     ManagedInstance = "ManagedInstance"
     EC2Instance = "EC2Instance"
 
 
-class ResourceTypeForTagging(str):
+class ResourceTypeForTagging(StrEnum):
     Document = "Document"
     ManagedInstance = "ManagedInstance"
     MaintenanceWindow = "MaintenanceWindow"
@@ -983,14 +984,14 @@ class ResourceTypeForTagging(str):
     Association = "Association"
 
 
-class ReviewStatus(str):
+class ReviewStatus(StrEnum):
     APPROVED = "APPROVED"
     NOT_REVIEWED = "NOT_REVIEWED"
     PENDING = "PENDING"
     REJECTED = "REJECTED"
 
 
-class SessionFilterKey(str):
+class SessionFilterKey(StrEnum):
     InvokedAfter = "InvokedAfter"
     InvokedBefore = "InvokedBefore"
     Target = "Target"
@@ -999,12 +1000,12 @@ class SessionFilterKey(str):
     SessionId = "SessionId"
 
 
-class SessionState(str):
+class SessionState(StrEnum):
     Active = "Active"
     History = "History"
 
 
-class SessionStatus(str):
+class SessionStatus(StrEnum):
     Connected = "Connected"
     Connecting = "Connecting"
     Disconnected = "Disconnected"
@@ -1013,7 +1014,7 @@ class SessionStatus(str):
     Failed = "Failed"
 
 
-class SignalType(str):
+class SignalType(StrEnum):
     Approve = "Approve"
     Reject = "Reject"
     StartStep = "StartStep"
@@ -1021,13 +1022,13 @@ class SignalType(str):
     Resume = "Resume"
 
 
-class SourceType(str):
+class SourceType(StrEnum):
     AWS_EC2_Instance = "AWS::EC2::Instance"
     AWS_IoT_Thing = "AWS::IoT::Thing"
     AWS_SSM_ManagedInstance = "AWS::SSM::ManagedInstance"
 
 
-class StepExecutionFilterKey(str):
+class StepExecutionFilterKey(StrEnum):
     StartTimeBefore = "StartTimeBefore"
     StartTimeAfter = "StartTimeAfter"
     StepExecutionStatus = "StepExecutionStatus"
@@ -1039,7 +1040,7 @@ class StepExecutionFilterKey(str):
     ParentStepIteratorValue = "ParentStepIteratorValue"
 
 
-class StopType(str):
+class StopType(StrEnum):
     Complete = "Complete"
     Cancel = "Cancel"
 

--- a/localstack-core/localstack/aws/api/stepfunctions/__init__.py
+++ b/localstack-core/localstack/aws/api/stepfunctions/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -53,18 +54,18 @@ includedDetails = bool
 truncated = bool
 
 
-class ExecutionRedriveFilter(str):
+class ExecutionRedriveFilter(StrEnum):
     REDRIVEN = "REDRIVEN"
     NOT_REDRIVEN = "NOT_REDRIVEN"
 
 
-class ExecutionRedriveStatus(str):
+class ExecutionRedriveStatus(StrEnum):
     REDRIVABLE = "REDRIVABLE"
     NOT_REDRIVABLE = "NOT_REDRIVABLE"
     REDRIVABLE_BY_MAP_RUN = "REDRIVABLE_BY_MAP_RUN"
 
 
-class ExecutionStatus(str):
+class ExecutionStatus(StrEnum):
     RUNNING = "RUNNING"
     SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"
@@ -73,7 +74,7 @@ class ExecutionStatus(str):
     PENDING_REDRIVE = "PENDING_REDRIVE"
 
 
-class HistoryEventType(str):
+class HistoryEventType(StrEnum):
     ActivityFailed = "ActivityFailed"
     ActivityScheduled = "ActivityScheduled"
     ActivityScheduleFailed = "ActivityScheduleFailed"
@@ -137,59 +138,59 @@ class HistoryEventType(str):
     MapRunRedriven = "MapRunRedriven"
 
 
-class InspectionLevel(str):
+class InspectionLevel(StrEnum):
     INFO = "INFO"
     DEBUG = "DEBUG"
     TRACE = "TRACE"
 
 
-class LogLevel(str):
+class LogLevel(StrEnum):
     ALL = "ALL"
     ERROR = "ERROR"
     FATAL = "FATAL"
     OFF = "OFF"
 
 
-class MapRunStatus(str):
+class MapRunStatus(StrEnum):
     RUNNING = "RUNNING"
     SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"
     ABORTED = "ABORTED"
 
 
-class StateMachineStatus(str):
+class StateMachineStatus(StrEnum):
     ACTIVE = "ACTIVE"
     DELETING = "DELETING"
 
 
-class StateMachineType(str):
+class StateMachineType(StrEnum):
     STANDARD = "STANDARD"
     EXPRESS = "EXPRESS"
 
 
-class SyncExecutionStatus(str):
+class SyncExecutionStatus(StrEnum):
     SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"
     TIMED_OUT = "TIMED_OUT"
 
 
-class TestExecutionStatus(str):
+class TestExecutionStatus(StrEnum):
     SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"
     RETRIABLE = "RETRIABLE"
     CAUGHT_ERROR = "CAUGHT_ERROR"
 
 
-class ValidateStateMachineDefinitionResultCode(str):
+class ValidateStateMachineDefinitionResultCode(StrEnum):
     OK = "OK"
     FAIL = "FAIL"
 
 
-class ValidateStateMachineDefinitionSeverity(str):
+class ValidateStateMachineDefinitionSeverity(StrEnum):
     ERROR = "ERROR"
 
 
-class ValidationExceptionReason(str):
+class ValidationExceptionReason(StrEnum):
     API_DOES_NOT_SUPPORT_LABELED_ARNS = "API_DOES_NOT_SUPPORT_LABELED_ARNS"
     MISSING_REQUIRED_PARAMETER = "MISSING_REQUIRED_PARAMETER"
     CANNOT_UPDATE_COMPLETED_MAP_RUN = "CANNOT_UPDATE_COMPLETED_MAP_RUN"

--- a/localstack-core/localstack/aws/api/swf/__init__.py
+++ b/localstack-core/localstack/aws/api/swf/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -44,30 +45,30 @@ WorkflowRunId = str
 WorkflowRunIdOptional = str
 
 
-class ActivityTaskTimeoutType(str):
+class ActivityTaskTimeoutType(StrEnum):
     START_TO_CLOSE = "START_TO_CLOSE"
     SCHEDULE_TO_START = "SCHEDULE_TO_START"
     SCHEDULE_TO_CLOSE = "SCHEDULE_TO_CLOSE"
     HEARTBEAT = "HEARTBEAT"
 
 
-class CancelTimerFailedCause(str):
+class CancelTimerFailedCause(StrEnum):
     TIMER_ID_UNKNOWN = "TIMER_ID_UNKNOWN"
     OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
 
 
-class CancelWorkflowExecutionFailedCause(str):
+class CancelWorkflowExecutionFailedCause(StrEnum):
     UNHANDLED_DECISION = "UNHANDLED_DECISION"
     OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
 
 
-class ChildPolicy(str):
+class ChildPolicy(StrEnum):
     TERMINATE = "TERMINATE"
     REQUEST_CANCEL = "REQUEST_CANCEL"
     ABANDON = "ABANDON"
 
 
-class CloseStatus(str):
+class CloseStatus(StrEnum):
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
     CANCELED = "CANCELED"
@@ -76,12 +77,12 @@ class CloseStatus(str):
     TIMED_OUT = "TIMED_OUT"
 
 
-class CompleteWorkflowExecutionFailedCause(str):
+class CompleteWorkflowExecutionFailedCause(StrEnum):
     UNHANDLED_DECISION = "UNHANDLED_DECISION"
     OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
 
 
-class ContinueAsNewWorkflowExecutionFailedCause(str):
+class ContinueAsNewWorkflowExecutionFailedCause(StrEnum):
     UNHANDLED_DECISION = "UNHANDLED_DECISION"
     WORKFLOW_TYPE_DEPRECATED = "WORKFLOW_TYPE_DEPRECATED"
     WORKFLOW_TYPE_DOES_NOT_EXIST = "WORKFLOW_TYPE_DOES_NOT_EXIST"
@@ -97,12 +98,12 @@ class ContinueAsNewWorkflowExecutionFailedCause(str):
     OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
 
 
-class DecisionTaskTimeoutType(str):
+class DecisionTaskTimeoutType(StrEnum):
     START_TO_CLOSE = "START_TO_CLOSE"
     SCHEDULE_TO_START = "SCHEDULE_TO_START"
 
 
-class DecisionType(str):
+class DecisionType(StrEnum):
     ScheduleActivityTask = "ScheduleActivityTask"
     RequestCancelActivityTask = "RequestCancelActivityTask"
     CompleteWorkflowExecution = "CompleteWorkflowExecution"
@@ -118,7 +119,7 @@ class DecisionType(str):
     ScheduleLambdaFunction = "ScheduleLambdaFunction"
 
 
-class EventType(str):
+class EventType(StrEnum):
     WorkflowExecutionStarted = "WorkflowExecutionStarted"
     WorkflowExecutionCancelRequested = "WorkflowExecutionCancelRequested"
     WorkflowExecutionCompleted = "WorkflowExecutionCompleted"
@@ -177,35 +178,35 @@ class EventType(str):
     StartLambdaFunctionFailed = "StartLambdaFunctionFailed"
 
 
-class ExecutionStatus(str):
+class ExecutionStatus(StrEnum):
     OPEN = "OPEN"
     CLOSED = "CLOSED"
 
 
-class FailWorkflowExecutionFailedCause(str):
+class FailWorkflowExecutionFailedCause(StrEnum):
     UNHANDLED_DECISION = "UNHANDLED_DECISION"
     OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
 
 
-class LambdaFunctionTimeoutType(str):
+class LambdaFunctionTimeoutType(StrEnum):
     START_TO_CLOSE = "START_TO_CLOSE"
 
 
-class RecordMarkerFailedCause(str):
+class RecordMarkerFailedCause(StrEnum):
     OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
 
 
-class RegistrationStatus(str):
+class RegistrationStatus(StrEnum):
     REGISTERED = "REGISTERED"
     DEPRECATED = "DEPRECATED"
 
 
-class RequestCancelActivityTaskFailedCause(str):
+class RequestCancelActivityTaskFailedCause(StrEnum):
     ACTIVITY_ID_UNKNOWN = "ACTIVITY_ID_UNKNOWN"
     OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
 
 
-class RequestCancelExternalWorkflowExecutionFailedCause(str):
+class RequestCancelExternalWorkflowExecutionFailedCause(StrEnum):
     UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION = "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
     REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED = (
         "REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED"
@@ -213,7 +214,7 @@ class RequestCancelExternalWorkflowExecutionFailedCause(str):
     OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
 
 
-class ScheduleActivityTaskFailedCause(str):
+class ScheduleActivityTaskFailedCause(StrEnum):
     ACTIVITY_TYPE_DEPRECATED = "ACTIVITY_TYPE_DEPRECATED"
     ACTIVITY_TYPE_DOES_NOT_EXIST = "ACTIVITY_TYPE_DOES_NOT_EXIST"
     ACTIVITY_ID_ALREADY_IN_USE = "ACTIVITY_ID_ALREADY_IN_USE"
@@ -227,14 +228,14 @@ class ScheduleActivityTaskFailedCause(str):
     OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
 
 
-class ScheduleLambdaFunctionFailedCause(str):
+class ScheduleLambdaFunctionFailedCause(StrEnum):
     ID_ALREADY_IN_USE = "ID_ALREADY_IN_USE"
     OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED = "OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED"
     LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED = "LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED"
     LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION = "LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION"
 
 
-class SignalExternalWorkflowExecutionFailedCause(str):
+class SignalExternalWorkflowExecutionFailedCause(StrEnum):
     UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION = "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
     SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED = (
         "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED"
@@ -242,7 +243,7 @@ class SignalExternalWorkflowExecutionFailedCause(str):
     OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
 
 
-class StartChildWorkflowExecutionFailedCause(str):
+class StartChildWorkflowExecutionFailedCause(StrEnum):
     WORKFLOW_TYPE_DOES_NOT_EXIST = "WORKFLOW_TYPE_DOES_NOT_EXIST"
     WORKFLOW_TYPE_DEPRECATED = "WORKFLOW_TYPE_DEPRECATED"
     OPEN_CHILDREN_LIMIT_EXCEEDED = "OPEN_CHILDREN_LIMIT_EXCEEDED"
@@ -258,28 +259,28 @@ class StartChildWorkflowExecutionFailedCause(str):
     OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
 
 
-class StartLambdaFunctionFailedCause(str):
+class StartLambdaFunctionFailedCause(StrEnum):
     ASSUME_ROLE_FAILED = "ASSUME_ROLE_FAILED"
 
 
-class StartTimerFailedCause(str):
+class StartTimerFailedCause(StrEnum):
     TIMER_ID_ALREADY_IN_USE = "TIMER_ID_ALREADY_IN_USE"
     OPEN_TIMERS_LIMIT_EXCEEDED = "OPEN_TIMERS_LIMIT_EXCEEDED"
     TIMER_CREATION_RATE_EXCEEDED = "TIMER_CREATION_RATE_EXCEEDED"
     OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
 
 
-class WorkflowExecutionCancelRequestedCause(str):
+class WorkflowExecutionCancelRequestedCause(StrEnum):
     CHILD_POLICY_APPLIED = "CHILD_POLICY_APPLIED"
 
 
-class WorkflowExecutionTerminatedCause(str):
+class WorkflowExecutionTerminatedCause(StrEnum):
     CHILD_POLICY_APPLIED = "CHILD_POLICY_APPLIED"
     EVENT_LIMIT_EXCEEDED = "EVENT_LIMIT_EXCEEDED"
     OPERATOR_INITIATED = "OPERATOR_INITIATED"
 
 
-class WorkflowExecutionTimeoutType(str):
+class WorkflowExecutionTimeoutType(StrEnum):
     START_TO_CLOSE = "START_TO_CLOSE"
 
 

--- a/localstack-core/localstack/aws/api/transcribe/__init__.py
+++ b/localstack-core/localstack/aws/api/transcribe/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
@@ -37,12 +38,12 @@ VocabularyName = str
 Word = str
 
 
-class BaseModelName(str):
+class BaseModelName(StrEnum):
     NarrowBand = "NarrowBand"
     WideBand = "WideBand"
 
 
-class CLMLanguageCode(str):
+class CLMLanguageCode(StrEnum):
     en_US = "en-US"
     hi_IN = "hi-IN"
     es_US = "es-US"
@@ -52,28 +53,28 @@ class CLMLanguageCode(str):
     ja_JP = "ja-JP"
 
 
-class CallAnalyticsFeature(str):
+class CallAnalyticsFeature(StrEnum):
     GENERATIVE_SUMMARIZATION = "GENERATIVE_SUMMARIZATION"
 
 
-class CallAnalyticsJobStatus(str):
+class CallAnalyticsJobStatus(StrEnum):
     QUEUED = "QUEUED"
     IN_PROGRESS = "IN_PROGRESS"
     FAILED = "FAILED"
     COMPLETED = "COMPLETED"
 
 
-class CallAnalyticsSkippedReasonCode(str):
+class CallAnalyticsSkippedReasonCode(StrEnum):
     INSUFFICIENT_CONVERSATION_CONTENT = "INSUFFICIENT_CONVERSATION_CONTENT"
     FAILED_SAFETY_GUIDELINES = "FAILED_SAFETY_GUIDELINES"
 
 
-class InputType(str):
+class InputType(StrEnum):
     REAL_TIME = "REAL_TIME"
     POST_CALL = "POST_CALL"
 
 
-class LanguageCode(str):
+class LanguageCode(StrEnum):
     af_ZA = "af-ZA"
     ar_AE = "ar-AE"
     ar_SA = "ar-SA"
@@ -179,7 +180,7 @@ class LanguageCode(str):
     zu_ZA = "zu-ZA"
 
 
-class MediaFormat(str):
+class MediaFormat(StrEnum):
     mp3 = "mp3"
     mp4 = "mp4"
     wav = "wav"
@@ -190,43 +191,43 @@ class MediaFormat(str):
     m4a = "m4a"
 
 
-class MedicalContentIdentificationType(str):
+class MedicalContentIdentificationType(StrEnum):
     PHI = "PHI"
 
 
-class MedicalScribeJobStatus(str):
+class MedicalScribeJobStatus(StrEnum):
     QUEUED = "QUEUED"
     IN_PROGRESS = "IN_PROGRESS"
     FAILED = "FAILED"
     COMPLETED = "COMPLETED"
 
 
-class MedicalScribeLanguageCode(str):
+class MedicalScribeLanguageCode(StrEnum):
     en_US = "en-US"
 
 
-class MedicalScribeParticipantRole(str):
+class MedicalScribeParticipantRole(StrEnum):
     PATIENT = "PATIENT"
     CLINICIAN = "CLINICIAN"
 
 
-class ModelStatus(str):
+class ModelStatus(StrEnum):
     IN_PROGRESS = "IN_PROGRESS"
     FAILED = "FAILED"
     COMPLETED = "COMPLETED"
 
 
-class OutputLocationType(str):
+class OutputLocationType(StrEnum):
     CUSTOMER_BUCKET = "CUSTOMER_BUCKET"
     SERVICE_BUCKET = "SERVICE_BUCKET"
 
 
-class ParticipantRole(str):
+class ParticipantRole(StrEnum):
     AGENT = "AGENT"
     CUSTOMER = "CUSTOMER"
 
 
-class PiiEntityType(str):
+class PiiEntityType(StrEnum):
     BANK_ACCOUNT_NUMBER = "BANK_ACCOUNT_NUMBER"
     BANK_ROUTING = "BANK_ROUTING"
     CREDIT_DEBIT_NUMBER = "CREDIT_DEBIT_NUMBER"
@@ -241,58 +242,58 @@ class PiiEntityType(str):
     ALL = "ALL"
 
 
-class RedactionOutput(str):
+class RedactionOutput(StrEnum):
     redacted = "redacted"
     redacted_and_unredacted = "redacted_and_unredacted"
 
 
-class RedactionType(str):
+class RedactionType(StrEnum):
     PII = "PII"
 
 
-class SentimentValue(str):
+class SentimentValue(StrEnum):
     POSITIVE = "POSITIVE"
     NEGATIVE = "NEGATIVE"
     NEUTRAL = "NEUTRAL"
     MIXED = "MIXED"
 
 
-class Specialty(str):
+class Specialty(StrEnum):
     PRIMARYCARE = "PRIMARYCARE"
 
 
-class SubtitleFormat(str):
+class SubtitleFormat(StrEnum):
     vtt = "vtt"
     srt = "srt"
 
 
-class ToxicityCategory(str):
+class ToxicityCategory(StrEnum):
     ALL = "ALL"
 
 
-class TranscriptFilterType(str):
+class TranscriptFilterType(StrEnum):
     EXACT = "EXACT"
 
 
-class TranscriptionJobStatus(str):
+class TranscriptionJobStatus(StrEnum):
     QUEUED = "QUEUED"
     IN_PROGRESS = "IN_PROGRESS"
     FAILED = "FAILED"
     COMPLETED = "COMPLETED"
 
 
-class Type(str):
+class Type(StrEnum):
     CONVERSATION = "CONVERSATION"
     DICTATION = "DICTATION"
 
 
-class VocabularyFilterMethod(str):
+class VocabularyFilterMethod(StrEnum):
     remove = "remove"
     mask = "mask"
     tag = "tag"
 
 
-class VocabularyState(str):
+class VocabularyState(StrEnum):
     PENDING = "PENDING"
     READY = "READY"
     FAILED = "FAILED"

--- a/localstack-core/localstack/aws/scaffold.py
+++ b/localstack-core/localstack/aws/scaffold.py
@@ -265,7 +265,7 @@ class ShapeNode:
             )
         elif isinstance(shape, StringShape):
             if shape.enum:
-                output.write(f"class {to_valid_python_name(shape.name)}(str):\n")
+                output.write(f"class {to_valid_python_name(shape.name)}(StrEnum):\n")
                 for value in shape.enum:
                     name = to_valid_python_name(value)
                     output.write(f'    {name} = "{value}"\n')
@@ -315,10 +315,11 @@ class ShapeNode:
 
 
 def generate_service_types(output, service: ServiceModel, doc=True):
+    output.write("from datetime import datetime\n")
+    output.write("from enum import StrEnum\n")
     output.write(
         "from typing import Dict, List, Optional, Iterator, Iterable, IO, Union, TypedDict\n"
     )
-    output.write("from datetime import datetime\n")
     output.write("\n")
     output.write(
         "from localstack.aws.api import handler, RequestContext, ServiceException, ServiceRequest"

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -5,7 +5,8 @@ import hashlib
 import logging
 import re
 import zlib
-from typing import IO, Any, Dict, Literal, NamedTuple, Optional, Protocol, Tuple, Type, Union
+from enum import StrEnum
+from typing import IO, Any, Dict, Literal, NamedTuple, Optional, Protocol, Tuple, Union
 from urllib import parse as urlparser
 
 import xmltodict
@@ -516,8 +517,8 @@ def uses_host_addressing(headers: Dict[str, str]) -> str | None:
         return bucket_name
 
 
-def get_class_attrs_from_spec_class(spec_class: Type[str]) -> set[str]:
-    return {getattr(spec_class, attr) for attr in vars(spec_class) if not attr.startswith("__")}
+def get_class_attrs_from_spec_class(spec_class: StrEnum) -> set[str]:
+    return {str(spec) for spec in spec_class}
 
 
 def get_system_metadata_from_request(request: dict) -> Metadata:

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -517,7 +517,7 @@ def uses_host_addressing(headers: Dict[str, str]) -> str | None:
         return bucket_name
 
 
-def get_class_attrs_from_spec_class(spec_class: StrEnum) -> set[str]:
+def get_class_attrs_from_spec_class(spec_class: type[StrEnum]) -> set[str]:
     return {str(spec) for spec in spec_class}
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, the scaffolding currently translates the `StringShape`s from the botocore specs to enum string classes, for example:

```python
class Architecture(str):
    x86_64 = "x86_64"
    arm64 = "arm64"
```

The issue here, from a type checking perspective, is that the values, for example Architecture.x86_64, are not of type Architecture, they are simple strings:

```python
from localstack.aws.api.lambda_ import Architecture

print(isinstance(Architecture.x86_64, Architecture))
print(isinstance(Architecture.x86_64, str))
```
for example, returns:

```
False
True
```

This is not really an issue for production - they are strings, and the exact type does not really matter after it is serialized anyway. However, when developing, we are hit with fun IDE warnings and mypy also reports it as an error:

```python
def test(param: Architecture):
    pass


test(Architecture.arm64)
```

Mypy error:

```bash
mypy test.py
test.py:14: error: Argument 1 to "test" has incompatible type "str"; expected "Architecture"  [arg-type]
Found 1 error in 1 file (checked 1 source file)
```

My proposed solution would be to switch those types to StrEnum, a new type of enum introduced with python3.11 (https://docs.python.org/3/library/enum.html#enum.StrEnum). It is only applicable for code not used by the CLI, but our API scaffolds should not be imported from the CLI.

A StrEnum is both an instance of str and enum, and more importantly, the members are also a type of the respective class.
Also, the dunder __str__ and __repr__ methods are those of string, therefore it should be interchangable (we will see how the testing of this PR works out).


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Use `StrEnum` instead of `str` for generated API `StringShape`s, which will lead to correct types for the enum members.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
