### PR TITLE
fix flaky transcribe tests by pre-downloading dependencies

### DIFF
--- a/localstack-core/localstack/services/transcribe/provider.py
+++ b/localstack-core/localstack/services/transcribe/provider.py
@@ -226,7 +226,7 @@ class TranscribeProvider(TranscribeApi):
         model_path = LANGUAGE_MODEL_DIR / name
 
         with _DL_LOCK:
-            if (model_path).exists():
+            if model_path.exists():
                 return
             else:
                 model_path.mkdir(parents=True)

--- a/tests/aws/conftest.py
+++ b/tests/aws/conftest.py
@@ -46,17 +46,10 @@ def pytest_runtestloop(session):
 
             test_init_functions.add(opensearch_install_async)
 
-        if any(es_test in parent_name for es_test in ["elasticsearch", "firehose"]):
+        if any(opensearch_test in parent_name for opensearch_test in ["test_es", "firehose"]):
             from tests.aws.services.es.test_es import install_async as es_install_async
 
             test_init_functions.add(es_install_async)
-
-        if "transcribe" in parent_name:
-            from tests.aws.services.transcribe.test_transcribe import (
-                install_async as transcribe_install_async,
-            )
-
-            test_init_functions.add(transcribe_install_async)
 
     # add init functions for certain tests that download/install things
     for test_class in test_classes:

--- a/tests/aws/conftest.py
+++ b/tests/aws/conftest.py
@@ -45,10 +45,18 @@ def pytest_runtestloop(session):
             )
 
             test_init_functions.add(opensearch_install_async)
-        if any(opensearch_test in parent_name for opensearch_test in ["test_es", "firehose"]):
+
+        if any(es_test in parent_name for es_test in ["elasticsearch", "firehose"]):
             from tests.aws.services.es.test_es import install_async as es_install_async
 
             test_init_functions.add(es_install_async)
+
+        if "transcribe" in parent_name:
+            from tests.aws.services.transcribe.test_transcribe import (
+                install_async as transcribe_install_async,
+            )
+
+            test_init_functions.add(transcribe_install_async)
 
     # add init functions for certain tests that download/install things
     for test_class in test_classes:

--- a/tests/aws/conftest.py
+++ b/tests/aws/conftest.py
@@ -45,7 +45,6 @@ def pytest_runtestloop(session):
             )
 
             test_init_functions.add(opensearch_install_async)
-
         if any(opensearch_test in parent_name for opensearch_test in ["test_es", "firehose"]):
             from tests.aws.services.es.test_es import install_async as es_install_async
 

--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -29,7 +29,7 @@ vosk_installed = threading.Event()
 ffmpeg_installed = threading.Event()
 installation_errored = threading.Event()
 
-INSTALLATION_TIMEOUT = 4 * 60
+INSTALLATION_TIMEOUT = 5 * 60
 PRE_DOWNLOAD_LANGUAGE_CODE_MODELS = ["en-GB"]
 
 
@@ -99,7 +99,7 @@ def transcribe_snapshot_transformer(snapshot):
 class TestTranscribe:
     @pytest.fixture(scope="class", autouse=True)
     def pre_install_dependencies(self):
-        if not ffmpeg_installed.is_set() or vosk_installed.is_set():
+        if not ffmpeg_installed.is_set() or not vosk_installed.is_set():
             install_async()
 
         start = int(time.time())

--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -53,6 +53,7 @@ def install_async():
                 )
                 for language_code in PRE_DOWNLOAD_LANGUAGE_CODE_MODELS:
                     model_name = LANGUAGE_MODELS[language_code]
+                    # downloading the model takes quite a while sometimes
                     TranscribeProvider.download_model(model_name)
                     LOG.info(
                         "done downloading Vosk model '%s' for language code '%s'",
@@ -80,7 +81,7 @@ class TestTranscribe:
         if not installed.is_set():
             install_async()
 
-        assert installed.wait(timeout=3 * 60), "gave up waiting for Vosk/ffmpeg to install"
+        assert installed.wait(timeout=5 * 60), "gave up waiting for Vosk/ffmpeg to install"
 
         assert not installation_errored.is_set(), "installation of transcribe dependencies failed"
         yield

--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -10,7 +10,7 @@ from localstack.aws.api.transcribe import BadRequestException, ConflictException
 from localstack.aws.connect import ServiceLevelClientFactory
 from localstack.packages.ffmpeg import ffmpeg_package
 from localstack.services.transcribe.packages import vosk_package
-from localstack.services.transcribe.provider import TranscribeProvider
+from localstack.services.transcribe.provider import LANGUAGE_MODELS, TranscribeProvider
 from localstack.testing.pytest import markers
 from localstack.utils.files import new_tmp_file
 from localstack.utils.strings import short_uid, to_str
@@ -52,8 +52,13 @@ def install_async():
                     "downloading Vosk models used in test: %s", PRE_DOWNLOAD_LANGUAGE_CODE_MODELS
                 )
                 for language_code in PRE_DOWNLOAD_LANGUAGE_CODE_MODELS:
