### PR TITLE
fix pro image detection in dev run script

### DIFF
--- a/localstack-core/localstack/dev/run/__main__.py
+++ b/localstack-core/localstack/dev/run/__main__.py
@@ -237,6 +237,8 @@ def run(
         if pro is None:
             if os.getcwd().endswith("localstack-ext"):
                 pro = True
+            elif "localstack-pro-" in os.getcwd().split(os.pathsep)[-1]:
+                pro = True
             else:
                 pro = False
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

`localstack.dev.run` determined whether to use the pro or community image based on the source path the script was run from. 
with the multi-distribution, we're no longer running from `./localstack-ext`, but perhaps `./localstack-ext/localstack-pro-core` (or any other module therein).


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* the pro image is used correctly again when running `localstack.dev.run` from `localstack-ext/localstack-pro-core`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
