### PR TITLE
SES: Add support for feedback campaign tags

### DIFF
--- a/localstack-core/localstack/services/ses/provider.py
+++ b/localstack-core/localstack/services/ses/provider.py
@@ -77,7 +77,8 @@ EMAILS_ENDPOINT = "/_aws/ses"
 
 _EMAILS_ENDPOINT_REGISTERED = False
 
-ALLOWED_TAG_CHARS = "^[A-Za-z0-9_-]*$"
+REGEX_TAG_NAME = r"^[A-Za-z0-9_-]*$"
+REGEX_TAG_VALUE = r"^[A-Za-z0-9_\-.@]*$"
 
 ALLOWED_TAG_LEN = 255
 
@@ -341,15 +342,17 @@ class SesProvider(SesApi, ServiceLifecycleHook):
                     raise InvalidParameterValue("The tag value must be specified.")
                 if len(tag_name) > 255:
                     raise InvalidParameterValue("Tag name cannot exceed 255 characters.")
-                if not re.match(ALLOWED_TAG_CHARS, tag_name):
+                if not re.match(REGEX_TAG_NAME, tag_name):
                     raise InvalidParameterValue(
-                        f"Invalid tag name <{tag_name}>: only alphanumeric ASCII characters, '_', and '-' are allowed.",
+                        f"Invalid tag name <{tag_name}>: only alphanumeric ASCII characters, '_',  '-' are allowed.",
                     )
                 if len(tag_value) > 255:
                     raise InvalidParameterValue("Tag value cannot exceed 255 characters.")
-                if not re.match(ALLOWED_TAG_CHARS, tag_value):
+                # The `ses:` prefix is for a special case and disregarded for validation
+                # see https://docs.aws.amazon.com/ses/latest/dg/monitor-using-event-publishing.html#event-publishing-fine-grained-feedback
+                if not re.match(REGEX_TAG_VALUE, tag_value.removeprefix("ses:")):
                     raise InvalidParameterValue(
-                        f"Invalid tag value <{tag_value}>: only alphanumeric ASCII characters, '_', and '-' are allowed.",
+                        f"Invalid tag value <{tag_value}>: only alphanumeric ASCII characters, '_',  '-' , '.', '@' are allowed.",
                     )
 
         response = call_moto(context)

--- a/localstack-core/localstack/services/ses/provider.py
+++ b/localstack-core/localstack/services/ses/provider.py
@@ -642,4 +642,6 @@ class SNSEmitter:
 
 class InvalidParameterValue(CommonServiceException):
     def __init__(self, message=None):
-        super().__init__("InvalidParameterValue", status_code=400, message=message)
+        super().__init__(
+            "InvalidParameterValue", status_code=400, message=message, sender_fault=True
+        )

--- a/localstack-core/localstack/services/ses/provider.py
+++ b/localstack-core/localstack/services/ses/provider.py
@@ -342,15 +342,15 @@ class SesProvider(SesApi, ServiceLifecycleHook):
                     raise InvalidParameterValue("The tag value must be specified.")
                 if len(tag_name) > 255:
                     raise InvalidParameterValue("Tag name cannot exceed 255 characters.")
-                if not re.match(REGEX_TAG_NAME, tag_name):
+                # The `ses:` prefix is for a special case and disregarded for validation
+                # see https://docs.aws.amazon.com/ses/latest/dg/monitor-using-event-publishing.html#event-publishing-fine-grained-feedback
+                if not re.match(REGEX_TAG_NAME, tag_name.removeprefix("ses:")):
                     raise InvalidParameterValue(
                         f"Invalid tag name <{tag_name}>: only alphanumeric ASCII characters, '_',  '-' are allowed.",
                     )
                 if len(tag_value) > 255:
                     raise InvalidParameterValue("Tag value cannot exceed 255 characters.")
