### PR TITLE
fix typing of kwargs for lambda URL router

### DIFF
--- a/localstack-core/localstack/services/lambda_/urlrouter.py
+++ b/localstack-core/localstack/services/lambda_/urlrouter.py
@@ -54,7 +54,11 @@ class FunctionUrlRouter:
         )
 
     def handle_lambda_url_invocation(
-        self, request: Request, api_id: str, region: str, **url_params: dict[str, str]
+        self,
+        request: Request,
+        api_id: str,
+        region: str,
+        **url_params: str,
     ) -> Response:
         response = Response()
         response.mimetype = "application/json"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The Lambda URL router typing had a small issue with `kwargs`, where it was using a mapping for it instead of one type (we could also use a `TypedDict` with `Unpack`, see https://typing.readthedocs.io/en/latest/spec/callables.html#unpack-kwargs). 

See also the discussion here: https://github.com/localstack/localstack/pull/11069#discussion_r1650648611 and the related Python PEP484: https://peps.python.org/pep-0484/#arbitrary-argument-lists-and-default-argument-values

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- modify the typing used to the `kwargs` argument 


(This is related to https://github.com/localstack/localstack/pull/11245#issuecomment-2244657232) 
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
