### PR TITLE
force all APIGW providers to use NextGen if main one is set

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1038,6 +1038,15 @@ LEGACY_SNS_GCM_PUBLISHING = is_env_true("LEGACY_SNS_GCM_PUBLISHING")
 
 # Whether the Next Gen APIGW invocation logic is enabled (handler chain)
 APIGW_NEXT_GEN_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_APIGATEWAY", "") == "next_gen"
+if APIGW_NEXT_GEN_PROVIDER:
+    # in order to not have conflicts with different implementation registering their own router, we need to have all of
+    # them use the same new implementation
+    if not os.environ.get("PROVIDER_OVERRIDE_APIGATEWAYV2"):
+        os.environ["PROVIDER_OVERRIDE_APIGATEWAYV2"] = "next_gen"
+
+    if not os.environ.get("PROVIDER_OVERRIDE_APIGATEWAYMANAGEMENTAPI"):
+        os.environ["PROVIDER_OVERRIDE_APIGATEWAYMANAGEMENTAPI"] = "next_gen"
+
 
 # TODO remove fallback to LAMBDA_DOCKER_NETWORK with next minor version
 MAIN_DOCKER_NETWORK = os.environ.get("MAIN_DOCKER_NETWORK", "") or LAMBDA_DOCKER_NETWORK


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We're planning to advertise the new implementation of API Gateway "Next Gen" in the next release.

However, we will need all our implementation of API Gateway (with upstream) to be on the same page, and to not try to register the same routes with different implementations. 

This PR makes sure we override the different versions of APIGW to use the new implementation if the flag is set.

Also sneaked a small refactor we've talked with @cloutierMat in order to be easier to override behavior. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update `apigatewayv2` and `apigatewaymanagementapi` to also use `next_gen` if set. 
- small refactor for the endpoint

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
