### PR TITLE
fix APIGW path converter with prepended multiple slashes

### DIFF
--- a/localstack-core/localstack/aws/protocol/op_router.py
+++ b/localstack-core/localstack/aws/protocol/op_router.py
@@ -8,7 +8,6 @@ from werkzeug.exceptions import MethodNotAllowed, NotFound
 from werkzeug.routing import Map, MapAdapter
 
 from localstack.aws.protocol.routing import (
-    GreedyPathConverter,
     StrictMethodRule,
     path_param_regex,
     post_process_arg_name,
@@ -16,6 +15,7 @@ from localstack.aws.protocol.routing import (
 )
 from localstack.http import Request
 from localstack.http.request import get_raw_path
+from localstack.services.edge import GreedyPathConverter
 
 
 class _HttpOperation(NamedTuple):

--- a/localstack-core/localstack/aws/protocol/op_router.py
+++ b/localstack-core/localstack/aws/protocol/op_router.py
@@ -15,7 +15,7 @@ from localstack.aws.protocol.routing import (
 )
 from localstack.http import Request
 from localstack.http.request import get_raw_path
-from localstack.services.edge import GreedyPathConverter
+from localstack.http.router import GreedyPathConverter
 
 
 class _HttpOperation(NamedTuple):

--- a/localstack-core/localstack/aws/protocol/routing.py
+++ b/localstack-core/localstack/aws/protocol/routing.py
@@ -1,7 +1,7 @@
 import re
 from typing import AnyStr
 
-from werkzeug.routing import PathConverter, Rule
+from werkzeug.routing import Rule
 
 # Regex to find path parameters in requestUris of AWS service specs (f.e. /{param1}/{param2+})
 path_param_regex = re.compile(r"({.+?})")
@@ -10,20 +10,6 @@ path_param_regex = re.compile(r"({.+?})")
 _rule_replacements = {"-": "_0_"}
 # String translation table for #_rule_replacements for str#translate
 _rule_replacement_table = str.maketrans(_rule_replacements)
-
-
-class GreedyPathConverter(PathConverter):
-    """
-    This converter makes sure that the path ``/mybucket//mykey`` can be matched to the pattern
-    ``<Bucket>/<path:Key>`` and will result in `Key` being `/mykey`.
-    """
-
-    regex = ".*?"
-
-    part_isolating = False
-    """From the werkzeug docs: If a custom converter can match a forward slash, /, it should have the
-    attribute part_isolating set to False. This will ensure that rules using the custom converter are
-    correctly matched."""
 
 
 class StrictMethodRule(Rule):

--- a/localstack-core/localstack/http/router.py
+++ b/localstack-core/localstack/http/router.py
@@ -14,11 +14,27 @@ from rolo.routing import (
     route,
 )
 from rolo.routing.router import Dispatcher, call_endpoint
+from werkzeug.routing import PathConverter
 
 HTTP_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE")
 
 E = TypeVar("E")
 RequestArguments = Mapping[str, Any]
+
+
+class GreedyPathConverter(PathConverter):
+    """
+    This converter makes sure that the path ``/mybucket//mykey`` can be matched to the pattern
+    ``<Bucket>/<path:Key>`` and will result in `Key` being `/mykey`.
+    """
+
+    regex = ".*?"
+
+    part_isolating = False
+    """From the werkzeug docs: If a custom converter can match a forward slash, /, it should have the
+    attribute part_isolating set to False. This will ensure that rules using the custom converter are
+    correctly matched."""
+
 
 __all__ = [
     "RequestArguments",
@@ -32,4 +48,5 @@ __all__ = [
     "RuleAdapter",
     "WithHost",
     "RuleGroup",
+    "GreedyPathConverter",
 ]

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -702,7 +702,8 @@ def extract_path_params(path: str, extracted_path: str) -> Dict[str, str]:
 
 def extract_query_string_params(path: str) -> Tuple[str, Dict[str, str]]:
     parsed_path = urlparse.urlparse(path)
-    path = parsed_path.path
+    if not path.startswith("//"):
+        path = parsed_path.path
     parsed_query_string_params = urlparse.parse_qs(parsed_path.query)
 
     query_string_params = {}

--- a/localstack-core/localstack/services/apigateway/integration.py
+++ b/localstack-core/localstack/services/apigateway/integration.py
@@ -293,7 +293,7 @@ class LambdaProxyIntegration(BackendIntegration):
         headers = canonicalize_headers(headers)
 
         return {
-            "path": path,
+            "path": "/" + path.lstrip("/"),
             "headers": headers,
             "multiValueHeaders": multi_value_dict_for_list(headers),
             "body": data,

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -144,8 +144,7 @@ class InvocationRequestParser(RestApiGatewayHandler):
                 userAgent=invocation_request["headers"].get("User-Agent"),
                 userArn=None,
             ),
-            # TODO: check if we need the raw path? with forward slashes
-            path=f"/{context.stage}{invocation_request['path']}",
+            path=f"/{context.stage}{invocation_request['raw_path']}",
             protocol="HTTP/1.1",
             requestId=long_uid(),
             requestTime=timestamp(time=now, format=REQUEST_TIME_DATE_FORMAT),

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
@@ -8,13 +8,13 @@ from werkzeug.routing import Map, MapAdapter, Rule
 
 from localstack.aws.api.apigateway import Resource
 from localstack.aws.protocol.routing import (
-    GreedyPathConverter,
     path_param_regex,
     post_process_arg_name,
     transform_path_params_to_rule_vars,
 )
 from localstack.http import Response
 from localstack.services.apigateway.models import RestApiDeployment
+from localstack.services.edge import GreedyPathConverter
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import RestApiInvocationContext

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
@@ -13,8 +13,8 @@ from localstack.aws.protocol.routing import (
     transform_path_params_to_rule_vars,
 )
 from localstack.http import Response
+from localstack.http.router import GreedyPathConverter
 from localstack.services.apigateway.models import RestApiDeployment
-from localstack.services.edge import GreedyPathConverter
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import RestApiInvocationContext

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -107,7 +107,7 @@ class ApiGatewayRouter:
                 strict_slashes=False,
             ),
             self.router.add(
-                path="/<stage>/<path:path>",
+                path="/<stage>/<greedy_path:path>",
                 host=host_pattern,
                 endpoint=self.handler,
                 strict_slashes=True,
@@ -119,7 +119,7 @@ class ApiGatewayRouter:
                 defaults={"path": ""},
             ),
             self.router.add(
-                path="/restapis/<api_id>/<stage>/_user_request_/<path:path>",
+                path="/restapis/<api_id>/<stage>/_user_request_/<greedy_path:path>",
                 endpoint=self.handler,
                 strict_slashes=True,
             ),

--- a/localstack-core/localstack/services/apigateway/router_asf.py
+++ b/localstack-core/localstack/services/apigateway/router_asf.py
@@ -129,7 +129,7 @@ class ApigatewayRouter:
             strict_slashes=False,
         )
         self.router.add(
-            "/<stage>/<path:path>",
+            "/<stage>/<greedy_path:path>",
             host=host_pattern,
             endpoint=self.invoke_rest_api,
             strict_slashes=True,
@@ -142,7 +142,7 @@ class ApigatewayRouter:
             defaults={"path": ""},
         )
         self.router.add(
-            "/restapis/<api_id>/<stage>/_user_request_/<path:path>",
+            "/restapis/<api_id>/<stage>/_user_request_/<greedy_path:path>",
             endpoint=self.invoke_rest_api,
             strict_slashes=True,
         )

