### PR TITLE
Add generic botocore-model-based conversion util for CFn resource providers

### DIFF
--- a/localstack-core/localstack/services/cloudformation/provider_utils.py
+++ b/localstack-core/localstack/services/cloudformation/provider_utils.py
@@ -13,6 +13,8 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Callable, List, Optional
 
+from botocore.model import Shape, StructureShape
+
 
 def generate_default_name(stack_name: str, logical_resource_id: str):
     random_id_part = str(uuid.uuid4())[0:8]
@@ -137,6 +139,47 @@ def fix_boto_parameters_based_on_report(original_params: dict, report: str) -> d
             new_value = cast_class(old_value)
         set_nested(params, param_name, new_value)
     return params
+
+
+def fix_casing_for_boto_request_parameters(parameters: dict, input_shape: StructureShape) -> dict:
+    """
+    Transform a dict of request kwargs for a boto3 request by making sure the keys in the structure recursively conform to the specified input shape.
+    :param parameters: the kwargs that would be passed to the boto3 client call, e.g. boto3.client("s3").create_bucket(**parameters)
+    :param input_shape: The botocore input shape of the operation that you want to call later with the fixed inputs
+    :return: a transformed dictionary with the correct casing recursively applied
+    """
+
+    def get_correct_key(key: str, members: dict[str, Shape]) -> str:
+        return next((k for k in members if k.lower() == key.lower()), key)
+
+    def transform_value(value, member_shape):
+        if isinstance(value, dict) and hasattr(member_shape, "members"):
+            return fix_casing_for_boto_request_parameters(value, member_shape)
+        elif isinstance(value, list) and hasattr(member_shape, "member"):
+            return [
+                transform_value(item, member_shape.member) if isinstance(item, dict) else item
+                for item in value
+            ]
+        return value
+
+    transformed_dict = {}
+    for key, value in parameters.items():
+        correct_key = get_correct_key(key, input_shape.members)
+        member_shape = input_shape.members.get(correct_key)
+
+        if isinstance(value, dict) and member_shape and hasattr(member_shape, "members"):
+            transformed_dict[correct_key] = fix_casing_for_boto_request_parameters(
+                value, member_shape
+            )
+        elif isinstance(value, list) and member_shape and hasattr(member_shape, "member"):
+            transformed_dict[correct_key] = [
+                transform_value(item, member_shape.member) if isinstance(item, dict) else item
+                for item in value
+            ]
+        else:
+            transformed_dict[correct_key] = value
+
+    return transformed_dict
 
 
 def convert_values_to_numbers(input_dict: dict, keys_to_skip: Optional[List[str]] = None):

--- a/localstack-core/localstack/services/cloudformation/provider_utils.py
+++ b/localstack-core/localstack/services/cloudformation/provider_utils.py
@@ -180,6 +180,8 @@ def fix_casing_for_boto_request_parameters(parameters: dict, input_shape: Struct
                 transform_value(item, member_shape.member) if isinstance(item, dict) else item
                 for item in value
             ]
+        elif member_shape is None:
+            continue  # skipping this entry, so it's not included in the transformed dict
         else:
             transformed_dict[correct_key] = value
 

