### PR TITLE
Bump moto-ext to 5.0.11.post1

### DIFF
--- a/localstack-core/localstack/services/events/v1/provider.py
+++ b/localstack-core/localstack/services/events/v1/provider.py
@@ -551,10 +551,9 @@ def events_handler_put_events(self):
         targets = []
         for rule in matching_rules:
             if filter_event_based_on_event_format(self, rule.name, event_bus_name, formatted_event):
-                rule_targets = self.events_backend.list_targets_by_rule(
+                rule_targets, _ = self.events_backend.list_targets_by_rule(
                     rule.name, event_bus_arn(event_bus_name, self.current_account, self.region)
-                ).get("Targets", [])
-
+                )
                 targets.extend([{"RuleArn": rule.arn} | target for target in rule_targets])
         # process event
         process_events(formatted_event, targets)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.10.post1",
+    "moto-ext[all]==5.0.11.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -245,7 +245,7 @@ markupsafe==2.1.5
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-moto-ext==5.0.10.post1
+moto-ext==5.0.11.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -182,7 +182,7 @@ markupsafe==2.1.5
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-moto-ext==5.0.10.post1
+moto-ext==5.0.11.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -229,7 +229,7 @@ markupsafe==2.1.5
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-moto-ext==5.0.10.post1
+moto-ext==5.0.11.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -249,7 +249,7 @@ markupsafe==2.1.5
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-moto-ext==5.0.10.post1
+moto-ext==5.0.11.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.0.11.post1

Contains:

- https://github.com/getmoto/moto/pull/7831 (closes https://github.com/localstack/localstack/issues/8985)

## To do

- [x] Ext integration tests https://github.com/localstack/localstack-ext/actions/runs/10004232192
- [x] Randomised account ID and region run https://app.circleci.com/pipelines/github/localstack/localstack/26885/workflows/d76ff6ac-2bc6-44cf-8c49-a7f9e42a3f6a