### PR TITLE
APIGW NG Refactor IntegrationRequest for Proxy Integration

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -36,7 +36,6 @@ from ..header_utils import build_multi_value_headers
 from ..helpers import (
     get_lambda_function_arn_from_invocation_uri,
     get_source_arn,
-    render_integration_uri,
     render_uri_with_stage_variables,
     validate_sub_dict_of_typed_dict,
 )
@@ -335,30 +334,24 @@ class RestApiAwsProxyIntegration(RestApiIntegration):
     name = "AWS_PROXY"
 
     def invoke(self, context: RestApiInvocationContext) -> EndpointResponse:
-        invocation_req: InvocationRequest = context.invocation_request
         integration: Integration = context.resource_method["methodIntegration"]
-        # if the integration method is defined and is not ANY, we can use it for the integration
-        if not (method := integration["httpMethod"]) or method == "ANY":
-            # otherwise, fallback to the request's method
-            method = invocation_req["http_method"]
+
+        integration_req: IntegrationRequest = context.integration_request
+        method = integration_req["http_method"]
 
         if method != HTTPMethod.POST:
             raise IntegrationFailureError("Internal server error")
 
         input_event = self.create_lambda_input_event(context)
 
-        # TODO: verify path/stage variables rendering in AWS_PROXY
-        integration_uri = render_integration_uri(
-            integration["uri"],
-            path_parameters=invocation_req["path_parameters"],
-            stage_variables=context.stage_variables,
-        )
+        # TODO: verify stage variables rendering in AWS_PROXY
+        integration_uri = integration_req["uri"]
 
         function_arn = get_lambda_function_arn_from_invocation_uri(integration_uri)
         source_arn = get_source_arn(context)
         # TODO: properly get the value out/validate it?
-        raw_headers = context.invocation_request["headers"]
-        is_invocation_asynchronous = raw_headers.get("X-Amz-Invocation-Type") == "'Event'"
+        headers = integration_req["headers"]
+        is_invocation_asynchronous = headers.get("X-Amz-Invocation-Type") == "'Event'"
 
         # TODO: write test for credentials rendering
         if credentials := integration.get("credentials"):
@@ -495,20 +488,24 @@ class RestApiAwsProxyIntegration(RestApiIntegration):
 
     def create_lambda_input_event(self, context: RestApiInvocationContext) -> LambdaInputEvent:
         # https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+        # for building the Lambda Payload, we need access to the Invocation Request, as some data is not available in
+        # the integration request and does not make sense for it
         invocation_req: InvocationRequest = context.invocation_request
+        integration_req: IntegrationRequest = context.integration_request
 
         # TODO: binary support of APIGW
-        body, is_b64_encoded = self._format_body(invocation_req["body"])
+        body, is_b64_encoded = self._format_body(integration_req["body"])
 
         input_event = LambdaInputEvent(
-            headers=self._format_headers(dict(invocation_req["headers"])),
+            headers=self._format_headers(dict(integration_req["headers"])),
             multiValueHeaders=self._format_headers(
-                build_multi_value_headers(invocation_req["headers"])
+                build_multi_value_headers(integration_req["headers"])
             ),
             body=body or None,
             isBase64Encoded=is_b64_encoded,
             requestContext=context.context_variables,
             stageVariables=context.stage_variables,
+            # still using the InvocationRequest query string parameters as the logic is the same, maybe refactor?
             queryStringParameters=invocation_req["query_string_parameters"] or None,
             multiValueQueryStringParameters=invocation_req["multi_value_query_string_parameters"]
             or None,
@@ -525,10 +522,10 @@ class RestApiAwsProxyIntegration(RestApiIntegration):
         # Some headers get capitalized like in CloudFront, see
         # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html#add-origin-custom-headers-forward-authorization
         # It seems AWS_PROXY lambda integrations are behind CloudFront, as seen by the returned headers in AWS
-        to_capitalize: list[str] = ["authorization"]  # some headers get capitalized
+        to_capitalize: list[str] = ["authorization", "user-agent"]  # some headers get capitalized
         to_filter: list[str] = ["content-length", "connection"]
         headers = {
-            k.capitalize() if k.lower() in to_capitalize else k: v
+            k.title() if k.lower() in to_capitalize else k: v
             for k, v in headers.items()
             if k.lower() not in to_filter
         }

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
@@ -10,7 +10,6 @@ import json
 import logging
 from typing import TypedDict
 
-from localstack.constants import APPLICATION_JSON
 from localstack.utils.json import extract_jsonpath
 from localstack.utils.strings import to_str
 
@@ -49,11 +48,6 @@ class ParametersMapper:
             path={},
             querystring={},
         )
