### PR TITLE
Rework AssetDirectory to use pathlib.Path

### DIFF
--- a/localstack-core/localstack/state/core.py
+++ b/localstack-core/localstack/state/core.py
@@ -1,6 +1,8 @@
 """Core concepts of the persistence API."""
 
 import io
+import os
+import pathlib
 from typing import IO, Any, Protocol, runtime_checkable
 
 
@@ -75,20 +77,23 @@ class AssetDirectory:
     """
 
     service_name: str
-    path: str
+    path: pathlib.Path
 
-    def __init__(self, service_name: str, path: str):
+    def __init__(self, service_name: str, path: str | os.PathLike):
         if not service_name:
             raise ValueError("service name must be set")
 
         if not path:
             raise ValueError("path must be set")
 
+        if not isinstance(path, os.PathLike):
+            path = pathlib.Path(path)
+
         self.service_name = service_name
         self.path = path
 
-    def __str__(self):
-        return self.path
+    def __str__(self) -> str:
+        return str(self.path)
 
 
 class Encoder:

--- a/tests/unit/state/test_core.py
+++ b/tests/unit/state/test_core.py
@@ -1,0 +1,20 @@
+import pathlib
+
+import pytest
+
+from localstack.state import AssetDirectory
+
+
+def test_asset_directory(tmp_path):
+    asset_dir = AssetDirectory("sqs", tmp_path)
+    assert isinstance(asset_dir.path, pathlib.Path)
+
+    asset_dir_str = AssetDirectory("sqs", str(tmp_path))
+    assert isinstance(asset_dir_str.path, pathlib.Path)
+    assert asset_dir.path == asset_dir_str.path
+
+    with pytest.raises(ValueError):
+        AssetDirectory("sqs", "")
+
+    with pytest.raises(ValueError):
+        AssetDirectory("", tmp_path)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Rework of the `AssetDirectory` to use `pathlib.Path` instead of `str`.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- use `pathlib.Path` to internally represent a path for `AssetDirectory`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
