### PR TITLE
Upgrade Bookstore test to OpenSearch 2.11 and revalidate

### DIFF
--- a/localstack-core/localstack/services/opensearch/versions.py
+++ b/localstack-core/localstack/services/opensearch/versions.py
@@ -15,8 +15,8 @@ from localstack.utils.common import get_arch
 
 # Internal representation of the OpenSearch versions (without the "OpenSearch_" prefix)
 _opensearch_install_versions = {
+    "2.13": "2.13.0",
     "2.11": "2.11.1",
-    "2.10": "2.10.0",
     "2.9": "2.9.0",
     "2.7": "2.7.0",
     "2.5": "2.5.0",
@@ -222,6 +222,7 @@ compatible_versions = [
             "OpenSearch_2.7",
             "OpenSearch_2.9",
             "OpenSearch_2.11",
+            "OpenSearch_2.13",
         ],
     ),
     CompatibleVersionsMap(
@@ -231,19 +232,24 @@ compatible_versions = [
             "OpenSearch_2.7",
             "OpenSearch_2.9",
             "OpenSearch_2.11",
+            "OpenSearch_2.13",
         ],
     ),
     CompatibleVersionsMap(
         SourceVersion="OpenSearch_2.5",
-        TargetVersions=["OpenSearch_2.7", "OpenSearch_2.9", "OpenSearch_2.11"],
+        TargetVersions=["OpenSearch_2.7", "OpenSearch_2.9", "OpenSearch_2.11", "OpenSearch_2.13"],
     ),
     CompatibleVersionsMap(
         SourceVersion="OpenSearch_2.7",
-        TargetVersions=["OpenSearch_2.9", "OpenSearch_2.11"],
+        TargetVersions=["OpenSearch_2.9", "OpenSearch_2.11", "OpenSearch_2.13"],
     ),
     CompatibleVersionsMap(
         SourceVersion="OpenSearch_2.9",
-        TargetVersions=["OpenSearch_2.11"],
+        TargetVersions=["OpenSearch_2.11", "OpenSearch_2.13"],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="OpenSearch_2.11",
+        TargetVersions=["OpenSearch_2.13"],
     ),
 ]
 

--- a/tests/aws/cdk_templates/Bookstore/BookstoreStack.json
+++ b/tests/aws/cdk_templates/Bookstore/BookstoreStack.json
@@ -202,7 +202,7 @@
         "EncryptionAtRestOptions": {
           "Enabled": false
         },
