### PR TITLE
Fix deletion of lambda function versions

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1314,7 +1314,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             # delete a version of the function
             version = function.versions.pop(qualifier, None)
             if version:
-                self.lambda_service.stop_version(version.qualified_arn())
+                self.lambda_service.stop_version(version.id.qualified_arn())
                 destroy_code_if_not_used(code=version.config.code, function=function)
         else:
             # delete the whole function

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -1584,6 +1584,10 @@ class TestLambdaVersions:
         )
         snapshot.match("list_versions_result_end", list_versions_result_end)
 
+        aws_client.lambda_.delete_function(
+            FunctionName=f"{function_name}:{first_publish_response['Version']}"
+        )
+
     @markers.aws.validated
     def test_publish_with_wrong_sha256(
         self, create_lambda_function_aws, lambda_su_role, snapshot, aws_client

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -1582,10 +1582,16 @@ class TestLambdaVersions:
         list_versions_result_end = aws_client.lambda_.list_versions_by_function(
             FunctionName=function_name
         )
-        snapshot.match("list_versions_result_end", list_versions_result_end)
+        snapshot.match("list_versions_result_after_third_publish", list_versions_result_end)
 
         aws_client.lambda_.delete_function(
             FunctionName=f"{function_name}:{first_publish_response['Version']}"
+        )
+        list_versions_result_end = aws_client.lambda_.list_versions_by_function(
+            FunctionName=function_name
+        )
+        snapshot.match(
+            "list_versions_result_after_deletion_of_first_version", list_versions_result_end
         )
 
     @markers.aws.validated

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -1806,7 +1806,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaVersions::test_version_lifecycle": {
-    "recorded-date": "10-04-2024, 09:12:12",
+    "recorded-date": "12-07-2024, 11:43:40",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -2340,7 +2340,7 @@
           "HTTPStatusCode": 201
         }
       },
-      "list_versions_result_end": {
+      "list_versions_result_after_third_publish": {
         "Versions": [
           {
             "Architectures": [
@@ -2407,6 +2407,80 @@
               "Mode": "PassThrough"
             },
             "Version": "1"
+          },
+          {
+            "Architectures": [
+              "x86_64"
+            ],
+            "CodeSha256": "<code-sha256:1>",
+            "CodeSize": "<code-size>",
+            "Description": "Second version :))",
+            "EphemeralStorage": {
+              "Size": 512
+            },
+            "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:2",
+            "FunctionName": "<function-name:1>",
+            "Handler": "index.handler",
+            "LastModified": "date",
+            "LoggingConfig": {
+              "LogFormat": "Text",
+              "LogGroup": "/aws/lambda/<function-name:1>"
+            },
+            "MemorySize": 128,
+            "PackageType": "Zip",
+            "RevisionId": "<uuid:7>",
+            "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+            "Runtime": "python3.12",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
+            "Timeout": 3,
+            "TracingConfig": {
+              "Mode": "PassThrough"
+            },
+            "Version": "2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_versions_result_after_deletion_of_first_version": {
+        "Versions": [
+          {
+            "Architectures": [
+              "x86_64"
+            ],
+            "CodeSha256": "<code-sha256:1>",
+            "CodeSize": "<code-size>",
+            "Description": "Second version :))",
+            "EphemeralStorage": {
+              "Size": 512
+            },
+            "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:$LATEST",
+            "FunctionName": "<function-name:1>",
+            "Handler": "index.handler",
+            "LastModified": "date",
+            "LoggingConfig": {
+              "LogFormat": "Text",
+              "LogGroup": "/aws/lambda/<function-name:1>"
+            },
+            "MemorySize": 128,
+            "PackageType": "Zip",
+            "RevisionId": "<uuid:8>",
+            "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+            "Runtime": "python3.12",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
+            "Timeout": 3,
+            "TracingConfig": {
+              "Mode": "PassThrough"
+            },
+            "Version": "$LATEST"
           },
           {
             "Architectures": [

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -330,7 +330,7 @@
     "last_validated_date": "2024-04-10T09:12:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaVersions::test_version_lifecycle": {
-    "last_validated_date": "2024-04-10T09:12:11+00:00"
+    "last_validated_date": "2024-07-12T11:43:40+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLoggingConfig::test_advanced_logging_configuration_format_switch": {
     "last_validated_date": "2024-04-17T14:16:55+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We are currently experiencing a bug when deleting a Lambda function version without deleting the entire function, due to a misuse of the `qualified_arn` property.

We had not test deleting only the function version before, which is why I added one as well.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Lambda function versions can now be deleted without an error

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
