### PR TITLE
fix breaking builds by avoiding setuptools==72.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,10 +151,10 @@ RUN --mount=type=cache,target=/var/cache/apt \
 
 # upgrade python build tools
 RUN --mount=type=cache,target=/root/.cache \
-    (virtualenv .venv && . .venv/bin/activate && pip3 install --upgrade pip wheel setuptools)
+    (virtualenv .venv && . .venv/bin/activate && pip3 install --upgrade pip wheel setuptools==71.1.0)
 
 # add files necessary to install runtime dependencies
-ADD Makefile pyproject.toml requirements-runtime.txt ./
+ADD Makefile pyproject.toml requirements-runtime.txt pip-constraints.txt ./
 # add the VERSION file to invalidate docker layers with version bumps
 ADD VERSION ./
 # add the localstack start scripts (necessary for the installation of the runtime dependencies, i.e. `pip install -e .`)

--- a/Dockerfile.s3
+++ b/Dockerfile.s3
@@ -53,10 +53,10 @@ RUN --mount=type=cache,target=/var/cache/apt \
 
 # upgrade python build tools
 RUN --mount=type=cache,target=/root/.cache \
-    (python3 -m venv .venv && . .venv/bin/activate && pip3 install --upgrade pip wheel setuptools build)
+    (python3 -m venv .venv && . .venv/bin/activate && pip3 install --upgrade pip wheel build setuptools==71.1.0)
 
 # add files necessary to install all dependencies
-ADD Makefile pyproject.toml requirements-base-runtime.txt ./
+ADD Makefile pyproject.toml requirements-base-runtime.txt pip-constraints.txt ./
 # add the VERSION file to invalidate docker layers with version bumps
 ADD VERSION ./
 # add the localstack start scripts (necessary for the installation of the runtime dependencies, i.e. `pip install -e .`)
@@ -77,7 +77,7 @@ FROM base
 COPY --from=builder /opt/code/localstack/.venv /opt/code/localstack/.venv
 
 # add project files necessary to install all dependencies
-ADD Makefile pyproject.toml VERSION requirements-base-runtime.txt setup.py ./
+ADD Makefile pyproject.toml VERSION requirements-base-runtime.txt setup.py pip-constraints.txt ./
 # add the localstack start scripts (necessary for the installation of the runtime dependencies, i.e. `pip install -e .`)
 ADD bin/localstack bin/localstack.bat bin/localstack-supervisor bin/
 

--- a/pip-constraints.txt
+++ b/pip-constraints.txt
@@ -1,0 +1,4 @@
+# TODO remove this complete file again!
+# - https://github.com/pypa/setuptools/issues/4519
+# - https://github.com/jpype-project/jpype/issues/1205
+setuptools==71.1.0


### PR DESCRIPTION
## Motivation
With `setuptools==72.0.0`, the test command was removed after being deprecated for a long time.
This is causing quite some issues (see https://github.com/pypa/setuptools/issues/4519).
For `localstack-ext`, this hits JPype, where a PR has been created to fix the issue:
- https://github.com/jpype-project/jpype/pull/1206

For as long as this package has not been upgraded, or the `setuptools` version has been yanked, we need to find a workaround.
This PR creates and uses a pip constraints file in order to avoid `setuptools>=72.0.0`.
As soon as either JPype have been fixed or the `setuptools` version has been yanked, we can revert this commit / use the latest version of `setuptools` again.

## Changes
- Adds a `pip-constraints.txt` file declaring to avoid `setuptools>=72.0.0`.
- Sneaks in the `PIP_CONSTRAINT` environment variable to be used with `pip` everywhere.

## Testing
- Currently all pipelines are broken (at least those where the cache was invalidated today).
- If the pipelines are green with this PR, we can be quite sure that it works correctly.