### PR TITLE
Apigw ng refactor headers to werkzeug headers

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -38,7 +38,7 @@ class IntegrationRequest(TypedDict, total=False):
     """URI of the integration"""
     query_string_parameters: dict[str, str | list[str]]
     """Query string parameters of the request"""
-    headers: dict[str, str]
+    headers: Headers
     # TODO: should this be Headers type? would maybe help access in the integrations if we need
     #  currently, we support headers with same name and different casing, it's up to the integration to support it
     """Headers of the request"""

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -23,15 +23,10 @@ class InvocationRequest(TypedDict, total=False):
     """Path parameters of the request"""
     query_string_parameters: dict[str, str]
     """Query string parameters of the request"""
-    # TODO: need to check if we need the raw headers (as it's practical for casing reasons)
-    raw_headers: Headers
+    headers: Headers
     """Raw headers using the Headers datastructure which allows access with no regards to casing"""
-    headers: dict[str, str]
-    """Headers of the request"""
     multi_value_query_string_parameters: dict[str, list[str]]
     """Multi value query string parameters of the request"""
-    multi_value_headers: dict[str, list[str]]
-    """Multi value headers of the request"""
     body: bytes
     """Body content of the request"""
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -39,8 +39,6 @@ class IntegrationRequest(TypedDict, total=False):
     query_string_parameters: dict[str, str | list[str]]
     """Query string parameters of the request"""
     headers: Headers
-    # TODO: should this be Headers type? would maybe help access in the integrations if we need
-    #  currently, we support headers with same name and different casing, it's up to the integration to support it
     """Headers of the request"""
     body: bytes
     """Body content of the request"""

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/api_key_validation.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/api_key_validation.py
@@ -105,7 +105,7 @@ class ApiKeyValidationHandler(RestApiGatewayHandler):
         match api_key_source := rest_api.get("apiKeySource"):
             case ApiKeySourceType.HEADER:
                 LOG.debug("Looking for api key in header 'X-API-Key'")
-                return request.get("raw_headers", {}).get("X-API-Key")
+                return request.get("headers", {}).get("X-API-Key")
             case ApiKeySourceType.AUTHORIZER:
                 LOG.debug("Looking for api key in Identity Context")
                 return identity.get("apiKey")

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -128,7 +128,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
                     params=MappingTemplateParams(
                         path=request.get("path_parameters"),
                         querystring=request.get("query_string_parameters", {}),
-                        header=request.get("headers", {}),
+                        header=dict(request.get("headers", {})),
                     ),
                 ),
             ),
@@ -144,7 +144,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
         request_templates = integration.get("requestTemplates") or {}
         passthrough_behavior = integration.get("passthroughBehavior")
         # If content-type is not provided aws assumes application/json
-        content_type = request["raw_headers"].get("Content-Type", APPLICATION_JSON)
+        content_type = request["headers"].get("Content-Type", APPLICATION_JSON)
         # first look to for a template associated to the content-type, otherwise look for the $default template
         request_template = request_templates.get(content_type) or request_templates.get("$default")
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -130,7 +130,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
                     params=MappingTemplateParams(
                         path=request.get("path_parameters"),
                         querystring=request.get("query_string_parameters", {}),
-                        header=dict(request.get("headers", {})),
+                        header=request.get("headers"),
                     ),
                 ),
             ),

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -1,5 +1,7 @@
 import logging
 
+from werkzeug.datastructures import Headers
+
 from localstack.aws.api.apigateway import Integration, IntegrationType
 from localstack.constants import APPLICATION_JSON
 from localstack.http import Response
@@ -89,7 +91,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
             http_method=integration_method,
             uri=rendered_integration_uri,
             query_string_parameters=request_data_mapping["querystring"],
-            headers=request_data_mapping["header"],
+            headers=Headers(request_data_mapping["header"]),
             body=body,
         )
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
@@ -84,7 +84,7 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
         response_template = self.get_response_template(
             integration_response=integration_response, request=context.invocation_request
         )