--- a/localstack-core/localstack/services/edge.py
+++ b/localstack-core/localstack/services/edge.py
@@ -5,8 +5,6 @@ import subprocess
 import sys
 from typing import List, Optional, TypeVar
 
-from werkzeug.routing import PathConverter
-
 from localstack import config, constants
 from localstack.config import HostAndPort
 from localstack.constants import (
@@ -14,6 +12,7 @@ from localstack.constants import (
 )
 from localstack.http import Router
 from localstack.http.dispatcher import Handler, handler_dispatcher
+from localstack.http.router import GreedyPathConverter
 from localstack.utils.collections import split_list_by
 from localstack.utils.net import get_free_tcp_port
 from localstack.utils.run import is_root, run
@@ -23,20 +22,6 @@ from localstack.utils.threads import start_thread
 T = TypeVar("T")
 
 LOG = logging.getLogger(__name__)
-
-
-class GreedyPathConverter(PathConverter):
-    """
-    This converter makes sure that the path ``/mybucket//mykey`` can be matched to the pattern
-    ``<Bucket>/<path:Key>`` and will result in `Key` being `/mykey`.
-    """
-
-    regex = ".*?"
-
-    part_isolating = False
-    """From the werkzeug docs: If a custom converter can match a forward slash, /, it should have the
-    attribute part_isolating set to False. This will ensure that rules using the custom converter are
-    correctly matched."""
 
 
 ROUTER: Router[Handler] = Router(

--- a/tests/aws/services/apigateway/test_apigateway_lambda.py
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.py
@@ -187,6 +187,13 @@ def test_lambda_aws_proxy_integration(
     )
     snapshot.match("invocation-payload-with-double-slash", response_double_slash.json())
 
+    # invoke rest api with prepended slash to the stage (//<stage>/<path>)
+    double_slash_before_stage = invocation_url.replace(f"/{stage_name}/", f"//{stage_name}/")
+    response_prepend_slash = retry(invoke_api, sleep=2, retries=10, url=double_slash_before_stage)
+    snapshot.match(
+        "invocation-payload-with-prepended-slash-to-stage", response_prepend_slash.json()
+    )
+
     # invoke rest api with prepended slash
     slash_between_stage_and_path = invocation_url.replace("/test-path", "//test-path")
     response_prepend_slash = retry(

--- a/tests/aws/services/apigateway/test_apigateway_lambda.py
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.py
@@ -181,6 +181,19 @@ def test_lambda_aws_proxy_integration(
     response_trailing_slash = retry(invoke_api, sleep=2, retries=10, url=f"{invocation_url}/")
     snapshot.match("invocation-payload-with-trailing-slash", response_trailing_slash.json())
 
+    # invoke rest api with double slash in proxy param
+    response_double_slash = retry(
+        invoke_api, sleep=2, retries=10, url=f"{invocation_url}//test-path"
+    )
+    snapshot.match("invocation-payload-with-double-slash", response_double_slash.json())
+
+    # invoke rest api with prepended slash
+    slash_between_stage_and_path = invocation_url.replace("/test-path", "//test-path")
+    response_prepend_slash = retry(
+        invoke_api, sleep=2, retries=10, url=slash_between_stage_and_path
+    )
+    snapshot.match("invocation-payload-with-prepended-slash", response_prepend_slash.json())
+
     response_no_trailing_slash = retry(
         invoke_api, sleep=2, retries=10, url=f"{invocation_url}?urlparam=test"
     )

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
-    "recorded-date": "22-07-2024, 22:41:52",
+    "recorded-date": "25-07-2024, 19:31:32",
     "recorded-content": {
       "invocation-payload-without-trailing-slash": {
         "body": null,
@@ -238,7 +238,7 @@
         "resource": "/{proxy+}",
         "stageVariables": null
       },
-      "invocation-payload-without-trailing-slash-and-query-params": {
+      "invocation-payload-with-double-slash": {
         "body": null,
         "headers": {
           "Accept": "*/*",
@@ -316,18 +316,12 @@
             "aValUE"
           ]
         },
-        "multiValueQueryStringParameters": {
-          "urlparam": [
-            "test"
-          ]
-        },
-        "path": "/test-path",
+        "multiValueQueryStringParameters": null,
+        "path": "/test-path//test-path",
         "pathParameters": {
-          "proxy": "test-path"
+          "proxy": "test-path//test-path"
         },
-        "queryStringParameters": {
-          "urlparam": "test"
-        },
+        "queryStringParameters": null,
         "requestContext": {
           "accountId": "111111111111",
           "apiId": "<api-id>",
@@ -350,7 +344,7 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test/test-path",
+          "path": "/test/test-path//test-path",
           "protocol": "HTTP/1.1",
           "requestId": "<uuid:3>",
           "requestTime": "<request-time>",
@@ -362,7 +356,7 @@
         "resource": "/{proxy+}",
         "stageVariables": null
       },
-      "invocation-payload-with-trailing-slash-and-query-params": {
+      "invocation-payload-with-prepended-slash": {
         "body": null,
         "headers": {
           "Accept": "*/*",
@@ -440,18 +434,12 @@
             "aValUE"
           ]
         },
-        "multiValueQueryStringParameters": {
-          "urlparam": [
-            "test"
-          ]
-        },
-        "path": "/test-path/",
+        "multiValueQueryStringParameters": null,
+        "path": "/test-path",
         "pathParameters": {
           "proxy": "test-path"
         },
-        "queryStringParameters": {
-          "urlparam": "test"
-        },
+        "queryStringParameters": null,
         "requestContext": {
           "accountId": "111111111111",
           "apiId": "<api-id>",
@@ -474,7 +462,7 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test/test-path/",
+          "path": "/test//test-path",
           "protocol": "HTTP/1.1",
           "requestId": "<uuid:4>",
           "requestTime": "<request-time>",
@@ -486,7 +474,7 @@
         "resource": "/{proxy+}",
         "stageVariables": null
       },
-      "invocation-payload-with-path-encoded-email": {
+      "invocation-payload-without-trailing-slash-and-query-params": {
         "body": null,
         "headers": {
           "Accept": "*/*",
@@ -501,7 +489,7 @@
           "CloudFront-Viewer-Country": "<cloudfront-country:1>",
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
-          "Via": "<via:3>",
+          "Via": "<via:5>",
           "X-Amz-Cf-Id": "<cf-id:5>",
           "X-Amzn-Trace-Id": "<trace-id:5>",
           "X-Forwarded-For": "<X-Forwarded-For>",
@@ -549,7 +537,7 @@
             "python-requests/testing"
           ],
           "Via": [
-            "<via:3>"
+            "<via:5>"
           ],
           "X-Amz-Cf-Id": [
             "<cf-id:5>"
@@ -564,12 +552,18 @@
             "aValUE"
           ]
         },
-        "multiValueQueryStringParameters": null,
-        "path": "/test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com",
-        "pathParameters": {
-          "proxy": "test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com"
+        "multiValueQueryStringParameters": {
+          "urlparam": [
+            "test"
+          ]
         },
-        "queryStringParameters": null,
+        "path": "/test-path",
+        "pathParameters": {
+          "proxy": "test-path"
+        },
+        "queryStringParameters": {
+          "urlparam": "test"
+        },
         "requestContext": {
           "accountId": "111111111111",
           "apiId": "<api-id>",
@@ -592,7 +586,7 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test/test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com",
+          "path": "/test/test-path",
           "protocol": "HTTP/1.1",
           "requestId": "<uuid:5>",
           "requestTime": "<request-time>",
@@ -604,7 +598,7 @@
         "resource": "/{proxy+}",
         "stageVariables": null
       },
-      "invocation-payload-with-params-encoding": {
+      "invocation-payload-with-trailing-slash-and-query-params": {
         "body": null,
         "headers": {
           "Accept": "*/*",
@@ -619,7 +613,7 @@
           "CloudFront-Viewer-Country": "<cloudfront-country:1>",
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
-          "Via": "<via:5>",
+          "Via": "<via:6>",
           "X-Amz-Cf-Id": "<cf-id:6>",
           "X-Amzn-Trace-Id": "<trace-id:6>",
           "X-Forwarded-For": "<X-Forwarded-For>",
@@ -667,13 +661,255 @@
             "python-requests/testing"
           ],
           "Via": [
-            "<via:5>"
+            "<via:6>"
           ],
           "X-Amz-Cf-Id": [
             "<cf-id:6>"
           ],
           "X-Amzn-Trace-Id": [
             "<trace-id:6>"
+          ],
+          "X-Forwarded-For": "<X-Forwarded-For>",
+          "X-Forwarded-Port": "<X-Forwarded-Port>",
+          "X-Forwarded-Proto": "<X-Forwarded-Proto>",
+          "tEsT-HEADeR": [
+            "aValUE"
+          ]
+        },
+        "multiValueQueryStringParameters": {
+          "urlparam": [
+            "test"
+          ]
+        },
+        "path": "/test-path/",
+        "pathParameters": {
+          "proxy": "test-path"
+        },
+        "queryStringParameters": {
+          "urlparam": "test"
+        },
+        "requestContext": {
+          "accountId": "111111111111",
+          "apiId": "<api-id>",
+          "deploymentId": "<deployment-id:1>",
+          "domainName": "<host:1>",
+          "domainPrefix": "<api-id>",
+          "extendedRequestId": "<extended-request-id:6>",
+          "httpMethod": "GET",
+          "identity": {
+            "accessKey": null,
+            "accountId": null,
+            "caller": null,
+            "cognitoAuthenticationProvider": null,
+            "cognitoAuthenticationType": null,
+            "cognitoIdentityId": null,
+            "cognitoIdentityPoolId": null,
+            "principalOrgId": null,
+            "sourceIp": "<source-ip:1>",
+            "user": null,
+            "userAgent": "python-requests/testing",
+            "userArn": null
+          },
+          "path": "/test/test-path/",
+          "protocol": "HTTP/1.1",
+          "requestId": "<uuid:6>",
+          "requestTime": "<request-time>",
+          "requestTimeEpoch": "<request-time-epoch>",
+          "resourceId": "<resource-id:1>",
+          "resourcePath": "/{proxy+}",
+          "stage": "test"
+        },
+        "resource": "/{proxy+}",
+        "stageVariables": null
+      },
+      "invocation-payload-with-path-encoded-email": {
+        "body": null,
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "random-value",
+          "CloudFront-Forwarded-Proto": "https",
+          "CloudFront-Is-Desktop-Viewer": "true",
+          "CloudFront-Is-Mobile-Viewer": "false",
+          "CloudFront-Is-SmartTV-Viewer": "false",
+          "CloudFront-Is-Tablet-Viewer": "false",
+          "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
+          "CloudFront-Viewer-Country": "<cloudfront-country:1>",
+          "Host": "<host:1>",
+          "User-Agent": "python-requests/testing",
+          "Via": "<via:7>",
+          "X-Amz-Cf-Id": "<cf-id:7>",
+          "X-Amzn-Trace-Id": "<trace-id:7>",
+          "X-Forwarded-For": "<X-Forwarded-For>",
+          "X-Forwarded-Port": "<X-Forwarded-Port>",
+          "X-Forwarded-Proto": "<X-Forwarded-Proto>",
+          "tEsT-HEADeR": "aValUE"
+        },
+        "httpMethod": "GET",
+        "isBase64Encoded": false,
+        "multiValueHeaders": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "random-value"
+          ],
+          "CloudFront-Forwarded-Proto": [
+            "https"
+          ],
+          "CloudFront-Is-Desktop-Viewer": [
+            "true"
+          ],
+          "CloudFront-Is-Mobile-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-SmartTV-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-Tablet-Viewer": [
+            "false"
+          ],
+          "CloudFront-Viewer-ASN": [
+            "<cloudfront-asn:1>"
+          ],
+          "CloudFront-Viewer-Country": [
+            "<cloudfront-country:1>"
+          ],
+          "Host": [
+            "<host:1>"
+          ],
+          "User-Agent": [
+            "python-requests/testing"
+          ],
+          "Via": [
+            "<via:7>"
+          ],
+          "X-Amz-Cf-Id": [
+            "<cf-id:7>"
+          ],
+          "X-Amzn-Trace-Id": [
+            "<trace-id:7>"
+          ],
+          "X-Forwarded-For": "<X-Forwarded-For>",
+          "X-Forwarded-Port": "<X-Forwarded-Port>",
+          "X-Forwarded-Proto": "<X-Forwarded-Proto>",
+          "tEsT-HEADeR": [
+            "aValUE"
+          ]
+        },
+        "multiValueQueryStringParameters": null,
+        "path": "/test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com",
+        "pathParameters": {
+          "proxy": "test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com"
+        },
+        "queryStringParameters": null,
+        "requestContext": {
+          "accountId": "111111111111",
+          "apiId": "<api-id>",
+          "deploymentId": "<deployment-id:1>",
+          "domainName": "<host:1>",
+          "domainPrefix": "<api-id>",
+          "extendedRequestId": "<extended-request-id:7>",
+          "httpMethod": "GET",
+          "identity": {
+            "accessKey": null,
+            "accountId": null,
+            "caller": null,
+            "cognitoAuthenticationProvider": null,
+            "cognitoAuthenticationType": null,
+            "cognitoIdentityId": null,
+            "cognitoIdentityPoolId": null,
+            "principalOrgId": null,
+            "sourceIp": "<source-ip:1>",
+            "user": null,
+            "userAgent": "python-requests/testing",
+            "userArn": null
+          },
+          "path": "/test/test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com",
+          "protocol": "HTTP/1.1",
+          "requestId": "<uuid:7>",
+          "requestTime": "<request-time>",
+          "requestTimeEpoch": "<request-time-epoch>",
+          "resourceId": "<resource-id:1>",
+          "resourcePath": "/{proxy+}",
+          "stage": "test"
+        },
+        "resource": "/{proxy+}",
+        "stageVariables": null
+      },
+      "invocation-payload-with-params-encoding": {
+        "body": null,
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "random-value",
+          "CloudFront-Forwarded-Proto": "https",
+          "CloudFront-Is-Desktop-Viewer": "true",
+          "CloudFront-Is-Mobile-Viewer": "false",
+          "CloudFront-Is-SmartTV-Viewer": "false",
+          "CloudFront-Is-Tablet-Viewer": "false",
+          "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
+          "CloudFront-Viewer-Country": "<cloudfront-country:1>",
+          "Host": "<host:1>",
+          "User-Agent": "python-requests/testing",
+          "Via": "<via:8>",
+          "X-Amz-Cf-Id": "<cf-id:8>",
+          "X-Amzn-Trace-Id": "<trace-id:8>",
+          "X-Forwarded-For": "<X-Forwarded-For>",
+          "X-Forwarded-Port": "<X-Forwarded-Port>",
+          "X-Forwarded-Proto": "<X-Forwarded-Proto>",
+          "tEsT-HEADeR": "aValUE"
+        },
+        "httpMethod": "GET",
+        "isBase64Encoded": false,
+        "multiValueHeaders": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "random-value"
+          ],
+          "CloudFront-Forwarded-Proto": [
+            "https"
+          ],
+          "CloudFront-Is-Desktop-Viewer": [
+            "true"
+          ],
+          "CloudFront-Is-Mobile-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-SmartTV-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-Tablet-Viewer": [
+            "false"
+          ],
+          "CloudFront-Viewer-ASN": [
+            "<cloudfront-asn:1>"
+          ],
+          "CloudFront-Viewer-Country": [
+            "<cloudfront-country:1>"
+          ],
+          "Host": [
+            "<host:1>"
+          ],
+          "User-Agent": [
+            "python-requests/testing"
+          ],
+          "Via": [
+            "<via:8>"
+          ],
+          "X-Amz-Cf-Id": [
+            "<cf-id:8>"
+          ],
+          "X-Amzn-Trace-Id": [
+            "<trace-id:8>"
           ],
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
@@ -720,7 +956,7 @@
           "deploymentId": "<deployment-id:1>",
           "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:6>",
+          "extendedRequestId": "<extended-request-id:8>",
           "httpMethod": "GET",
           "identity": {
             "accessKey": null,
@@ -738,7 +974,7 @@
           },
           "path": "/test/test-path/api",
           "protocol": "HTTP/1.1",
-          "requestId": "<uuid:6>",
+          "requestId": "<uuid:8>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
@@ -766,9 +1002,9 @@
           "Content-Type": "application/json;charset=utf-8",
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
-          "Via": "<via:5>",
-          "X-Amz-Cf-Id": "<cf-id:7>",
-          "X-Amzn-Trace-Id": "<trace-id:7>",
+          "Via": "<via:9>",
+          "X-Amz-Cf-Id": "<cf-id:9>",
+          "X-Amzn-Trace-Id": "<trace-id:9>",
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>"
@@ -816,13 +1052,13 @@
             "python-requests/testing"
           ],
           "Via": [
-            "<via:5>"
+            "<via:9>"
           ],
           "X-Amz-Cf-Id": [
-            "<cf-id:7>"
+            "<cf-id:9>"
           ],
           "X-Amzn-Trace-Id": [
-            "<trace-id:7>"
+            "<trace-id:9>"
           ],
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
@@ -853,7 +1089,7 @@
           "deploymentId": "<deployment-id:1>",
           "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:7>",
+          "extendedRequestId": "<extended-request-id:9>",
           "httpMethod": "POST",
           "identity": {
             "accessKey": null,
@@ -871,7 +1107,7 @@
           },
           "path": "/test/test-path",
           "protocol": "HTTP/1.1",
-          "requestId": "<uuid:7>",
+          "requestId": "<uuid:9>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
-    "recorded-date": "25-07-2024, 19:31:32",
+    "recorded-date": "25-07-2024, 20:18:13",
     "recorded-content": {
       "invocation-payload-without-trailing-slash": {
         "body": null,
@@ -356,6 +356,124 @@
         "resource": "/{proxy+}",
         "stageVariables": null
       },
+      "invocation-payload-with-prepended-slash-to-stage": {
+        "body": null,
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "random-value",
+          "CloudFront-Forwarded-Proto": "https",
+          "CloudFront-Is-Desktop-Viewer": "true",
+          "CloudFront-Is-Mobile-Viewer": "false",
+          "CloudFront-Is-SmartTV-Viewer": "false",
+          "CloudFront-Is-Tablet-Viewer": "false",
+          "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
+          "CloudFront-Viewer-Country": "<cloudfront-country:1>",
+          "Host": "<host:1>",
+          "User-Agent": "python-requests/testing",
+          "Via": "<via:1>",
+          "X-Amz-Cf-Id": "<cf-id:4>",
+          "X-Amzn-Trace-Id": "<trace-id:4>",
+          "X-Forwarded-For": "<X-Forwarded-For>",
+          "X-Forwarded-Port": "<X-Forwarded-Port>",
+          "X-Forwarded-Proto": "<X-Forwarded-Proto>",
+          "tEsT-HEADeR": "aValUE"
+        },
+        "httpMethod": "GET",
+        "isBase64Encoded": false,
+        "multiValueHeaders": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "random-value"
+          ],
+          "CloudFront-Forwarded-Proto": [
+            "https"
+          ],
+          "CloudFront-Is-Desktop-Viewer": [
+            "true"
+          ],
+          "CloudFront-Is-Mobile-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-SmartTV-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-Tablet-Viewer": [
+            "false"
+          ],
+          "CloudFront-Viewer-ASN": [
+            "<cloudfront-asn:1>"
+          ],
+          "CloudFront-Viewer-Country": [
+            "<cloudfront-country:1>"
+          ],
+          "Host": [
+            "<host:1>"
+          ],
+          "User-Agent": [
+            "python-requests/testing"
+          ],
+          "Via": [
+            "<via:1>"
+          ],
+          "X-Amz-Cf-Id": [
+            "<cf-id:4>"
+          ],
+          "X-Amzn-Trace-Id": [
+            "<trace-id:4>"
+          ],
+          "X-Forwarded-For": "<X-Forwarded-For>",
+          "X-Forwarded-Port": "<X-Forwarded-Port>",
+          "X-Forwarded-Proto": "<X-Forwarded-Proto>",
+          "tEsT-HEADeR": [
+            "aValUE"
+          ]
+        },
+        "multiValueQueryStringParameters": null,
+        "path": "/test-path",
+        "pathParameters": {
+          "proxy": "test-path"
+        },
+        "queryStringParameters": null,
+        "requestContext": {
+          "accountId": "111111111111",
+          "apiId": "<api-id>",
+          "deploymentId": "<deployment-id:1>",
+          "domainName": "<host:1>",
+          "domainPrefix": "<api-id>",
+          "extendedRequestId": "<extended-request-id:4>",
+          "httpMethod": "GET",
+          "identity": {
+            "accessKey": null,
+            "accountId": null,
+            "caller": null,
+            "cognitoAuthenticationProvider": null,
+            "cognitoAuthenticationType": null,
+            "cognitoIdentityId": null,
+            "cognitoIdentityPoolId": null,
+            "principalOrgId": null,
+            "sourceIp": "<source-ip:1>",
+            "user": null,
+            "userAgent": "python-requests/testing",
+            "userArn": null
+          },
+          "path": "/test/test-path",
+          "protocol": "HTTP/1.1",
+          "requestId": "<uuid:4>",
+          "requestTime": "<request-time>",
+          "requestTimeEpoch": "<request-time-epoch>",
+          "resourceId": "<resource-id:1>",
+          "resourcePath": "/{proxy+}",
+          "stage": "test"
+        },
+        "resource": "/{proxy+}",
+        "stageVariables": null
+      },
       "invocation-payload-with-prepended-slash": {
         "body": null,
         "headers": {
@@ -372,8 +490,8 @@
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:4>",
-          "X-Amz-Cf-Id": "<cf-id:4>",
-          "X-Amzn-Trace-Id": "<trace-id:4>",
+          "X-Amz-Cf-Id": "<cf-id:5>",
+          "X-Amzn-Trace-Id": "<trace-id:5>",
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>",
@@ -422,10 +540,10 @@
             "<via:4>"
           ],
           "X-Amz-Cf-Id": [
-            "<cf-id:4>"
+            "<cf-id:5>"
           ],
           "X-Amzn-Trace-Id": [
-            "<trace-id:4>"
+            "<trace-id:5>"
           ],
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
@@ -446,7 +564,7 @@
           "deploymentId": "<deployment-id:1>",
           "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:4>",
+          "extendedRequestId": "<extended-request-id:5>",
           "httpMethod": "GET",
           "identity": {
             "accessKey": null,
@@ -464,7 +582,7 @@
           },
           "path": "/test//test-path",
           "protocol": "HTTP/1.1",
-          "requestId": "<uuid:4>",
+          "requestId": "<uuid:5>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
@@ -490,8 +608,8 @@
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:5>",
-          "X-Amz-Cf-Id": "<cf-id:5>",
-          "X-Amzn-Trace-Id": "<trace-id:5>",
+          "X-Amz-Cf-Id": "<cf-id:6>",
+          "X-Amzn-Trace-Id": "<trace-id:6>",
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>",
@@ -540,10 +658,10 @@
             "<via:5>"
           ],
           "X-Amz-Cf-Id": [
-            "<cf-id:5>"
+            "<cf-id:6>"
           ],
           "X-Amzn-Trace-Id": [
-            "<trace-id:5>"
+            "<trace-id:6>"
           ],
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
@@ -570,7 +688,7 @@
           "deploymentId": "<deployment-id:1>",
           "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:5>",
+          "extendedRequestId": "<extended-request-id:6>",
           "httpMethod": "GET",
           "identity": {
             "accessKey": null,
@@ -588,7 +706,7 @@
           },
           "path": "/test/test-path",
           "protocol": "HTTP/1.1",
-          "requestId": "<uuid:5>",
+          "requestId": "<uuid:6>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
@@ -614,8 +732,8 @@
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:6>",
-          "X-Amz-Cf-Id": "<cf-id:6>",
-          "X-Amzn-Trace-Id": "<trace-id:6>",
+          "X-Amz-Cf-Id": "<cf-id:7>",
+          "X-Amzn-Trace-Id": "<trace-id:7>",
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>",
@@ -664,10 +782,10 @@
             "<via:6>"
           ],
           "X-Amz-Cf-Id": [
-            "<cf-id:6>"
+            "<cf-id:7>"
           ],
           "X-Amzn-Trace-Id": [
-            "<trace-id:6>"
+            "<trace-id:7>"
           ],
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
@@ -694,7 +812,7 @@
           "deploymentId": "<deployment-id:1>",
           "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:6>",
+          "extendedRequestId": "<extended-request-id:7>",
           "httpMethod": "GET",
           "identity": {
             "accessKey": null,
@@ -712,7 +830,7 @@
           },
           "path": "/test/test-path/",
           "protocol": "HTTP/1.1",
-          "requestId": "<uuid:6>",
+          "requestId": "<uuid:7>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
@@ -738,8 +856,8 @@
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:7>",
-          "X-Amz-Cf-Id": "<cf-id:7>",
-          "X-Amzn-Trace-Id": "<trace-id:7>",
+          "X-Amz-Cf-Id": "<cf-id:8>",
+          "X-Amzn-Trace-Id": "<trace-id:8>",
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>",
@@ -788,10 +906,10 @@
             "<via:7>"
           ],
           "X-Amz-Cf-Id": [
-            "<cf-id:7>"
+            "<cf-id:8>"
           ],
           "X-Amzn-Trace-Id": [
-            "<trace-id:7>"
+            "<trace-id:8>"
           ],
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
@@ -812,7 +930,7 @@
           "deploymentId": "<deployment-id:1>",
           "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:7>",
