### PR TITLE
allow SSM::GetParameter action to use ARNs instead of only names

### DIFF
--- a/localstack-core/localstack/services/ssm/provider.py
+++ b/localstack-core/localstack/services/ssm/provider.py
@@ -363,10 +363,10 @@ class SsmProvider(SsmApi, ABC):
 
     @staticmethod
     def _normalize_name(param_name: ParameterName, validate=False) -> ParameterName:
-        if validate:
-            if is_arn(param_name):
-                return extract_resource_from_arn(param_name).split("/")[-1]
+        if is_arn(param_name):
+            return extract_resource_from_arn(param_name).split("/")[-1]
 
+        if validate:
             if "//" in param_name or ("/" in param_name and not param_name.startswith("/")):
                 raise InvalidParameterNameException()
         param_name = param_name.strip("/")

--- a/localstack-core/localstack/services/ssm/provider.py
+++ b/localstack-core/localstack/services/ssm/provider.py
@@ -80,6 +80,7 @@ from localstack.aws.api.ssm import (
 )
 from localstack.aws.connect import connect_to
 from localstack.services.moto import call_moto, call_moto_with_request
+from localstack.utils.aws.arns import extract_resource_from_arn, is_arn
 from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.collections import remove_attributes
 from localstack.utils.objects import keys_to_lower
@@ -363,6 +364,9 @@ class SsmProvider(SsmApi, ABC):
     @staticmethod
     def _normalize_name(param_name: ParameterName, validate=False) -> ParameterName:
         if validate:
+            if is_arn(param_name):
+                return extract_resource_from_arn(param_name).split("/")[-1]
+
             if "//" in param_name or ("/" in param_name and not param_name.startswith("/")):
                 raise InvalidParameterNameException()
         param_name = param_name.strip("/")

--- a/localstack-core/localstack/utils/aws/arns.py
+++ b/localstack-core/localstack/utils/aws/arns.py
@@ -547,3 +547,11 @@ def sqs_queue_name(queue_arn: str) -> str:
 
 def s3_bucket_name(bucket_name_or_arn: str) -> str:
     return bucket_name_or_arn.split(":::")[-1]
+
+
+def is_arn(possible_arn: str) -> bool:
+    try:
+        parse_arn(possible_arn)
+        return True
+    except InvalidArnException:
+        return False

--- a/tests/aws/services/ssm/test_ssm.py
+++ b/tests/aws/services/ssm/test_ssm.py
@@ -150,6 +150,16 @@ class TestSSM:
         assert found_param["Value"] == "value"
 
     @markers.aws.validated
+    def test_get_parameter_by_arn(self, create_parameter, aws_client, snapshot, cleanups):
+        param_name = f"param-{short_uid()}"
+        create_parameter(Name=param_name, Value="test", Type="String")
+        parameter_by_name = aws_client.ssm.get_parameter(Name=param_name)["Parameter"]
+
+        parameter_by_arn = aws_client.ssm.get_parameter(Name=parameter_by_name["ARN"])["Parameter"]
+        snapshot.match("Parameter", parameter_by_arn)
+        snapshot.add_transformer(snapshot.transform.key_value("Name"))
+
+    @markers.aws.validated
     def test_get_inexistent_maintenance_window(self, aws_client):
         invalid_name = "mw-00000000000000000"
         with pytest.raises(aws_client.ssm.exceptions.DoesNotExistException) as exc:

--- a/tests/aws/services/ssm/test_ssm.snapshot.json
+++ b/tests/aws/services/ssm/test_ssm.snapshot.json
@@ -1,0 +1,16 @@
+{
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_arn": {
+    "recorded-date": "16-07-2024, 17:17:40",
+    "recorded-content": {
+      "Parameter": {
+        "ARN": "arn:aws:ssm:<region>:111111111111:parameter/<name:1>",
+        "DataType": "text",
+        "LastModifiedDate": "<datetime>",
+        "Name": "<name:1>",
+        "Type": "String",
+        "Value": "test",
+        "Version": 1
+      }
+    }
+  }
+}

--- a/tests/aws/services/ssm/test_ssm.validation.json
+++ b/tests/aws/services/ssm/test_ssm.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_arn": {
+    "last_validated_date": "2024-07-16T17:17:40+00:00"
+  }
+}


### PR DESCRIPTION
## Motivation
As shown in the issue #11048. The SSM service allows the usage of ARN's as Names in the GetParameter action. 

## Changes
- Extend the name validation function to detect if it's an ARN and extract the parameter name if it is.

## Testing
- New AWS validated test that confirms the behavior.