### PR TITLE
fix S3 CRC32 checksum with empty body logic

### DIFF
--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -237,13 +237,9 @@ class S3CRC32Checksum:
     __slots__ = ["checksum"]
 
     def __init__(self):
-        self.checksum = None
+        self.checksum = zlib.crc32(b"")
 
     def update(self, value: bytes):
-        if self.checksum is None:
-            self.checksum = zlib.crc32(value)
-            return
-
         self.checksum = zlib.crc32(value, self.checksum)
 
     def digest(self) -> bytes:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #11224, we had an issue when the body of an S3 object was empty with a CRC32 checksum. 
This was due to a flawed logic always considering the `Checksum.update()` was called, and not properly initializing the checksum object.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix the logic in the CRC32 util
- add a test with an empty body to assert the fix
- update a previous test which did not declare the checksum trailing header, which made the test not validate the checksum

_fixes #11224_
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
