### PR TITLE
fix SOURCES.txt by avoiding plux entrypoints command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,7 +172,7 @@ FROM base
 COPY --from=builder /opt/code/localstack/.venv /opt/code/localstack/.venv
 
 # add project files necessary to install all dependencies
-ADD Makefile pyproject.toml VERSION ./
+ADD Makefile pyproject.toml VERSION setup.py ./
 # add the localstack start scripts (necessary for the installation of the runtime dependencies, i.e. `pip install -e .`)
 ADD bin/localstack bin/localstack.bat bin/localstack-supervisor bin/
 

--- a/Dockerfile.s3
+++ b/Dockerfile.s3
@@ -77,7 +77,7 @@ FROM base
 COPY --from=builder /opt/code/localstack/.venv /opt/code/localstack/.venv
 
 # add project files necessary to install all dependencies
-ADD Makefile pyproject.toml VERSION requirements-base-runtime.txt ./
+ADD Makefile pyproject.toml VERSION requirements-base-runtime.txt setup.py ./
 # add the localstack start scripts (necessary for the installation of the runtime dependencies, i.e. `pip install -e .`)
 ADD bin/localstack bin/localstack.bat bin/localstack-supervisor bin/
 

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ install-s3: venv     ## Install dependencies for the localstack runtime for s3-o
 install: install-dev entrypoints  ## Install full dependencies into venv
 
 entrypoints:              ## Run plux to build entry points
-	$(VENV_RUN); python -m plux entrypoints
+	$(VENV_RUN); python3 -m setup plugins egg_info
 	@# make sure that the entrypoints were correctly created and are non-empty
 	@test -s localstack-core/localstack_core.egg-info/entry_points.txt || (echo "Entrypoints were not correctly created! Aborting!" && exit 1)
 


### PR DESCRIPTION
## Motivation
We recently switched to namespace packages in this repo (with https://github.com/localstack/localstack/pull/11190) as well as in downstream repos, and we are currently trying to upgrade the CLI according to the new import paths with https://github.com/localstack/localstack-cli/pull/27.
During this upgrade, we stumbled upon an issue with the generated `SOURCES.txt` containing an absolute path (which kills the Windows PyInstaller build of the CLI), and could potentially impact Windows users installing the python package with the CLI install.
It turns out that this issue is somehow caused by `plux entrypoints`. More info can be found in https://github.com/localstack/plux/issues/23.

## Changes
- Temporarily replaces `plux entrypoints` with `setup plugins egg_info` to avoid the absolute path in `SOURCES.txt`.

## Testing
- See https://github.com/localstack/plux/issues/23 for more infos on how to reproduce the issue / test the fix.
