### PR TITLE
apigw next gen add circle ci pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -563,7 +563,7 @@ jobs:
           name: Test ApiGateway Next Gen provider
           environment:
             PROVIDER_OVERRIDE_APIGATEWAY: "next_gen"
-            TEST_PATH: "tests/aws/services/apigateway/ tests/unit/services/apigateway/"
+            TEST_PATH: "tests/aws/services/apigateway/"
             COVERAGE_ARGS: "-p"
           command: |
             COVERAGE_FILE="target/coverage/.coverage.apigwNG.${CIRCLE_NODE_INDEX}" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -943,6 +943,10 @@ workflows:
           requires:
             - preflight
             - test-selection
+      - itest-apigw-ng-provider:
+          requires:
+            - preflight
+            - test-selection
       - unit-tests:
           requires:
             - preflight
@@ -1005,6 +1009,7 @@ workflows:
             - itest-s3-v2-legacy-provider
             - itest-cloudwatch-v2-provider
             - itest-events-v2-provider
+            - itest-apigw-ng-provider
             - acceptance-tests-amd64
             - acceptance-tests-arm64
             - integration-tests-amd64
@@ -1020,6 +1025,7 @@ workflows:
             - itest-s3-v2-legacy-provider
             - itest-cloudwatch-v2-provider
             - itest-events-v2-provider
+            - itest-apigw-ng-provider
             - acceptance-tests-amd64
             - acceptance-tests-arm64
             - integration-tests-amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,6 +547,36 @@ jobs:
       - store_test_results:
           path: target/reports/
 
+  itest-apigw-ng-provider:
+    executor: ubuntu-machine-amd64
+    working_directory: /tmp/workspace/repo
+    environment:
+      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
+    steps:
+      - prepare-acceptance-tests
+      - attach_workspace:
+          at: /tmp/workspace
+      - prepare-testselection
+      - prepare-pytest-tinybird
+      - prepare-account-region-randomization
+      - run:
+          name: Test ApiGateway Next Gen provider
+          environment:
+            PROVIDER_OVERRIDE_APIGATEWAY: "next_gen"
+            TEST_PATH: "tests/aws/services/apigateway/ tests/unit/services/apigateway/"
+            COVERAGE_ARGS: "-p"
+          command: |
+            COVERAGE_FILE="target/coverage/.coverage.apigwNG.${CIRCLE_NODE_INDEX}" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/apigw_ng.xml -o junit_suite_name='apigw_ng'" \
+            make test-coverage
+      - persist_to_workspace:
+          root:
+            /tmp/workspace
+          paths:
+            - repo/target/coverage/
+      - store_test_results:
+          path: target/reports/
+
 
   #########################
   ## Parity Metrics Jobs ##


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Now that we have a set of stable feature for the apigw Next Gen and all tests are now green :partying_face: . We are adding a new pipeline for apigw to help ensure we don't introduce any regression as we keep working on new features and extend the work to apigwv2.

PR #11198 enabled all tests and links to run https://app.circleci.com/jobs/github/localstack/localstack/227232 that was executed with the flag enabled.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

A new pipeline for circle-ci that sets `PROVIDER_OVERRIDE_APIGATEWAY=next_gen`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
