### PR TITLE
add new folder Matcher in test selection for conftest.py

### DIFF
--- a/localstack-core/localstack/testing/testselection/matching.py
+++ b/localstack-core/localstack/testing/testselection/matching.py
@@ -64,7 +64,7 @@ def get_test_dir_for_service(svc: str) -> str:
     return f"tests/aws/services/{svc}"
 
 
-def get_folder(t: str) -> str:
+def get_directory(t: str) -> str:
     # we take the parent of the match file, and we split it in parts
     parent_parts = pathlib.PurePath(t).parent.parts
     # we remove any parts that can be present in front of the first `tests` folder, could be caused by namespacing
@@ -93,8 +93,8 @@ class Matcher:
     def passthrough(self):
         return lambda t: [t] if self.matching_func(t) else []
 
-    def folder(self):
-        return lambda t: [get_folder(t)] if self.matching_func(t) else []
+    def directory(self):
+        return lambda t: [get_directory(t)] if self.matching_func(t) else []
 
 
 class Matchers:
@@ -192,7 +192,7 @@ MATCHING_RULES: list[MatchingRule] = [
     Matchers.glob("localstack/utils/**").full_suite(),
     # testing
     Matchers.glob("localstack/testing/**").full_suite(),
-    Matchers.glob("**/conftest.py").folder(),
+    Matchers.glob("**/conftest.py").directory(),
     Matchers.glob("**/fixtures.py").full_suite(),
     # ignore
     Matchers.glob("**/*.md").ignore(),

--- a/localstack-core/localstack/testing/testselection/matching.py
+++ b/localstack-core/localstack/testing/testselection/matching.py
@@ -1,4 +1,5 @@
 import fnmatch
+import pathlib
 import re
 from collections import defaultdict
 from typing import Callable, Iterable, Optional
@@ -59,8 +60,17 @@ def _reverse_dependency_map(dependency_map: dict[str, Iterable[str]]) -> dict[st
     return result
 
 
-def get_test_dir_for_service(svc: str):
+def get_test_dir_for_service(svc: str) -> str:
     return f"tests/aws/services/{svc}"
+
+
+def get_folder(t: str) -> str:
+    # we take the parent of the match file, and we split it in parts
+    parent_parts = pathlib.PurePath(t).parent.parts
+    # we remove any parts that can be present in front of the first `tests` folder, could be caused by namespacing
+    root = parent_parts.index("tests")
+    folder_path = "/".join(parent_parts[root:]) + "/"
+    return folder_path
 
 
 class Matcher:
@@ -82,6 +92,9 @@ class Matcher:
 
     def passthrough(self):
         return lambda t: [t] if self.matching_func(t) else []
+
+    def folder(self):
+        return lambda t: [get_folder(t)] if self.matching_func(t) else []
 
 
 class Matchers:
@@ -179,7 +192,7 @@ MATCHING_RULES: list[MatchingRule] = [
     Matchers.glob("localstack/utils/**").full_suite(),
     # testing
     Matchers.glob("localstack/testing/**").full_suite(),
-    Matchers.glob("**/conftest.py").full_suite(),
+    Matchers.glob("**/conftest.py").folder(),
     Matchers.glob("**/fixtures.py").full_suite(),
     # ignore
     Matchers.glob("**/*.md").ignore(),


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Previously, a change in a `conftest.py` file would select all tests with our test selection. 

This PR aims to introduce a new concept to our matcher for the test selection, where we would set the directory where a `conftest.py` is modified: `pytest` will select that folder and run all tests inside of it. 

It is a bit hard to test, I'm currently opening a PR targeting this one, because triggering a pipeline run manually seems to skip the test selection all together, it makes sense. 

Copying the result of the test run:
```
Checking for confirming to opt-in guards
Number of changed files detected: 1
        tests/aws/services/apigateway/conftest.py
Number of affected test determined: 2
        tests/aws/services/apigateway/
        tests/aws/services/stepfunctions/
Writing test selection to target/testselection/test-selection.txt
Successfully written test selection to target/testselection/test-selection.txt
tests/aws/services/apigateway/
tests/aws/services/stepfunctions/
```

here's the run: https://app.circleci.com/pipelines/github/localstack/localstack/26992/workflows/bf4546a0-ccf4-4670-80f0-c7906c4daa9a/jobs/230716

For the following PR: #11266

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- introduce a new Matcher named `directory` which return the test folder where the passed file lives

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
