### PR TITLE
Fixes for proper ARN generation / testing

### DIFF
--- a/localstack-core/localstack/services/events/event_bus.py
+++ b/localstack-core/localstack/services/events/event_bus.py
@@ -107,7 +107,7 @@ class EventBusService:
         if condition and principal != "*":
             raise ValueError("Condition can only be set when principal is '*'")
         if principal != "*":
-            principal = {"AWS": f"arn:{get_partition(self.region)}:iam::{principal}:root"}
+            principal = {"AWS": f"arn:{get_partition(self.event_bus.region)}:iam::{principal}:root"}
         statement = Statement(
             Sid=statement_id,
             Effect="Allow",

--- a/localstack-core/localstack/services/events/event_bus.py
+++ b/localstack-core/localstack/services/events/event_bus.py
@@ -13,6 +13,7 @@ from localstack.aws.api.events import (
     TagList,
 )
 from localstack.services.events.models import EventBus, ResourcePolicy, RuleDict, Statement
+from localstack.utils.aws.arns import get_partition
 
 
 class EventBusService:
@@ -106,7 +107,7 @@ class EventBusService:
         if condition and principal != "*":
             raise ValueError("Condition can only be set when principal is '*'")
         if principal != "*":
-            principal = {"AWS": f"arn:aws:iam::{principal}:root"}
+            principal = {"AWS": f"arn:{get_partition(self.region)}:iam::{principal}:root"}
         statement = Statement(
             Sid=statement_id,
             Effect="Allow",

--- a/tests/aws/services/cloudformation/resources/test_secretsmanager.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_secretsmanager.validation.json
@@ -6,10 +6,10 @@
     "last_validated_date": "2024-07-03T18:36:35+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cfn_secret_policy[default]": {
-    "last_validated_date": "2024-07-03T18:52:05+00:00"
+    "last_validated_date": "2024-08-01T12:22:53+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cfn_secret_policy[true]": {
-    "last_validated_date": "2024-07-03T18:51:39+00:00"
+    "last_validated_date": "2024-08-01T12:22:32+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cfn_secretsmanager_gen_secret": {
     "last_validated_date": "2024-07-03T15:39:56+00:00"

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -4,6 +4,7 @@ from typing import Tuple
 
 import pytest
 
+from localstack.utils.aws.arns import get_partition
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
 from tests.aws.services.events.helper_functions import put_entries_assert_results_sqs
@@ -71,7 +72,7 @@ def events_create_default_or_custom_event_bus(events_create_event_bus, region_na
     def _create_default_or_custom_event_bus(event_bus_type: str = "default"):
         if event_bus_type == "default":
             event_bus_name = "default"
-            event_bus_arn = f"arn:aws:events:{region_name}:{account_id}:event-bus/default"
+            event_bus_arn = f"arn:{get_partition(region_name)}:events:{region_name}:{account_id}:event-bus/default"
         else:
             event_bus_name = f"test-bus-{short_uid()}"
             response = events_create_event_bus(Name=event_bus_name)

--- a/tests/aws/templates/secretsmanager_secret_policy.yml
+++ b/tests/aws/templates/secretsmanager_secret_policy.yml
@@ -28,7 +28,7 @@ Resources:
             Effect: Allow
             Principal:
               AWS:
-                Fn::Sub: arn:aws:iam::${AWS::AccountId}:root
+                Fn::Sub: arn:${AWS::Partition}:iam::${AWS::AccountId}:root
 Outputs:
   SecretId:
     Value: !GetAtt MySecret.Id


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With #10912 we introduced some fixes regarding returning proper ARNs in non-default partitions.

However, some have been missed, uncovered due to recently modified or added tests.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Use proper partition placeholders in tests or use the correct partition for manually generated ARNs in tests
* Events returns the correct partition in the generated ARN for root account principal ARNs on `put_permission` calls.

More fixes for events and resourcegroups are in getmoto/moto#7913

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
