### PR TITLE
fix S3 pre-signed issue importing moto in S3 image

### DIFF
--- a/localstack-core/localstack/services/s3/presigned_url.py
+++ b/localstack-core/localstack/services/s3/presigned_url.py
@@ -257,9 +257,13 @@ def get_secret_access_key_from_access_key_id(access_key_id: str, region: str) ->
     If the AccessKey is not registered, use the default `test` value that was historically used for pre-signed URLs, in
     order to support default use cases
     :param access_key_id: the provided AccessKeyID in the Credentials parameter
+    :param region: the region from the credentials
     :return: the linked secret_access_key to the access_key
     """
-    from moto.iam.models import AccessKey, iam_backends
+    try:
+        from moto.iam.models import AccessKey, iam_backends
+    except ImportError:
+        return
 
     account_id = get_account_id_from_access_key_id(access_key_id)
     moto_access_key: AccessKey = iam_backends[account_id][get_partition(region)].access_keys.get(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
It got reported in our Slack community channel that there was an issue with pre-signed URL and the S3 image. 

This is a regression introduced by #10265, to allow users to use credentials created by LocalStack to pre-signed URL. However, this introduced a dependency on `moto` which the tests did not catch. 

I'm still a bit surprised how it hasn't been caught, but I think our current setup to run the tests inside the docker container might make so that `moto` is installed inside it. At some point we should revisit the setup to have the tests run outside the container and against the built image (almost there!).

Trying to access a pre-signed URL in the S3 image raises the following exception:
```python
localstack-test  | 2024-08-01T14:01:07.994  INFO --- [et.reactor-0] localstack.request.aws     : AWS s3.GetObject => 500 (InternalError); None/None; GetObjectRequest(None, headers={'Host': 'localhost:4566', 'Sec-Fetch-Site': 'none', 'Connection': 'keep-alive', 'Upgrade-Insecure-Requests': '1', 'Sec-Fetch-Mode': 'navigate', 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15', 'Accept-Language': 'en-US,en;q=0.9', 'Sec-Fetch-Dest': 'document', 'Accept-Encoding': 'gzip, deflate'}); InternalError(exception while calling s3.GetObject: Traceback (most recent call last):
localstack-test  |   File "/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo/gateway/chain.py", line 166, in handle
localstack-test  |     handler(self, self.context, response)
localstack-test  |   File "/opt/code/localstack/localstack-core/localstack/aws/handlers/presigned_url.py", line 23, in __call__
localstack-test  |     handler(chain, context, response)
localstack-test  |   File "/opt/code/localstack/localstack-core/localstack/services/s3/presigned_url.py", line 198, in __call__
localstack-test  |     validate_presigned_url_s3(context)
localstack-test  |   File "/opt/code/localstack/localstack-core/localstack/services/s3/presigned_url.py", line 319, in validate_presigned_url_s3
localstack-test  |     credentials = get_credentials_from_parameters(query_parameters)
localstack-test  |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
localstack-test  |   File "/opt/code/localstack/localstack-core/localstack/services/s3/presigned_url.py", line 242, in get_credentials_from_parameters
localstack-test  |     if not (secret_access_key := get_secret_access_key_from_access_key_id(access_key_id)):
localstack-test  |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
localstack-test  |   File "/opt/code/localstack/localstack-core/localstack/services/s3/presigned_url.py", line 261, in get_secret_access_key_from_access_key_id
localstack-test  |     from moto.iam.models import AccessKey, iam_backends
localstack-test  | ModuleNotFoundError: No module named 'moto'
localstack-test  | , headers={'Content-Type': 'application/xml', 'Content-Length': '1491', 'x-amz-request-id': '0777e3a2-2ef7-4169-985d-e54339473bec', 'x-amz-id-2': 's9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234='})
```

\cc @HarshCasper for the community channel issue, thanks for helping the user!
https://localstack-community.slack.com/archives/CMAFN2KSP/p1722017331093119

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- return if the import fails, to skip that additional logic in the S3 image

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