+          "extendedRequestId": "<extended-request-id:8>",
           "httpMethod": "GET",
           "identity": {
             "accessKey": null,
@@ -830,7 +948,7 @@
           },
           "path": "/test/test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com",
           "protocol": "HTTP/1.1",
-          "requestId": "<uuid:7>",
+          "requestId": "<uuid:8>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
@@ -856,8 +974,8 @@
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:8>",
-          "X-Amz-Cf-Id": "<cf-id:8>",
-          "X-Amzn-Trace-Id": "<trace-id:8>",
+          "X-Amz-Cf-Id": "<cf-id:9>",
+          "X-Amzn-Trace-Id": "<trace-id:9>",
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>",
@@ -906,10 +1024,10 @@
             "<via:8>"
           ],
           "X-Amz-Cf-Id": [
-            "<cf-id:8>"
+            "<cf-id:9>"
           ],
           "X-Amzn-Trace-Id": [
-            "<trace-id:8>"
+            "<trace-id:9>"
           ],
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
@@ -956,7 +1074,7 @@
           "deploymentId": "<deployment-id:1>",
           "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:8>",
+          "extendedRequestId": "<extended-request-id:9>",
           "httpMethod": "GET",
           "identity": {
             "accessKey": null,
@@ -974,7 +1092,7 @@
           },
           "path": "/test/test-path/api",
           "protocol": "HTTP/1.1",
