### PR TITLE
Lambda DevX, Introducing Lambda Debug Mode

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -429,9 +429,9 @@ if TMP_FOLDER.startswith("/var/folders/") and os.path.exists("/private%s" % TMP_
 LS_LOG = eval_log_type("LS_LOG")
 DEBUG = is_env_true("DEBUG") or LS_LOG in TRACE_LOG_LEVELS
 
-# PUBLIC: 0 (default)
+# PUBLIC PREVIEW: 0 (default), 1 (preview)
 # When enabled it triggers specialised workflows for the debugging.
-DEBUG_MODE = is_env_true("DEBUG_MODE")
+LAMBDA_DEBUG_MODE = is_env_true("LAMBDA_DEBUG_MODE")
 
 # whether to enable debugpy
 DEVELOP = is_env_true("DEVELOP")

--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -429,6 +429,10 @@ if TMP_FOLDER.startswith("/var/folders/") and os.path.exists("/private%s" % TMP_
 LS_LOG = eval_log_type("LS_LOG")
 DEBUG = is_env_true("DEBUG") or LS_LOG in TRACE_LOG_LEVELS
 
+# PUBLIC: 0 (default)
+# When enabled it triggers specialised workflows for the debugging.
+DEBUG_MODE = is_env_true("DEBUG_MODE")
+
 # whether to enable debugpy
 DEVELOP = is_env_true("DEVELOP")
 

--- a/localstack-core/localstack/services/lambda_/invocation/execution_environment.py
+++ b/localstack-core/localstack/services/lambda_/invocation/execution_environment.py
@@ -23,7 +23,10 @@ from localstack.services.lambda_.invocation.runtime_executor import (
     RuntimeExecutor,
     get_runtime_executor,
 )
-from localstack.utils.debug_mode import DEFAULT_DEBUG_MODE_TIMEOUT_SECONDS, is_debug_mode
+from localstack.utils.lambda_debug_mode import (
+    DEFAULT_LAMBDA_DEBUG_MODE_TIMEOUT_SECONDS,
+    is_lambda_debug_mode,
+)
 from localstack.utils.strings import to_str
 
 STARTUP_TIMEOUT_SEC = config.LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT
@@ -396,6 +399,6 @@ class ExecutionEnvironment:
         # Returns the timeout value in seconds to be enforced during the execution of the
         # lambda function. This is the configured value or the DEBUG MODE default if this
         # is enabled.
-        if is_debug_mode():
-            return DEFAULT_DEBUG_MODE_TIMEOUT_SECONDS
+        if is_lambda_debug_mode():
+            return DEFAULT_LAMBDA_DEBUG_MODE_TIMEOUT_SECONDS
         return self.function_version.config.timeout

--- a/localstack-core/localstack/services/lambda_/invocation/executor_endpoint.py
+++ b/localstack-core/localstack/services/lambda_/invocation/executor_endpoint.py
@@ -10,6 +10,7 @@ from werkzeug import Request
 from localstack.http import Response, route
 from localstack.services.edge import ROUTER
 from localstack.services.lambda_.invocation.lambda_models import InvocationResult
+from localstack.utils.debug_mode import DEFAULT_DEBUG_MODE_TIMEOUT_SECONDS, is_debug_mode
 from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import to_str
 
@@ -193,10 +194,12 @@ class ExecutorEndpoint(Endpoint):
             raise InvokeSendError(
                 f"Error while sending invocation {payload} to {invocation_url}. Error Code: {response.status_code}"
             )
-        # Do not wait longer for an invoke than the maximum lambda timeout plus a buffer
-        # TODO: Can we really make this assumption for debugging?
-        lambda_max_timeout_seconds = 900
-        invoke_timeout_buffer_seconds = 5
-        return self.invocation_future.result(
-            timeout=lambda_max_timeout_seconds + invoke_timeout_buffer_seconds
-        )
+        if is_debug_mode():
+            timeout_seconds = DEFAULT_DEBUG_MODE_TIMEOUT_SECONDS
+        else:
+            # TODO: integration timeouts should be enforced instead.
+            # Do not wait longer for an invoke than the maximum lambda timeout plus a buffer
+            lambda_max_timeout_seconds = 900
+            invoke_timeout_buffer_seconds = 5
+            timeout_seconds = lambda_max_timeout_seconds + invoke_timeout_buffer_seconds
+        return self.invocation_future.result(timeout=timeout_seconds)

--- a/localstack-core/localstack/services/lambda_/invocation/executor_endpoint.py
+++ b/localstack-core/localstack/services/lambda_/invocation/executor_endpoint.py
@@ -10,7 +10,10 @@ from werkzeug import Request
 from localstack.http import Response, route
 from localstack.services.edge import ROUTER
 from localstack.services.lambda_.invocation.lambda_models import InvocationResult
-from localstack.utils.debug_mode import DEFAULT_DEBUG_MODE_TIMEOUT_SECONDS, is_debug_mode
+from localstack.utils.lambda_debug_mode import (
+    DEFAULT_LAMBDA_DEBUG_MODE_TIMEOUT_SECONDS,
+    is_lambda_debug_mode,
+)
 from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import to_str
 
@@ -194,8 +197,8 @@ class ExecutorEndpoint(Endpoint):
             raise InvokeSendError(
                 f"Error while sending invocation {payload} to {invocation_url}. Error Code: {response.status_code}"
             )
-        if is_debug_mode():
-            timeout_seconds = DEFAULT_DEBUG_MODE_TIMEOUT_SECONDS
+        if is_lambda_debug_mode():
+            timeout_seconds = DEFAULT_LAMBDA_DEBUG_MODE_TIMEOUT_SECONDS
         else:
             # TODO: integration timeouts should be enforced instead.
             # Do not wait longer for an invoke than the maximum lambda timeout plus a buffer

--- a/localstack-core/localstack/utils/debug_mode.py
+++ b/localstack-core/localstack/utils/debug_mode.py
@@ -1,0 +1,13 @@
+from typing import Final
+
+from localstack.config import DEBUG_MODE
+
+# Specifies the fault timeout value in seconds to be used by time restricted workflows when
+# Debug Mode is enabled. The value is set to one hour to ensure eventual termination of
+# long-running processes.
+DEFAULT_DEBUG_MODE_TIMEOUT_SECONDS: Final[int] = 3_600
+
+
+def is_debug_mode() -> bool:
+    # Returns the state of debug mode. True if enabled, False otherwise.
+    return DEBUG_MODE

--- a/localstack-core/localstack/utils/lambda_debug_mode.py
+++ b/localstack-core/localstack/utils/lambda_debug_mode.py
@@ -1,13 +1,11 @@
-from typing import Final
-
-from localstack.config import DEBUG_MODE
+from localstack.config import LAMBDA_DEBUG_MODE
 
 # Specifies the fault timeout value in seconds to be used by time restricted workflows when
 # Debug Mode is enabled. The value is set to one hour to ensure eventual termination of
 # long-running processes.
-DEFAULT_DEBUG_MODE_TIMEOUT_SECONDS: Final[int] = 3_600
+DEFAULT_LAMBDA_DEBUG_MODE_TIMEOUT_SECONDS: int = 3_600
 
 
-def is_debug_mode() -> bool:
+def is_lambda_debug_mode() -> bool:
     # Returns the state of debug mode. True if enabled, False otherwise.
-    return DEBUG_MODE
+    return LAMBDA_DEBUG_MODE


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The debugging of Lambda functions is currently hampered by the need to manually manage or disable execution timeouts, which often do not provide enough time to connect a remote debugger and perform the necessary evaluations. This issue is particularly relevant for services like Lambda and API Gateway. By default, Lambda limits execution to three seconds, though it can be configured for up to 15 minutes, while API Gateway can impose its own timeout on integrations.
To enhance the developer experience when debugging Lambda functions, this pull request (PR) proposes introducing a "Debug Mode." This mode would signal to the system that the deployment is in a debugging phase, allowing any provider to adjust relevant settings, such as timeouts, accordingly. The changes also suggest setting a default timeout value and implementing dynamic timeout adjustments that do not alter the system's static state. This ensures compatibility with persistence logic and maintains readability of timeout values during debugging, improving transparency and reducing potential distractions.
This initial effort will be followed by a more substantial configurable pattern designed to enable debugging across multiple Lambda functions simultaneously when in Debug Mode.
The new recommended command for starting LocalStack for the debug of lambda functions is now: 
`LAMBDA_DEBUG_MODE=1 LAMBDA_DOCKER_FLAGS='-p 19891:19891' localstack start`

_Note that API Gateway was found to not strictly enforce the evaluation of Lambda functions within its set integration timeouts. Instead, it ensures that the process is halted after the maximum Lambda execution time is reached. This behaviour has been maintained, with an extended timeout applied when in Debug Mode. However, enforcing timeouts in API Gateway should be considered in future efforts._

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- addition of the `LAMBDA_DEBUG_MODE` environment variable and related support constants and functions
- addition of automatic lambda evaluation timeout increase when in debug mode
- addition of automatic API Gateway timeout increase when in debug mode

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
