### PR TITLE
fix APIGW NG response enricher handler

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -116,6 +116,7 @@ class RestApiInvocationContext(RequestContext):
         self.invocation_request = None
         self.resource = None
         self.resource_method = None
+        self.integration = None
         self.stage_variables = None
         self.context_variables = None
         self.logging_context_variables = None

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/response_enricher.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/response_enricher.py
@@ -21,7 +21,9 @@ class InvocationResponseEnricher(RestApiGatewayHandler):
 
         # Todo, as we go into monitoring, we will want to have these values come from the context?
         headers.set("x-amz-apigw-id", short_uid() + "=")
-        if context.integration[
-            "type"
-        ] != IntegrationType.HTTP_PROXY and not context.context_variables.get("error"):
+        if (
+            context.integration
+            and context.integration["type"] != IntegrationType.HTTP_PROXY
+            and not context.context_variables.get("error")
+        ):
             headers.set("X-Amzn-Trace-Id", short_uid())  # TODO

--- a/tests/unit/services/apigateway/test_handler_response_enricher.py
+++ b/tests/unit/services/apigateway/test_handler_response_enricher.py
@@ -74,3 +74,13 @@ class TestResponseEnricherHandler:
         assert apigw_response.headers.get("x-amzn-RequestId") == TEST_REQUEST_ID
         assert apigw_response.headers.get("x-amz-apigw-id") is not None
         assert apigw_response.headers.get("X-Amzn-Trace-Id") is None
+
+    def test_error_at_routing(self, ctx, response_enricher_handler, apigw_response):
+        # in the case where we fail early, in routing for example, we do not have the integration in the context yet
+        ctx.integration = None
+        response_enricher_handler(ctx, apigw_response)
+        assert apigw_response.headers.get("Content-Type") == "application/json"
+        assert apigw_response.headers.get("Connection") == "keep-alive"
+        assert apigw_response.headers.get("x-amzn-RequestId") == TEST_REQUEST_ID
+        assert apigw_response.headers.get("x-amz-apigw-id") is not None
+        assert apigw_response.headers.get("X-Amzn-Trace-Id") is None


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following #11237 and a last minute change + the new handling for routing with #11251, the default value for `context.integration` was not set. This PR handles the case where we fail early in the chain and the integration is not set yet

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update the default value
- add a unit test to catch the regression

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