-          "requestId": "<uuid:8>",
+          "requestId": "<uuid:9>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
@@ -1002,9 +1120,9 @@
           "Content-Type": "application/json;charset=utf-8",
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
-          "Via": "<via:9>",
-          "X-Amz-Cf-Id": "<cf-id:9>",
-          "X-Amzn-Trace-Id": "<trace-id:9>",
+          "Via": "<via:8>",
+          "X-Amz-Cf-Id": "<cf-id:10>",
+          "X-Amzn-Trace-Id": "<trace-id:10>",
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>"
@@ -1052,13 +1170,13 @@
             "python-requests/testing"
           ],
           "Via": [
-            "<via:9>"
+            "<via:8>"
           ],
           "X-Amz-Cf-Id": [
-            "<cf-id:9>"
+            "<cf-id:10>"
           ],
           "X-Amzn-Trace-Id": [
-            "<trace-id:9>"
+            "<trace-id:10>"
           ],
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
@@ -1089,7 +1207,7 @@
           "deploymentId": "<deployment-id:1>",
           "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:9>",
+          "extendedRequestId": "<extended-request-id:10>",
           "httpMethod": "POST",
           "identity": {
             "accessKey": null,
@@ -1107,7 +1225,7 @@
           },
           "path": "/test/test-path",
           "protocol": "HTTP/1.1",
