### PR TITLE
use new runtime procedure for starting localstack in host mode

### DIFF
--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -360,9 +360,9 @@ def should_eager_load_api(api: str) -> bool:
 
 
 def start_infra_locally():
-    from localstack.services import infra
+    from localstack.runtime.main import main
 
-    return infra.start_infra()
+    return main()
 
 
 def validate_localstack_config(name: str):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

With #10942 we wanted to deprecate `localstack start --host`, which is why I didn't update it. However, @alexrashed argued (correctly) that people are still using it and we should keep backwards compatibility.

This PR does a minimal change to simply make `localstack start --host` basically equivalent to ``python -m localstack.runtime.main``.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* `localstack start --host` now uses the new runtime to start localstack

<!-- Optional section: How to test these changes? -->

## Testing

* check out the PR, activate venv
* run `python -m localstack.cli.main start --host`, observe it still works


<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