-
-        # default values, can be overridden with right casing
-        for header in ("Content-Type", "Accept"):
-            request_data_mapping["header"][header] = APPLICATION_JSON
-
         # storing the case-sensitive headers once, the mapping is strict
         case_sensitive_headers = build_multi_value_headers(invocation_request["headers"])
 

--- a/tests/aws/services/apigateway/test_apigateway_http.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_http.snapshot.json
@@ -250,5 +250,54 @@
         "path": "/"
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_http.py::test_http_proxy_integration_request_data_mappings": {
+    "recorded-date": "18-07-2024, 13:59:19",
+    "recorded-content": {
+      "api_id": {
+        "rest_api_id": "<rest_api_id:1>"
+      },
+      "http-proxy-invocation": {
+        "content": {
+          "args": {
+            "queryString": "foo",
+            "testQs": "bar,foo",
+            "testQueryString": "foo",
+            "testVar": "foobar,bar"
+          },
+          "data": {
+            "message": "hello world"
+          },
+          "domain": "<domain:1>",
+          "headers": {
+            "accept": "application/json",
+            "accept-encoding": "gzip, deflate",
+            "content-length": "26",
+            "content-type": "application/json",
+            "foobar": "mapped-value",
+            "headervar": "mapped-value",
+            "host": "<domain:1>",
+            "user-agent": "test/integration"
+          },
+          "method": "POST",
+          "origin": "<origin:1>",
+          "path": "/"
+        },
+        "headers": {
+          "connection": "keep-alive",
+          "content-length": "<content_length:1>",
+          "content-type": "application/json",
+          "date": "<date:1>",
+          "x-amz-apigw-id": "<x-amz-apigw-id:1>",
+          "x-amzn-remapped-connection": "keep-alive",
+          "x-amzn-remapped-content-length": "<content_length:1>",
+          "x-amzn-remapped-date": "<date>",
+          "x-amzn-remapped-x-amzn-requestid": "<uuid:1>",
+          "x-amzn-requestid": "<x-amzn-requestid:1>",
+          "x-amzn-trace-id": "<x-amzn-trace-id:1>"
+        },
+        "status_code": 200
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_http.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_http.validation.json
@@ -16,5 +16,8 @@
   },
   "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_with_lambda[HTTP_PROXY]": {
     "last_validated_date": "2024-07-12T20:28:06+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_http.py::test_http_proxy_integration_request_data_mappings": {
+    "last_validated_date": "2024-07-18T13:59:19+00:00"
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1092,5 +1092,156 @@
         "message": "Internal server error"
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration_request_data_mapping": {
+    "recorded-date": "18-07-2024, 15:01:27",
+    "recorded-content": {
+      "api_id": {
+        "rest_api_id": "<rest_api_id:1>"
+      },
+      "http-proxy-invocation-data-mapping": {
+        "content": {
+          "body": {
+            "message": "hello world"
+          },
+          "headers": {
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip, deflate",
+            "CloudFront-Forwarded-Proto": "https",
+            "CloudFront-Is-Desktop-Viewer": "true",
+            "CloudFront-Is-Mobile-Viewer": "false",
+            "CloudFront-Is-SmartTV-Viewer": "false",
+            "CloudFront-Is-Tablet-Viewer": "false",
+            "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
+            "CloudFront-Viewer-Country": "<cloudfront-country:1>",
+            "Content-Type": "application/json",
+            "Host": "<host:1>",
+            "User-Agent": "test/integration",
+            "Via": "<via:1>",
+            "X-Amz-Cf-Id": "<cf-id:1>",
+            "X-Amzn-Trace-Id": "<trace-id:1>",
+            "X-Forwarded-For": "<source-ip:1>, <ip>",
+            "X-Forwarded-Port": "443",
+            "X-Forwarded-Proto": "https",
+            "foobar": "mapped-value",
+            "headerVar": "request-value"
+          },
+          "httpMethod": "POST",
+          "isBase64Encoded": false,
+          "multiValueHeaders": {
+            "Accept": [
+              "application/json"
+            ],
+            "Accept-Encoding": [
+              "gzip, deflate"
+            ],
+            "CloudFront-Forwarded-Proto": [
+              "https"
+            ],
+            "CloudFront-Is-Desktop-Viewer": [
+              "true"
+            ],
+            "CloudFront-Is-Mobile-Viewer": [
+              "false"
+            ],
+            "CloudFront-Is-SmartTV-Viewer": [
+              "false"
+            ],
+            "CloudFront-Is-Tablet-Viewer": [
+              "false"
+            ],
+            "CloudFront-Viewer-ASN": [
+              "<cloudfront-asn:1>"
+            ],
+            "CloudFront-Viewer-Country": [
+              "<cloudfront-country:1>"
+            ],
+            "Content-Type": [
+              "application/json"
+            ],
+            "Host": [
+              "<host:1>"
+            ],
+            "User-Agent": [
+              "test/integration"
+            ],
+            "Via": [
+              "<via:1>"
+            ],
+            "X-Amz-Cf-Id": [
+              "<cf-id:1>"
+            ],
+            "X-Amzn-Trace-Id": [
+              "<trace-id:1>"
+            ],
+            "X-Forwarded-For": [
+              "<source-ip:1>, <ip>"
+            ],
+            "X-Forwarded-Port": [
+              "443"
+            ],
+            "X-Forwarded-Proto": [
+              "https"
+            ],
+            "foobar": [
+              "mapped-value"
+            ],
+            "headerVar": [
+              "request-value"
+            ]
+          },
+          "multiValueQueryStringParameters": {
+            "testQueryString": [
+              "foo"
+            ],
+            "testVar": [
+              "bar"
+            ]
+          },
+          "path": "/foobar",
+          "pathParameters": {
+            "pathVariable": "foobar"
+          },
+          "queryStringParameters": {
+            "testQueryString": "foo",
+            "testVar": "bar"
+          },
+          "requestContext": {
+            "accountId": "111111111111",
+            "apiId": "<rest_api_id:1>",
+            "deploymentId": "<deployment-id:1>",
+            "domainName": "<host:1>",
+            "domainPrefix": "<rest_api_id:1>",
+            "extendedRequestId": "<extended-request-id:1>",
+            "httpMethod": "POST",
+            "identity": {
+              "accessKey": null,
+              "accountId": null,
+              "caller": null,
+              "cognitoAuthenticationProvider": null,
+              "cognitoAuthenticationType": null,
+              "cognitoIdentityId": null,
+              "cognitoIdentityPoolId": null,
+              "principalOrgId": null,
+              "sourceIp": "<source-ip:1>",
+              "user": null,
+              "userAgent": "test/integration",
+              "userArn": null
+            },
+            "path": "/test/foobar",
+            "protocol": "HTTP/1.1",
+            "requestId": "<uuid:1>",
+            "requestTime": "<request-time>",
+            "requestTimeEpoch": "<request-time-epoch>",
+            "resourceId": "<resource-id:1>",
+            "resourcePath": "/{pathVariable}",
+            "stage": "test"
+          },
+          "resource": "/{pathVariable}",
+          "stageVariables": null
+        },
+        "status_code": 200
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -14,6 +14,9 @@
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration_non_post_method": {
     "last_validated_date": "2024-07-10T15:43:36+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration_request_data_mapping": {
+    "last_validated_date": "2024-07-18T15:01:27+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_response_format": {
     "last_validated_date": "2024-02-23T18:39:48+00:00"
   },

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -1204,7 +1204,7 @@ class TestLambdaURL:
             snapshot.add_transformer(snapshot.transform.key_value(key))
         echo_url = create_echo_http_server()
         response = requests.post(
-            url=echo_url + "/path/1?q=query",
+            url=echo_url + "/pa2%Fth/1?q=query&multiQuery=foo&multiQuery=%2Fbar",
             headers={
                 "content-type": "application/json",
                 "ExTrA-HeadErs": "With WeiRd CapS",

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4093,10 +4093,11 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_echo_http_fixture_default": {
-    "recorded-date": "08-04-2024, 16:57:31",
+    "recorded-date": "18-07-2024, 14:18:08",
     "recorded-content": {
       "url_response": {
         "args": {
+          "multiQuery": "foo,/bar",
           "q": "query"
         },
         "data": {
@@ -4120,7 +4121,7 @@
         },
         "method": "POST",
         "origin": "<origin:1>",
-        "path": "/path/1"
+        "path": "/pa2%Fth/1"
       }
     }
   },

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -189,7 +189,7 @@
     "last_validated_date": "2024-03-28T22:20:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_echo_http_fixture_default": {
-    "last_validated_date": "2024-04-08T16:57:30+00:00"
+    "last_validated_date": "2024-07-18T14:18:07+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_echo_http_fixture_trim_x_headers": {
     "last_validated_date": "2024-04-08T16:57:34+00:00"

--- a/tests/unit/services/apigateway/test_parameters_mapping.py
+++ b/tests/unit/services/apigateway/test_parameters_mapping.py
@@ -86,8 +86,6 @@ class TestApigatewayRequestParametersMapping:
 
         assert mapping == {
             "header": {
-                "Accept": "application/json",
-                "Content-Type": "application/json",
                 "test": "test-qs-value",
             },
             "path": {"test": "test-header-value"},
@@ -110,8 +108,6 @@ class TestApigatewayRequestParametersMapping:
         assert mapping == {
             "header": {
                 "api_id": TEST_API_ID,
-                "Accept": "application/json",
-                "Content-Type": "application/json",
             },
             "path": {},
             "querystring": {},
@@ -134,8 +130,6 @@ class TestApigatewayRequestParametersMapping:
         assert mapping == {
             "header": {
                 "my_api_key": TEST_IDENTITY_API_KEY,
-                "Accept": "application/json",
-                "Content-Type": "application/json",
             },
             "path": {},
             "querystring": {"userAgent": TEST_USER_AGENT},
@@ -157,8 +151,6 @@ class TestApigatewayRequestParametersMapping:
         assert mapping == {
             "header": {
                 "my_stage_var": "a stage variable",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
             },
             "path": {},
             "querystring": {},
@@ -181,8 +173,6 @@ class TestApigatewayRequestParametersMapping:
         assert mapping == {
             "header": {
                 "body_value": "<This is a body value>",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
             },
             "path": {},
             "querystring": {},
@@ -207,8 +197,6 @@ class TestApigatewayRequestParametersMapping:
         assert mapping == {
             "header": {
                 "body_value": "{}",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
             },
             "path": {},
             "querystring": {},
@@ -243,8 +231,6 @@ class TestApigatewayRequestParametersMapping:
         assert mapping == {
             "header": {
                 "body_value": "nested pet name value",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
             },
             "path": {},
             "querystring": {},
@@ -279,10 +265,7 @@ class TestApigatewayRequestParametersMapping:
         )
 
         assert mapping == {
-            "header": {
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
+            "header": {},
             "path": {},
             "querystring": {},
         }
@@ -353,8 +336,6 @@ class TestApigatewayRequestParametersMapping:
                 "test": "value2",
                 "test_multi": "value1,value2",
                 "test_multi_solo": "value",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
             },
             "path": {},
             "querystring": {},
@@ -388,10 +369,7 @@ class TestApigatewayRequestParametersMapping:
         # it seems the mapping picks the last value of the multivalues, but the `headers` part of the context picks the
         # first one
         assert mapping == {
-            "header": {
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
+            "header": {},
             "path": {},
             "querystring": {
                 "test": "value2",
@@ -423,10 +401,7 @@ class TestApigatewayRequestParametersMapping:
         )
 
         assert mapping == {
-            "header": {
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
+            "header": {},
             "path": {},
             "querystring": {},
         }
@@ -447,33 +422,7 @@ class TestApigatewayRequestParametersMapping:
         )
 
         assert mapping == {
-            "header": {
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
-            "path": {},
-            "querystring": {},
-        }
-
-    def test_default_values_headers_request_mapping(
-        self, default_invocation_request, default_context_variables
-    ):
-        mapper = ParametersMapper()
-        default_invocation_request["headers"].add("Content-Type", "application/xml")
-        default_invocation_request["headers"].add("Accept", "application/xml")
-
-        mapping = mapper.map_integration_request(
-            request_parameters={},
-            invocation_request=default_invocation_request,
-            context_variables=default_context_variables,
-            stage_variables={},
-        )
-
-        assert mapping == {
-            "header": {
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-            },
+            "header": {},
             "path": {},
             "querystring": {},
         }
@@ -498,7 +447,6 @@ class TestApigatewayRequestParametersMapping:
         assert mapping == {
             "header": {
                 "Content-Type": "test-header-value",
-                "Accept": "application/json",
                 "accept": "test-header-value",
             },
             "path": {},


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
~This PR is based on #11227 and #11226.~

As part of the header remapping work, it has been shown by @cloutierMat that `HTTP_PROXY` integration still supported Request Parameters Mappings, which isn't exactly documented.

To properly support this (and also Private API in the future), it made sense to always create an `IntegrationRequest` object to attach to the context so that the PROXY integration can use it: they don't need to render their own URI. 

I've also sneaked a little fix to a bug put into light by our tests: Lambda URL did not support multi value query string parameters. I've simplified the logic there and also wrote a specific test for it. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- refactor IntegrationRequest handler to always create an IntegrationRequest and attach it to the context
- refactor `AWS_PROXY` and especially `HTTP_PROXY` to make use of the new IntegrationRequest (AWS_PROXY still needs the Invocation Request, as it needs quite a lot of the original request data)
- fixed Lambda URL multi value query string

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