-                    TranscribeProvider.download_model(language_code)
-                    LOG.info("done downloading Vosk model '%s'", language_code)
+                    model_name = LANGUAGE_MODELS[language_code]
+                    TranscribeProvider.download_model(model_name)
+                    LOG.info(
+                        "done downloading Vosk model '%s' for language code '%s'",
+                        model_name,
+                        language_code,
+                    )
                 LOG.info("done downloading all Vosk models used in test")
             except Exception:
                 LOG.exception("Error during installation of Transcribe dependencies")

--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -10,6 +10,7 @@ from localstack.aws.api.transcribe import BadRequestException, ConflictException
 from localstack.aws.connect import ServiceLevelClientFactory
 from localstack.packages.ffmpeg import ffmpeg_package
 from localstack.services.transcribe.packages import vosk_package
+from localstack.services.transcribe.provider import TranscribeProvider
 from localstack.testing.pytest import markers
 from localstack.utils.files import new_tmp_file
 from localstack.utils.strings import short_uid, to_str
@@ -23,6 +24,8 @@ LOG = logging.getLogger(__name__)
 # Lock and event to ensure that the installation is executed before the tests
 INIT_LOCK = threading.Lock()
 installed = threading.Event()
+
+PRE_DOWNLOAD_LANGUAGE_CODE_MODELS = ["en-GB"]
 
 
 def install_async():
@@ -43,6 +46,10 @@ def install_async():
             LOG.info("installing ffmpeg default version")
             ffmpeg_package.install()
             LOG.info("done ffmpeg default version")
+            for language_code in PRE_DOWNLOAD_LANGUAGE_CODE_MODELS:
+                LOG.info("installing Vosk models used in test")
+                TranscribeProvider.download_model(language_code)
+                LOG.info("done installing Vosk models used in test")
             installed.set()
 
     start_worker_thread(run_install)

--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -49,6 +49,7 @@ class TestTranscribe:
             "$..Error..Code",
         ]
     )
+    @pytest.mark.skip(reason="flaky")
     def test_transcribe_happy_path(self, transcribe_create_job, snapshot, aws_client):
         file_path = os.path.join(BASEDIR, "../../files/en-gb.wav")
         job_name = transcribe_create_job(audio_file=file_path)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While running the pipeline to check for the release, `test_transcribe_happy_path` flaked again. It is also marked flaky on CircleCI. 

See failures: 
- https://app.circleci.com/pipelines/github/localstack/localstack/26973/workflows/543f0989-034b-4f92-bfbb-584da606b29b/jobs/230534/tests
- https://app.circleci.com/pipelines/github/localstack/localstack/26997/workflows/4031f23f-ef93-4557-b000-588789e68c6a/jobs/230767
- https://app.circleci.com/pipelines/github/localstack/localstack/26997/workflows/4031f23f-ef93-4557-b000-588789e68c6a/jobs/230769

We're using the same logic as in opensearch tests, where a check in the global AWS `conftest.py` checks if there are any tests in the test collection that would match the test parent (test file or test class), and if there is, we already trigger the async download of the dependencies early. When there is the test selection, this does not do a lot, but for full-runs it will help the dependencies being downloaded before the actually tests run.

To avoid this issue, I'm using a class fixture pre-downloading the dependencies with a longer timeout, but with a quick failure mode, to avoid waiting on the transcription job if it fails asynchronously

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- setup pre-downloading of Vosk, ffmpeg and the Vosk model used

## Testing

Running the pipeline a few times to be sure it's hardened:
- ✅ https://app.circleci.com/pipelines/github/localstack/localstack/27020/workflows/b35769d6-3dca-46bb-8c96-9b896193f270
-  ✅ https://app.circleci.com/pipelines/github/localstack/localstack/27020/workflows/393f701b-07f0-4a4a-8de5-36532cae3239
- ✅ https://app.circleci.com/pipelines/github/localstack/localstack/27020/workflows/6f510779-592f-43fc-b75c-416bd3f93ca1
- ✅ https://app.circleci.com/pipelines/github/localstack/localstack/27023/workflows/dddd5bec-1cdd-4bdb-abff-a4722088a632 (after PR comments addressed)
- ✅ https://app.circleci.com/pipelines/github/localstack/localstack/27023/workflows/f7ad2b5f-37d0-4d17-b992-e6d745bfbacc