### PR TITLE
Fix: Set ci logs to default value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,7 +230,7 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
-log_cli = true
+log_cli = false
 log_level = "DEBUG"
 log_cli_format = "%(asctime)s.%(msecs)03d %(levelname)5s --- [%(threadName)12s] %(name)-26s : %(message)s"
 log_cli_date_format = "%Y-%m-%dT%H:%M:%S"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR: https://github.com/localstack/localstack/pull/10890 wrongly sets the default value for `log_cli` to true, as discussed we want to keep ci logs cleaner this is why the decision has been made to set the default value to false, which is fix with the current PR.
