### PR TITLE
APIGW NG add routing exceptions

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
@@ -149,6 +149,11 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
         selection_value: str, integration_responses: dict[str, IntegrationResponse]
     ) -> IntegrationResponse:
         if not integration_responses:
+            LOG.warning(
+                "Configuration error: No match for output mapping and no default output mapping configured. "
+                "Endpoint Response Status Code: %s",
+                selection_value,
+            )
             raise ApiConfigurationError("Internal server error")
 
         if select_by_pattern := [

--- a/localstack-core/localstack/services/apigateway/next_gen/provider.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/provider.py
@@ -107,6 +107,7 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
         tracing_enabled: NullableBoolean = None,
         **kwargs,
     ) -> Deployment:
+        # TODO: if the REST API does not contain any method, we should raise an exception
         deployment: Deployment = call_moto(context)
         # https://docs.aws.amazon.com/apigateway/latest/developerguide/updating-api.html
         # TODO: the deployment is not accessible until it is linked to a stage

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -1111,7 +1111,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApigatewayRouting::test_routing_not_found": {
-    "recorded-date": "23-07-2024, 17:26:25",
+    "recorded-date": "23-07-2024, 17:41:58",
     "recorded-content": {
       "working-route": {
         "message": "exists",

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -1109,5 +1109,26 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApigatewayRouting::test_routing_not_found": {
+    "recorded-date": "23-07-2024, 17:26:25",
+    "recorded-content": {
+      "working-route": {
+        "message": "exists",
+        "statusCode": 200
+      },
+      "not-found": {
+        "content": {
+          "message": "Missing Authentication Token"
+        },
+        "errorType": "MissingAuthenticationTokenException"
+      },
+      "wrong-method": {
+        "content": {
+          "message": "Missing Authentication Token"
+        },
+        "errorType": "MissingAuthenticationTokenException"
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -5,14 +5,14 @@
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_integration_request_parameters_mapping": {
     "last_validated_date": "2024-02-05T19:37:03+00:00"
   },
-  "tests/aws/services/apigateway/test_apigateway_common.py::TestApigatewayRouting::test_proxy_routing_not_found": {
-    "last_validated_date": "2024-07-23T17:14:36+00:00"
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApigatewayRouting::test_proxy_routing_with_hardcoded_resource_sibling": {
+    "last_validated_date": "2024-07-23T17:41:36+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApigatewayRouting::test_routing_not_found": {
-    "last_validated_date": "2024-07-23T17:26:25+00:00"
+    "last_validated_date": "2024-07-23T17:41:58+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApigatewayRouting::test_routing_with_hardcoded_resource_sibling_order": {
-    "last_validated_date": "2024-02-24T23:51:00+00:00"
+    "last_validated_date": "2024-07-23T17:41:43+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestDeployments::test_create_delete_deployments[False]": {
     "last_validated_date": "2023-09-07T17:20:47+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -5,6 +5,12 @@
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_integration_request_parameters_mapping": {
     "last_validated_date": "2024-02-05T19:37:03+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApigatewayRouting::test_proxy_routing_not_found": {
+    "last_validated_date": "2024-07-23T17:14:36+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApigatewayRouting::test_routing_not_found": {
+    "last_validated_date": "2024-07-23T17:26:25+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApigatewayRouting::test_routing_with_hardcoded_resource_sibling_order": {
     "last_validated_date": "2024-02-24T23:51:00+00:00"
   },

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -7,6 +7,9 @@ from localstack.http import Request, Response
 from localstack.services.apigateway.models import RestApiContainer
 from localstack.services.apigateway.next_gen.execute_api.api import RestApiGatewayHandlerChain
 from localstack.services.apigateway.next_gen.execute_api.context import RestApiInvocationContext
+from localstack.services.apigateway.next_gen.execute_api.gateway_response import (
+    MissingAuthTokenError,
+)
 from localstack.services.apigateway.next_gen.execute_api.handlers.parse import (
     InvocationRequestParser,
 )
@@ -414,7 +417,7 @@ class TestRoutingHandler:
         parse_handler_chain.handle(context, Response())
         # manually invoking the handler here as exceptions would be swallowed by the chain
         handler = InvocationRequestRouter()
-        with pytest.raises(Exception, match="Not found"):
+        with pytest.raises(MissingAuthTokenError):
             handler(parse_handler_chain, context, Response())
 
     @pytest.mark.parametrize("addressing", ["host", "user_request"])
@@ -432,7 +435,7 @@ class TestRoutingHandler:
         parse_handler_chain.handle(context, Response())
         # manually invoking the handler here as exceptions would be swallowed by the chain
         handler = InvocationRequestRouter()
-        with pytest.raises(Exception, match="Not found"):
+        with pytest.raises(MissingAuthTokenError):
             handler(parse_handler_chain, context, Response())
 
     @pytest.mark.parametrize("addressing", ["host", "user_request"])


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
There was a TODO left regarding the Exception to be raised when we have a routing error. This one of the bad one in APIGW, where it will raise a 403 exception when you're trying to send a request to something you haven't defined. 

From the documentation:
> The gateway response for a missing authentication token error, including the cases when the client attempts to invoke an unsupported API method or resource.

In some raised exceptions, I've also forgot to add log statements to help the user to understand why it is raising an exception.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement the `MissingAuthenticationToken` exception when we have a routing exception
- write an AWS validated test
- add missing log statements

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