-        body, response_override = self.render_request_template_mapping(
+        body, response_override = self.render_response_template_mapping(
             context=context, template=response_template, body=body
         )
 
@@ -214,7 +214,7 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
         LOG.warning("No templates were matched, Using template: %s", template)
         return template
 
-    def render_request_template_mapping(
+    def render_response_template_mapping(
         self, context: RestApiInvocationContext, template: str, body: bytes | str
     ) -> tuple[bytes, ContextVarsResponseOverride]:
         if not template:

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
@@ -203,7 +203,7 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
             return ""
 
         # The invocation request header is used to find the right response templated
-        accepts = request["raw_headers"].getlist("accept")
+        accepts = request["headers"].getlist("accept")
         if accepts and (template := response_templates.get(accepts[-1])):
             return template
         # TODO aws seemed to favor application/json as default when unmatched regardless of "first"

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_request.py
@@ -120,7 +120,7 @@ class MethodRequestHandler(RestApiGatewayHandler):
             param_type, param_value = request_parameter.removeprefix("method.request.").split(".")
             match param_type:
                 case "header":
-                    is_missing = param_value not in request.get("headers", [])
+                    is_missing = param_value not in dict(request.get("headers"))
                 case "path":
                     path = request.get("path_parameters", "")
                     is_missing = param_value not in path

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_request.py
@@ -113,6 +113,8 @@ class MethodRequestHandler(RestApiGatewayHandler):
         if not (request_parameters := method.get("requestParameters")):
             return missing_params
 
+        case_sensitive_headers = list(request.get("headers").keys())
+
         for request_parameter, required in sorted(request_parameters.items()):
             if not required:
                 continue
@@ -120,7 +122,7 @@ class MethodRequestHandler(RestApiGatewayHandler):
             param_type, param_value = request_parameter.removeprefix("method.request.").split(".")
             match param_type:
                 case "header":
-                    is_missing = param_value not in dict(request.get("headers"))
+                    is_missing = param_value not in case_sensitive_headers
                 case "path":
                     path = request.get("path_parameters", "")
                     is_missing = param_value not in path

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -116,7 +116,7 @@ class InvocationRequestParser(RestApiGatewayHandler):
     @staticmethod
     def create_context_variables(context: RestApiInvocationContext) -> ContextVariables:
         invocation_request: InvocationRequest = context.invocation_request
-        domain_name = invocation_request["raw_headers"].get("Host", "")
+        domain_name = invocation_request["headers"].get("Host", "")
         domain_prefix = domain_name.split(".")[0]
         now = datetime.datetime.now()
 
@@ -140,7 +140,7 @@ class InvocationRequestParser(RestApiGatewayHandler):
                 principalOrgId=None,
                 sourceIp="127.0.0.1",  # TODO: get the sourceIp from the Request
                 user=None,
-                userAgent=invocation_request["raw_headers"].get("User-Agent"),
+                userAgent=invocation_request["headers"].get("User-Agent"),
                 userArn=None,
             ),
             # TODO: check if we need the raw path? with forward slashes

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/header_utils.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/header_utils.py
@@ -1,0 +1,23 @@
+DROPPED_FROM_INVOCATION_REQUEST_COMMON = [
+    "Connection",
+    "Content-Length",
+    "Content-MD5",
+    "Expect",
+    "Max-Forwards",
+    "Proxy-Authenticate",
+    "Server",
+    "TE",
+    "Transfer-Encoding",
+    "Trailer",
+    "Upgrade",
+    "WWW-Authenticate",
+]
+DROPPED_FROM_INVOCATION_REQUEST_COMMON_LOWER = [
+    header.lower() for header in DROPPED_FROM_INVOCATION_REQUEST_COMMON
+]
+
+
+def should_drop_header_from_invocation(header: str) -> bool:
+    """These headers are not making it to the invocation requests. Even Proxy integrations are not sending them."""
+    if header.lower() in DROPPED_FROM_INVOCATION_REQUEST_COMMON_LOWER:
+        return True

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/header_utils.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/header_utils.py
@@ -1,3 +1,7 @@
+from collections import defaultdict
+
+from werkzeug.datastructures import Headers
+
 DROPPED_FROM_INVOCATION_REQUEST_COMMON = [
     "Connection",
     "Content-Length",
@@ -19,5 +23,12 @@ DROPPED_FROM_INVOCATION_REQUEST_COMMON_LOWER = [
 
 def should_drop_header_from_invocation(header: str) -> bool:
     """These headers are not making it to the invocation requests. Even Proxy integrations are not sending them."""
-    if header.lower() in DROPPED_FROM_INVOCATION_REQUEST_COMMON_LOWER:
-        return True
+    return header.lower() in DROPPED_FROM_INVOCATION_REQUEST_COMMON_LOWER
+
+
+def build_multi_value_headers(headers: Headers) -> dict[str, list[str]]:
+    multi_value_headers = defaultdict(list)
+    for key, value in headers:
+        multi_value_headers[key].append(value)
+
+    return multi_value_headers

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -1,7 +1,6 @@
 import base64
 import json
 import logging
-from collections import defaultdict
 from functools import lru_cache
 from http import HTTPMethod
 from typing import Literal, Optional, TypedDict
@@ -33,6 +32,7 @@ from ..context import (
     RestApiInvocationContext,
 )
 from ..gateway_response import IntegrationFailureError, InternalServerError
+from ..header_utils import build_multi_value_headers
 from ..helpers import (
     get_lambda_function_arn_from_invocation_uri,
     get_source_arn,
@@ -503,7 +503,7 @@ class RestApiAwsProxyIntegration(RestApiIntegration):
         input_event = LambdaInputEvent(
             headers=self._format_headers(dict(invocation_req["headers"])),
             multiValueHeaders=self._format_headers(
-                self._build_multi_value_headers(invocation_req["headers"])
+                build_multi_value_headers(invocation_req["headers"])
             ),
             body=body or None,
             isBase64Encoded=is_b64_encoded,
@@ -519,14 +519,6 @@ class RestApiAwsProxyIntegration(RestApiIntegration):
         )
 
         return input_event
-
-    @staticmethod
-    def _build_multi_value_headers(headers: Headers) -> dict[str, list[str]]:
-        multi_value_headers = defaultdict(list)
-        for key, value in headers:
-            multi_value_headers[key].append(value)
-
-        return multi_value_headers
 
     @staticmethod
     def _format_headers(headers: dict[str, str | list[str]]) -> dict[str, str | list[str]]:

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -188,11 +188,14 @@ class RestApiAwsIntegration(RestApiIntegration):
         if credentials := integration.get("credentials"):
             credentials = render_uri_with_stage_variables(credentials, context.stage_variables)
 
-        headers = integration_req["headers"] | get_internal_mocked_headers(
-            service_name=service_name,
-            region_name=integration_region,
-            source_arn=get_source_arn(context),
-            role_arn=credentials,
+        headers = integration_req["headers"]
+        headers.update(
+            get_internal_mocked_headers(
+                service_name=service_name,
+                region_name=integration_region,
+                source_arn=get_source_arn(context),
+                role_arn=credentials,
+            )
         )
         query_params = integration_req["query_string_parameters"].copy()
         data = integration_req["body"]

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
@@ -123,7 +123,7 @@ class RestApiHttpProxyIntegration(BaseRestApiHttpIntegration):
         default_apigw_headers = self._get_default_headers(context)
 
         multi_value_headers = build_multi_value_headers(invocation_req["headers"])
-        request_headers = {key: ",".join(value) for key, value in multi_value_headers}
+        request_headers = {key: ",".join(value) for key, value in multi_value_headers.items()}
         # TODO: check which headers to pop
         request_headers.pop("Host", None)
         default_apigw_headers.update(request_headers)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
@@ -12,6 +12,7 @@ from ..context import (
     InvocationRequest,
     RestApiInvocationContext,
 )
+from ..header_utils import build_multi_value_headers
 from ..helpers import render_integration_uri
 from .core import RestApiIntegration
 
@@ -121,8 +122,8 @@ class RestApiHttpProxyIntegration(BaseRestApiHttpIntegration):
 
         default_apigw_headers = self._get_default_headers(context)
 
-        raw_headers = invocation_req["headers"]
-        request_headers = {key: ",".join(raw_headers.getlist(key)) for key in raw_headers.keys()}
+        multi_value_headers = build_multi_value_headers(invocation_req["headers"])
+        request_headers = {key: ",".join(value) for key, value in multi_value_headers}
         # TODO: check which headers to pop
         request_headers.pop("Host", None)
         default_apigw_headers.update(request_headers)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
@@ -121,9 +121,8 @@ class RestApiHttpProxyIntegration(BaseRestApiHttpIntegration):
 
         default_apigw_headers = self._get_default_headers(context)
 
-        request_headers = {
-            key: ",".join(value) for key, value in invocation_req["multi_value_headers"].items()
-        }
+        raw_headers = invocation_req["headers"]
+        request_headers = {key: ",".join(raw_headers.getlist(key)) for key in raw_headers.keys()}
         # TODO: check which headers to pop
         request_headers.pop("Host", None)
         default_apigw_headers.update(request_headers)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
@@ -243,12 +243,12 @@ class ParametersMapper:
             return multi_qs_params
 
         elif param_type == "header":
-            multi_headers = invocation_request["multi_value_headers"].get(param_name)
+            multi_headers = invocation_request["headers"].getlist(param_name)
             if multi_headers:
                 return multi_headers[-1]
 
         elif param_type == "multivalueheader":
-            multi_headers = invocation_request["multi_value_headers"].get(param_name, [])
+            multi_headers = invocation_request["headers"].getlist(param_name)
             return ",".join(multi_headers)
 
         else:

--- a/tests/unit/services/apigateway/test_handler_api_key_validation.py
+++ b/tests/unit/services/apigateway/test_handler_api_key_validation.py
@@ -51,7 +51,7 @@ def create_context():
         context = RestApiInvocationContext(Request())
 
         # The api key validator only relies on the raw headers from the invocation requests
-        context.invocation_request = InvocationRequest(raw_headers=Headers(headers))
+        context.invocation_request = InvocationRequest(headers=Headers(headers))
 
         # Frozen deployment populated by the router
         context.deployment = RestApiDeployment(

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -1,6 +1,7 @@
 from http import HTTPMethod
 
 import pytest
+from werkzeug.datastructures import Headers
 
 from localstack.aws.api.apigateway import Integration, IntegrationType, Method
 from localstack.http import Request, Response
@@ -98,10 +99,12 @@ class TestHandlerIntegrationRequest:
         integration_request_handler(default_context)
         assert default_context.integration_request == {
             "body": b"",
-            "headers": {
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
+            "headers": Headers(
+                {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                }
+            ),
             "http_method": "POST",
             "query_string_parameters": {},
             "uri": "https://example.com",
@@ -205,11 +208,13 @@ class TestHandlerIntegrationRequest:
         # TODO this test will fail when we implement uri mapping
         assert default_context.integration_request["uri"] == "https://example.com/path"
         assert default_context.integration_request["query_string_parameters"] == {"qs": "qs2"}
-        assert default_context.integration_request["headers"] == {
-            "header": "header2",
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        }
+        assert default_context.integration_request["headers"] == Headers(
+            {
+                "header": "header2",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            }
+        )
 
     def test_request_override(self, integration_request_handler, default_context):
         default_context.resource_method["methodIntegration"]["requestParameters"] = {
@@ -226,12 +231,14 @@ class TestHandlerIntegrationRequest:
         assert default_context.integration_request["query_string_parameters"] == {
             "qs": "queryOverride"
         }
-        assert default_context.integration_request["headers"] == {
-            "header": "headerOverride",
-            "multivalue": ["1header", "2header"],
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        }
+        assert default_context.integration_request["headers"] == Headers(
+            {
+                "header": "headerOverride",
+                "multivalue": ["1header", "2header"],
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            }
+        )
 
     def test_request_override_casing(self, integration_request_handler, default_context):
         default_context.resource_method["methodIntegration"]["requestParameters"] = {
@@ -242,12 +249,14 @@ class TestHandlerIntegrationRequest:
         }
         integration_request_handler(default_context)
         # TODO: for now, it's up to the integration to properly merge headers (`requests` does it automatically)
-        assert default_context.integration_request["headers"] == {
-            "myHeader": "header2",
-            "myheader": "headerOverride",
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        }
+        assert default_context.integration_request["headers"] == Headers(
+            {
+                "myHeader": "header2",
+                "myheader": "headerOverride",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            }
+        )
 
     def test_multivalue_mapping(self, integration_request_handler, default_context):
         default_context.resource_method["methodIntegration"]["requestParameters"] = {

--- a/tests/unit/services/apigateway/test_handler_method_request.py
+++ b/tests/unit/services/apigateway/test_handler_method_request.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from werkzeug.datastructures import Headers
 
 from localstack.aws.api.apigateway import Method, Model, RequestValidator, RestApi
 from localstack.http import Request, Response
@@ -85,7 +86,7 @@ class TestMethodRequestHandler:
 
         # Invocation with no valid element
         dummy_context.invocation_request = InvocationRequest(
-            headers={}, query_string_parameters={}, path=""
+            headers=Headers(), query_string_parameters={}, path=""
         )
         with pytest.raises(BadRequestParametersError) as e:
             method_request_handler(dummy_context)

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -96,26 +96,13 @@ class TestParsingHandler:
         assert context.region == TEST_AWS_REGION_NAME
 
         assert context.invocation_request["http_method"] == "GET"
-        assert context.invocation_request["raw_headers"] == Headers(
+        assert context.invocation_request["headers"] == Headers(
             {
                 "host": host_header,
                 "test-header": "value1",
                 "test-header-multi": ["value2", "value3"],
-                "content-length": len(body),
             }
         )
-        assert context.invocation_request["headers"] == {
-            "host": host_header,
-            "test-header": "value1",
-            "test-header-multi": "value2",
-            "content-length": "11",
-        }
-        assert context.invocation_request["multi_value_headers"] == {
-            "host": [host_header],
-            "test-header": ["value1"],
-            "test-header-multi": ["value2", "value3"],
-            "content-length": ["11"],
-        }
         assert context.invocation_request["body"] == body
         assert (
             context.invocation_request["path"]

--- a/tests/unit/services/apigateway/test_parameters_mapping.py
+++ b/tests/unit/services/apigateway/test_parameters_mapping.py
@@ -45,7 +45,7 @@ def default_invocation_request() -> InvocationRequest:
     context = RestApiInvocationContext(
         Request(
             method=HTTPMethod.POST,
-            headers={"header_value": "test-header-value"},
+            headers=Headers({"header_value": "test-header-value"}),
             path=f"{TEST_API_STAGE}/test/test-path-value",
             query_string="qs_value=test-qs-value",
         )
@@ -336,14 +336,8 @@ class TestApigatewayRequestParametersMapping:
 
         headers = {"testMultiHeader": ["value1", "value2"], "testHeader": "value"}
 
-        default_invocation_request["raw_headers"] = Headers(headers)
+        default_invocation_request["headers"] = Headers(headers)
         # this is how AWS maps to the variables passed to proxy integration, it only picks the first of the multi values
-        default_invocation_request["headers"] = {"testMultiHeader": "value1", "testHeader": "value"}
-
-        default_invocation_request["multi_value_headers"] = {
-            "testMultiHeader": ["value1", "value2"],
-            "testHeader": ["value"],
-        }
 
         mapping = mapper.map_integration_request(
             request_parameters=request_parameters,
@@ -415,9 +409,7 @@ class TestApigatewayRequestParametersMapping:
         }
 
         request = InvocationRequest(
-            raw_headers=Headers(),
-            headers={},
-            multi_value_headers={},
+            headers=Headers(),
             query_string_parameters={},
             multi_value_query_string_parameters={},
             path_parameters={},
@@ -467,8 +459,8 @@ class TestApigatewayRequestParametersMapping:
         self, default_invocation_request, default_context_variables
     ):
         mapper = ParametersMapper()
-        default_invocation_request["raw_headers"].add("Content-Type", "application/xml")
-        default_invocation_request["raw_headers"].add("Accept", "application/xml")
+        default_invocation_request["headers"].add("Content-Type", "application/xml")
+        default_invocation_request["headers"].add("Accept", "application/xml")
 
         mapping = mapper.map_integration_request(
             request_parameters={},
@@ -494,8 +486,8 @@ class TestApigatewayRequestParametersMapping:
             "integration.request.header.Content-Type": "method.request.header.header_value",
             "integration.request.header.accept": "method.request.header.header_value",
         }
-        default_invocation_request["raw_headers"].add("Content-Type", "application/json")
-        default_invocation_request["raw_headers"].add("Accept", "application/json")
+        default_invocation_request["headers"].add("Content-Type", "application/json")
+        default_invocation_request["headers"].add("Accept", "application/json")
 
         mapping = mapper.map_integration_request(
             request_parameters=request_parameters,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

As discussed with @bentsku, to simplify the usage of headers through the invocation, we will only keep the Werzeug headers as part of the context. We were mostly using the `raw_headers` through the handlers anyway, so it makes sense to only keep them in the context.

This is also in preparation to a refactor that will move some of the duplicate code in the integration handlers to the integration request handler.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- `InvocationContext` gets rid of `raw_headers` and `multi_value_headers`. The value of header is what used to be known as `raw_headers`
- `IntegrationRequest` type for `headers` is now a Werkzeug `Headers`
- Various fixes through the handlers to fully support the new types

## TODO

- [x] Currently targeting #11226 to allow for ci-pipeline with Next Gen enabled. Rebase and target master once merge

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--

What's left to do:

- [ ] ...
- [ ] ...
-->