-          "requestId": "<uuid:9>",
+          "requestId": "<uuid:10>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -9,7 +9,7 @@
     "last_validated_date": "2023-05-31T21:09:38+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
-    "last_validated_date": "2024-07-25T19:31:32+00:00"
+    "last_validated_date": "2024-07-25T20:18:13+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration_non_post_method": {
     "last_validated_date": "2024-07-10T15:43:36+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -9,7 +9,7 @@
     "last_validated_date": "2023-05-31T21:09:38+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
-    "last_validated_date": "2024-07-22T22:41:52+00:00"
+    "last_validated_date": "2024-07-25T19:31:32+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration_non_post_method": {
     "last_validated_date": "2024-07-10T15:43:36+00:00"

--- a/tests/unit/aws/protocol/test_op_router.py
+++ b/tests/unit/aws/protocol/test_op_router.py
@@ -2,9 +2,10 @@ import pytest
 from werkzeug.exceptions import NotFound
 from werkzeug.routing import Map, Rule
 
-from localstack.aws.protocol.op_router import GreedyPathConverter, RestServiceOperationRouter
+from localstack.aws.protocol.op_router import RestServiceOperationRouter
 from localstack.aws.spec import list_services, load_service
 from localstack.http import Request
+from localstack.services.edge import GreedyPathConverter
 
 
 def _collect_services():

--- a/tests/unit/aws/protocol/test_op_router.py
+++ b/tests/unit/aws/protocol/test_op_router.py
@@ -5,7 +5,7 @@ from werkzeug.routing import Map, Rule
 from localstack.aws.protocol.op_router import RestServiceOperationRouter
 from localstack.aws.spec import list_services, load_service
 from localstack.http import Request
-from localstack.services.edge import GreedyPathConverter
+from localstack.http.router import GreedyPathConverter
 
 
 def _collect_services():

--- a/tests/unit/http_/test_router.py
+++ b/tests/unit/http_/test_router.py
@@ -8,8 +8,14 @@ from werkzeug.exceptions import MethodNotAllowed, NotFound
 from werkzeug.routing import RequestRedirect, Submount
 
 from localstack.http import Request, Response, Router
-from localstack.http.router import E, RequestArguments, RuleAdapter, WithHost, route
-from localstack.services.edge import GreedyPathConverter
+from localstack.http.router import (
+    E,
+    GreedyPathConverter,
+    RequestArguments,
+    RuleAdapter,
+    WithHost,
+    route,
+)
 from localstack.utils.common import get_free_tcp_port
 
 

--- a/tests/unit/http_/test_router.py
+++ b/tests/unit/http_/test_router.py
@@ -9,6 +9,7 @@ from werkzeug.routing import RequestRedirect, Submount
 
 from localstack.http import Request, Response, Router
 from localstack.http.router import E, RequestArguments, RuleAdapter, WithHost, route
+from localstack.services.edge import GreedyPathConverter
 from localstack.utils.common import get_free_tcp_port
 
 
@@ -286,6 +287,56 @@ class TestRouter:
             "path": "_cluster/health",
             "host": "localhost.localstack.cloud:4566",
             "port": None,
+        }
+
+    def test_greedy_path_converter(self):
+        router = Router(converters={"greedy_path": GreedyPathConverter})
+        router.add(path="/<greedy_path:path>", endpoint=echo_params_json)
+
+        assert router.dispatch(Request(path="/my")).json == {"path": "my"}
+        assert router.dispatch(Request(path="/my/")).json == {"path": "my/"}
+        assert router.dispatch(Request(path="/my//path")).json == {"path": "my//path"}
+        assert router.dispatch(Request(path="/my//path/")).json == {"path": "my//path/"}
+        assert router.dispatch(Request(path="/my/path foobar")).json == {"path": "my/path foobar"}
+        assert router.dispatch(Request(path="//foobar")).json == {"path": "foobar"}
+        assert router.dispatch(Request(path="//foobar/")).json == {"path": "foobar/"}
+
+    def test_greedy_path_converter_with_args(self):
+        router = Router(converters={"greedy_path": GreedyPathConverter})
+        router.add(path="/with-args/<some_id>/<greedy_path:path>", endpoint=echo_params_json)
+
+        assert router.dispatch(Request(path="/with-args/123456/my")).json == {
+            "some_id": "123456",
+            "path": "my",
+        }
+
+        # werkzeug no longer removes trailing slashes in matches
+        assert router.dispatch(Request(path="/with-args/123456/my/")).json == {
+            "some_id": "123456",
+            "path": "my/",
+        }
+
+        # works with sub paths
+        assert router.dispatch(Request(path="/with-args/123456/my/path")).json == {
+            "some_id": "123456",
+            "path": "my/path",
+        }
+
+        # no sub path with no trailing slash raises 404
+        with pytest.raises(NotFound):
+            router.dispatch(Request(path="/with-args/123456"))
+
+        # greedy path accepts empty sub path if there's a trailing slash
+        assert router.dispatch(Request(path="/with-args/123456/")).json == {
+            "some_id": "123456",
+            "path": "",
+        }
+
+        # with the GreedyPath converter, we no longer redirect and accept the request
+        # in order the retrieve the double slash between parameter, we might need to use the RAW_URI
+        assert router.dispatch(Request(path="/with-args/123456//my/test//")).json == {
+            "some_id": "123456",
+            "path": "/my/test//",
         }
 
     def test_remove_rule(self):

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -859,17 +859,18 @@ def test_create_invocation_headers():
 
 
 class TestApigatewayEvents:
+    # TODO: remove this tests, assertion are wrong
     def test_construct_invocation_event(self):
         tt = [
             {
                 "method": "GET",
-                "path": "http://localhost.localstack.cloud",
+                "path": "/test/path",
                 "headers": {},
                 "data": None,
                 "query_string_params": None,
                 "is_base64_encoded": False,
                 "expected": {
-                    "path": "http://localhost.localstack.cloud",
+                    "path": "/test/path",
                     "headers": {},
                     "multiValueHeaders": {},
                     "body": None,
@@ -881,13 +882,13 @@ class TestApigatewayEvents:
             },
             {
                 "method": "GET",
-                "path": "http://localhost.localstack.cloud",
+                "path": "/test/path",
                 "headers": {},
                 "data": None,
                 "query_string_params": {},
                 "is_base64_encoded": False,
                 "expected": {
-                    "path": "http://localhost.localstack.cloud",
+                    "path": "/test/path",
                     "headers": {},
                     "multiValueHeaders": {},
                     "body": None,
@@ -899,13 +900,13 @@ class TestApigatewayEvents:
             },
             {
                 "method": "GET",
-                "path": "http://localhost.localstack.cloud",
+                "path": "/test/path",
                 "headers": {},
                 "data": None,
                 "query_string_params": {"foo": "bar"},
                 "is_base64_encoded": False,
                 "expected": {
-                    "path": "http://localhost.localstack.cloud",
+                    "path": "/test/path",
                     "headers": {},
                     "multiValueHeaders": {},
                     "body": None,
@@ -917,13 +918,13 @@ class TestApigatewayEvents:
             },
             {
                 "method": "GET",
-                "path": "http://localhost.localstack.cloud?baz=qux",
+                "path": "/test/path?baz=qux",
                 "headers": {},
                 "data": None,
                 "query_string_params": {"foo": "bar"},
                 "is_base64_encoded": False,
                 "expected": {
-                    "path": "http://localhost.localstack.cloud?baz=qux",
+                    "path": "/test/path?baz=qux",
                     "headers": {},
                     "multiValueHeaders": {},
                     "body": None,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #11253, our Edge Router had issue with `path` parameter starting with multiple slashes, as it would return a redirect which we shouldn't do. 

This PR introduces a new converter in the default `ROUTER`, which is the one we already use internally for the OP Router for AWS, and also internally for the new generation APIGW. 

This PR introduces the change and uses the new converter for APIGW routes, and fixes the behavior around it, with added integration test cases. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- migrate the `GreedyPathConverter` to `edge.py` as we need to use it in our default router, and refactor its usages
- add new tests for the router with the greedy path converter
- fix APIGW NG behavior with the new greedy path 
- fix the legacy APIGW, which was a bit more tricky, I'll run tests from upstream as well to be sure we're not breaking behavior

Note: failing tests are unrelated, and I'm running upstream full test suite to validate the changes which is green. Failing tests will be addressed with #11261

_fixes #11253_

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