-                # The `ses:` prefix is for a special case and disregarded for validation
-                # see https://docs.aws.amazon.com/ses/latest/dg/monitor-using-event-publishing.html#event-publishing-fine-grained-feedback
-                if not re.match(REGEX_TAG_VALUE, tag_value.removeprefix("ses:")):
+                if not re.match(REGEX_TAG_VALUE, tag_value):
                     raise InvalidParameterValue(
                         f"Invalid tag value <{tag_value}>: only alphanumeric ASCII characters, '_',  '-' , '.', '@' are allowed.",
                     )

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -844,36 +844,6 @@ class TestSES:
             )
         snapshot.match("response", e.value.response)
 
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Message"])
-    @pytest.mark.parametrize(
-        "tag_name,tag_value",
-        [
-            ("ses:feedback-id-a", "this-marketing-campaign"),
-            ("ses:feedback-id-b", "that-campaign"),
-        ],
-    )
-    def test_special_tags_send_email(self, tag_name, tag_value, snapshot, aws_client):
-        source = f"user-{short_uid()}@example.com"
-        destination = "success@example.com"
-
-        # Ensure that request passes validation and throws MessageRejected due to unverified sender identity
-        with pytest.raises(ClientError) as e:
-            aws_client.ses.send_email(
-                Source=source,
-                Tags=[
-                    {
-                        "Name": tag_name,
-                        "Value": tag_value,
-                    }
-                ],
-                Message=SAMPLE_SIMPLE_EMAIL,
-                Destination={
-                    "ToAddresses": [destination],
-                },
-            )
-        snapshot.match("response", e.value.response)
-
 
 class TestSESRetrospection:
     @markers.aws.only_localstack

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -819,15 +819,13 @@ class TestSES:
             ("", ""),
             ("", "test"),
             ("test", ""),
-            # The `ses:` tags are special case that contain the `:` character and pass request validation.
-            # These raise `MessageRejected` instead of `InvalidParameterValue`.
-            ("ses:feedback-id-a", "this-marketing-campaign"),
-            ("ses:feedback-id-b", "that-campaign"),
         ],
     )
     def test_invalid_tags_send_email(self, tag_name, tag_value, snapshot, aws_client):
         source = f"user-{short_uid()}@example.com"
         destination = "success@example.com"
+
+        aws_client.ses.verify_email_identity(EmailAddress=source)
 
         with pytest.raises(ClientError) as e:
             aws_client.ses.send_email(

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -820,13 +820,15 @@ class TestSES:
             ("", ""),
             ("", "test"),
             ("test", ""),
+            # The `ses:` tags are special case that contain the `:` character and pass request validation.
+            # These raise `MessageRejected` instead of `InvalidParameterValue`.
+            ("ses:feedback-id-a", "this-marketing-campaign"),
+            ("ses:feedback-id-b", "that-campaign"),
         ],
     )
     def test_invalid_tags_send_email(self, tag_name, tag_value, snapshot, aws_client):
         source = f"user-{short_uid()}@example.com"
         destination = "success@example.com"
