### PR TITLE
fix: kinesis CBOR blob handling

### DIFF
--- a/localstack-core/localstack/aws/protocol/parser.py
+++ b/localstack-core/localstack/aws/protocol/parser.py
@@ -898,6 +898,15 @@ class BaseJSONRequestParser(RequestParser, ABC):
             return self._convert_str_to_timestamp(node, self.CBOR_TIMESTAMP_FORMAT)
         return super()._parse_timestamp(request, shape, node, uri_params)
 
+    def _parse_blob(
+        self, request: Request, shape: Shape, node: bool, uri_params: Mapping[str, Any] = None
+    ) -> bytes:
+        if isinstance(node, bytes) and request.mimetype.startswith("application/x-amz-cbor"):
+            # CBOR does not base64 encode binary data
+            return bytes(node)
+        else:
+            return super()._parse_blob(request, shape, node, uri_params)
+
 
 class JSONRequestParser(BaseJSONRequestParser):
     """

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from datetime import datetime, timedelta
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -27,6 +28,60 @@ LOGGER = logging.getLogger(__name__)
 # make sure cbor2 patches are applied
 # (for the test-data decoding, usually done as init hook in LocalStack)
 _patch_cbor2()
+
+
+class KinesisHTTPClient:
+    """
+    Simple HTTP client for making Kinesis requests manually using the CBOR serialization type.
+
+    This serialization type is not available via botocore.
+    """
+
+    def __init__(
+        self,
+        account_id: str,
+        region_name: str,
+        client_factory,
+    ):
+        self.account_id = account_id
+        self.region_name = region_name
+        self._client = client_factory("kinesis", region=self.region_name, signer_factory=SigV4Auth)
+
+    def post(self, operation: str, payload: dict, datetime_as_timestamp: bool = True) -> Any:
+        """
+        Perform a kinesis operation, encoding the request payload with CBOR and decoding the
+        response with CBOR.
+        """
+        response = self._client.post(
+            self.endpoint,
+            data=cbor2_dumps(payload, datetime_as_timestamp=datetime_as_timestamp),
+            headers=self._build_headers(operation),
+        )
+        response_body = cbor2_loads(response.content)
+        if response.status_code != 200:
+            raise ValueError(f"Bad status: {response.status_code}, response body: {response_body}")
+
+        return response_body
+
+    def _build_headers(self, operation: str) -> dict:
+        return {
+            "content-type": constants.APPLICATION_AMZ_CBOR_1_1,
+            "x-amz-target": f"Kinesis_20131202.{operation}",
+            "host": self.endpoint,
+        }
+
+    @property
+    def endpoint(self) -> str:
+        return (
+            f"https://{self.account_id}.control-kinesis.{self.region_name}.amazonaws.com"
+            if is_aws_cloud()
+            else config.internal_service_url()
+        )
+
+
+@pytest.fixture
+def kinesis_http_client(account_id, region_name, aws_http_client_factory):
+    return KinesisHTTPClient(account_id, region_name, client_factory=aws_http_client_factory)
 
 
 class TestKinesis:
@@ -577,12 +632,8 @@ class TestKinesis:
         self,
         kinesis_create_stream,
         wait_for_stream_ready,
-        kinesis_register_consumer,
-        wait_for_kinesis_consumer_ready,
         aws_client,
-        aws_http_client_factory,
-        account_id,
-        region_name,
+        kinesis_http_client,
     ):
         # create stream
         pre_create_timestamp = (datetime.now() - timedelta(hours=0, minutes=1)).astimezone()
@@ -594,26 +645,13 @@ class TestKinesis:
         post_create_timestamp = (datetime.now() + timedelta(hours=0, minutes=1)).astimezone()
 
         # perform a raw DescribeStream request to test the datetime serialization by LocalStack
-        kinesis_http_client = aws_http_client_factory("kinesis", signer_factory=SigV4Auth)
-        endpoint = (
-            f"https://{account_id}.control-kinesis.{region_name}.amazonaws.com"
-            if is_aws_cloud()
-            else config.internal_service_url()
-        )
-        describe_response = kinesis_http_client.post(
-            endpoint,
-            data=cbor2_dumps({"StreamARN": stream_arn}, datetime_as_timestamp=True),
-            headers={
-                "content-type": constants.APPLICATION_AMZ_CBOR_1_1,
-                "x-amz-target": "Kinesis_20131202.DescribeStream",
-                "host": endpoint,
-            },
+        describe_response_data = kinesis_http_client.post(
+            operation="DescribeStream",
+            payload={"StreamARN": stream_arn},
         )
 
-        # verify that the request can be properly parsed, and that the timestamp is within the boundaries
-        assert describe_response.status_code == 200
-        describe_response_content = describe_response.content
-        describe_response_data = cbor2_loads(describe_response_content)
+        # verify that the request can be properly parsed, and that the timestamp is within the
+        # boundaries
         assert (
             pre_create_timestamp
             <= describe_response_data["StreamDescription"]["StreamCreationTimestamp"]
@@ -621,26 +659,15 @@ class TestKinesis:
         )
 
         shard_id = describe_response_data["StreamDescription"]["Shards"][0]["ShardId"]
-        shard_iterator_response = kinesis_http_client.post(
-            endpoint,
-            data=cbor2_dumps(
-                {
-                    "StreamARN": stream_arn,
-                    "ShardId": shard_id,
-                    "ShardIteratorType": "AT_TIMESTAMP",
-                    "Timestamp": datetime.now().astimezone(),
-                },
-                datetime_as_timestamp=True,
-            ),
-            headers={
-                "content-type": constants.APPLICATION_AMZ_CBOR_1_1,
-                "x-amz-target": "Kinesis_20131202.GetShardIterator",
-                "host": endpoint,
+        shard_iterator_response_data = kinesis_http_client.post(
+            "GetShardIterator",
+            payload={
+                "StreamARN": stream_arn,
+                "ShardId": shard_id,
+                "ShardIteratorType": "AT_TIMESTAMP",
+                "Timestamp": datetime.now().astimezone(),
             },
         )
-        assert shard_iterator_response.status_code == 200
-        shard_iterator_content = shard_iterator_response.content
-        shard_iterator_response_data = cbor2_loads(shard_iterator_content)
         assert "ShardIterator" in shard_iterator_response_data
 
 

--- a/tests/aws/services/kinesis/test_kinesis.validation.json
+++ b/tests/aws/services/kinesis/test_kinesis.validation.json
@@ -27,7 +27,7 @@
     "last_validated_date": "2024-06-21T15:20:46+00:00"
   },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_at_timestamp_cbor": {
-    "last_validated_date": "2024-07-04T09:16:32+00:00"
+    "last_validated_date": "2024-07-17T20:16:42+00:00"
   },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_sequence_number_as_iterator": {
     "last_validated_date": "2022-08-26T07:29:21+00:00"

--- a/tests/aws/services/kinesis/test_kinesis.validation.json
+++ b/tests/aws/services/kinesis/test_kinesis.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_add_tags_to_stream": {
     "last_validated_date": "2022-08-25T06:56:43+00:00"
   },
+  "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_cbor_blob_handling": {
+    "last_validated_date": "2024-07-17T20:09:34+00:00"
+  },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_create_stream_without_shard_count": {
     "last_validated_date": "2022-08-26T07:30:59+00:00"
   },

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -642,7 +642,7 @@ def test_json_cbor_blob_parsing():
             "X-Amz-Target": "Kinesis_20131202.PutRecord",
             "x-localstack-tgt-api": "kinesis",
         },
-        "body": b"\xa3dDataTaGVsbG8sIHdvcmxkIQ==jStreamNamedtestlPartitionKeylpartitionkey",
+        "body": b"\xbfjStreamNamedtestdDataMhello, world!lPartitionKeylpartitionkey\xff",
         "url": "/",
         "context": {},
     }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A report from a customer showed that a round trip of data through a Kinesis stream from LocalStack did not preserve the data content.

For example:

* `PutRecord` in Kinesis stream, `"test data"`
* `GetRecords` from kinesis stream, convert 1st record to `String`, which turns out different from "test data": `��-u�Z`

They were using the Java SDK. When testing on AWS, a `GetRecords` request returns the message body (decoded as a String) of `"test data"` correctly.

Since this is exercised via the Java SDK, it is the handling of the [CBOR](https://cbor.io/) format that it as fault. It turned out that we did not parse `CBOR` `blob`s correctly.

* #11133 made some changes to the CBOR parsing to do with timestamps milliseconds vs seconds.
* As part of this change, the [`BaseJSONRequestParser._parse_blob`](https://github.com/localstack/localstack/blob/a4095638a6c92a70e15aebb07b9520e8907c3e50/localstack-core/localstack/aws/protocol/parser.py#L894-L901) method was removed.
* This meant that blob data types (like plain strings) were parsed using the [`RequestParser._parse_blob`](https://github.com/localstack/localstack/blob/a87cba7f0308262aa518368236700a20855a411e/localstack-core/localstack/aws/protocol/parser.py#L297-L299) method, which incorrectly base64-decoded the value.
* This PR also updated `tests/unit/aws/protocol/test_parser.py::test_json_cbor_blob_parsing` to test this incorrect behaviour.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

This PR reverts the removal of `BaseJSONRequestParser._parse_blob` and updates the relevant test accordingly.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->