-        "EngineVersion": "OpenSearch_2.5",
+        "EngineVersion": "OpenSearch_2.11",
         "LogPublishingOptions": {},
         "NodeToNodeEncryptionOptions": {
           "Enabled": false

--- a/tests/aws/scenario/bookstore/test_bookstore.py
+++ b/tests/aws/scenario/bookstore/test_bookstore.py
@@ -288,6 +288,8 @@ class TestBookstoreApplication:
             "$..ClusterConfig.Options.DedicatedMasterType",  # added in LS
             "$..DomainStatusList..EBSOptions.Iops",  # added in LS
             "$..DomainStatusList..IPAddressType",  # missing
+            "$..DomainStatusList..DomainProcessingStatus",  # missing
+            "$..DomainStatusList..ModifyingProperties",  # missing
             "$..SoftwareUpdateOptions",  # missing
             "$..OffPeakWindowOptions",  # missing
             "$..ChangeProgressDetails",  # missing
@@ -298,6 +300,7 @@ class TestBookstoreApplication:
             "$..AdvancedSecurityOptions.Options.AnonymousAuthEnabled",  # missing
             "$..DomainConfig.ClusterConfig.Options.WarmEnabled",  # missing
             "$..DomainConfig.IPAddressType",  # missing
+            "$..DomainConfig.ModifyingProperties",  # missing
             "$..ClusterConfig.Options.ColdStorageOptions",  # missing
             "$..ClusterConfig.Options.MultiAZWithStandbyEnabled",  # missing
             # TODO different values:

--- a/tests/aws/scenario/bookstore/test_bookstore.snapshot.json
+++ b/tests/aws/scenario/bookstore/test_bookstore.snapshot.json
@@ -1,7 +1,15 @@
 {
   "tests/aws/scenario/bookstore/test_bookstore.py::TestBookstoreApplication::test_setup": {
-    "recorded-date": "29-08-2023, 17:20:44",
+    "recorded-date": "15-07-2024, 12:54:12",
     "recorded-content": {
+      "scan_count": {
+        "Count": 56,
+        "ScannedCount": 56,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "get-item": {
         "Item": {
           "author": {
@@ -30,19 +38,11 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      },
-      "scan_count": {
-        "Count": 56,
-        "ScannedCount": 56,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
       }
     }
   },
   "tests/aws/scenario/bookstore/test_bookstore.py::TestBookstoreApplication::test_lambda_dynamodb": {
-    "recorded-date": "30-08-2023, 13:23:16",
+    "recorded-date": "15-07-2024, 12:54:17",
     "recorded-content": {
       "get_books_fn": {
         "ExecutedVersion": "$LATEST",
@@ -161,14 +161,14 @@
     }
   },
   "tests/aws/scenario/bookstore/test_bookstore.py::TestBookstoreApplication::test_search_books": {
-    "recorded-date": "31-08-2023, 13:39:41",
+    "recorded-date": "15-07-2024, 12:55:25",
     "recorded-content": {
       "search_name_spaghetti": {
         "_shards": {
           "failed": 0,
           "skipped": 0,
-          "successful": 6,
-          "total": 6
+          "successful": 12,
+          "total": 12
         },
         "hits": {
           "hits": [
@@ -214,8 +214,8 @@
         "_shards": {
           "failed": 0,
           "skipped": 0,
-          "successful": 6,
-          "total": 6
+          "successful": 12,
+          "total": 12
         },
         "hits": {
           "hits": [
@@ -373,8 +373,8 @@
         "_shards": {
           "failed": 0,
           "skipped": 0,
-          "successful": 6,
-          "total": 6
+          "successful": 12,
+          "total": 12
         },
         "hits": {
           "hits": [
@@ -532,8 +532,8 @@
         "_shards": {
           "failed": 0,
           "skipped": 0,
-          "successful": 6,
-          "total": 6
+          "successful": 12,
+          "total": 12
         },
         "hits": {
           "hits": [],
@@ -549,7 +549,7 @@
     }
   },
   "tests/aws/scenario/bookstore/test_bookstore.py::TestBookstoreApplication::test_opensearch_crud": {
-    "recorded-date": "12-02-2024, 15:44:19",
+    "recorded-date": "15-07-2024, 12:55:29",
     "recorded-content": {
       "describe_domains": {
         "DomainStatusList": [
@@ -570,7 +570,11 @@
               "UseOffPeakWindow": false
             },
             "ChangeProgressDetails": {
-              "ChangeId": "<change-id:1>"
+              "ChangeId": "<change-id:1>",
+              "ConfigChangeStatus": "Completed",
+              "InitiatedBy": "CUSTOMER",
+              "LastUpdatedTime": "datetime",
+              "StartTime": "datetime"
             },
             "ClusterConfig": {
               "ColdStorageOptions": {
@@ -595,6 +599,7 @@
             },
             "DomainId": "<domain-id:1>",
             "DomainName": "<domain-name:1>",
+            "DomainProcessingStatus": "Active",
             "EBSOptions": {
               "EBSEnabled": true,
               "VolumeSize": 10,
@@ -604,8 +609,9 @@
               "Enabled": false
             },
             "Endpoint": "<endpoint:1>",
-            "EngineVersion": "OpenSearch_2.5",
+            "EngineVersion": "OpenSearch_2.11",
             "IPAddressType": "ipv4",
+            "ModifyingProperties": [],
             "NodeToNodeEncryptionOptions": {
               "Enabled": false
             },
@@ -613,7 +619,7 @@
               "Enabled": true,
               "OffPeakWindow": {
                 "WindowStartTime": {
-                  "Hours": 3,
+                  "Hours": 2,
                   "Minutes": 0
                 }
               }
@@ -622,7 +628,7 @@
             "ServiceSoftwareOptions": {
               "AutomatedUpdateDate": "datetime",
               "Cancellable": false,
-              "CurrentVersion": "OpenSearch_2_5_R20230928-P3",
+              "CurrentVersion": "OpenSearch_2_11_R20240502-P2",
               "Description": "There is no software update available for this domain.",
               "NewVersion": "",
               "OptionalDeployment": true,
@@ -710,7 +716,11 @@
             }
           },
           "ChangeProgressDetails": {
-            "ChangeId": "<change-id:1>"
+            "ChangeId": "<change-id:1>",
+            "ConfigChangeStatus": "Completed",
+            "InitiatedBy": "CUSTOMER",
+            "LastUpdatedTime": "datetime",
+            "StartTime": "datetime"
           },
           "ClusterConfig": {
             "Options": {
@@ -785,7 +795,7 @@
             }
           },
           "EngineVersion": {
-            "Options": "OpenSearch_2.5",
+            "Options": "OpenSearch_2.11",
             "Status": {
               "CreationDate": "datetime",
               "PendingDeletion": false,
@@ -814,6 +824,7 @@
               "UpdateVersion": "update-version"
             }
           },
+          "ModifyingProperties": [],
           "NodeToNodeEncryptionOptions": {
             "Options": {
               "Enabled": false
@@ -831,7 +842,7 @@
               "Enabled": true,
               "OffPeakWindow": {
                 "WindowStartTime": {
-                  "Hours": 3,
+                  "Hours": 2,
                   "Minutes": 0
                 }
               }
@@ -915,11 +926,9 @@
       "get_compatible_versions": {
         "CompatibleVersions": [
           {
-            "SourceVersion": "OpenSearch_2.5",
+            "SourceVersion": "OpenSearch_2.11",
             "TargetVersions": [
-              "OpenSearch_2.7",
-              "OpenSearch_2.9",
-              "OpenSearch_2.11"
+              "OpenSearch_2.13"
             ]
           }
         ],
@@ -930,6 +939,7 @@
       },
       "list_versions": {
         "Versions": [
+          "OpenSearch_2.13",
           "OpenSearch_2.11",
           "OpenSearch_2.9",
           "OpenSearch_2.7",

--- a/tests/aws/scenario/bookstore/test_bookstore.validation.json
+++ b/tests/aws/scenario/bookstore/test_bookstore.validation.json
@@ -1,14 +1,14 @@
 {
   "tests/aws/scenario/bookstore/test_bookstore.py::TestBookstoreApplication::test_lambda_dynamodb": {
-    "last_validated_date": "2024-01-31T13:47:03+00:00"
+    "last_validated_date": "2024-07-15T12:54:17+00:00"
   },
   "tests/aws/scenario/bookstore/test_bookstore.py::TestBookstoreApplication::test_opensearch_crud": {
-    "last_validated_date": "2024-02-12T15:44:19+00:00"
+    "last_validated_date": "2024-07-15T12:55:29+00:00"
   },
   "tests/aws/scenario/bookstore/test_bookstore.py::TestBookstoreApplication::test_search_books": {
-    "last_validated_date": "2024-01-31T13:47:48+00:00"
+    "last_validated_date": "2024-07-15T12:55:25+00:00"
   },
   "tests/aws/scenario/bookstore/test_bookstore.py::TestBookstoreApplication::test_setup": {
-    "last_validated_date": "2024-01-31T13:46:54+00:00"
+    "last_validated_date": "2024-07-15T12:54:12+00:00"
   }
 }

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -95,241 +95,25 @@ class TestOpensearchProvider:
     """
 
     @markers.aws.validated
-    def test_list_versions(self, aws_client):
+    def test_list_versions(self, aws_client, snapshot):
         response = aws_client.opensearch.list_versions()
+        versions = sorted(
+            version
+            for version in response["Versions"]
+            # LocalStack does not support these versions
+            if version not in ["Elasticsearch_1.5", "Elasticsearch_2.3"]
+        )
+        snapshot.match("versions", versions)
 
-        assert "Versions" in response
-        versions = response["Versions"]
-
-        expected_versions = [
-            "OpenSearch_2.5",
-            "OpenSearch_2.3",
-            "OpenSearch_1.3",
-            "OpenSearch_1.2",
-            "OpenSearch_1.1",
-            "OpenSearch_1.0",
-            "Elasticsearch_7.10",
-            "Elasticsearch_7.9",
-            "Elasticsearch_7.8",
-            "Elasticsearch_7.7",
-            "Elasticsearch_7.4",
-            "Elasticsearch_7.1",
-            "Elasticsearch_6.8",
-            "Elasticsearch_6.7",
-            "Elasticsearch_6.5",
-            "Elasticsearch_6.4",
-            "Elasticsearch_6.3",
-            "Elasticsearch_6.2",
-            "Elasticsearch_6.0",
-            "Elasticsearch_5.6",
-            "Elasticsearch_5.5",
-            "Elasticsearch_5.3",
-            "Elasticsearch_5.1",
-        ]
-        # We iterate over the expected versions to avoid breaking the test if new versions are supported
-        for expected_version in expected_versions:
-            assert expected_version in versions
-
-    @markers.aws.needs_fixing
-    def test_get_compatible_versions(self, aws_client):
+    @markers.aws.validated
+    def test_get_compatible_versions(self, aws_client, snapshot):
         response = aws_client.opensearch.get_compatible_versions()
-
-        assert "CompatibleVersions" in response
-
-        compatible_versions = response["CompatibleVersions"]
-
-        assert len(compatible_versions) >= 20
-        expected_compatible_versions = [
-            {
-                "SourceVersion": "OpenSearch_2.9",
-                "TargetVersions": ["OpenSearch_2.11"],
-            },
-            {
-                "SourceVersion": "OpenSearch_2.7",
-                "TargetVersions": ["OpenSearch_2.9", "OpenSearch_2.11"],
-            },
-            {
-                "SourceVersion": "OpenSearch_2.5",
-                "TargetVersions": [
-                    "OpenSearch_2.7",
-                    "OpenSearch_2.9",
-                    "OpenSearch_2.11",
-                ],
-            },
-            {
-                "SourceVersion": "OpenSearch_2.3",
-                "TargetVersions": [
-                    "OpenSearch_2.5",
-                    "OpenSearch_2.7",
-                    "OpenSearch_2.9",
-                    "OpenSearch_2.11",
-                ],
-            },
-            {
-                "SourceVersion": "OpenSearch_1.0",
-                "TargetVersions": ["OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3"],
-            },
-            {
-                "SourceVersion": "OpenSearch_1.1",
-                "TargetVersions": ["OpenSearch_1.2", "OpenSearch_1.3"],
-            },
-            {
-                "SourceVersion": "OpenSearch_1.2",
-                "TargetVersions": ["OpenSearch_1.3"],
-            },
-            {
-                "SourceVersion": "OpenSearch_1.3",
-                "TargetVersions": [
-                    "OpenSearch_2.3",
-                    "OpenSearch_2.5",
-                    "OpenSearch_2.7",
-                    "OpenSearch_2.9",
-                    "OpenSearch_2.11",
-                ],
-            },
-            {
-                "SourceVersion": "Elasticsearch_7.10",
-                "TargetVersions": [
-                    "OpenSearch_1.0",
-                    "OpenSearch_1.1",
-                    "OpenSearch_1.2",
-                    "OpenSearch_1.3",
-                ],
-            },
-            {
-                "SourceVersion": "Elasticsearch_7.9",
-                "TargetVersions": [
-                    "Elasticsearch_7.10",
-                    "OpenSearch_1.0",
-                    "OpenSearch_1.1",
-                    "OpenSearch_1.2",
-                    "OpenSearch_1.3",
-                ],
-            },
-            {
-                "SourceVersion": "Elasticsearch_7.8",
-                "TargetVersions": [
-                    "Elasticsearch_7.9",
-                    "Elasticsearch_7.10",
-                    "OpenSearch_1.0",
-                    "OpenSearch_1.1",
-                    "OpenSearch_1.2",
-                    "OpenSearch_1.3",
-                ],
-            },
-            {
-                "SourceVersion": "Elasticsearch_7.7",
-                "TargetVersions": [
-                    "Elasticsearch_7.8",
-                    "Elasticsearch_7.9",
-                    "Elasticsearch_7.10",
-                    "OpenSearch_1.0",
-                    "OpenSearch_1.1",
-                    "OpenSearch_1.2",
-                    "OpenSearch_1.3",
-                ],
-            },
-            {
-                "SourceVersion": "Elasticsearch_7.4",
-                "TargetVersions": [
-                    "Elasticsearch_7.7",
-                    "Elasticsearch_7.8",
-                    "Elasticsearch_7.9",
-                    "Elasticsearch_7.10",
-                    "OpenSearch_1.0",
-                    "OpenSearch_1.1",
-                    "OpenSearch_1.2",
-                    "OpenSearch_1.3",
-                ],
-            },
-            {
-                "SourceVersion": "Elasticsearch_7.1",
-                "TargetVersions": [
-                    "Elasticsearch_7.4",
-                    "Elasticsearch_7.7",
-                    "Elasticsearch_7.8",
-                    "Elasticsearch_7.9",
-                    "Elasticsearch_7.10",
-                    "OpenSearch_1.0",
-                    "OpenSearch_1.1",
-                    "OpenSearch_1.2",
-                    "OpenSearch_1.3",
-                ],
-            },
-            {
-                "SourceVersion": "Elasticsearch_6.8",
-                "TargetVersions": [
-                    "Elasticsearch_7.1",
-                    "Elasticsearch_7.4",
-                    "Elasticsearch_7.7",
-                    "Elasticsearch_7.8",
-                    "Elasticsearch_7.9",
-                    "Elasticsearch_7.10",
-                    "OpenSearch_1.0",
-                    "OpenSearch_1.1",
-                    "OpenSearch_1.2",
-                    "OpenSearch_1.3",
-                ],
-            },
-            {"SourceVersion": "Elasticsearch_6.7", "TargetVersions": ["Elasticsearch_6.8"]},
-            {
-                "SourceVersion": "Elasticsearch_6.5",
-                "TargetVersions": ["Elasticsearch_6.7", "Elasticsearch_6.8"],
-            },
-            {
-                "SourceVersion": "Elasticsearch_6.4",
-                "TargetVersions": [
-                    "Elasticsearch_6.5",
-                    "Elasticsearch_6.7",
-                    "Elasticsearch_6.8",
-                ],
-            },
-            {
-                "SourceVersion": "Elasticsearch_6.3",
-                "TargetVersions": [
-                    "Elasticsearch_6.4",
-                    "Elasticsearch_6.5",
-                    "Elasticsearch_6.7",
-                    "Elasticsearch_6.8",
-                ],
-            },
-            {
-                "SourceVersion": "Elasticsearch_6.2",
-                "TargetVersions": [
-                    "Elasticsearch_6.3",
-                    "Elasticsearch_6.4",
-                    "Elasticsearch_6.5",
-                    "Elasticsearch_6.7",
-                    "Elasticsearch_6.8",
-                ],
-            },
-            {
-                "SourceVersion": "Elasticsearch_6.0",
-                "TargetVersions": [
-                    "Elasticsearch_6.3",
-                    "Elasticsearch_6.4",
-                    "Elasticsearch_6.5",
-                    "Elasticsearch_6.7",
-                    "Elasticsearch_6.8",
-                ],
-            },
-            {
-                "SourceVersion": "Elasticsearch_5.6",
-                "TargetVersions": [
-                    "Elasticsearch_6.3",
-                    "Elasticsearch_6.4",
-                    "Elasticsearch_6.5",
-                    "Elasticsearch_6.7",
-                    "Elasticsearch_6.8",
-                ],
-            },
-            {"SourceVersion": "Elasticsearch_5.5", "TargetVersions": ["Elasticsearch_5.6"]},
-            {"SourceVersion": "Elasticsearch_5.3", "TargetVersions": ["Elasticsearch_5.6"]},
-            {"SourceVersion": "Elasticsearch_5.1", "TargetVersions": ["Elasticsearch_5.6"]},
-        ]
-        # Iterate over the expected compatible versions to avoid breaking the test if new versions are supported
-        for expected_compatible_version in expected_compatible_versions:
-            assert expected_compatible_version in compatible_versions
+        source_versions = sorted(
+            version["SourceVersion"] for version in response["CompatibleVersions"]
+        )
+        snapshot.match("source_versions", source_versions)
+        for version in sorted(response["CompatibleVersions"], key=lambda x: x["SourceVersion"]):
+            snapshot.match(f"source_{version['SourceVersion'].lower()}", version["TargetVersions"])
 
     @markers.aws.needs_fixing
     def test_get_compatible_version_for_domain(self, opensearch_create_domain, aws_client):

--- a/tests/aws/services/opensearch/test_opensearch.snapshot.json
+++ b/tests/aws/services/opensearch/test_opensearch.snapshot.json
@@ -1,0 +1,225 @@
+{
+  "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_get_compatible_versions": {
+    "recorded-date": "16-07-2024, 13:05:15",
+    "recorded-content": {
+      "source_versions": [
+        "Elasticsearch_5.1",
+        "Elasticsearch_5.3",
+        "Elasticsearch_5.5",
+        "Elasticsearch_5.6",
+        "Elasticsearch_6.0",
+        "Elasticsearch_6.2",
+        "Elasticsearch_6.3",
+        "Elasticsearch_6.4",
+        "Elasticsearch_6.5",
+        "Elasticsearch_6.7",
+        "Elasticsearch_6.8",
+        "Elasticsearch_7.1",
+        "Elasticsearch_7.10",
+        "Elasticsearch_7.4",
+        "Elasticsearch_7.7",
+        "Elasticsearch_7.8",
+        "Elasticsearch_7.9",
+        "OpenSearch_1.0",
+        "OpenSearch_1.1",
+        "OpenSearch_1.2",
+        "OpenSearch_1.3",
+        "OpenSearch_2.11",
+        "OpenSearch_2.3",
+        "OpenSearch_2.5",
+        "OpenSearch_2.7",
+        "OpenSearch_2.9"
+      ],
+      "source_elasticsearch_5.1": [
+        "Elasticsearch_5.6"
+      ],
+      "source_elasticsearch_5.3": [
+        "Elasticsearch_5.6"
+      ],
+      "source_elasticsearch_5.5": [
+        "Elasticsearch_5.6"
+      ],
+      "source_elasticsearch_5.6": [
+        "Elasticsearch_6.3",
+        "Elasticsearch_6.4",
+        "Elasticsearch_6.5",
+        "Elasticsearch_6.7",
+        "Elasticsearch_6.8"
+      ],
+      "source_elasticsearch_6.0": [
+        "Elasticsearch_6.3",
+        "Elasticsearch_6.4",
+        "Elasticsearch_6.5",
+        "Elasticsearch_6.7",
+        "Elasticsearch_6.8"
+      ],
+      "source_elasticsearch_6.2": [
+        "Elasticsearch_6.3",
+        "Elasticsearch_6.4",
+        "Elasticsearch_6.5",
+        "Elasticsearch_6.7",
+        "Elasticsearch_6.8"
+      ],
+      "source_elasticsearch_6.3": [
+        "Elasticsearch_6.4",
+        "Elasticsearch_6.5",
+        "Elasticsearch_6.7",
+        "Elasticsearch_6.8"
+      ],
+      "source_elasticsearch_6.4": [
+        "Elasticsearch_6.5",
+        "Elasticsearch_6.7",
+        "Elasticsearch_6.8"
+      ],
+      "source_elasticsearch_6.5": [
+        "Elasticsearch_6.7",
+        "Elasticsearch_6.8"
+      ],
+      "source_elasticsearch_6.7": [
+        "Elasticsearch_6.8"
+      ],
+      "source_elasticsearch_6.8": [
+        "Elasticsearch_7.1",
+        "Elasticsearch_7.4",
+        "Elasticsearch_7.7",
+        "Elasticsearch_7.8",
+        "Elasticsearch_7.9",
+        "Elasticsearch_7.10",
+        "OpenSearch_1.0",
+        "OpenSearch_1.1",
+        "OpenSearch_1.2",
+        "OpenSearch_1.3"
+      ],
+      "source_elasticsearch_7.1": [
+        "Elasticsearch_7.4",
+        "Elasticsearch_7.7",
+        "Elasticsearch_7.8",
+        "Elasticsearch_7.9",
+        "Elasticsearch_7.10",
+        "OpenSearch_1.0",
+        "OpenSearch_1.1",
+        "OpenSearch_1.2",
+        "OpenSearch_1.3"
+      ],
+      "source_elasticsearch_7.10": [
+        "OpenSearch_1.0",
+        "OpenSearch_1.1",
+        "OpenSearch_1.2",
+        "OpenSearch_1.3"
+      ],
+      "source_elasticsearch_7.4": [
+        "Elasticsearch_7.7",
+        "Elasticsearch_7.8",
+        "Elasticsearch_7.9",
+        "Elasticsearch_7.10",
+        "OpenSearch_1.0",
+        "OpenSearch_1.1",
+        "OpenSearch_1.2",
+        "OpenSearch_1.3"
+      ],
+      "source_elasticsearch_7.7": [
+        "Elasticsearch_7.8",
+        "Elasticsearch_7.9",
+        "Elasticsearch_7.10",
+        "OpenSearch_1.0",
+        "OpenSearch_1.1",
+        "OpenSearch_1.2",
+        "OpenSearch_1.3"
+      ],
+      "source_elasticsearch_7.8": [
+        "Elasticsearch_7.9",
+        "Elasticsearch_7.10",
+        "OpenSearch_1.0",
+        "OpenSearch_1.1",
+        "OpenSearch_1.2",
+        "OpenSearch_1.3"
+      ],
+      "source_elasticsearch_7.9": [
+        "Elasticsearch_7.10",
+        "OpenSearch_1.0",
+        "OpenSearch_1.1",
+        "OpenSearch_1.2",
+        "OpenSearch_1.3"
+      ],
+      "source_opensearch_1.0": [
+        "OpenSearch_1.1",
+        "OpenSearch_1.2",
+        "OpenSearch_1.3"
+      ],
+      "source_opensearch_1.1": [
+        "OpenSearch_1.2",
+        "OpenSearch_1.3"
+      ],
+      "source_opensearch_1.2": [
+        "OpenSearch_1.3"
+      ],
+      "source_opensearch_1.3": [
+        "OpenSearch_2.3",
+        "OpenSearch_2.5",
+        "OpenSearch_2.7",
+        "OpenSearch_2.9",
+        "OpenSearch_2.11",
+        "OpenSearch_2.13"
+      ],
+      "source_opensearch_2.11": [
+        "OpenSearch_2.13"
+      ],
+      "source_opensearch_2.3": [
+        "OpenSearch_2.5",
+        "OpenSearch_2.7",
+        "OpenSearch_2.9",
+        "OpenSearch_2.11",
+        "OpenSearch_2.13"
+      ],
+      "source_opensearch_2.5": [
+        "OpenSearch_2.7",
+        "OpenSearch_2.9",
+        "OpenSearch_2.11",
+        "OpenSearch_2.13"
+      ],
+      "source_opensearch_2.7": [
+        "OpenSearch_2.9",
+        "OpenSearch_2.11",
+        "OpenSearch_2.13"
+      ],
+      "source_opensearch_2.9": [
+        "OpenSearch_2.11",
+        "OpenSearch_2.13"
+      ]
+    }
+  },
+  "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_list_versions": {
+    "recorded-date": "16-07-2024, 13:18:18",
+    "recorded-content": {
+      "versions": [
+        "Elasticsearch_5.1",
+        "Elasticsearch_5.3",
+        "Elasticsearch_5.5",
+        "Elasticsearch_5.6",
+        "Elasticsearch_6.0",
+        "Elasticsearch_6.2",
+        "Elasticsearch_6.3",
+        "Elasticsearch_6.4",
+        "Elasticsearch_6.5",
+        "Elasticsearch_6.7",
+        "Elasticsearch_6.8",
+        "Elasticsearch_7.1",
+        "Elasticsearch_7.10",
+        "Elasticsearch_7.4",
+        "Elasticsearch_7.7",
+        "Elasticsearch_7.8",
+        "Elasticsearch_7.9",
+        "OpenSearch_1.0",
+        "OpenSearch_1.1",
+        "OpenSearch_1.2",
+        "OpenSearch_1.3",
+        "OpenSearch_2.11",
+        "OpenSearch_2.13",
+        "OpenSearch_2.3",
+        "OpenSearch_2.5",
+        "OpenSearch_2.7",
+        "OpenSearch_2.9"
+      ]
+    }
+  }
+}

--- a/tests/aws/services/opensearch/test_opensearch.validation.json
+++ b/tests/aws/services/opensearch/test_opensearch.validation.json
@@ -1,5 +1,8 @@
 {
+  "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_get_compatible_versions": {
+    "last_validated_date": "2024-07-16T13:05:15+00:00"
+  },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_list_versions": {
-    "last_validated_date": "2024-07-04T15:26:07+00:00"
+    "last_validated_date": "2024-07-16T13:18:18+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The Bookstore tests show flaky behavior, which was supposed to be mitigated by ...
That PR fixed the usage of the cache for OpenSearch installation.
However, it can still lead to issues, because the version used for OpenSearch in the Bookstore test is not the default version and thus needs to be downloaded extra. This might again lead to rate limiting issues.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- This PR upgrades the Bookstore test to use the current default version of OpenSearch (2.11). 
- To facilitate that, it also fixes the responses given by the compatible version check in the new version and skips some of the new keys that are in the response
- For the fix of the version output, two of the opensearch tests were converted to snapshot tests and validated against AWS. This will make changes like these easier in the future.



## Testing

- The Bookstore test should be more stable now

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
