### PR TITLE
fix ObjectTagging with DeleteMarker

### DIFF
--- a/localstack-core/localstack/services/s3/models.py
+++ b/localstack-core/localstack/services/s3/models.py
@@ -171,6 +171,8 @@ class S3Bucket:
         see: https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html
         :param raise_for_delete_marker: optional, indicates if the method should raise an exception if the found object
         is a S3DeleteMarker. If False, it can return a S3DeleteMarker
+        TODO: we need to remove the `raise_for_delete_marker` parameter and replace it with the error type to raise
+         (MethodNotAllowed or NoSuchKey)
         :return:
         :raises NoSuchKey if the object key does not exist at all, or if the object is a DeleteMarker
         :raises MethodNotAllowed if the object is a DeleteMarker and the operation is not allowed against it

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -1837,7 +1837,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_versioned": {
-    "recorded-date": "20-11-2023, 17:25:12",
+    "recorded-date": "11-07-2024, 13:53:37",
     "recorded-content": {
       "put-obj-0": {
         "ETag": "\"86639701cdcc5b39438a5f009bd74cb1\"",
@@ -1918,24 +1918,76 @@
           "HTTPStatusCode": 204
         }
       },
-      "put-object-tags-delete-marker": {
-        "VersionId": "<version-id:1>",
+      "put-object-tags-delete-marker-id": {
+        "Error": {
+          "Code": "MethodNotAllowed",
+          "Message": "The specified method is not allowed against this resource.",
+          "Method": "PUT",
+          "ResourceType": "DeleteMarker"
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+          "HTTPStatusCode": 405
         }
       },
-      "get-object-tags-delete-marker": {
-        "TagSet": [
-          {
-            "Key": "tag1",
-            "Value": "tag1"
-          }
-        ],
-        "VersionId": "<version-id:1>",
+      "get-object-tags-delete-marker-id": {
+        "Error": {
+          "Code": "MethodNotAllowed",
+          "Message": "The specified method is not allowed against this resource.",
+          "Method": "GET",
+          "ResourceType": "DeleteMarker"
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+          "HTTPStatusCode": 405
+        }
+      },
+      "delete-object-tags-delete-marker-id": {
+        "Error": {
+          "Code": "MethodNotAllowed",
+          "Message": "The specified method is not allowed against this resource.",
+          "Method": "DELETE",
+          "ResourceType": "DeleteMarker"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 405
+        }
+      },
+      "put-object-tags-delete-marker-latest": {
+        "Error": {
+          "Code": "MethodNotAllowed",
+          "Message": "The specified method is not allowed against this resource.",
+          "Method": "PUT",
+          "ResourceType": "DeleteMarker"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 405
+        }
+      },
+      "get-object-tags-delete-marker-latest": {
+        "Error": {
+          "Code": "MethodNotAllowed",
+          "Message": "The specified method is not allowed against this resource.",
+          "Method": "GET",
+          "ResourceType": "DeleteMarker"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 405
+        }
+      },
+      "delete-object-tags-delete-marker-latest": {
+        "Error": {
+          "Code": "MethodNotAllowed",
+          "Message": "The specified method is not allowed against this resource.",
+          "Method": "DELETE",
+          "ResourceType": "DeleteMarker"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 405
         }
       }
     }

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -39,7 +39,7 @@
     "last_validated_date": "2023-08-02T22:04:47+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_versioned": {
-    "last_validated_date": "2023-11-20T16:25:12+00:00"
+    "last_validated_date": "2024-07-11T13:53:37+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tags_delete_or_overwrite_object": {
     "last_validated_date": "2023-08-02T21:52:10+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #11180, we've had the wrong behavior for DeleteMarker with `ObjectTagging` operations. 

However, my previous assumptions were wrong due to a mistake in a test, which lead to a design decision in the S3 models (the `S3Bucket` `get_object` method signature). 

We will need to update it to support properly this behavior, however this might break persistence as the previous loaded objects might have the previous signature, and fails when used in the provider. We will need to wait for the next major release to remove the previous parameter `raise_for_delete_marker` and add a new one permitting use to separate behavior between calls from `GetObject` vs `GetObjectTagging` (one raise `NoSuchKey` and the other `MethodNotAllowed`). 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a hacky way to support the behavior reported, and add a TODO for the future to fix the behavior without that hack


_fixes #11180_
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
