### PR TITLE
skip flaky firehose test

### DIFF
--- a/tests/aws/services/firehose/test_firehose.py
+++ b/tests/aws/services/firehose/test_firehose.py
@@ -136,6 +136,7 @@ def test_kinesis_firehose_http(
 class TestFirehoseIntegration:
     @markers.skip_offline
     @markers.aws.unknown
+    @pytest.mark.skip(reason="flaky")
     def test_kinesis_firehose_elasticsearch_s3_backup(
         self,
         s3_bucket,


### PR DESCRIPTION
## Motivation
`test_kinesis_firehose_elasticsearch_s3_backup` was flaky for quite a while.
According to our internal test analytics, in some pipelines this test has a failure rate of ~16 % over the last 30 days.

## Changes
- Skips `test_kinesis_firehose_elasticsearch_s3_backup` to stabilize the pipeline.