### PR TITLE
Feature/EventStudio: patch put events

### DIFF
--- a/localstack-core/localstack/services/events/models.py
+++ b/localstack-core/localstack/services/events/models.py
@@ -76,6 +76,7 @@ FormattedEvent = TypedDict(  # functional syntax required due to name-name keys
         "resources": Optional[EventResourceList],
         "detail": dict[str, str | dict],
         "replay-name": Optional[ReplayName],
+        "event-bus-name": EventBusName,
     },
 )
 

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -1338,7 +1338,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                 event, context.region, context.account_id, region, account_id
             ):
                 event["TraceHeader"] = encoded_trace_header
-            event_formatted = format_event(event, region, account_id)
+            event_formatted = format_event(event, region, account_id, event_bus_name)
             store = self.get_store(region, account_id)
             try:
                 event_bus = self.get_event_bus(event_bus_name, store)

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -140,7 +140,10 @@ class TargetSender(ABC):
 
     def proxy_send_event(self, event: FormattedEvent | TransformedEvent):
         """Proxy method to process the event and send it to the target.
-        required for EventStudio extension"""
+        required for EventStudio extension,
+        in addition it removes the field event-bus-name from the event"""
+        if isinstance(event, dict):
+            event.pop("event-bus-name", None)
         self.send_event(event)
 
     def process_event(self, event: FormattedEvent):

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -138,7 +138,7 @@ class TargetSender(ABC):
     def send_event(self, event: FormattedEvent | TransformedEvent):
         pass
 
-    def proxy_send_event(self, event: FormattedEvent):
+    def proxy_send_event(self, event: FormattedEvent | TransformedEvent):
         """Proxy method to process the event and send it to the target.
         required for EventStudio extension"""
         self.send_event(event)

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -138,13 +138,18 @@ class TargetSender(ABC):
     def send_event(self, event: FormattedEvent | TransformedEvent):
         pass
 
+    def proxy_send_event(self, event: FormattedEvent):
+        """Proxy method to process the event and send it to the target.
+        required for EventStudio extension"""
+        self.send_event(event)
+
     def process_event(self, event: FormattedEvent):
         """Processes the event and send it to the target."""
         if input_path := self.target.get("InputPath"):
             event = transform_event_with_target_input_path(input_path, event)
         if input_transformer := self.target.get("InputTransformer"):
             event = self.transform_event_with_target_input_transformer(input_transformer, event)
-        self.send_event(event)
+        self.proxy_send_event(event)
 
     def transform_event_with_target_input_transformer(
         self, input_transformer: InputTransformer, event: FormattedEvent

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -139,9 +139,9 @@ class TargetSender(ABC):
         pass
 
     def proxy_send_event(self, event: FormattedEvent | TransformedEvent):
-        """Proxy method to process the event and send it to the target.
-        required for EventStudio extension,
-        in addition it removes the field event-bus-name from the event"""
+        """Proxy method to process the event and send it to the target,
+        in addition it removes the field event-bus-name from the event,
+        required for EventStudio extension"""
         if isinstance(event, dict):
             event.pop("event-bus-name", None)
         self.send_event(event)
@@ -158,6 +158,7 @@ class TargetSender(ABC):
         self, input_transformer: InputTransformer, event: FormattedEvent
     ) -> TransformedEvent:
         input_template = input_transformer["InputTemplate"]
+        event.pop("event-bus-name", None)
         template_replacements = get_template_replacements(input_transformer, event)
         predefined_template_replacements = self._get_predefined_template_replacements(event)
         template_replacements.update(predefined_template_replacements)

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -161,7 +161,9 @@ def recursive_remove_none_values_from_dict(d: Dict[str, Any]) -> Dict[str, Any]:
     return clean_dict
 
 
-def format_event(event: PutEventsRequestEntry, region: str, account_id: str) -> FormattedEvent:
+def format_event(
+    event: PutEventsRequestEntry, region: str, account_id: str, event_bus_name: EventBusName
+) -> FormattedEvent:
     # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-events.html
     trace_header = event.get("TraceHeader")
     message = {}
@@ -184,6 +186,7 @@ def format_event(event: PutEventsRequestEntry, region: str, account_id: str) -> 
         "region": region,
         "resources": event.get("Resources", []),
         "detail": json.loads(event.get("Detail", "{}")),
+        "event-bus-name": event_bus_name,
     }
     if replay_name := event.get("ReplayName"):
         formatted_event["replay-name"] = replay_name  # required for replay from archive

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -186,7 +186,7 @@ def format_event(
         "region": region,
         "resources": event.get("Resources", []),
         "detail": json.loads(event.get("Detail", "{}")),
-        "event-bus-name": event_bus_name,
+        "event-bus-name": event_bus_name,  # current workaround for EventStudio extension
     }
     if replay_name := event.get("ReplayName"):
         formatted_event["replay-name"] = replay_name  # required for replay from archive


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
To receive incoming events in their final form (after all transformers have been applied) a new proxy function is introduced in TargetSender. 
This proxy function is patched with the extension EventStduio in this PR: https://github.com/localstack/localstack-extension-event-studio/pull/26
In addition, the PR also introduces event-bus-name as a new field for the Event, required by the extension.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add proxy_send_event in TargetSender
- add additional field `event-bus-name` to Event

