### PR TITLE
fix version.py glob after source package move

### DIFF
--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
-set -e
+# set -x
+set -euo pipefail
+shopt -s nullglob
+shopt -s globstar
 
-VERSION_FILE=${VERSION_FILE-VERSION}
-VERSION_PY=${VERSION_PY-"**/version.py"}
-DEPENDENCY_FILE=${DEPENDENCY_FILE-pyproject.toml}
+VERSION_FILE=${VERSION_FILE:-VERSION}
+VERSION_PY=${VERSION_PY:-"**/version.py"}
+DEPENDENCY_FILE=${DEPENDENCY_FILE:-pyproject.toml}
 
 function usage() {
     echo "A set of commands that facilitate release automation"
@@ -193,7 +196,7 @@ function cmd-git-commit-release() {
     echo $1 || verify_valid_version
 
     for file in ${VERSION_FILE} ${VERSION_PY} ${DEPENDENCY_FILE}; do
-            git add "$file" || echo "did not add file '$file' to commit"
+        git add "$file" || echo "did not add file '$file' to commit"
     done
     git commit -m "release version ${1}"
     git tag -a "v${1}" -m "Release version ${1}"
@@ -201,7 +204,7 @@ function cmd-git-commit-release() {
 
 function cmd-git-commit-increment() {
     for file in ${VERSION_FILE} ${VERSION_PY} ${DEPENDENCY_FILE}; do
-            [ -e "$file" ] && git add "$file"
+        git add "$file" || echo "did not add file '$file' to commit"
     done
     git commit -m "prepare next development iteration"
 }


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/11275 we have seen that the release helper currently does not properly add the `version.py` to the git commits for the release / version increments.

## Changes
This PR addresses this issue by:
- Setting sane defaults for bash settings in the `release-helper.sh` (`set -euo pipefail`, `shopt -s nullglob`) and for variable default assignments (use `:-` instead of `:` in order to also use defaults for empty but set variables).
- Also explicitly enables `globstar` tto fix the issue that the glob does not detect files in subdirectories properly.

## Testing
Tested with the following script which basically shows our release workflow:
```bash
make install
unset VERSION_PY
unset VERSION_FILE
unset DEPENDENCY_FILE

# set release version 0.0.0
bin/release-helper.sh set-ver 0.0.0
pip install -e .
bin/release-helper.sh git-commit-release 0.0.0

# set version increment
bin/release-helper.sh set-ver 0.0.1.dev
pip install -e .
bin/release-helper.sh git-commit-increment

# show commits and reset
git show HEAD
git show HEAD^
git reset --hard HEAD~2
```