### PR TITLE
fix flaky test_edge.py by explicitly waiting for proxy

### DIFF
--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -29,6 +29,7 @@ def test_edge_tcp_proxy(httpserver):
         target_address=gateway_listen[0],
         asynchronous=True,
     )
+    proxy_server.wait_is_up()
 
     # Check that the forwarding works correctly
     try:
@@ -51,6 +52,7 @@ def test_edge_tcp_proxy_does_not_terminate_on_connection_error():
         asynchronous=True,
     )
     try:
+        proxy_server.wait_is_up()
         # Start the proxy server and send a request (which is proxied towards a non-bound port)
         with pytest.raises(requests.exceptions.ConnectionError):
             requests.get(f"http://localhost:{port}")


### PR DESCRIPTION
## Motivation
One of the unit test modules is a bit flaky sometimes: `test_edge.py`
One of the tests in the module for example [failed in this run](https://app.circleci.com/pipelines/github/localstack/localstack/26926/workflows/6adbf07e-ef0e-4857-aed3-ca7f2fc9e56c/jobs/230023).
I suspect that this is caused by a race condition: The proxy server might not be up when the connection is being established.
This PR tries to fix this by explicitly waiting for the proxy to be up before trying to establish a connection.

## Changes
- Use `wait_is_up` on proxy server before trying to establish a connection to address potential race condition / flakiness.