### PR TITLE
fix defaults for ResourceGroups::Group provider

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_resource_groups.py
+++ b/tests/aws/services/cloudformation/resources/test_resource_groups.py
@@ -1,0 +1,16 @@
+import os
+
+from localstack.testing.pytest import markers
+
+
+@markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(paths=["$..Group.Description", "$..Group.GroupArn"])
+def test_group_defaults(aws_client, deploy_cfn_template, snapshot):
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/resource_group_defaults.yml"
+        ),
+    )
+
+    resource_group = aws_client.resource_groups.get_group(GroupName=stack.outputs["ResourceGroup"])
+    snapshot.match("resource-group", resource_group)

--- a/tests/aws/services/cloudformation/resources/test_resource_groups.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_resource_groups.snapshot.json
@@ -1,0 +1,17 @@
+{
+  "tests/aws/services/cloudformation/resources/test_resource_groups.py::test_group_defaults": {
+    "recorded-date": "16-07-2024, 15:15:11",
+    "recorded-content": {
+      "resource-group": {
+        "Group": {
+          "GroupArn": "arn:aws:resource-groups:<region>:111111111111:group/testgroup",
+          "Name": "testgroup"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/cloudformation/resources/test_resource_groups.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_resource_groups.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/cloudformation/resources/test_resource_groups.py::test_group_defaults": {
+    "last_validated_date": "2024-07-16T15:15:11+00:00"
+  }
+}

--- a/tests/aws/templates/resource_group_defaults.yml
+++ b/tests/aws/templates/resource_group_defaults.yml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  ApplicationResourceGroup:
+    Type: AWS::ResourceGroups::Group
+    Properties:
+      Name: testgroup
+      ResourceQuery:
+        Type: CLOUDFORMATION_STACK_1_0
+
+Outputs:
+  ResourceGroup:
+    Value: !Ref ApplicationResourceGroup


### PR DESCRIPTION
## Motivation
As mentioned in the issue #11175 the resource provider for AWS::ResourceGroups::Group is supposed to handle a Group definition without a Query if the Type is CLOUDFORMATION_STACK_1_0. 

## Changes
- Replace auto generation of the Name attribute as it's a required attribute.
- Add default query

## Testing
- New CFn test that replicates the issue