### PR TITLE
Add test for deleting an alias associated with a Lambda URL

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1719,11 +1719,18 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         )
         if name not in function.aliases:
             raise ValueError("Alias not found")  # TODO proper exception
-        function.aliases.pop(name, None)
+        version_alias = function.aliases.pop(name, None)
 
         # cleanup related resources
         if name in function.provisioned_concurrency_configs:
             function.provisioned_concurrency_configs.pop(name)
+
+        # TODO: Allow for deactivating/unregistering specific Lambda URLs
+        if version_alias and name in function.function_url_configs:
+            url_config = function.function_url_configs.pop(name)
+            LOG.debug(
+                f"Stopping aliased Lambda Function URL {url_config.url} for {url_config.function_arn}"
+            )
 
     def get_alias(
         self, context: RequestContext, function_name: FunctionName, name: Alias, **kwargs

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4375,5 +4375,39 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_invocation_custom_id_aliased": {
     "recorded-date": "05-08-2024, 12:48:07",
     "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_persists_after_alias_delete": {
+    "recorded-date": "05-08-2024, 13:57:04",
+    "recorded-content": {
+      "create_lambda_url_config": {
+        "AuthType": "NONE",
+        "CreationTime": "date",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:1>",
+        "FunctionUrl": "<function-url>",
+        "InvokeMode": "BUFFERED",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "invoke_aliased_url_response": {
+        "status_code": 200
+      },
+      "delete_alias_resp": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "invoke_deleted_alias_url_response_delayed": {
+        "content": {
+          "Message": null
+        },
+        "headers": {
+          "x-amzn-ErrorType": "AccessDeniedException"
+        },
+        "status_code": 403
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -248,6 +248,9 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_non_existing_url": {
     "last_validated_date": "2024-04-11T17:16:39+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_persists_after_alias_delete": {
+    "last_validated_date": "2024-08-05T13:57:02+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_async_invoke_queue_upon_function_update": {
     "last_validated_date": "2024-05-15T18:29:38+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Records the AWS behaviour when a Lambda URL is created for an aliased version of a Lambda function; and then the alias is deleted post-creation of the URL.

The current behaviour is that the Lambda URL will remain. I believe a parity test for this edge-case is nesessary since the ARN of the function URL still points to the alias.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Single new test-case added called `test_lambda_url_persists_after_alias_delete` to test the above flow.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
