### PR TITLE
APIGW NG implement AWS bug for INTEGRATION_FAILURE GatewayResponse

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway_response.py
@@ -39,7 +39,7 @@ class BaseGatewayException(Exception):
     """
 
     message: str = "Unimplemented Response"
-    type: GatewayResponseType
+    type: GatewayResponseType = None
     status_code: int | str = None
     code: str = ""
 
@@ -48,7 +48,7 @@ class BaseGatewayException(Exception):
             self.message = message
         if status_code is not None:
             self.status_code = status_code
-        elif self.status_code is None:
+        elif self.status_code is None and self.type:
             # Fallback to the default value
             self.status_code = GatewayResponseCode[self.type]
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While implementing the `AWS_PROXY` integration with #11167, I've stumbled onto a weird issue: AWS would raise an `INTEGRATION_FAILURE` error, which the default status code should be 504 (Gateway Timeout, that's already suspicious), but instead returned `500`. 

After a lot of investigation with @cloutierMat, we came to the conclusion that the CRUD later (`PutGatewayResponse`, `GetGatewayResponse` etc) is not in line with the actual behavior, and that the actual default status code is `500`, but the CRUD calls still returns 504. 

This PR implements the logic to enable the difference between the CRUD layer and the actual invocation layer by attaching a default status code to the exception, while still using the previous default for other exceptions, allowing us to override the behavior. 

This behavior is validated by `tests.aws.services.apigateway.test_apigateway_lambda.test_lambda_aws_proxy_integration_non_post_method`. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- use the Python exception status code if provided
- add a fix in the provider to deal with the inconsistency between what the AWS CRUD operations returns and what AWS actually does under the hood

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
