### PR TITLE
migrate imports from localstack_ext to localstack.pro.core

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -16,6 +16,10 @@ on:
         description: 'LocalStack Pro Ref'
         required: false
         type: string
+      PYTEST_LOGLEVEL:
+        type: string
+        description: Loglevel for PyTest
+        default: WARNING
   workflow_dispatch:
     inputs:
       disableCaching:
@@ -101,10 +105,10 @@ env:
   CI_COMMIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
-  # report to tinybird if executed on master
-  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+  # report to tinybird if executed on master on community AND pro (targetRef not set)
+  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && inputs.targetRef == '' && '--report-to-tinybird ' || '' }}"
   # enable test selection if  not running on master and test selection is not explicitly disabled
-  TESTSELECTION_PYTEST_ARGS: "${{ !inputs.disableTestSelection && '--path-filter=../localstack/target/testselection/test-selection.txt ' || '' }}"
+  TESTSELECTION_PYTEST_ARGS: "${{ !inputs.disableTestSelection && '--path-filter=../../localstack/target/testselection/test-selection.txt ' || '' }}"
 
 jobs:
   test-pro:
@@ -230,9 +234,9 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get update
-          # libvirt-dev is required by the libvirt-python Python package
           # postgresql-14 pin is required to make explicit install of the version from the Ubuntu repos and not PGDG repos
           sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.12-0ubuntu0* postgresql-client postgresql-plpython3 libvirt-dev
+
       - name: Cache Ext Dependencies (venv)
         if: inputs.disableCaching != true
         uses: actions/cache@v4
@@ -240,9 +244,9 @@ jobs:
           path: |
             localstack-ext/.venv
           # include the matrix group (to re-use the venv)
-          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/requirements-test.txt') }}-${{steps.determine-companion-ref.outputs.result}}
+          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/localstack-pro-core/requirements-test.txt') }}-${{steps.determine-companion-ref.outputs.result}}
           restore-keys: |
-            community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/requirements-test.txt') }}-refs/heads/master
+            community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/localstack-pro-core/requirements-test.txt') }}-refs/heads/master
 
       - name: Cache Ext Dependencies (libs)
         if: inputs.disableCaching != true
@@ -278,7 +282,7 @@ jobs:
 
       - name: Install Python Dependencies for Pro
         working-directory: localstack-ext
-        run: make install
+        run: make install-ci
 
       - name: Link Community into Pro venv
         working-directory: localstack-ext
@@ -298,7 +302,8 @@ jobs:
         # Entrypoints need to be generated _after_ the community edition has been linked into the venv
         run: |
           make entrypoints
-          .venv/bin/python -m plux show
+          cd localstack-pro-core
+          ../.venv/bin/python -m plux show
 
       - name: Test Pro Startup
         env:
@@ -325,7 +330,6 @@ jobs:
           echo "Resulting Test Selection file:"
           cat target/testselection/test-selection.txt
 
-
       - name: Run Community Integration Tests
         env:
           # add the GitHub API token to avoid rate limit issues
@@ -333,13 +337,14 @@ jobs:
           DEBUG: 1
           DISABLE_BOTO_RETRIES: 1
           DNS_ADDRESS: 0
+          LAMBDA_EXECUTOR: "local"
           LOCALSTACK_API_KEY: "test"
           AWS_SECRET_ACCESS_KEY: "test"
           AWS_ACCESS_KEY_ID: "test"
           AWS_DEFAULT_REGION: "us-east-1"
-          TEST_PATH: "../localstack/tests/aws/"  # TODO: also include tests/integration/
           JUNIT_REPORTS_FILE: "pytest-junit-community-${{ matrix.group }}.xml"
-          PYTEST_ARGS: "${{ env.TINYBIRD_PYTEST_ARGS }}${{ env.TESTSELECTION_PYTEST_ARGS }}--splits 2 --group ${{ matrix.group }} --store-durations --durations-path ../localstack/.test_durations"
+          TEST_PATH: "../../localstack/tests/aws/"  # TODO: run tests in tests/integration
+          PYTEST_ARGS: "${{ env.TINYBIRD_PYTEST_ARGS }}${{ env.TESTSELECTION_PYTEST_ARGS }}--splits ${{ strategy.job-total }} --group ${{ matrix.group }} --durations-path ../../localstack/.test_durations --store-durations"
         working-directory: localstack-ext
         run: |
           # Remove the host tmp folder (might contain remnant files with different permissions)
@@ -361,7 +366,7 @@ jobs:
         with:
           name: test-results-community-${{ matrix.group }}
           path: |
-            localstack-ext/pytest-junit-community-${{ matrix.group }}.xml
+            localstack-ext/localstack-pro-core/pytest-junit-community-${{ matrix.group }}.xml
           retention-days: 30
 
   publish-pro-test-results:

