### PR TITLE
Switch default provider for cloudwatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,7 +487,7 @@ jobs:
       - store_test_results:
           path: target/reports/
 
-  itest-cloudwatch-v2-provider:
+  itest-cloudwatch-v1-provider:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     environment:
@@ -500,14 +500,14 @@ jobs:
       - prepare-pytest-tinybird
       - prepare-account-region-randomization
       - run:
-          name: Test CloudWatch v2 provider
+          name: Test CloudWatch v1 provider
           environment:
-            PROVIDER_OVERRIDE_CLOUDWATCH: "v2"
+            PROVIDER_OVERRIDE_CLOUDWATCH: "v1"
             TEST_PATH: "tests/aws/services/cloudwatch/"
             COVERAGE_ARGS: "-p"
           command: |
-            COVERAGE_FILE="target/coverage/.coverage.cloudwatchV2.${CIRCLE_NODE_INDEX}" \
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/cloudwatch_v2.xml -o junit_suite_name='cloudwatch_v2'" \
+            COVERAGE_FILE="target/coverage/.coverage.cloudwatchV1.${CIRCLE_NODE_INDEX}" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/cloudwatch_v1.xml -o junit_suite_name='cloudwatch_v1'" \
             make test-coverage
       - persist_to_workspace:
           root:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -905,7 +905,7 @@ workflows:
           requires:
             - preflight
             - test-selection
-      - itest-cloudwatch-v2-provider:
+      - itest-cloudwatch-v1-provider:
           requires:
             - preflight
             - test-selection
@@ -973,7 +973,7 @@ workflows:
           requires:
             - itest-sfn-legacy-provider
             - itest-s3-v2-legacy-provider
-            - itest-cloudwatch-v2-provider
+            - itest-cloudwatch-v1-provider
             - itest-events-v2-provider
             - acceptance-tests-amd64
             - acceptance-tests-arm64
@@ -988,7 +988,7 @@ workflows:
           requires:
             - itest-sfn-legacy-provider
             - itest-s3-v2-legacy-provider
-            - itest-cloudwatch-v2-provider
+            - itest-cloudwatch-v1-provider
             - itest-events-v2-provider
             - acceptance-tests-amd64
             - acceptance-tests-arm64

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -437,11 +437,11 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
     def put_composite_alarm(self, context: RequestContext, request: PutCompositeAlarmInput) -> None:
         composite_to_metric_alarm = {
             "AlarmName": request.get("AlarmName"),
-            "Description": request.get("AlarmDescription"),
+            "AlarmDescription": request.get("AlarmDescription"),
             "AlarmActions": request.get("AlarmActions", []),
             "OKActions": request.get("OKActions", []),
             "InsufficientDataActions": request.get("InsufficientDataActions", []),
-            "ActionsEnabled": request.get("ActionsEnabled"),
+            "ActionsEnabled": request.get("ActionsEnabled", True),
             "AlarmRule": request.get("AlarmRule"),
             "Tags": request.get("Tags", []),
         }

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -82,6 +82,7 @@ from localstack.services.cloudwatch.models import (
 )
 from localstack.services.edge import ROUTER
 from localstack.services.plugins import SERVICE_PLUGINS, ServiceLifecycleHook
+from localstack.state import AssetDirectory, StateVisitor
 from localstack.utils.aws import arns
 from localstack.utils.aws.arns import extract_account_id_from_arn, lambda_function_name
 from localstack.utils.collections import PaginatedList
@@ -148,6 +149,10 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
     @staticmethod
     def get_store(account_id: str, region: str) -> CloudWatchStore:
         return cloudwatch_stores[account_id][region]
+
+    def accept_state_visitor(self, visitor: StateVisitor):
+        visitor.visit(cloudwatch_stores)
+        visitor.visit(AssetDirectory(self.service, CloudwatchDatabase.CLOUDWATCH_DATA_ROOT))
 
     def on_after_init(self):
         ROUTER.add(PATH_GET_RAW_METRICS, self.get_raw_metrics)

--- a/localstack-core/localstack/services/providers.py
+++ b/localstack-core/localstack/services/providers.py
@@ -51,11 +51,10 @@ def awsconfig():
 
 @aws_provider(api="cloudwatch", name="default")
 def cloudwatch():