-
-        aws_client.ses.verify_email_identity(EmailAddress=source)
 
         with pytest.raises(ClientError) as e:
             aws_client.ses.send_email(

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -803,7 +803,6 @@ class TestSES:
         snapshot.match("delete-error", e_info.value.response)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Type"])
     @pytest.mark.parametrize(
         "tag_name,tag_value",
         [

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -844,6 +844,36 @@ class TestSES:
             )
         snapshot.match("response", e.value.response)
 
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Message"])
+    @pytest.mark.parametrize(
+        "tag_name,tag_value",
+        [
+            ("ses:feedback-id-a", "this-marketing-campaign"),
+            ("ses:feedback-id-b", "that-campaign"),
+        ],
+    )
+    def test_special_tags_send_email(self, tag_name, tag_value, snapshot, aws_client):
+        source = f"user-{short_uid()}@example.com"
+        destination = "success@example.com"
+
+        # Ensure that request passes validation and throws MessageRejected due to unverified sender identity
+        with pytest.raises(ClientError) as e:
+            aws_client.ses.send_email(
+                Source=source,
+                Tags=[
+                    {
+                        "Name": tag_name,
+                        "Value": tag_value,
+                    }
+                ],
+                Message=SAMPLE_SIMPLE_EMAIL,
+                Destination={
+                    "ToAddresses": [destination],
+                },
+            )
+        snapshot.match("response", e.value.response)
+
 
 class TestSESRetrospection:
     @markers.aws.only_localstack

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -826,7 +826,7 @@ class TestSES:
         source = f"user-{short_uid()}@example.com"
         destination = "success@example.com"
 
-        aws_client.ses.verify_email_address(EmailAddress=source)
+        aws_client.ses.verify_email_identity(EmailAddress=source)
 
         with pytest.raises(ClientError) as e:
             aws_client.ses.send_email(

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -826,6 +826,8 @@ class TestSES:
         source = f"user-{short_uid()}@example.com"
         destination = "success@example.com"
 
+        aws_client.ses.verify_email_address(EmailAddress=source)
+
         with pytest.raises(ClientError) as e:
             aws_client.ses.send_email(
                 Source=source,

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -825,8 +825,6 @@ class TestSES:
         source = f"user-{short_uid()}@example.com"
         destination = "success@example.com"
 
-        aws_client.ses.verify_email_identity(EmailAddress=source)
-
         with pytest.raises(ClientError) as e:
             aws_client.ses.send_email(
                 Source=source,

--- a/tests/aws/services/ses/test_ses.snapshot.json
+++ b/tests/aws/services/ses/test_ses.snapshot.json
@@ -590,7 +590,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name:123-test]": {
-    "recorded-date": "30-07-2024, 10:18:07",
+    "recorded-date": "30-07-2024, 12:03:11",
     "recorded-content": {
       "response": {
         "Error": {
@@ -606,7 +606,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test-test_invalid_value:123]": {
-    "recorded-date": "30-07-2024, 10:18:08",
+    "recorded-date": "30-07-2024, 12:03:12",
     "recorded-content": {
       "response": {
         "Error": {
@@ -622,7 +622,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name:123-test_invalid_value:123]": {
-    "recorded-date": "30-07-2024, 10:18:08",
+    "recorded-date": "30-07-2024, 12:03:12",
     "recorded-content": {
       "response": {
         "Error": {
@@ -638,7 +638,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name_len]": {
-    "recorded-date": "30-07-2024, 10:18:08",
+    "recorded-date": "30-07-2024, 12:03:12",
     "recorded-content": {
       "response": {
         "Error": {
@@ -654,7 +654,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_value_len]": {
-    "recorded-date": "30-07-2024, 10:18:08",
+    "recorded-date": "30-07-2024, 12:03:12",
     "recorded-content": {
       "response": {
         "Error": {
@@ -670,7 +670,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_priority_name_value]": {
-    "recorded-date": "30-07-2024, 10:18:08",
+    "recorded-date": "30-07-2024, 12:03:12",
     "recorded-content": {
       "response": {
         "Error": {
@@ -686,7 +686,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-]": {
-    "recorded-date": "30-07-2024, 10:18:09",
+    "recorded-date": "30-07-2024, 12:03:13",
     "recorded-content": {
       "response": {
         "Error": {
@@ -702,7 +702,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-test]": {
-    "recorded-date": "30-07-2024, 10:18:09",
+    "recorded-date": "30-07-2024, 12:03:13",
     "recorded-content": {
       "response": {
         "Error": {
@@ -718,7 +718,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test-]": {
-    "recorded-date": "30-07-2024, 10:18:09",
+    "recorded-date": "30-07-2024, 12:03:13",
     "recorded-content": {
       "response": {
         "Error": {
@@ -912,6 +912,38 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[ses:feedback-id-a-this-marketing-campaign]": {
+    "recorded-date": "30-07-2024, 12:03:13",
+    "recorded-content": {
+      "response": {
+        "Error": {
+          "Code": "MessageRejected",
+          "Message": "Email address is not verified. The following identities failed the check in region EU-CENTRAL-1: success@example.com, user-549e4edf@example.com",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[ses:feedback-id-b-that-campaign]": {
+    "recorded-date": "30-07-2024, 12:03:13",
+    "recorded-content": {
+      "response": {
+        "Error": {
+          "Code": "MessageRejected",
+          "Message": "Email address is not verified. The following identities failed the check in region EU-CENTRAL-1: success@example.com, user-106baa2f@example.com",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/ses/test_ses.snapshot.json
+++ b/tests/aws/services/ses/test_ses.snapshot.json
@@ -590,12 +590,12 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name:123-test]": {
-    "recorded-date": "26-08-2023, 00:05:47",
+    "recorded-date": "30-07-2024, 10:18:07",
     "recorded-content": {
       "response": {
         "Error": {
           "Code": "InvalidParameterValue",
-          "Message": "Invalid tag name <test_invalid_name:123>: only alphanumeric ASCII characters, '_', and '-' are allowed.",
+          "Message": "Invalid tag name <test_invalid_name:123>: only alphanumeric ASCII characters, '_',  '-' are allowed.",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -606,12 +606,12 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test-test_invalid_value:123]": {
-    "recorded-date": "26-08-2023, 00:05:47",
+    "recorded-date": "30-07-2024, 10:18:08",
     "recorded-content": {
       "response": {
         "Error": {
           "Code": "InvalidParameterValue",
-          "Message": "Invalid tag value <test_invalid_value:123>: only alphanumeric ASCII characters, '_', and '-' are allowed.",
+          "Message": "Invalid tag value <test_invalid_value:123>: only alphanumeric ASCII characters, '_',  '-' , '.', '@' are allowed.",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -622,12 +622,12 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name:123-test_invalid_value:123]": {
-    "recorded-date": "26-08-2023, 00:05:47",
+    "recorded-date": "30-07-2024, 10:18:08",
     "recorded-content": {
       "response": {
         "Error": {
           "Code": "InvalidParameterValue",
-          "Message": "Invalid tag name <test_invalid_name:123>: only alphanumeric ASCII characters, '_', and '-' are allowed.",
+          "Message": "Invalid tag name <test_invalid_name:123>: only alphanumeric ASCII characters, '_',  '-' are allowed.",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -638,7 +638,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name_len]": {
-    "recorded-date": "26-08-2023, 00:05:47",
+    "recorded-date": "30-07-2024, 10:18:08",
     "recorded-content": {
       "response": {
         "Error": {
@@ -654,7 +654,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_value_len]": {
-    "recorded-date": "26-08-2023, 00:05:47",
+    "recorded-date": "30-07-2024, 10:18:08",
     "recorded-content": {
       "response": {
         "Error": {
@@ -670,12 +670,12 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_priority_name_value]": {
-    "recorded-date": "26-08-2023, 00:05:47",
+    "recorded-date": "30-07-2024, 10:18:08",
     "recorded-content": {
       "response": {
         "Error": {
           "Code": "InvalidParameterValue",
-          "Message": "Invalid tag name <test_invalid_name@123>: only alphanumeric ASCII characters, '_', and '-' are allowed.",
+          "Message": "Invalid tag name <test_invalid_name@123>: only alphanumeric ASCII characters, '_',  '-' are allowed.",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -686,7 +686,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-]": {
-    "recorded-date": "26-08-2023, 00:05:47",
+    "recorded-date": "30-07-2024, 10:18:09",
     "recorded-content": {
       "response": {
         "Error": {
@@ -702,7 +702,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-test]": {
-    "recorded-date": "26-08-2023, 00:05:48",
+    "recorded-date": "30-07-2024, 10:18:09",
     "recorded-content": {
       "response": {
         "Error": {
@@ -718,7 +718,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test-]": {
-    "recorded-date": "26-08-2023, 00:05:48",
+    "recorded-date": "30-07-2024, 10:18:09",
     "recorded-content": {
       "response": {
         "Error": {

--- a/tests/aws/services/ses/test_ses.snapshot.json
+++ b/tests/aws/services/ses/test_ses.snapshot.json
@@ -915,37 +915,5 @@
         }
       }
     }
-  },
-  "tests/aws/services/ses/test_ses.py::TestSES::test_special_tags_send_email[ses:feedback-id-a-this-marketing-campaign]": {
-    "recorded-date": "30-07-2024, 11:32:59",
-    "recorded-content": {
-      "response": {
-        "Error": {
-          "Code": "MessageRejected",
-          "Message": "Email address is not verified. The following identities failed the check in region EU-CENTRAL-1: user-7611f06b@example.com, success@example.com",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/ses/test_ses.py::TestSES::test_special_tags_send_email[ses:feedback-id-b-that-campaign]": {
-    "recorded-date": "30-07-2024, 11:32:59",
-    "recorded-content": {
-      "response": {
-        "Error": {
-          "Code": "MessageRejected",
-          "Message": "Email address is not verified. The following identities failed the check in region EU-CENTRAL-1: success@example.com, user-e1a947ca@example.com",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
   }
 }

--- a/tests/aws/services/ses/test_ses.snapshot.json
+++ b/tests/aws/services/ses/test_ses.snapshot.json
@@ -915,5 +915,37 @@
         }
       }
     }
+  },
+  "tests/aws/services/ses/test_ses.py::TestSES::test_special_tags_send_email[ses:feedback-id-a-this-marketing-campaign]": {
+    "recorded-date": "30-07-2024, 11:32:59",
+    "recorded-content": {
+      "response": {
+        "Error": {
+          "Code": "MessageRejected",
+          "Message": "Email address is not verified. The following identities failed the check in region EU-CENTRAL-1: user-7611f06b@example.com, success@example.com",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/ses/test_ses.py::TestSES::test_special_tags_send_email[ses:feedback-id-b-that-campaign]": {
+    "recorded-date": "30-07-2024, 11:32:59",
+    "recorded-content": {
+      "response": {
+        "Error": {
+          "Code": "MessageRejected",
+          "Message": "Email address is not verified. The following identities failed the check in region EU-CENTRAL-1: success@example.com, user-e1a947ca@example.com",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/ses/test_ses.snapshot.json
+++ b/tests/aws/services/ses/test_ses.snapshot.json
@@ -590,7 +590,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name:123-test]": {
-    "recorded-date": "30-07-2024, 12:03:11",
+    "recorded-date": "30-07-2024, 10:18:07",
     "recorded-content": {
       "response": {
         "Error": {
@@ -606,7 +606,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test-test_invalid_value:123]": {
-    "recorded-date": "30-07-2024, 12:03:12",
+    "recorded-date": "30-07-2024, 10:18:08",
     "recorded-content": {
       "response": {
         "Error": {
@@ -622,7 +622,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name:123-test_invalid_value:123]": {
-    "recorded-date": "30-07-2024, 12:03:12",
+    "recorded-date": "30-07-2024, 10:18:08",
     "recorded-content": {
       "response": {
         "Error": {
@@ -638,7 +638,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name_len]": {
-    "recorded-date": "30-07-2024, 12:03:12",
+    "recorded-date": "30-07-2024, 10:18:08",
     "recorded-content": {
       "response": {
         "Error": {
@@ -654,7 +654,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_value_len]": {
-    "recorded-date": "30-07-2024, 12:03:12",
+    "recorded-date": "30-07-2024, 10:18:08",
     "recorded-content": {
       "response": {
         "Error": {
@@ -670,7 +670,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_priority_name_value]": {
-    "recorded-date": "30-07-2024, 12:03:12",
+    "recorded-date": "30-07-2024, 10:18:08",
     "recorded-content": {
       "response": {
         "Error": {
@@ -686,7 +686,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-]": {
-    "recorded-date": "30-07-2024, 12:03:13",
+    "recorded-date": "30-07-2024, 10:18:09",
     "recorded-content": {
       "response": {
         "Error": {
@@ -702,7 +702,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-test]": {
-    "recorded-date": "30-07-2024, 12:03:13",
+    "recorded-date": "30-07-2024, 10:18:09",
     "recorded-content": {
       "response": {
         "Error": {
@@ -718,7 +718,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test-]": {
-    "recorded-date": "30-07-2024, 12:03:13",
+    "recorded-date": "30-07-2024, 10:18:09",
     "recorded-content": {
       "response": {
         "Error": {
@@ -912,38 +912,6 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[ses:feedback-id-a-this-marketing-campaign]": {
-    "recorded-date": "30-07-2024, 12:03:13",
-    "recorded-content": {
-      "response": {
-        "Error": {
-          "Code": "MessageRejected",
-          "Message": "Email address is not verified. The following identities failed the check in region EU-CENTRAL-1: success@example.com, user-549e4edf@example.com",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[ses:feedback-id-b-that-campaign]": {
-    "recorded-date": "30-07-2024, 12:03:13",
-    "recorded-content": {
-      "response": {
-        "Error": {
-          "Code": "MessageRejected",
-          "Message": "Email address is not verified. The following identities failed the check in region EU-CENTRAL-1: success@example.com, user-106baa2f@example.com",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/ses/test_ses.validation.json
+++ b/tests/aws/services/ses/test_ses.validation.json
@@ -18,37 +18,31 @@
     "last_validated_date": "2023-08-25T22:04:53+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-]": {
-    "last_validated_date": "2024-07-30T12:03:13+00:00"
+    "last_validated_date": "2024-07-30T10:18:09+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-test]": {
-    "last_validated_date": "2024-07-30T12:03:13+00:00"
-  },
-  "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[ses:feedback-id-a-this-marketing-campaign]": {
-    "last_validated_date": "2024-07-30T12:03:13+00:00"
-  },
-  "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[ses:feedback-id-b-that-campaign]": {
-    "last_validated_date": "2024-07-30T12:03:13+00:00"
+    "last_validated_date": "2024-07-30T10:18:09+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test-]": {
-    "last_validated_date": "2024-07-30T12:03:13+00:00"
+    "last_validated_date": "2024-07-30T10:18:09+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test-test_invalid_value:123]": {
-    "last_validated_date": "2024-07-30T12:03:12+00:00"
+    "last_validated_date": "2024-07-30T10:18:08+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name:123-test]": {
-    "last_validated_date": "2024-07-30T12:03:11+00:00"
+    "last_validated_date": "2024-07-30T10:18:07+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name:123-test_invalid_value:123]": {
-    "last_validated_date": "2024-07-30T12:03:12+00:00"
+    "last_validated_date": "2024-07-30T10:18:08+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name_len]": {
-    "last_validated_date": "2024-07-30T12:03:12+00:00"
+    "last_validated_date": "2024-07-30T10:18:08+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_value_len]": {
-    "last_validated_date": "2024-07-30T12:03:12+00:00"
+    "last_validated_date": "2024-07-30T10:18:08+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_priority_name_value]": {
-    "last_validated_date": "2024-07-30T12:03:12+00:00"
+    "last_validated_date": "2024-07-30T10:18:08+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_list_templates": {
     "last_validated_date": "2023-08-25T16:33:54+00:00"

--- a/tests/aws/services/ses/test_ses.validation.json
+++ b/tests/aws/services/ses/test_ses.validation.json
@@ -62,6 +62,12 @@
   "tests/aws/services/ses/test_ses.py::TestSES::test_ses_sns_topic_integration_send_templated_email": {
     "last_validated_date": "2023-08-25T22:00:04+00:00"
   },
+  "tests/aws/services/ses/test_ses.py::TestSES::test_special_tags_send_email[ses:feedback-id-a-this-marketing-campaign]": {
+    "last_validated_date": "2024-07-30T11:32:59+00:00"
+  },
+  "tests/aws/services/ses/test_ses.py::TestSES::test_special_tags_send_email[ses:feedback-id-b-that-campaign]": {
+    "last_validated_date": "2024-07-30T11:32:59+00:00"
+  },
   "tests/aws/services/ses/test_ses.py::TestSES::test_trying_to_delete_event_destination_from_non_existent_configuration_set": {
     "last_validated_date": "2023-08-25T22:05:02+00:00"
   }

--- a/tests/aws/services/ses/test_ses.validation.json
+++ b/tests/aws/services/ses/test_ses.validation.json
@@ -18,31 +18,37 @@
     "last_validated_date": "2023-08-25T22:04:53+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-]": {
-    "last_validated_date": "2024-07-30T10:18:09+00:00"
+    "last_validated_date": "2024-07-30T12:03:13+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-test]": {
-    "last_validated_date": "2024-07-30T10:18:09+00:00"
+    "last_validated_date": "2024-07-30T12:03:13+00:00"
+  },
+  "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[ses:feedback-id-a-this-marketing-campaign]": {
+    "last_validated_date": "2024-07-30T12:03:13+00:00"
+  },
+  "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[ses:feedback-id-b-that-campaign]": {
+    "last_validated_date": "2024-07-30T12:03:13+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test-]": {
-    "last_validated_date": "2024-07-30T10:18:09+00:00"
+    "last_validated_date": "2024-07-30T12:03:13+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test-test_invalid_value:123]": {
-    "last_validated_date": "2024-07-30T10:18:08+00:00"
+    "last_validated_date": "2024-07-30T12:03:12+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name:123-test]": {
-    "last_validated_date": "2024-07-30T10:18:07+00:00"
+    "last_validated_date": "2024-07-30T12:03:11+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name:123-test_invalid_value:123]": {
-    "last_validated_date": "2024-07-30T10:18:08+00:00"
+    "last_validated_date": "2024-07-30T12:03:12+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name_len]": {
-    "last_validated_date": "2024-07-30T10:18:08+00:00"
+    "last_validated_date": "2024-07-30T12:03:12+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_value_len]": {
-    "last_validated_date": "2024-07-30T10:18:08+00:00"
+    "last_validated_date": "2024-07-30T12:03:12+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_priority_name_value]": {
-    "last_validated_date": "2024-07-30T10:18:08+00:00"
+    "last_validated_date": "2024-07-30T12:03:12+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_list_templates": {
     "last_validated_date": "2023-08-25T16:33:54+00:00"

--- a/tests/aws/services/ses/test_ses.validation.json
+++ b/tests/aws/services/ses/test_ses.validation.json
@@ -62,12 +62,6 @@
   "tests/aws/services/ses/test_ses.py::TestSES::test_ses_sns_topic_integration_send_templated_email": {
     "last_validated_date": "2023-08-25T22:00:04+00:00"
   },
-  "tests/aws/services/ses/test_ses.py::TestSES::test_special_tags_send_email[ses:feedback-id-a-this-marketing-campaign]": {
-    "last_validated_date": "2024-07-30T11:32:59+00:00"
-  },
-  "tests/aws/services/ses/test_ses.py::TestSES::test_special_tags_send_email[ses:feedback-id-b-that-campaign]": {
-    "last_validated_date": "2024-07-30T11:32:59+00:00"
-  },
   "tests/aws/services/ses/test_ses.py::TestSES::test_trying_to_delete_event_destination_from_non_existent_configuration_set": {
     "last_validated_date": "2023-08-25T22:05:02+00:00"
   }

--- a/tests/aws/services/ses/test_ses.validation.json
+++ b/tests/aws/services/ses/test_ses.validation.json
@@ -18,31 +18,31 @@
     "last_validated_date": "2023-08-25T22:04:53+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-]": {
-    "last_validated_date": "2023-08-25T22:05:47+00:00"
+    "last_validated_date": "2024-07-30T10:18:09+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-test]": {
-    "last_validated_date": "2023-08-25T22:05:48+00:00"
+    "last_validated_date": "2024-07-30T10:18:09+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test-]": {
-    "last_validated_date": "2023-08-25T22:05:48+00:00"
+    "last_validated_date": "2024-07-30T10:18:09+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test-test_invalid_value:123]": {
-    "last_validated_date": "2023-08-25T22:05:47+00:00"
+    "last_validated_date": "2024-07-30T10:18:08+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name:123-test]": {
-    "last_validated_date": "2023-08-25T22:05:47+00:00"
+    "last_validated_date": "2024-07-30T10:18:07+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name:123-test_invalid_value:123]": {
-    "last_validated_date": "2023-08-25T22:05:47+00:00"
+    "last_validated_date": "2024-07-30T10:18:08+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_name_len]": {
-    "last_validated_date": "2023-08-25T22:05:47+00:00"
+    "last_validated_date": "2024-07-30T10:18:08+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_invalid_value_len]": {
-    "last_validated_date": "2023-08-25T22:05:47+00:00"
+    "last_validated_date": "2024-07-30T10:18:08+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[test_priority_name_value]": {
-    "last_validated_date": "2023-08-25T22:05:47+00:00"
+    "last_validated_date": "2024-07-30T10:18:08+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_list_templates": {
     "last_validated_date": "2023-08-25T16:33:54+00:00"

--- a/tests/aws/services/ses/test_ses.validation.json
+++ b/tests/aws/services/ses/test_ses.validation.json
@@ -62,6 +62,12 @@
   "tests/aws/services/ses/test_ses.py::TestSES::test_ses_sns_topic_integration_send_templated_email": {
     "last_validated_date": "2023-08-25T22:00:04+00:00"
   },
+  "tests/aws/services/ses/test_ses.py::TestSES::test_special_tags_send_email[ses:feedback-id-a-this-marketing-campaign]": {
+    "last_validated_date": "2024-07-30T13:01:32+00:00"
+  },
+  "tests/aws/services/ses/test_ses.py::TestSES::test_special_tags_send_email[ses:feedback-id-b-that-campaign]": {
+    "last_validated_date": "2024-07-30T13:01:32+00:00"
+  },
   "tests/aws/services/ses/test_ses.py::TestSES::test_trying_to_delete_event_destination_from_non_existent_configuration_set": {
     "last_validated_date": "2023-08-25T22:05:02+00:00"
   }


### PR DESCRIPTION
## Background

AWS SES supports a special tag for sent emails that start with the prefix `ses:`. This is despite the character `:` not allowed in standard tag values.

https://docs.aws.amazon.com/ses/latest/dg/monitor-using-event-publishing.html#event-publishing-fine-grained-feedback

## Changes

This PR implements this special case in LocalStack. The snapshot tests are also updated.

## Related

Closes: https://github.com/localstack/localstack/issues/11243