--- a/localstack-core/localstack/cli/localstack.py
+++ b/localstack-core/localstack/cli/localstack.py
@@ -202,7 +202,7 @@ def cmd_config_show(format_: str) -> None:
 
     try:
         # only load the ext config if it's available
-        from localstack_ext import config as ext_config
+        from localstack.pro.core import config as ext_config
 
         assert ext_config
     except ImportError:

--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -173,7 +173,7 @@ class Directories:
             tmp=tmp_dir,
             mounted_tmp=tmp_dir,
             functions=None,
-            data=os.path.join(tmp_dir, "state"),  # used by localstack_ext config TODO: remove
+            data=os.path.join(tmp_dir, "state"),  # used by localstack-pro config TODO: remove
             logs=os.path.join(tmp_dir, "logs"),  # used for container logs
             config=None,  # in the context of the CLI, config.CONFIG_DIR should be used
             init=None,

--- a/localstack-core/localstack/dev/kubernetes/__main__.py
+++ b/localstack-core/localstack/dev/kubernetes/__main__.py
@@ -27,17 +27,17 @@ def generate_k8s_cluster_config(pro: bool = False, mount_moto: bool = False, por
         }
     )
     if pro:
-        ext_path = os.path.join(root_path, "..", "localstack-ext")
-        ext_code_path = os.path.join(ext_path, "localstack-pro-core", "localstack_ext")
+        pro_path = os.path.join(root_path, "..", "localstack-ext")
+        pro_code_path = os.path.join(pro_path, "localstack-pro-core", "localstack", "pro", "core")
         volumes.append(
             {
-                "volume": f"{os.path.normpath(ext_code_path)}:/code/localstack_ext",
+                "volume": f"{os.path.normpath(pro_code_path)}:/code/localstack_ext",
                 "nodeFilters": ["server:*", "agent:*"],
             }
         )
 
         egg_path = os.path.join(
-            ext_path, "localstack-pro-core", "localstack_ext.egg-info/entry_points.txt"
+            pro_path, "localstack-pro-core", "localstack_ext.egg-info/entry_points.txt"
         )
         volumes.append(
             {
@@ -157,7 +157,7 @@ def print_file(content: dict, file_name: str):
 
 @click.command("run")
 @click.option(
-    "--pro", is_flag=True, default=None, help="Mount the localstack-ext code into the cluster."
+    "--pro", is_flag=True, default=None, help="Mount the localstack-pro code into the cluster."
 )
 @click.option(
     "--mount-moto", is_flag=True, default=None, help="Mount the moto code into the cluster."

--- a/localstack-core/localstack/dev/run/__main__.py
+++ b/localstack-core/localstack/dev/run/__main__.py
@@ -189,17 +189,21 @@ def run(
         somedir                              <- your workspace directory
         ├── localstack                       <- execute script in here
         │   ├── ...
-        │   ├── localstack                   <- will be mounted into the container
-        │   ├── localstack_core.egg-info
+        │   ├── localstack-core
+        │   │   ├── localstack               <- will be mounted into the container
+        │   │   └── localstack_core.egg-info
         │   ├── pyproject.toml
         │   ├── tests
         │   └── ...
         ├── localstack-ext                   <- or execute script in here
         │   ├── ...
-        │   ├── localstack_ext               <- will be mounted into the container
-        │   ├── localstack_ext.egg-info
-        │   ├── pyproject.toml
-        │   ├── tests
+        │   ├── localstack-pro-core
+        │   │   ├── localstack
+        │   │   │   └── pro
+        │   │   │       └── core             <- will be mounted into the container
+        │   │   ├── localstack_ext.egg-info
+        │   │   ├── pyproject.toml
+        │   │   └── tests
         │   └── ...
         ├── moto
         │   ├── AUTHORS.md
@@ -252,7 +256,7 @@ def run(
         # replicate pro startup
         if pro:
             try:
-                from localstack_ext.plugins import modify_gateway_listen_config
+                from localstack.pro.core.plugins import modify_gateway_listen_config
 
                 modify_gateway_listen_config(config)
             except ImportError:

--- a/localstack-core/localstack/dev/run/configurators.py
+++ b/localstack-core/localstack/dev/run/configurators.py
@@ -24,7 +24,7 @@ from .paths import CommunityContainerPaths, ContainerPaths, HostPaths, ProContai
 
 
 class ConfigEnvironmentConfigurator:
-    """Configures the environment variables from the localstack and localstack_ext config."""
+    """Configures the environment variables from the localstack and localstack-pro config."""
 
     def __init__(self, pro: bool):
         self.pro = pro
@@ -34,8 +34,8 @@ class ConfigEnvironmentConfigurator:
             cfg.env_vars = {}
 
         if self.pro:
-            # import localstack_ext config extends the list of config vars
-            from localstack_ext import config as config_ext  # noqa
+            # import localstack.pro.core.config extends the list of config vars
+            from localstack.pro.core import config as config_pro  # noqa
 
         ContainerConfigurators.config_env_vars(cfg)
 
@@ -133,14 +133,16 @@ class SourceVolumeMountConfigurator:
         # ext source code if available
         if self.pro:
             source = (
-                self.host_paths.localstack_ext_project_dir
+                self.host_paths.localstack_pro_project_dir
                 / "localstack-pro-core"
-                / "localstack_ext"
+                / "localstack"
+                / "pro"
+                / "core"
             )
             if source.exists():
                 cfg.volumes.add(
                     VolumeBind(
-                        str(source), self.container_paths.localstack_ext_source_dir, read_only=True
+                        str(source), self.container_paths.localstack_pro_source_dir, read_only=True
                     )
                 )
 
@@ -158,7 +160,7 @@ class SourceVolumeMountConfigurator:
 
         # docker entrypoint
         if self.pro:
-            source = self.host_paths.localstack_ext_project_dir / "bin" / "docker-entrypoint.sh"
+            source = self.host_paths.localstack_pro_project_dir / "bin" / "docker-entrypoint.sh"
         else:
             source = self.host_paths.localstack_project_dir / "bin" / "docker-entrypoint.sh"
         if source.exists():
@@ -190,7 +192,7 @@ class EntryPointMountConfigurator:
     Mounts ``entry_points.txt`` files of localstack and dependencies into the venv in the container.
 
     For example, when starting the pro container, the entrypoints of localstack-ext on the host would be in
-    ``~/workspace/localstack-ext/localstack_ext.egg-info/entry_points.txt``
+    ``~/workspace/localstack-ext/localstack-pro-core/localstack_ext.egg-info/entry_points.txt``
     which needs to be mounted into the distribution info of the installed dependency within the container:
     ``/opt/code/localstack/.venv/.../site-packages/localstack_ext-2.1.0.dev0.dist-info/entry_points.txt``.
     """

--- a/localstack-core/localstack/dev/run/paths.py
+++ b/localstack-core/localstack/dev/run/paths.py
@@ -11,7 +11,7 @@ class HostPaths:
     ``~/workspace/ls/localstack-ext``, ..."""
 
     localstack_project_dir: Path
-    localstack_ext_project_dir: Path
+    localstack_pro_project_dir: Path
     moto_project_dir: Path
     postgresql_proxy: Path
     rolo_dir: Path
@@ -26,7 +26,7 @@ class HostPaths:
     ):
         self.workspace_dir = Path(workspace_dir or os.path.abspath(os.path.join(os.getcwd(), "..")))
         self.localstack_project_dir = self.workspace_dir / "localstack"
-        self.localstack_ext_project_dir = self.workspace_dir / "localstack-ext"
+        self.localstack_pro_project_dir = self.workspace_dir / "localstack-ext"
         self.moto_project_dir = self.workspace_dir / "moto"
         self.postgresql_proxy = self.workspace_dir / "postgresql-proxy"
         self.rolo_dir = self.workspace_dir / "rolo"
@@ -47,7 +47,7 @@ class ContainerPaths:
     docker_entrypoint: str = "/usr/local/bin/docker-entrypoint.sh"
     localstack_supervisor: str = "/usr/local/bin/localstack-supervisor"
     localstack_source_dir: str
-    localstack_ext_source_dir: Optional[str]
+    localstack_pro_source_dir: Optional[str]
 
     def dependency_source(self, name: str) -> str:
         """Returns path of the given source dependency in the site-packages directory."""
@@ -66,4 +66,4 @@ class ProContainerPaths(ContainerPaths):
 
     def __init__(self):
         self.localstack_source_dir = self.dependency_source("localstack")
-        self.localstack_ext_source_dir = self.dependency_source("localstack_ext")
+        self.localstack_pro_source_dir = self.dependency_source("localstack_ext")

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -30,7 +30,7 @@ from localstack.services.cloudformation.service_models import KEY_RESOURCE_STATE
 
 PRO_RESOURCE_PROVIDERS = False
 try:
-    from localstack_ext.services.cloudformation.resource_provider import (
+    from localstack.pro.core.services.cloudformation.resource_provider import (
         CloudFormationResourceProviderPluginExt,
     )
 

--- a/localstack-core/localstack/services/cloudformation/scaffolding/__main__.py
+++ b/localstack-core/localstack/services/cloudformation/scaffolding/__main__.py
@@ -145,7 +145,7 @@ TESTS_ROOT_DIR = LOCALSTACK_ROOT_DIR.joinpath(
     "tests/aws/services/cloudformation/resource_providers"
 )
 TESTS_PRO_ROOT_DIR = LOCALSTACK_PRO_ROOT_DIR.joinpath(
-    "tests/aws/services/cloudformation/resource_providers"
+    "localstack-pro-core/tests/aws/services/cloudformation/resource_providers"
 )
 
 assert LOCALSTACK_ROOT_DIR.is_dir(), f"{LOCALSTACK_ROOT_DIR} does not exist"
@@ -500,26 +500,29 @@ class FileWriter:
         self.overwrite = overwrite
         self.pro = pro
 
+        base_path = (
+            ["localstack-pro-core", "localstack", "pro", "core"]
+            if self.pro
+            else ["localstack-core", "localstack"]
+        )
+
         self.destination_files = {
             FileType.provider: root_dir(self.pro).joinpath(
-                "localstack-pro-core" if self.pro else "localstack-core",
-                "localstack_ext" if self.pro else "localstack",
+                *base_path,
                 "services",
                 self.resource_name.python_compatible_service_name.lower(),
                 "resource_providers",
                 f"{self.resource_name.namespace.lower()}_{self.resource_name.service.lower()}_{self.resource_name.resource.lower()}.py",
             ),
             FileType.plugin: root_dir(self.pro).joinpath(
-                "localstack-pro-core" if self.pro else "localstack-core",
-                "localstack_ext" if self.pro else "localstack",
+                *base_path,
                 "services",
                 self.resource_name.python_compatible_service_name.lower(),
                 "resource_providers",
                 f"{self.resource_name.namespace.lower()}_{self.resource_name.service.lower()}_{self.resource_name.resource.lower()}_plugin.py",
             ),
             FileType.schema: root_dir(self.pro).joinpath(
-                "localstack-pro-core" if self.pro else "localstack-core",
-                "localstack_ext" if self.pro else "localstack",
+                *base_path,
                 "services",
                 self.resource_name.python_compatible_service_name.lower(),
                 "resource_providers",

--- a/localstack-core/localstack/services/cloudformation/scaffolding/templates/plugin_template.py.j2
+++ b/localstack-core/localstack/services/cloudformation/scaffolding/templates/plugin_template.py.j2
@@ -3,7 +3,7 @@ from typing import Optional, Type
 from localstack.services.cloudformation.resource_provider import ResourceProvider
 {%- if pro %}
 {%- set base_class = "CloudFormationResourceProviderPluginExt" %}
-{%- set root_module = "localstack_ext" %}
+{%- set root_module = "localstack.pro.core" %}
 {%- else %}
 {%- set base_class = "CloudFormationResourceProviderPlugin" %}
 {%- set root_module = "localstack" %}

--- a/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
+++ b/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
@@ -1,5 +1,5 @@
 """Lambda models for internal use and persistence.
-The LambdaProviderPro in localstack-ext imports this model and configures persistence.
+The LambdaProviderPro in localstack-pro imports this model and configures persistence.
 The actual function code is stored in S3 (see S3Code).
 """
 

--- a/localstack-core/localstack/state/inspect.py
+++ b/localstack-core/localstack/state/inspect.py
@@ -70,7 +70,7 @@ class ReflectionStateLocator:
 
         # try to load AccountRegionBundle from predictable location
         attribute_name = f"{service_name}_stores"
-        module_name = f"localstack_ext.services.{service_name}.models"
+        module_name = f"localstack.pro.core.services.{service_name}.models"
 
         # it first looks for a module in ext; eventually, it falls back to community
         attribute = _load_attribute_from_module(module_name, attribute_name)

--- a/localstack-core/localstack/utils/analytics/metadata.py
+++ b/localstack-core/localstack/utils/analytics/metadata.py
@@ -119,12 +119,12 @@ def get_localstack_edition() -> Optional[Literal["enterprise", "pro", "community
 
 def is_license_activated() -> bool:
     try:
-        from localstack_ext import config  # noqa
+        from localstack.pro.core import config  # noqa
     except ImportError:
         return False
 
     try:
-        from localstack_ext.bootstrap import licensingv2
+        from localstack.pro.core.bootstrap import licensingv2
 
         return licensingv2.get_licensed_environment().activated
     except Exception:


### PR DESCRIPTION
## Motivation
After migrating `localstack/localstack` to implicit namespace packaging with https://github.com/localstack/localstack/pull/11190, we are now moving towards namespace packages for our Pro code, which comes with some necessary adjustments of any imports from Pro: `localstack_ext` becomes `localstack.pro.core`.

This PR prepares the adjustment of the imports and should be merged as soon as the first dev package with the new namespace packaging in the `localstack_ext` distribution is out.

## Changes
- Adjusts the imports of `localstack_ext` modules.