### PR TITLE
fix Kinesis CBOR date encoding for AWS SDK v2

### DIFF
--- a/localstack-core/localstack/aws/client.py
+++ b/localstack-core/localstack/aws/client.py
@@ -243,9 +243,11 @@ def _patch_cbor2():
             else:
                 timestamp = timegm(value.utctimetuple()) + value.microsecond / 1000000
             # The next line is the only change in this patch compared to the original function.
-            # AWS breaks the CBOR spec by using the millis instead of seconds (with floating point support for millis)
-            # https://github.com/aws/aws-sdk-java-v2/issues/4661
-            timestamp = timestamp * 1000
+            # - AWS breaks the CBOR spec by using the millis instead of seconds (with floating point support for millis)
+            #   https://github.com/aws/aws-sdk-java-v2/issues/4661
+            # - AWS SDKs in addition have very tight assumptions on the type.
+            #   This needs to be an integer, and must not be a floating point number (CBOR is typed)!
+            timestamp = int(timestamp * 1000)
             self.encode_semantic(CBORTag(1, timestamp))
         else:
             datestring = value.isoformat().replace("+00:00", "Z")

--- a/localstack-core/localstack/aws/client.py
+++ b/localstack-core/localstack/aws/client.py
@@ -214,7 +214,7 @@ def _patch_cbor2():
 
         try:
             # The next line is the only change in this patch compared to the original function.
-            # AWS breaks the CBOR spec by using the millis instead of seconds (with floating point support for millis)
+            # AWS breaks the CBOR spec by using the millis (instead of seconds with floating point support for millis)
             # https://github.com/aws/aws-sdk-java-v2/issues/4661
             value = value / 1000
             tmp = datetime.fromtimestamp(value, timezone.utc)
@@ -243,7 +243,7 @@ def _patch_cbor2():
             else:
                 timestamp = timegm(value.utctimetuple()) + value.microsecond / 1000000
             # The next line is the only change in this patch compared to the original function.
-            # - AWS breaks the CBOR spec by using the millis instead of seconds (with floating point support for millis)
+            # - AWS breaks the CBOR spec by using the millis (instead of seconds with floating point support for millis)
             #   https://github.com/aws/aws-sdk-java-v2/issues/4661
             # - AWS SDKs in addition have very tight assumptions on the type.
             #   This needs to be an integer, and must not be a floating point number (CBOR is typed)!

--- a/tests/aws/services/kinesis/test_kinesis.snapshot.json
+++ b/tests/aws/services/kinesis/test_kinesis.snapshot.json
@@ -220,5 +220,9 @@
         }
       ]
     }
+  },
+  "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_cbor_blob_handling": {
+    "recorded-date": "31-07-2024, 11:17:28",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/kinesis/test_kinesis.snapshot.json
+++ b/tests/aws/services/kinesis/test_kinesis.snapshot.json
@@ -220,9 +220,5 @@
         }
       ]
     }
-  },
-  "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_cbor_blob_handling": {
-    "recorded-date": "31-07-2024, 11:17:28",
-    "recorded-content": {}
   }
 }

--- a/tests/aws/services/kinesis/test_kinesis.validation.json
+++ b/tests/aws/services/kinesis/test_kinesis.validation.json
@@ -30,7 +30,7 @@
     "last_validated_date": "2024-06-21T15:20:46+00:00"
   },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_at_timestamp_cbor": {
-    "last_validated_date": "2024-07-17T20:16:42+00:00"
+    "last_validated_date": "2024-07-30T14:49:34+00:00"
   },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_sequence_number_as_iterator": {
     "last_validated_date": "2022-08-26T07:29:21+00:00"

--- a/tests/aws/services/kinesis/test_kinesis.validation.json
+++ b/tests/aws/services/kinesis/test_kinesis.validation.json
@@ -3,7 +3,7 @@
     "last_validated_date": "2022-08-25T06:56:43+00:00"
   },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_cbor_blob_handling": {
-    "last_validated_date": "2024-07-17T20:09:34+00:00"
+    "last_validated_date": "2024-07-31T11:17:28+00:00"
   },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_create_stream_without_shard_count": {
     "last_validated_date": "2022-08-26T07:30:59+00:00"
@@ -34,6 +34,9 @@
   },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_sequence_number_as_iterator": {
     "last_validated_date": "2022-08-26T07:29:21+00:00"
