### PR TITLE
upgrade ffmpeg to use version 7.0.1

### DIFF
--- a/localstack-core/localstack/packages/ffmpeg.py
+++ b/localstack-core/localstack/packages/ffmpeg.py
@@ -6,19 +6,19 @@ from localstack.packages.core import ArchiveDownloadAndExtractInstaller
 from localstack.utils.platform import get_arch
 
 FFMPEG_STATIC_BIN_URL = (
-    "https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-{version}-{arch}-static.tar.xz"
+    "https://www.johnvansickle.com/ffmpeg/releases/ffmpeg-{version}-{arch}-static.tar.xz"
 )
 
 
 class FfmpegPackage(Package):
     def __init__(self):
-        super().__init__(name="ffmpeg", default_version="4.4.1")
+        super().__init__(name="ffmpeg", default_version="7.0.1")
 
     def _get_installer(self, version: str) -> PackageInstaller:
         return FfmpegPackageInstaller(version)
 
     def get_versions(self) -> List[str]:
-        return ["4.4.1"]
+        return ["7.0.1"]
 
 
 class FfmpegPackageInstaller(ArchiveDownloadAndExtractInstaller):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As a follow up to PR: https://github.com/localstack/localstack/pull/11261, we decided to upgrade the `ffmpeg` package version. Currently we use an old release version `4.4.1`, for more information check out: https://www.johnvansickle.com/ffmpeg/old-releases.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Upgrade the package to the latest release: `7.0.1`. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
