### PR TITLE
Make localstack an implicit namespace package

### DIFF
--- a/localstack-core/localstack/dns/server.py
+++ b/localstack-core/localstack/dns/server.py
@@ -12,12 +12,8 @@ from pathlib import Path
 from socket import AddressFamily
 from typing import Iterable, Literal, Tuple
 
-import dns.flags
-import dns.message
-import dns.query
 import psutil
 from cachetools import TTLCache, cached
-from dns.exception import Timeout
 from dnslib import (
     AAAA,
     CNAME,
@@ -38,6 +34,11 @@ from dnslib import (
 )
 from dnslib.server import DNSHandler, DNSServer
 from psutil._common import snicaddr
+
+import dns.flags
+import dns.message
+import dns.query
+from dns.exception import Timeout
 
 # Note: avoid adding additional imports here, to avoid import issues when running the CLI
 from localstack import config


### PR DESCRIPTION
## Motivation

To allow us to introduce namespace packages downstream like `localstack.pro.core` or `localstack.pro.aws`, we need to first make `localstack` itself a namespace package.

## Changes

- With the removal of `localstack/__init__.py`, `localstack` will become an [implicit namespace package](https://packaging.python.org/en/latest/guides/packaging-namespace-packages)

## TODO

What's left to do:

- [x] Check if anything breaks => caching the venv was breaking the pro integration tests
