### PR TITLE
fix: ttl with a reserved keyword as attribute

### DIFF
--- a/localstack-core/localstack/services/dynamodb/provider.py
+++ b/localstack-core/localstack/services/dynamodb/provider.py
@@ -427,8 +427,9 @@ def delete_expired_items() -> int:
                 try:
                     result = client.scan(
                         TableName=table_name,
-                        FilterExpression=f"{attribute_name} <= :threshold",
+                        FilterExpression="#ttl <= :threshold",
                         ExpressionAttributeValues={":threshold": {"N": str(current_time)}},
+                        ExpressionAttributeNames={"#ttl": attribute_name},
                     )
                     items_to_delete = result.get("Items", [])
                     no_expired_items += len(items_to_delete)

--- a/localstack-core/localstack/utils/files.py
+++ b/localstack-core/localstack/utils/files.py
@@ -73,7 +73,7 @@ def save_file(file, content, append=False, permissions=None):
     def _opener(path, flags):
         return os.open(path, flags, permissions)
 
-    # make sure that the parent dir exsits
+    # make sure that the parent dir exists
     mkdir(os.path.dirname(file))
     # store file contents
     with open(file, mode, opener=_opener if permissions else None) as f:

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -97,6 +97,8 @@ class TestDynamoDB:
     @markers.aws.only_localstack
     def test_time_to_live_deletion(self, aws_client, ddb_test_table, cleanups):
         table_name = ddb_test_table
+        # Note: we use a reserved keyboard (ttl) as an attribute name for the time to live specification to make sure
+        #   that the deletion logic works also in this case.
         aws_client.dynamodb.update_time_to_live(
             TableName=table_name,
             TimeToLiveSpecification={"Enabled": True, "AttributeName": "ttl"},

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -99,14 +99,14 @@ class TestDynamoDB:
         table_name = ddb_test_table
         aws_client.dynamodb.update_time_to_live(
             TableName=table_name,
-            TimeToLiveSpecification={"Enabled": True, "AttributeName": "expiringAt"},
+            TimeToLiveSpecification={"Enabled": True, "AttributeName": "ttl"},
         )
         aws_client.dynamodb.describe_time_to_live(TableName=table_name)
 
         exp = int(time.time()) - 10  # expired
         items = [
-            {PARTITION_KEY: {"S": "expired"}, "expiringAt": {"N": str(exp)}},
-            {PARTITION_KEY: {"S": "not-expired"}, "expiringAt": {"N": str(exp + 120)}},
+            {PARTITION_KEY: {"S": "expired"}, "ttl": {"N": str(exp)}},
+            {PARTITION_KEY: {"S": "not-expired"}, "ttl": {"N": str(exp + 120)}},
         ]
         for item in items:
             aws_client.dynamodb.put_item(TableName=table_name, Item=item)
@@ -142,19 +142,19 @@ class TestDynamoDB:
         cleanups.append(lambda: aws_client.dynamodb.delete_table(TableName=table_with_range_key))
         aws_client.dynamodb.update_time_to_live(
             TableName=table_with_range_key,
-            TimeToLiveSpecification={"Enabled": True, "AttributeName": "expiringAt"},
+            TimeToLiveSpecification={"Enabled": True, "AttributeName": "ttl"},
         )
         exp = int(time.time()) - 10  # expired
         items = [
             {
                 PARTITION_KEY: {"S": "expired"},
                 "range": {"S": "range_one"},
-                "expiringAt": {"N": str(exp)},
+                "ttl": {"N": str(exp)},
             },
             {
                 PARTITION_KEY: {"S": "not-expired"},
                 "range": {"S": "range_two"},
-                "expiringAt": {"N": str(exp + 120)},
+                "ttl": {"N": str(exp + 120)},
             },
         ]
         for item in items:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In our TTL feature, we use a `Scan` operation to look for the expired keys to be deleted.
An expression with a reserved keyword (e.g., `ttl` might lead to errors).
This issue was raised in #11186.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Use expression attribute names (see [docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html)) in the `Scan` operation to avoid the mentioned issue.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
