### PR TITLE
APIGW NG fix _user_request_ format parsing

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -70,10 +70,11 @@ class InvocationRequestParser(RestApiGatewayHandler):
         # if the request comes from the LocalStack only `_user_request_` route, we need to remove this prefix from the
         # path, in order to properly route the request
         if "_user_request_" in raw_uri:
+            # in this format, the stage is before `_user_request_`, so we don't need to remove it
             raw_uri = raw_uri.partition("_user_request_")[2]
-
-        # remove the stage from the path, only replace the first occurrence
-        raw_uri = raw_uri.replace(f"/{stage_name}", "", 1)
+        else:
+            # remove the stage from the path, only replace the first occurrence
+            raw_uri = raw_uri.replace(f"/{stage_name}", "", 1)
 
         if raw_uri.startswith("//"):
             # TODO: AWS validate this assumption

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -138,8 +138,8 @@ class TestParsingHandler:
         # simulate a path request
         request = Request(
             "GET",
-            path=f"/restapis/{TEST_API_ID}/_user_request_/{TEST_API_STAGE}/foo/bar/ed",
-            raw_path=f"/restapis/{TEST_API_ID}/_user_request_/{TEST_API_STAGE}//foo%2Fbar/ed",
+            path=f"/restapis/{TEST_API_ID}/{TEST_API_STAGE}/_user_request_/foo/bar/ed",
+            raw_path=f"/restapis/{TEST_API_ID}/{TEST_API_STAGE}/_user_request_//foo%2Fbar/ed",
         )
 
         context = get_invocation_context(request)

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -151,6 +151,28 @@ class TestParsingHandler:
         assert context.invocation_request["path"] == "/foo%2Fbar/ed"
         assert context.invocation_request["raw_path"] == "//foo%2Fbar/ed"
 
+    @pytest.mark.parametrize("addressing", ["host", "user_request"])
+    def test_parse_path_same_as_stage(
+        self, dummy_deployment, parse_handler_chain, get_invocation_context, addressing
+    ):
+        path = TEST_API_STAGE
+        if addressing == "host":
+            full_path = f"/{TEST_API_STAGE}/{path}"
+        else:
+            full_path = f"/restapis/{TEST_API_ID}/{TEST_API_STAGE}/_user_request_/{path}"
+
+        # simulate a path request
+        request = Request("GET", path=full_path)
+
+        context = get_invocation_context(request)
+        context.deployment = dummy_deployment
+
+        parse_handler_chain.handle(context, Response())
+
+        # assert that the user request prefix has been stripped off
+        assert context.invocation_request["path"] == f"/{TEST_API_STAGE}"
+        assert context.invocation_request["raw_path"] == f"/{TEST_API_STAGE}"
+
 
 class TestRoutingHandler:
     @pytest.fixture
@@ -288,7 +310,7 @@ class TestRoutingHandler:
         if addressing == "host":
             return f"/{TEST_API_STAGE}{path}"
         else:
-            return f"/restapis/{TEST_API_ID}/_user_request_/{TEST_API_STAGE}{path}"
+            return f"/restapis/{TEST_API_ID}/{TEST_API_STAGE}/_user_request_/{path}"
 
     @pytest.mark.parametrize("addressing", ["host", "user_request"])
     def test_route_request_no_param(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While implement more changes, I've spotted an issue with the `_user_request_` format style, there was a bad assumption from my side that the stage was before the path, but for some reason the format is very different. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix removing the stage from the path when using `_user_request_` style format

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
