### PR TITLE
Fix: CFn security group id

### DIFF
--- a/localstack-core/localstack/services/ec2/resource_providers/aws_ec2_securitygroup.py
+++ b/localstack-core/localstack/services/ec2/resource_providers/aws_ec2_securitygroup.py
@@ -107,7 +107,16 @@ class EC2SecurityGroupProvider(ResourceProvider[EC2SecurityGroupProperties]):
 
         response = ec2.create_security_group(**params)
         model["GroupId"] = response["GroupId"]
-        model["Id"] = response["GroupId"]
+
+        # When you pass the logical ID of this resource to the intrinsic Ref function,
+        # Ref returns the ID of the security group if you specified the VpcId property.
+        # Otherwise, it returns the name of the security group.
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-securitygroup.html#aws-resource-ec2-securitygroup-return-values-ref
+        if "VpcId" in model:
+            model["Id"] = response["GroupId"]
+        else:
+            model["Id"] = params["GroupName"]
+
         return ProgressEvent(
             status=OperationStatus.SUCCESS,
             resource_model=model,

--- a/tests/aws/services/cloudformation/resources/test_ec2.py
+++ b/tests/aws/services/cloudformation/resources/test_ec2.py
@@ -289,7 +289,6 @@ def test_cfn_update_ec2_instance_type(deploy_cfn_template, aws_client, cleanups)
 
 
 @markers.aws.validated
-@pytest.mark.skip(reason="WIP")
 def test_ec2_security_group_id_with_vpc(deploy_cfn_template, snapshot, aws_client):
     stack = deploy_cfn_template(
         template_path=os.path.join(

--- a/tests/aws/services/cloudformation/resources/test_ec2.py
+++ b/tests/aws/services/cloudformation/resources/test_ec2.py
@@ -286,3 +286,44 @@ def test_cfn_update_ec2_instance_type(deploy_cfn_template, aws_client, cleanups)
         "Instances"
     ][0]
     assert instance["InstanceType"] == "t2.medium"
+
+
+@markers.aws.validated
+@pytest.mark.skip(reason="WIP")
+def test_ec2_security_group_id_with_vpc(deploy_cfn_template, snapshot, aws_client):
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/ec2_vpc_securitygroup.yml"
+        ),
+    )
+
+    ec2_client = aws_client.ec2
+    with_vpcid_sg_group_id = ec2_client.describe_security_groups(
+        Filters=[
+            {
+                "Name": "group-id",
+                "Values": [stack.outputs["SGWithVpcIdGroupId"]],
+            },
+        ]
+    )["SecurityGroups"][0]
+    without_vpcid_sg_group_id = ec2_client.describe_security_groups(
+        Filters=[
+            {
+                "Name": "group-id",
+                "Values": [stack.outputs["SGWithoutVpcIdGroupId"]],
+            },
+        ]
+    )["SecurityGroups"][0]
+
+    snapshot.add_transformer(
+        snapshot.transform.regex(with_vpcid_sg_group_id["GroupId"], "<with-vpcid-group-id>")
+    )
+    snapshot.add_transformer(
+        snapshot.transform.regex(without_vpcid_sg_group_id["GroupId"], "<without-vpcid-group-id>")
+    )
+    snapshot.add_transformer(
+        snapshot.transform.regex(
+            without_vpcid_sg_group_id["GroupName"], "<without-vpcid-group-name>"
+        )
+    )
+    snapshot.match("references", stack.outputs)

--- a/tests/aws/services/cloudformation/resources/test_ec2.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.snapshot.json
@@ -276,5 +276,16 @@
         "VpcId": "<vpc-id:1>"
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_ec2.py::test_ec2_security_group_id_with_vpc": {
+    "recorded-date": "19-07-2024, 15:53:16",
+    "recorded-content": {
+      "references": {
+        "SGWithVpcIdGroupId": "<with-vpcid-group-id>",
+        "SGWithVpcIdRef": "<with-vpcid-group-id>",
+        "SGWithoutVpcIdGroupId": "<without-vpcid-group-id>",
+        "SGWithoutVpcIdRef": "<without-vpcid-group-name>"
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_ec2.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.validation.json
@@ -8,6 +8,9 @@
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_dhcp_options": {
     "last_validated_date": "2023-10-19T12:51:28+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_ec2.py::test_ec2_security_group_id_with_vpc": {
+    "last_validated_date": "2024-07-19T15:53:16+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_internet_gateway_ref_and_attr": {
     "last_validated_date": "2023-02-13T16:13:41+00:00"
   },

--- a/tests/aws/templates/ec2_vpc_securitygroup.yml
+++ b/tests/aws/templates/ec2_vpc_securitygroup.yml
@@ -1,0 +1,35 @@
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/24
+
+  SecurityGroupWithoutVpc:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Group without assigned VPC
+
+  SecurityGroupWithVpc:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Group with assigned VPC
+      VpcId:
+        Ref: Vpc
+
+Outputs:
+  SGWithoutVpcIdRef:
+    Value:
+      Ref: SecurityGroupWithoutVpc
+  SGWithVpcIdRef:
+    Value:
+      Ref: SecurityGroupWithVpc
+  SGWithoutVpcIdGroupId:
+    Value:
+      Fn::GetAtt:
+        - SecurityGroupWithoutVpc
+        - GroupId
+  SGWithVpcIdGroupId:
+    Value:
+      Fn::GetAtt:
+        - SecurityGroupWithVpc
+        - GroupId


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

As described in AWS documentation:

> When you pass the logical ID of this resource to the intrinsic Ref function, Ref returns the ID of the security group if you specified the VpcId property. Otherwise, it returns the name of the security group. If you omit the VpcId property and need the ID of the VPC, use Fn::GetAtt instead.

[source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-securitygroup.html#aws-resource-ec2-securitygroup-return-values-ref)

Closes #11120

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Implement different behaviour as described in the above quote.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