--- a/localstack-core/localstack/services/cloudformation/provider_utils.py
+++ b/localstack-core/localstack/services/cloudformation/provider_utils.py
@@ -149,8 +149,12 @@ def fix_casing_for_boto_request_parameters(parameters: dict, input_shape: Struct
     :return: a transformed dictionary with the correct casing recursively applied
     """
 
-    def get_correct_key(key: str, members: dict[str, Shape]) -> str:
-        return next((k for k in members if k.lower() == key.lower()), key)
+    def get_fixed_key(key: str, members: dict[str, Shape]) -> str:
+        """return the case-insensitively matched key from the shape or default to the current key"""
+        for k in members:
+            if k.lower() == key.lower():
+                return k
+        return key
 
     def transform_value(value, member_shape):
         if isinstance(value, dict) and hasattr(member_shape, "members"):
@@ -164,7 +168,7 @@ def fix_casing_for_boto_request_parameters(parameters: dict, input_shape: Struct
 
     transformed_dict = {}
     for key, value in parameters.items():
-        correct_key = get_correct_key(key, input_shape.members)
+        correct_key = get_fixed_key(key, input_shape.members)
         member_shape = input_shape.members.get(correct_key)
 
         if isinstance(value, dict) and member_shape and hasattr(member_shape, "members"):

--- a/localstack-core/localstack/services/events/resource_providers/aws_events_rule.py
+++ b/localstack-core/localstack/services/events/resource_providers/aws_events_rule.py
@@ -255,6 +255,11 @@ class EventsRuleProvider(ResourceProvider[EventsRuleProperties]):
             if event_bus_name:
                 put_targets_kwargs["EventBusName"] = event_bus_name
 
+            put_targets_kwargs = util.fix_casing_for_boto_request_parameters(
+                put_targets_kwargs,
+                events.meta.service_model.operation_model("PutTargets").input_shape,
+            )
+
             events.put_targets(**put_targets_kwargs)
 
         return ProgressEvent(

--- a/localstack-core/localstack/services/events/resource_providers/aws_events_rule.py
+++ b/localstack-core/localstack/services/events/resource_providers/aws_events_rule.py
@@ -255,7 +255,7 @@ class EventsRuleProvider(ResourceProvider[EventsRuleProperties]):
             if event_bus_name:
                 put_targets_kwargs["EventBusName"] = event_bus_name
 
-            put_targets_kwargs = util.fix_casing_for_boto_request_parameters(
+            put_targets_kwargs = util.convert_request_kwargs(
                 put_targets_kwargs,
                 events.meta.service_model.operation_model("PutTargets").input_shape,
             )

--- a/tests/unit/services/cloudformation/test_provider_utils.py
+++ b/tests/unit/services/cloudformation/test_provider_utils.py
@@ -19,13 +19,66 @@ class TestDictUtils:
             "EventBusName": "my-event-bus",
             "UnknownKey": "somevalue",
         }
-        transformed_dict = utils.fix_casing_for_boto_request_parameters(original_dict, input_shape)
+        transformed_dict = utils.convert_request_kwargs(original_dict, input_shape)
 
         assert transformed_dict == {
             "EventBusName": "my-event-bus",
         }
 
-    def test_transform_casing(self):
+    def test_convert_type_integers(self):
+        svc_name = "efs"
+        operation_name = "CreateAccessPoint"
+        operation = boto3.client(svc_name).meta.service_model.operation_model(operation_name)
+        input_shape = operation.input_shape
+        original_dict = {
+            "FileSystemId": "fs-29d6b02c",
+            "PosixUser": {"Gid": "1322", "SecondaryGids": ["1344", "1452"], "Uid": "13234"},
+            "RootDirectory": {
+                "CreationInfo": {
+                    "OwnerGid": "708798",
+                    "OwnerUid": "7987987",
+                    "Permissions": "0755",
+                },
+                "Path": "/testcfn/abc",
+            },
+        }
+        transformed_dict = utils.convert_request_kwargs(original_dict, input_shape)
+        assert transformed_dict == {
+            "FileSystemId": "fs-29d6b02c",
+            "PosixUser": {"Gid": 1322, "SecondaryGids": [1344, 1452], "Uid": 13234},
+            "RootDirectory": {
+                "CreationInfo": {"OwnerGid": 708798, "OwnerUid": 7987987, "Permissions": "0755"},
+                "Path": "/testcfn/abc",
+            },
+        }
+
+    def test_convert_type_boolean(self):
+        svc_name = "events"
+        operation_name = "PutTargets"
+        operation = boto3.client(svc_name).meta.service_model.operation_model(operation_name)
+        input_shape = operation.input_shape
+        original_dict = {
+            "EventBusName": "my-event-bus",
+            "Targets": [
+                {
+                    "Id": "an-id",
+                    "EcsParameters": {"EnableECSManagedTags": "false"},
+                }
+            ],
+        }
+        transformed_dict = utils.convert_request_kwargs(original_dict, input_shape)
+
+        assert transformed_dict == {
+            "EventBusName": "my-event-bus",
+            "Targets": [
+                {
+                    "Id": "an-id",
+                    "EcsParameters": {"EnableECSManagedTags": False},
+                }
+            ],
+        }
+
+    def test_convert_key_casing(self):
         svc_name = "events"
         operation_name = "PutTargets"
         operation = boto3.client(svc_name).meta.service_model.operation_model(operation_name)
@@ -45,7 +98,7 @@ class TestDictUtils:
                 }
             ],
         }
-        transformed_dict = utils.fix_casing_for_boto_request_parameters(original_dict, input_shape)
+        transformed_dict = utils.convert_request_kwargs(original_dict, input_shape)
 
         assert transformed_dict == {
             "EventBusName": "my-event-bus",

--- a/tests/unit/services/cloudformation/test_provider_utils.py
+++ b/tests/unit/services/cloudformation/test_provider_utils.py
@@ -10,6 +10,21 @@ class TestDictUtils:
 
         assert transformed == {"Parameter": 1, "SecondParameter": [2, 2], "ThirdParameter": "3"}
 
+    def test_drop_unknown(self):
+        svc_name = "events"
+        operation_name = "PutTargets"
+        operation = boto3.client(svc_name).meta.service_model.operation_model(operation_name)
+        input_shape = operation.input_shape
+        original_dict = {
+            "EventBusName": "my-event-bus",
+            "UnknownKey": "somevalue",
+        }
+        transformed_dict = utils.fix_casing_for_boto_request_parameters(original_dict, input_shape)
+
+        assert transformed_dict == {
+            "EventBusName": "my-event-bus",
+        }
+
     def test_transform_casing(self):
         svc_name = "events"
         operation_name = "PutTargets"

--- a/tests/unit/services/cloudformation/test_provider_utils.py
+++ b/tests/unit/services/cloudformation/test_provider_utils.py
@@ -1,3 +1,5 @@
+import boto3
+
 import localstack.services.cloudformation.provider_utils as utils
 
 
@@ -7,3 +9,41 @@ class TestDictUtils:
         transformed = utils.convert_values_to_numbers(original, ["ThirdParameter"])
 
         assert transformed == {"Parameter": 1, "SecondParameter": [2, 2], "ThirdParameter": "3"}
+
+    def test_transform_casing(self):
+        svc_name = "events"
+        operation_name = "PutTargets"
+        operation = boto3.client(svc_name).meta.service_model.operation_model(operation_name)
+        input_shape = operation.input_shape
+        original_dict = {
+            "EventBusName": "my-event-bus",
+            "Targets": [
+                {
+                    "Id": "an-id",
+                    "EcsParameters": {
+                        "NetworkConfiguration": {
+                            "AwsVpcConfiguration": {  # wrong casing!
+                                "AssignPublicIp": "ENABLED",
+                            }
+                        }
+                    },
+                }
+            ],
+        }
+        transformed_dict = utils.fix_casing_for_boto_request_parameters(original_dict, input_shape)
+
+        assert transformed_dict == {
+            "EventBusName": "my-event-bus",
+            "Targets": [
+                {
+                    "Id": "an-id",
+                    "EcsParameters": {
+                        "NetworkConfiguration": {
+                            "awsvpcConfiguration": {  # fixed casing
+                                "AssignPublicIp": "ENABLED",
+                            }
+                        }
+                    },
+                }
+            ],
+        }


### PR DESCRIPTION
## Motivation

Recently we had a report for another casing mismatch between the definition of the CloudFormation resource properties (as defined in the corresponding resource schema) and the downstream service API. This is quite tedious to hunt down on a case-by-case basis, so I thought I'd introduce a util that takes care of this recursively for the whole request kwargs.

The reported issue specifically affected `AWS::Events::Rule` and  the downstream `Events.PutTargets` API call when using the `AwsVpcConfiguration` key. On the API side this is actually `awsvpcConfiguration` which lead to an exception being raised on the `client.put_targets` call.

## Changes

- Resource providers now have another util at their disposal. `convert_request_kwargs` can be used to recursively fix issues mapping from the resource properties to the botocore client call.
  - Casing issues are fixed
  - Types are converted automatically between int/str/boolean
  - Unknown keys are dropped
- `AWS::Events::Rule` resources can now successfully be deployed with ecs parameters that include the `AwsVpcConfiguration` property.

## Discussion

This approach can be extended in various ways like:
- ~Drop elements if the input shape doesn't expect them~ :heavy_check_mark: 
- ~Convert passed types automatically~ :heavy_check_mark: 
- Instrument the boto client factory that we pass into the resource provider to do this automatically via boto hooks
