### PR TITLE
Add aliasing support for custom predictable Lambda URLs

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -2106,15 +2106,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         )
 
         custom_id: str | None = None
-        # Note: currently this only works with $LATEST. However, it would
-        # be nice if we could specify a custom URL for any alias being
-        # passed via the qualifier parameter. Once a strategy for that has
-        # been decided on, it can go here.
-        if (
-            fn.tags is not None
-            and TAG_KEY_CUSTOM_URL in fn.tags
-            and normalized_qualifier == "$LATEST"
-        ):
+        if fn.tags is not None and TAG_KEY_CUSTOM_URL in fn.tags:
             # Note: I really wanted to add verification here that the
             # url_id is unique, so we could surface that to the user ASAP.
             # However, it seems like that information isn't available yet,
@@ -2123,7 +2115,11 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             # of the routes -- and we need to verify that it's unique not
             # just for this particular lambda function, but for the entire
             # lambda provider. Therefore... that idea proved non-trivial!
-            custom_id_tag_value = fn.tags[TAG_KEY_CUSTOM_URL]
+            custom_id_tag_value = (
+                f"{fn.tags[TAG_KEY_CUSTOM_URL]}-{qualifier}"
+                if qualifier
+                else fn.tags[TAG_KEY_CUSTOM_URL]
+            )
             if TAG_KEY_CUSTOM_URL_VALIDATOR.match(custom_id_tag_value):
                 custom_id = custom_id_tag_value
 

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4367,5 +4367,13 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaMultiAccounts::test_delete_function": {
     "recorded-date": "14-06-2024, 15:17:17",
     "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_invocation_custom_id": {
+    "recorded-date": "05-08-2024, 12:24:48",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_invocation_custom_id_aliased": {
+    "recorded-date": "05-08-2024, 12:48:07",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -236,6 +236,12 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[string]": {
     "last_validated_date": "2024-04-08T16:56:44+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_invocation_custom_id": {
+    "last_validated_date": "2024-08-05T12:24:46+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_invocation_custom_id_aliased": {
+    "last_validated_date": "2024-08-05T12:48:05+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_invocation_exception": {
     "last_validated_date": "2024-04-08T16:57:22+00:00"
   },

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -3911,6 +3911,7 @@ class TestLambdaUrl:
             {
                 "args": {
                     "FunctionName": function_name,
+                    # Note: Shouldn't raise an exception (according to docs) but it does.
                     "Qualifier": "$LATEST",
                 },
                 "SnapshotName": "qualifier_latest",
@@ -4105,6 +4106,95 @@ class TestLambdaUrl:
             )
         assert any("Invalid custom ID tag value" in record.message for record in caplog.records)
         assert f"://{custom_id_value}.lambda-url." not in url_config_created["FunctionUrl"]
+
+    @markers.aws.only_localstack
+    def test_create_url_config_custom_id_tag_alias(self, create_lambda_function, aws_client):
+        custom_id_value = "my-custom-subdomain"
+        function_name = f"test-function-{short_uid()}"
+        zip_contents = testutil.create_zip_file(TEST_LAMBDA_PYTHON_ECHO, get_content=True)
+
+        create_lambda_function(
+            func_name=function_name,
+            zip_file=zip_contents,
+            runtime=Runtime.nodejs20_x,
+            handler="lambda_handler.handler",
+            Tags={TAG_KEY_CUSTOM_URL: custom_id_value},
+        )
+
+        def _assert_create_function_url(qualifier: str | None, expected_url_id: str):
+            params = {"FunctionName": function_name, "AuthType": "NONE"}
+            if qualifier:
+                # Note: boto3 will throw an exception if the Qualifier parameter is None or ""
+                params["Qualifier"] = qualifier
+
+            aws_client.lambda_.get_waiter("function_updated_v2").wait(FunctionName=function_name)
+            url_config_created = aws_client.lambda_.create_function_url_config(**params)
+            assert f"://{expected_url_id}.lambda-url." in url_config_created["FunctionUrl"]
+
+        def _assert_create_aliased_function_url(fn_version: str, fn_alias: str):
+            aws_client.lambda_.create_alias(
+                FunctionName=function_name, FunctionVersion=fn_version, Name=fn_alias
+            )
+
+            aws_client.lambda_.add_permission(
+                FunctionName=function_name,
+                StatementId="urlPermission",
+                Action="lambda:InvokeFunctionUrl",
+                Principal="*",
+                FunctionUrlAuthType="NONE",
+                Qualifier=fn_alias,
+            )
+
+            _assert_create_function_url(fn_alias, f"{custom_id_value}-{fn_alias}")
+
+        # Publishes a new version and creates an aliased URL
+        update_function_code_v1_resp = aws_client.lambda_.update_function_code(
+            FunctionName=function_name, ZipFile=zip_contents, Publish=True
+        )
+        version = update_function_code_v1_resp.get("Version")
+        _assert_create_aliased_function_url(fn_version=version, fn_alias="v1")
+
+        # Alias the $LATEST version
+        _assert_create_aliased_function_url(fn_version="$LATEST", fn_alias="latest")
+
+        # Update the code, creating an unpublished version
+        update_function_code_latest_resp = aws_client.lambda_.update_function_code(
+            FunctionName=function_name, ZipFile=zip_contents
+        )
+
+        # Assert that both functions are equal
+        function_v1_sha256 = update_function_code_v1_resp.get("CodeSha256")
+        function_latest_sha256 = update_function_code_latest_resp.get("CodeSha256")
+        assert function_v1_sha256 and function_latest_sha256
+        assert function_v1_sha256 == function_latest_sha256
+
+        # Assert that update actually did occur
+        rev_id_v1 = update_function_code_v1_resp.get("RevisionId")
+        rev_id_latest = update_function_code_latest_resp.get("RevisionId")
+        assert rev_id_latest > rev_id_v1
+
+        # Create a URL for an unpublished function
+        _assert_create_function_url(qualifier=None, expected_url_id=custom_id_value)
+
+        # Ensure that these compound url-id's are stored correctly
+        with pytest.raises(aws_client.lambda_.exceptions.ResourceConflictException) as ex:
+            aws_client.lambda_.create_function_url_config(
+                FunctionName=function_name, AuthType="NONE", Qualifier="v1"
+            )
+        assert ex.match("ResourceConflictException")
+
+        # Ensure that all aliased URLs can be correctly retrieved
+        for alias in ["v1", "latest"]:
+            function_url = aws_client.lambda_.get_function_url_config(
+                FunctionName=function_name, Qualifier=alias
+            ).get("FunctionUrl")
+            assert f"://{custom_id_value}-{alias}.lambda-url." in function_url
+
+        # Finally, check if the non-aliased URL can be retrieved
+        function_url = aws_client.lambda_.get_function_url_config(FunctionName=function_name).get(
+            "FunctionUrl"
+        )
+        assert f"://{custom_id_value}.lambda-url." in function_url
 
 
 class TestLambdaSizeLimits:

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -18,7 +18,7 @@
     "last_validated_date": "2024-04-10T09:12:27+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaAlias::test_alias_naming": {
-    "last_validated_date": "2024-04-10T09:12:45+00:00"
+    "last_validated_date": "2024-07-26T13:07:55+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaAlias::test_notfound_and_invalid_routingconfigs": {
     "last_validated_date": "2024-04-10T09:12:41+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
- This PR is a followup to https://github.com/localstack/localstack/pull/11103 that adds support for including an alias when constructing a custom predictble URL

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Including an existing `alias` in the `Qualifier` parameter when running a [CreateFunctionUrlConfig](https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunctionUrlConfig.html) will create a compound custom URL in the form `<custom-id-value>-<qualifier-or-alias>`.
- Remove comment from previous PR outlining noting to add this functionality.

### Testing
- Ran all `only_localstack` tests in the `TestLambdaUrl` suite.
- Tested against local instance using `awslocal`.

## TODO

What's left to do:

- [x] Update the [Lambda docs](https://docs.localstack.cloud/user-guide/aws/lambda/) to include these changes in a follow-up PR.
- [x] Currently, deleting an alias does not remove it's corresponding URL (verified via CLI) -- there should be a parity test checking whether this is intended functionality.