-    from localstack.services.cloudwatch.provider import CloudwatchProvider
-    from localstack.services.moto import MotoFallbackDispatcher
+    from localstack.services.cloudwatch.provider_v2 import CloudwatchProvider
 
     provider = CloudwatchProvider()
-    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
+    return Service.for_provider(provider)
 
 
 @aws_provider(api="cloudwatch", name="v1")

--- a/tests/aws/services/cloudformation/resources/test_cloudwatch.py
+++ b/tests/aws/services/cloudformation/resources/test_cloudwatch.py
@@ -1,7 +1,12 @@
 import json
 import os
+import re
+from typing import List
+
+from localstack_snapshot.snapshots.transformer import KeyValueBasedTransformer
 
 from localstack.testing.pytest import markers
+from localstack.testing.snapshots.transformer_utility import PATTERN_ARN
 from localstack.utils.strings import short_uid
 
 
@@ -43,24 +48,34 @@ def test_alarm_creation(deploy_cfn_template, snapshot):
     paths=[
         "$..StateReason",
         "$..StateReasonData",
-        "$..StateTransitionedTimestamp",
-        "$..StateValue",
-        "$..AlarmActions",
-        "$..AlarmRule",
-        "$..StateReason",
-        "$..StateReasonData",
-        "$..StateTransitionedTimestamp",
         "$..StateValue",
     ]
 )
 def test_composite_alarm_creation(aws_client, deploy_cfn_template, snapshot):
-    snapshot.add_transformer(snapshot.transform.cloudwatch_api())
+    snapshot.add_transformer(snapshot.transform.key_value("Region", "region-name-full"))
+
     stack = deploy_cfn_template(
         template_path=os.path.join(
             os.path.dirname(__file__), "../../../templates/cfn_cw_composite_alarm.yml"
         ),
     )
     composite_alarm_name = stack.outputs["CompositeAlarmName"]
+
+    def alarm_action_name_transformer(key: str, val: str):
+        if key == "AlarmActions" and isinstance(val, List) and len(val) == 1:
+            # we expect only one item in the list
+            value = val[0]
+            match = re.match(PATTERN_ARN, value)
+            if match:
+                res = match.groups()[-1]
+                if ":" in res:
+                    return res.split(":")[-1]
+                return res
+            return None
+
+    snapshot.add_transformer(
+        KeyValueBasedTransformer(alarm_action_name_transformer, "alarm-action-name"),
+    )
     response = aws_client.cloudwatch.describe_alarms(
         AlarmNames=[composite_alarm_name], AlarmTypes=["CompositeAlarm"]
     )
@@ -80,7 +95,6 @@ def test_composite_alarm_creation(aws_client, deploy_cfn_template, snapshot):
 
 
 @markers.aws.validated