+  },
+  "tests/aws/services/kinesis/test_kinesis.py::TestKinesisJavaSDK::test_subscribe_to_shard_with_java_sdk_v2_lambda": {
+    "last_validated_date": "2024-07-31T11:18:43+00:00"
   },
   "tests/aws/services/kinesis/test_kinesis.py::test_subscribe_to_shard_with_at_timestamp_cbor": {
     "last_validated_date": "2024-07-04T07:13:22+00:00"

--- a/tests/aws/services/lambda_/functions/common/kinesis_sdkv2/README.md
+++ b/tests/aws/services/lambda_/functions/common/kinesis_sdkv2/README.md
@@ -1,0 +1,10 @@
+## Java Lambda with AWS SDK v2  -> Kinesis
+
+This lambda function is used to ensure the compatibility of Kinesis with the Java AWS SDK v2,
+especially the CBOR content encoding (which is enabled by default).
+
+This Lambda is not directly being used for the multi-runtime lambda tests, but it is here in this folder in order to
+benefit from the caching mechanisms in CI.
+The JAR file is too big to be directly commited to the Git repo (~10MB).
+
+Initially introduced with https://github.com/localstack/localstack/pull/11286.

--- a/tests/aws/services/lambda_/functions/common/kinesis_sdkv2/java17/Makefile
+++ b/tests/aws/services/lambda_/functions/common/kinesis_sdkv2/java17/Makefile
@@ -1,0 +1,12 @@
+# https://hub.docker.com/_/gradle/tags
+IMAGE ?= gradle:8.4.0-jdk17
+
+build:
+	mkdir -p build && \
+	docker run --rm -v "$$(pwd)/src:/app" -v "$$(pwd)/build:/out" $(IMAGE) bash -c "mkdir -p /build && cp -r /app/* /build && cd /build && gradle packageFat && cp build/distributions/build.zip /out/handler.zip" && \
+	cp build/handler.zip handler.zip
+
+clean:
+	$(RM) -r build handler.zip
+
+.PHONY: build clean

--- a/tests/aws/services/lambda_/functions/common/kinesis_sdkv2/java17/src/build.gradle
+++ b/tests/aws/services/lambda_/functions/common/kinesis_sdkv2/java17/src/build.gradle
@@ -1,0 +1,55 @@
+plugins {
+    id 'java'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // AWS SDK v2: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/home.html
+    implementation platform('software.amazon.awssdk:bom:2.26.27')
+    // AWS Java libraries https://github.com/aws/aws-lambda-java-libs
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.3'
+
+    // Kinesis clients
+    implementation 'software.amazon.awssdk:kinesis'
+
+     // SLF4J logging
+    implementation 'org.slf4j:slf4j-nop:2.0.13'
+}
+
+task packageFat(type: Zip) {
+    from compileJava
+    from processResources
+    into('lib') {
+        from configurations.runtimeClasspath
+    }
+    dirMode = 0755
+    fileMode = 0755
+}
+
+task packageLibs(type: Zip) {
+    into('java/lib') {
+        from configurations.runtimeClasspath
+    }
+    dirMode = 0755
+    fileMode = 0755
+}
+
+task packageSkinny(type: Zip) {
+    from compileJava
+    from processResources
+}
+
+tasks.withType(AbstractArchiveTask) {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}
+
+build.dependsOn packageSkinny

--- a/tests/aws/services/lambda_/functions/common/kinesis_sdkv2/java17/src/src/main/java/kinesis/Handler.java
+++ b/tests/aws/services/lambda_/functions/common/kinesis_sdkv2/java17/src/src/main/java/kinesis/Handler.java
@@ -1,0 +1,56 @@
+package kinesis;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.*;
+
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.time.Instant;
+import java.util.*;
+
+
+public class Handler implements RequestHandler<Map<String, String>, String> {
+
+    public String handleRequest(Map<String, String> event, Context context) {
+        // extract the StreamARN from the event
+        String streamArn = event.get("StreamARN");
+        System.out.print("Stream ARN = " + streamArn);
+
+        // get the first shard
+        DescribeStreamResponse streamDescription = this.getKinesisClient().describeStream(DescribeStreamRequest.builder().streamARN(streamArn).build());
+        Instant streamCreationTimestamp = streamDescription.streamDescription().streamCreationTimestamp();
+        Shard shard = streamDescription.streamDescription().shards().get(0);;
+        System.out.println("Shard ID = " + shard.shardId());
+
+        // create the shardIterator starting now
+        GetShardIteratorResponse shardIterator = this.getKinesisClient().getShardIterator(GetShardIteratorRequest.builder().streamARN(streamArn).shardId(shard.shardId()).shardIteratorType(ShardIteratorType.AT_TIMESTAMP).timestamp(Instant.now()).build());
+        System.out.println("Stream Creation Timestamp = " + streamCreationTimestamp);
+
+        // put a record
+        SdkBytes testData = SdkBytes.fromString("test-string", Charset.defaultCharset());
+        this.getKinesisClient().putRecord(PutRecordRequest.builder().streamARN(streamArn).partitionKey("test-partition-key").data(testData).build());
+
+        // get the record again
+        GetRecordsResponse records = this.getKinesisClient().getRecords(GetRecordsRequest.builder().streamARN(streamArn).shardIterator(shardIterator.shardIterator()).build());
+
+        // expect the record has been returned
+        assert records.hasRecords();
+        assert records.records().get(0).data() == testData;
+
+        return "ok";
+    }
+
+    private KinesisClient getKinesisClient() {
+        String endpointUrl = System.getenv("AWS_ENDPOINT_URL");
+        if (endpointUrl != null) {
+            // Choosing a specific endpoint
+            // https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html
+            return KinesisClient.builder()
+                    .endpointOverride(URI.create(endpointUrl)).build();
+        }
+        return KinesisClient.builder().build();
+    }
+}


### PR DESCRIPTION
## Motivation
Kinesis is the only service (afaik) which supports CBOR as `Content-Type` as well as `Accept-Type`.
- Support for CBOR was initially added to ASF when Kinesis was migrated to ASF with #6166.
- Unfortunately, AWS Kinesis breaks the CBOR specs when it comes to datetime fields, which was initially addressed with #6791.
- Initially, we thought the spec is just broken when it comes to the serializer / server-side encoding, but it's also for requests being sent. Fixing (or breaking?) the datetime parsing / server-side decoding was implemented in #11071.
- After quite some time, it turned out that the CBOR implementation still causes issues with the AWS Java SDK, which were addressed with #11133.
  - This PR implemented a more thorough support for CBOR, but unfortunately added a small regression.
- This regression (blob parsing in requests) has been fixed by @simonrw with #11220.
- But there's another regression which was introduced with #11133:
  - The new proper datetime handling is still not compatible with the AWS SDK v2 (as outlined in #11216 and #11271).

This PR is hopefully the last PR on that matter, fixing the CBOR datetime handling in Kinesis for the AWS SDK v2, and introducing a better test coverage to avoid any kind of regressions in the future.
It turns out that the issue really only is that the datetime is encoded as a floating point number, instead of an integer (which most CBOR decoders can decode, but not the one in the AWS SDK v2).

Fixes #11216
Fixes #11271

## Changes
- Send the datetime as unixtime milliseconds as integer.
- Cleans up some test.
- Introduces a Lambda -> Kinesis test using the AWS SDK v2.
  - This new test uses a lambda which is added to `tests/aws/services/lambda_/functions/common/`, because these lambdas are already automatically built and cached across CI runs.
  - @joe4dev @dfangl: I hope this is okay, maybe this could be evolved towards a concept which is usable for multiple services. I feel like we often have the problem that some edge cases are super-hard to test in Python (especially when it comes to certain peculiarities in SDKs of other languages). At the same time these tests are not really testing Lambda (which is why they should not really be part of the Lambda tests).

## Testing
During development I used a simple snippet (with AWS SDK v2 version 2.20.43) to verify the reported issues:
```
KinesisClient kinesisClient = KinesisClient.builder()
        .endpointOverride(new URI("http://localhost.localstack.cloud:4566"))
        .credentialsProvider(() -> AwsBasicCredentials.create("test", "test"))
        .region(Region.US_EAST_1)
        .build();
kinesisClient.createStream(CreateStreamRequest.builder().streamName("test-stream").shardCount(1).build());
DescribeStreamResponse describeStream = kinesisClient.describeStream(DescribeStreamRequest.builder().streamName("test-stream").streamARN("arn:aws:kinesis:us-east-1:000000000000:stream/test-stream").build());
System.out.println(describeStream.streamDescription().streamCreationTimestamp());
```

## TODO
- [x] Implement Lambda -> Kinesis test using the AWS Java SDK v2.
- [x] Describe the binary signature test in `test_kinesis` a bit more in detail.
