### PR TITLE
fix ARN construction for APIGW NG get_source_arn

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
@@ -6,6 +6,7 @@ from typing import Type, TypedDict
 from moto.apigateway.models import RestAPI as MotoRestAPI
 
 from localstack.services.apigateway.models import MergedRestApi, RestApiContainer, RestApiDeployment
+from localstack.utils.aws.arns import get_partition
 
 from .context import RestApiInvocationContext
 from .moto_helpers import get_resources_from_moto_rest_api
@@ -85,7 +86,7 @@ def get_source_arn(context: RestApiInvocationContext):
     method = context.resource_method["httpMethod"]
     path = context.resource["path"]
     return (
-        "arn:aws:execute-api"
+        f"arn:{get_partition(context.region)}:execute-api"
         f":{context.region}"
         f":{context.account_id}"
         f":{context.api_id}"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #10912 and this comment: https://github.com/localstack/localstack/pull/10912#discussion_r1698667973

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- use `get_partition` in the ARN construction of the source ARN for an APIGW invocation

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
