### PR TITLE
Fix mounting of pro code in localstack.dev.run

### DIFF
--- a/localstack-core/localstack/dev/run/configurators.py
+++ b/localstack-core/localstack/dev/run/configurators.py
@@ -127,7 +127,9 @@ class SourceVolumeMountConfigurator:
         source = self.host_paths.localstack_project_dir / "localstack-core" / "localstack"
         if source.exists():
             cfg.volumes.add(
-                VolumeBind(str(source), self.container_paths.localstack_source_dir, read_only=True)
+                # read_only=False is a temporary workaround to make the mounting of the pro source work
+                # this can be reverted once we don't need the nested mounting anymore
+                VolumeBind(str(source), self.container_paths.localstack_source_dir, read_only=False)
             )
 
         # ext source code if available

--- a/localstack-core/localstack/dev/run/paths.py
+++ b/localstack-core/localstack/dev/run/paths.py
@@ -66,4 +66,4 @@ class ProContainerPaths(ContainerPaths):
 
     def __init__(self):
         self.localstack_source_dir = self.dependency_source("localstack")
-        self.localstack_pro_source_dir = self.dependency_source("localstack_ext")
+        self.localstack_pro_source_dir = self.dependency_source("localstack") + "/pro/core"


### PR DESCRIPTION
## Motivation

We noticed a small regression in the `localstack.dev.run` script after the recent changes in localstack-pro. Specifically, the mounting of the pro code was not working, and failing with this message:

```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/home/dominik/work/localstack/tempytemp/localstack-ext/localstack-pro-core/localstack/pro/core" to rootfs at "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/pro/core": mkdir /var/lib/docker/btrfs/subvolumes/2c1e6f4ca78e70ae380670fccfc47cd8cf355be1c962348c2d00e92f29d21701/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/pro: read-only file system: unknown
```

## Changes

- The pro code is now mounted at the correct location in the venv inside the container (`site-packages/localstack/pro/core`)
- The mount at `site-packages/localstack` now isn't read-only anymore since otherwise the nested mounting of the pro code would fail

## Testing

`ACTIVATE_PRO=0 python -m localstack.dev.run --pro`