-@markers.snapshot.skip_snapshot_verify(paths=["$..StateTransitionedTimestamp"])
 def test_alarm_ext_statistic(aws_client, deploy_cfn_template, snapshot):
     snapshot.add_transformer(snapshot.transform.cloudwatch_api())
     stack = deploy_cfn_template(

--- a/tests/aws/services/cloudformation/resources/test_cloudwatch.py
+++ b/tests/aws/services/cloudformation/resources/test_cloudwatch.py
@@ -1,7 +1,6 @@
 import json
 import os
 import re
-from typing import List
 
 from localstack_snapshot.snapshots.transformer import KeyValueBasedTransformer
 
@@ -62,7 +61,7 @@ def test_composite_alarm_creation(aws_client, deploy_cfn_template, snapshot):
     composite_alarm_name = stack.outputs["CompositeAlarmName"]
 
     def alarm_action_name_transformer(key: str, val: str):
-        if key == "AlarmActions" and isinstance(val, List) and len(val) == 1:
+        if key == "AlarmActions" and isinstance(val, list) and len(val) == 1:
             # we expect only one item in the list
             value = val[0]
             match = re.match(PATTERN_ARN, value)

--- a/tests/aws/services/cloudformation/resources/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_cloudwatch.snapshot.json
@@ -9,33 +9,33 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_cloudwatch.py::test_composite_alarm_creation": {
-    "recorded-date": "27-11-2023, 09:26:48",
+    "recorded-date": "16-07-2024, 10:41:22",
     "recorded-content": {
       "composite_alarm": [
         {
           "ActionsEnabled": true,
           "AlarmActions": [
-            "arn:aws:sns:<region>:111111111111:stack-fd398c48-SNS-7rt9W1qlY3qk"
+            "arn:aws:sns:<region>:111111111111:<alarm-action-name:1>"
           ],
-          "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+          "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:HighResourceUsage",
           "AlarmConfigurationUpdatedTimestamp": "timestamp",
           "AlarmDescription": "Indicates that the system resource usage is high while no known deployment is in progress",
-          "AlarmName": "<alarm-name:1>",
-          "AlarmRule": "(ALARM(<SubscriptionArn:2>) OR ALARM(<alarm-name:2>))",
+          "AlarmName": "HighResourceUsage",
+          "AlarmRule": "(ALARM(HighCPUUsage) OR ALARM(HighMemoryUsage))",
           "InsufficientDataActions": [],
           "OKActions": [],
-          "StateReason": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1> was created and its alarm rule evaluates to OK",
+          "StateReason": "arn:aws:cloudwatch:<region>:111111111111:alarm:HighResourceUsage was created and its alarm rule evaluates to OK",
           "StateReasonData": {
             "triggeringAlarms": [
               {
-                "arn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<SubscriptionArn:2>",
+                "arn": "arn:aws:cloudwatch:<region>:111111111111:alarm:HighCPUUsage",
                 "state": {
                   "value": "INSUFFICIENT_DATA",
                   "timestamp": "date"
                 }
               },
               {
-                "arn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:2>",
+                "arn": "arn:aws:cloudwatch:<region>:111111111111:alarm:HighMemoryUsage",
                 "state": {
                   "value": "INSUFFICIENT_DATA",
                   "timestamp": "date"
@@ -50,8 +50,8 @@
       ],
       "metric_alarm": [
         {
-          "AlarmName": "<alarm-name:2>",
-          "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:2>",
+          "AlarmName": "HighMemoryUsage",
+          "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:HighMemoryUsage",
           "AlarmDescription": "Memory usage is high",
           "AlarmConfigurationUpdatedTimestamp": "timestamp",
           "ActionsEnabled": true,
@@ -62,7 +62,7 @@
           "StateReason": "Unchecked: Initial alarm creation",
           "StateUpdatedTimestamp": "timestamp",
           "MetricName": "MemoryUsage",
-          "Namespace": "<namespace:1>",
+          "Namespace": "CustomNamespace",
           "Statistic": "Average",
           "Dimensions": [],
           "Period": 60,

--- a/tests/aws/services/cloudformation/resources/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_cloudwatch.validation.json
@@ -6,6 +6,6 @@
     "last_validated_date": "2023-11-27T09:09:46+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_cloudwatch.py::test_composite_alarm_creation": {
-    "last_validated_date": "2023-11-27T08:26:48+00:00"
+    "last_validated_date": "2024-07-16T10:43:30+00:00"
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -32,7 +32,7 @@ LOG = logging.getLogger(__name__)
 
 
 def is_old_provider():
-    return os.environ.get("PROVIDER_OVERRIDE_CLOUDWATCH") != "v2" and not is_aws_cloud()
+    return os.environ.get("PROVIDER_OVERRIDE_CLOUDWATCH") == "v1" and not is_aws_cloud()
 
 
 class TestCloudwatch:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We introduced the cloudwatch v2 provider a few months ago. 
There hasn't been a lot adoption yet, but the new provider was able to resolve some reported issues already. 

Moving forward, the new provider should be the default, so we also get more feedback and can fix potential oversights and issues only in the new provider.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* switch the `default` provider to use v2
* adapt the `old_provider` check for the test-skips
* adapt the circleci config to run the test suite also for v1
* fix some parameters for the composite alarm (revealed by a cloudformation test)
* re-create snapshot for cloudformation test and adapt transformers
* add the state-visitor pattern to v2 provider to fix persistence issue with cloudpods

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
