### PR TITLE
fix APIGW double slashes between stage and path

### DIFF
--- a/localstack-core/localstack/services/apigateway/context.py
+++ b/localstack-core/localstack/services/apigateway/context.py
@@ -77,7 +77,7 @@ class ApiInvocationContext:
         auth_context: Dict[str, Any] = None,
     ):
         self.method = method
-        self.path = path
+        self._path = path
         self.data = data
         self.headers = headers
         self.context = {"requestId": short_uid()} if context is None else context
@@ -99,6 +99,16 @@ class ApiInvocationContext:
         self.response = None
 
     @property
+    def path(self) -> str:
+        return self._path
+
+    @path.setter
+    def path(self, new_path: str):
+        if isinstance(new_path, str):
+            new_path = "/" + new_path.lstrip("/")
+        self._path = new_path
+
+    @property
     def resource_id(self) -> Optional[str]:
         return (self.resource or {}).get("id")
 
@@ -116,6 +126,8 @@ class ApiInvocationContext:
     @path_with_query_string.setter
     def path_with_query_string(self, new_path: str):
         """Set a custom invocation path with query string (used to handle "../_user_request_/.." paths)."""
+        if isinstance(new_path, str):
+            new_path = "/" + new_path.lstrip("/")
         self._path_with_query_string = new_path
 
     def query_params(self) -> Dict[str, str]:

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -1503,11 +1503,11 @@ def get_event_request_context(invocation_context: ApiInvocationContext):
     resource_id = invocation_context.resource_id
 
     set_api_id_stage_invocation_path(invocation_context)
-    relative_path, query_string_params = extract_query_string_params(
-        path=invocation_context.path_with_query_string
-    )
     api_id = invocation_context.api_id
     stage = invocation_context.stage
+
+    full_path = invocation_context.raw_uri.removeprefix(f"/{stage}")
+    relative_path, query_string_params = extract_query_string_params(path=full_path)
 
     source_ip = invocation_context.auth_identity.get("sourceIp")
     integration_uri = integration_uri or ""

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -514,7 +514,7 @@ class RestApiAwsProxyIntegration(RestApiIntegration):
             queryStringParameters=invocation_req["query_string_parameters"] or None,
             multiValueQueryStringParameters=invocation_req["multi_value_query_string_parameters"]
             or None,
-            pathParameters=invocation_req["path_parameters"],
+            pathParameters=invocation_req["path_parameters"] or None,
             httpMethod=invocation_req["http_method"],
             path=invocation_req["path"],
             resource=context.resource["path"],

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
-    "recorded-date": "25-07-2024, 20:18:13",
+    "recorded-date": "02-08-2024, 23:34:43",
     "recorded-content": {
       "invocation-payload-without-trailing-slash": {
         "body": null,
@@ -81,9 +81,9 @@
           ]
         },
         "multiValueQueryStringParameters": null,
-        "path": "/test-path",
+        "path": "/proxy-value",
         "pathParameters": {
-          "proxy": "test-path"
+          "proxy": "proxy-value"
         },
         "queryStringParameters": null,
         "requestContext": {
@@ -108,14 +108,14 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test/test-path",
+          "path": "/stage/proxy-value",
           "protocol": "HTTP/1.1",
           "requestId": "<uuid:1>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
           "resourcePath": "/{proxy+}",
-          "stage": "test"
+          "stage": "stage"
         },
         "resource": "/{proxy+}",
         "stageVariables": null
@@ -199,9 +199,9 @@
           ]
         },
         "multiValueQueryStringParameters": null,
-        "path": "/test-path/",
+        "path": "/proxy-value/",
         "pathParameters": {
-          "proxy": "test-path"
+          "proxy": "proxy-value"
         },
         "queryStringParameters": null,
         "requestContext": {
@@ -226,14 +226,14 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test/test-path/",
+          "path": "/stage/proxy-value/",
           "protocol": "HTTP/1.1",
           "requestId": "<uuid:2>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
           "resourcePath": "/{proxy+}",
-          "stage": "test"
+          "stage": "stage"
         },
         "resource": "/{proxy+}",
         "stageVariables": null
@@ -317,9 +317,9 @@
           ]
         },
         "multiValueQueryStringParameters": null,
-        "path": "/test-path//test-path",
+        "path": "/proxy-value//double-slash",
         "pathParameters": {
-          "proxy": "test-path//test-path"
+          "proxy": "proxy-value//double-slash"
         },
         "queryStringParameters": null,
         "requestContext": {
@@ -344,14 +344,14 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test/test-path//test-path",
+          "path": "/stage/proxy-value//double-slash",
           "protocol": "HTTP/1.1",
           "requestId": "<uuid:3>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
           "resourcePath": "/{proxy+}",
-          "stage": "test"
+          "stage": "stage"
         },
         "resource": "/{proxy+}",
         "stageVariables": null
@@ -371,127 +371,9 @@
           "CloudFront-Viewer-Country": "<cloudfront-country:1>",
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
-          "Via": "<via:1>",
+          "Via": "<via:4>",
           "X-Amz-Cf-Id": "<cf-id:4>",
           "X-Amzn-Trace-Id": "<trace-id:4>",
-          "X-Forwarded-For": "<X-Forwarded-For>",
-          "X-Forwarded-Port": "<X-Forwarded-Port>",
-          "X-Forwarded-Proto": "<X-Forwarded-Proto>",
-          "tEsT-HEADeR": "aValUE"
-        },
-        "httpMethod": "GET",
-        "isBase64Encoded": false,
-        "multiValueHeaders": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Authorization": [
-            "random-value"
-          ],
-          "CloudFront-Forwarded-Proto": [
-            "https"
-          ],
-          "CloudFront-Is-Desktop-Viewer": [
-            "true"
-          ],
-          "CloudFront-Is-Mobile-Viewer": [
-            "false"
-          ],
-          "CloudFront-Is-SmartTV-Viewer": [
-            "false"
-          ],
-          "CloudFront-Is-Tablet-Viewer": [
-            "false"
-          ],
-          "CloudFront-Viewer-ASN": [
-            "<cloudfront-asn:1>"
-          ],
-          "CloudFront-Viewer-Country": [
-            "<cloudfront-country:1>"
-          ],
-          "Host": [
-            "<host:1>"
-          ],
-          "User-Agent": [
-            "python-requests/testing"
-          ],
-          "Via": [
-            "<via:1>"
-          ],
-          "X-Amz-Cf-Id": [
-            "<cf-id:4>"
-          ],
-          "X-Amzn-Trace-Id": [
-            "<trace-id:4>"
-          ],
-          "X-Forwarded-For": "<X-Forwarded-For>",
-          "X-Forwarded-Port": "<X-Forwarded-Port>",
-          "X-Forwarded-Proto": "<X-Forwarded-Proto>",
-          "tEsT-HEADeR": [
-            "aValUE"
-          ]
-        },
-        "multiValueQueryStringParameters": null,
-        "path": "/test-path",
-        "pathParameters": {
-          "proxy": "test-path"
-        },
-        "queryStringParameters": null,
-        "requestContext": {
-          "accountId": "111111111111",
-          "apiId": "<api-id>",
-          "deploymentId": "<deployment-id:1>",
-          "domainName": "<host:1>",
-          "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:4>",
-          "httpMethod": "GET",
-          "identity": {
-            "accessKey": null,
-            "accountId": null,
-            "caller": null,
-            "cognitoAuthenticationProvider": null,
-            "cognitoAuthenticationType": null,
-            "cognitoIdentityId": null,
-            "cognitoIdentityPoolId": null,
-            "principalOrgId": null,
-            "sourceIp": "<source-ip:1>",
-            "user": null,
-            "userAgent": "python-requests/testing",
-            "userArn": null
-          },
-          "path": "/test/test-path",
-          "protocol": "HTTP/1.1",
-          "requestId": "<uuid:4>",
-          "requestTime": "<request-time>",
-          "requestTimeEpoch": "<request-time-epoch>",
-          "resourceId": "<resource-id:1>",
-          "resourcePath": "/{proxy+}",
-          "stage": "test"
-        },
-        "resource": "/{proxy+}",
-        "stageVariables": null
-      },
-      "invocation-payload-with-prepended-slash": {
-        "body": null,
-        "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "random-value",
-          "CloudFront-Forwarded-Proto": "https",
-          "CloudFront-Is-Desktop-Viewer": "true",
-          "CloudFront-Is-Mobile-Viewer": "false",
-          "CloudFront-Is-SmartTV-Viewer": "false",
-          "CloudFront-Is-Tablet-Viewer": "false",
-          "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
-          "CloudFront-Viewer-Country": "<cloudfront-country:1>",
-          "Host": "<host:1>",
-          "User-Agent": "python-requests/testing",
-          "Via": "<via:4>",
-          "X-Amz-Cf-Id": "<cf-id:5>",
-          "X-Amzn-Trace-Id": "<trace-id:5>",
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>",
@@ -540,10 +422,10 @@
             "<via:4>"
           ],
           "X-Amz-Cf-Id": [
-            "<cf-id:5>"
+            "<cf-id:4>"
           ],
           "X-Amzn-Trace-Id": [
-            "<trace-id:5>"
+            "<trace-id:4>"
           ],
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
@@ -553,9 +435,9 @@
           ]
         },
         "multiValueQueryStringParameters": null,
-        "path": "/test-path",
+        "path": "/proxy-value",
         "pathParameters": {
-          "proxy": "test-path"
+          "proxy": "proxy-value"
         },
         "queryStringParameters": null,
         "requestContext": {
@@ -564,7 +446,7 @@
           "deploymentId": "<deployment-id:1>",
           "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:5>",
+          "extendedRequestId": "<extended-request-id:4>",
           "httpMethod": "GET",
           "identity": {
             "accessKey": null,
@@ -580,19 +462,19 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test//test-path",
+          "path": "/stage/proxy-value",
           "protocol": "HTTP/1.1",
-          "requestId": "<uuid:5>",
+          "requestId": "<uuid:4>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
           "resourcePath": "/{proxy+}",
-          "stage": "test"
+          "stage": "stage"
         },
         "resource": "/{proxy+}",
         "stageVariables": null
       },
-      "invocation-payload-without-trailing-slash-and-query-params": {
+      "invocation-payload-with-prepended-slash": {
         "body": null,
         "headers": {
           "Accept": "*/*",
@@ -608,8 +490,8 @@
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:5>",
-          "X-Amz-Cf-Id": "<cf-id:6>",
-          "X-Amzn-Trace-Id": "<trace-id:6>",
+          "X-Amz-Cf-Id": "<cf-id:5>",
+          "X-Amzn-Trace-Id": "<trace-id:5>",
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>",
@@ -658,10 +540,10 @@
             "<via:5>"
           ],
           "X-Amz-Cf-Id": [
-            "<cf-id:6>"
+            "<cf-id:5>"
           ],
           "X-Amzn-Trace-Id": [
-            "<trace-id:6>"
+            "<trace-id:5>"
           ],
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
@@ -670,25 +552,19 @@
             "aValUE"
           ]
         },
-        "multiValueQueryStringParameters": {
-          "urlparam": [
-            "test"
-          ]
-        },
-        "path": "/test-path",
+        "multiValueQueryStringParameters": null,
+        "path": "/proxy-value",
         "pathParameters": {
-          "proxy": "test-path"
+          "proxy": "proxy-value"
         },
-        "queryStringParameters": {
-          "urlparam": "test"
-        },
+        "queryStringParameters": null,
         "requestContext": {
           "accountId": "111111111111",
           "apiId": "<api-id>",
           "deploymentId": "<deployment-id:1>",
           "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:6>",
+          "extendedRequestId": "<extended-request-id:5>",
           "httpMethod": "GET",
           "identity": {
             "accessKey": null,
@@ -704,19 +580,19 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test/test-path",
+          "path": "/stage//proxy-value",
           "protocol": "HTTP/1.1",
-          "requestId": "<uuid:6>",
+          "requestId": "<uuid:5>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
           "resourcePath": "/{proxy+}",
-          "stage": "test"
+          "stage": "stage"
         },
         "resource": "/{proxy+}",
         "stageVariables": null
       },
-      "invocation-payload-with-trailing-slash-and-query-params": {
+      "invocation-payload-without-trailing-slash-and-query-params": {
         "body": null,
         "headers": {
           "Accept": "*/*",
@@ -732,8 +608,8 @@
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:6>",
-          "X-Amz-Cf-Id": "<cf-id:7>",
-          "X-Amzn-Trace-Id": "<trace-id:7>",
+          "X-Amz-Cf-Id": "<cf-id:6>",
+          "X-Amzn-Trace-Id": "<trace-id:6>",
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>",
@@ -782,10 +658,10 @@
             "<via:6>"
           ],
           "X-Amz-Cf-Id": [
-            "<cf-id:7>"
+            "<cf-id:6>"
           ],
           "X-Amzn-Trace-Id": [
-            "<trace-id:7>"
+            "<trace-id:6>"
           ],
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
@@ -799,9 +675,9 @@
             "test"
           ]
         },
-        "path": "/test-path/",
+        "path": "/proxy-value",
         "pathParameters": {
-          "proxy": "test-path"
+          "proxy": "proxy-value"
         },
         "queryStringParameters": {
           "urlparam": "test"
@@ -812,7 +688,7 @@
           "deploymentId": "<deployment-id:1>",
           "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:7>",
+          "extendedRequestId": "<extended-request-id:6>",
           "httpMethod": "GET",
           "identity": {
             "accessKey": null,
@@ -828,19 +704,19 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test/test-path/",
+          "path": "/stage/proxy-value",
           "protocol": "HTTP/1.1",
-          "requestId": "<uuid:7>",
+          "requestId": "<uuid:6>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
           "resourcePath": "/{proxy+}",
-          "stage": "test"
+          "stage": "stage"
         },
         "resource": "/{proxy+}",
         "stageVariables": null
       },
-      "invocation-payload-with-path-encoded-email": {
+      "invocation-payload-with-trailing-slash-and-query-params": {
         "body": null,
         "headers": {
           "Accept": "*/*",
@@ -856,8 +732,8 @@
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:7>",
-          "X-Amz-Cf-Id": "<cf-id:8>",
-          "X-Amzn-Trace-Id": "<trace-id:8>",
+          "X-Amz-Cf-Id": "<cf-id:7>",
+          "X-Amzn-Trace-Id": "<trace-id:7>",
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>",
@@ -906,10 +782,10 @@
             "<via:7>"
           ],
           "X-Amz-Cf-Id": [
-            "<cf-id:8>"
+            "<cf-id:7>"
           ],
           "X-Amzn-Trace-Id": [
-            "<trace-id:8>"
+            "<trace-id:7>"
           ],
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
@@ -918,19 +794,25 @@
             "aValUE"
           ]
         },
-        "multiValueQueryStringParameters": null,
-        "path": "/test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com",
-        "pathParameters": {
-          "proxy": "test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com"
+        "multiValueQueryStringParameters": {
+          "urlparam": [
+            "test"
+          ]
         },
-        "queryStringParameters": null,
+        "path": "/proxy-value/",
+        "pathParameters": {
+          "proxy": "proxy-value"
+        },
+        "queryStringParameters": {
+          "urlparam": "test"
+        },
         "requestContext": {
           "accountId": "111111111111",
           "apiId": "<api-id>",
           "deploymentId": "<deployment-id:1>",
           "domainName": "<host:1>",
           "domainPrefix": "<api-id>",
-          "extendedRequestId": "<extended-request-id:8>",
+          "extendedRequestId": "<extended-request-id:7>",
           "httpMethod": "GET",
           "identity": {
             "accessKey": null,
@@ -946,19 +828,19 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test/test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com",
+          "path": "/stage/proxy-value/",
           "protocol": "HTTP/1.1",
-          "requestId": "<uuid:8>",
+          "requestId": "<uuid:7>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
           "resourcePath": "/{proxy+}",
-          "stage": "test"
+          "stage": "stage"
         },
         "resource": "/{proxy+}",
         "stageVariables": null
       },
-      "invocation-payload-with-params-encoding": {
+      "invocation-payload-with-path-encoded-email": {
         "body": null,
         "headers": {
           "Accept": "*/*",
@@ -974,8 +856,8 @@
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
           "Via": "<via:8>",
-          "X-Amz-Cf-Id": "<cf-id:9>",
-          "X-Amzn-Trace-Id": "<trace-id:9>",
+          "X-Amz-Cf-Id": "<cf-id:8>",
+          "X-Amzn-Trace-Id": "<trace-id:8>",
           "X-Forwarded-For": "<X-Forwarded-For>",
           "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>",
@@ -1024,6 +906,124 @@
             "<via:8>"
           ],
           "X-Amz-Cf-Id": [
+            "<cf-id:8>"
+          ],
+          "X-Amzn-Trace-Id": [
+            "<trace-id:8>"
+          ],
+          "X-Forwarded-For": "<X-Forwarded-For>",
+          "X-Forwarded-Port": "<X-Forwarded-Port>",
+          "X-Forwarded-Proto": "<X-Forwarded-Proto>",
+          "tEsT-HEADeR": [
+            "aValUE"
+          ]
+        },
+        "multiValueQueryStringParameters": null,
+        "path": "/proxy-value/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com",
+        "pathParameters": {
+          "proxy": "proxy-value/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com"
+        },
+        "queryStringParameters": null,
+        "requestContext": {
+          "accountId": "111111111111",
+          "apiId": "<api-id>",
+          "deploymentId": "<deployment-id:1>",
+          "domainName": "<host:1>",
+          "domainPrefix": "<api-id>",
+          "extendedRequestId": "<extended-request-id:8>",
+          "httpMethod": "GET",
+          "identity": {
+            "accessKey": null,
+            "accountId": null,
+            "caller": null,
+            "cognitoAuthenticationProvider": null,
+            "cognitoAuthenticationType": null,
+            "cognitoIdentityId": null,
+            "cognitoIdentityPoolId": null,
+            "principalOrgId": null,
+            "sourceIp": "<source-ip:1>",
+            "user": null,
+            "userAgent": "python-requests/testing",
+            "userArn": null
+          },
+          "path": "/stage/proxy-value/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com",
+          "protocol": "HTTP/1.1",
+          "requestId": "<uuid:8>",
+          "requestTime": "<request-time>",
+          "requestTimeEpoch": "<request-time-epoch>",
+          "resourceId": "<resource-id:1>",
+          "resourcePath": "/{proxy+}",
+          "stage": "stage"
+        },
+        "resource": "/{proxy+}",
+        "stageVariables": null
+      },
+      "invocation-payload-with-params-encoding": {
+        "body": null,
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "random-value",
+          "CloudFront-Forwarded-Proto": "https",
+          "CloudFront-Is-Desktop-Viewer": "true",
+          "CloudFront-Is-Mobile-Viewer": "false",
+          "CloudFront-Is-SmartTV-Viewer": "false",
+          "CloudFront-Is-Tablet-Viewer": "false",
+          "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
+          "CloudFront-Viewer-Country": "<cloudfront-country:1>",
+          "Host": "<host:1>",
+          "User-Agent": "python-requests/testing",
+          "Via": "<via:9>",
+          "X-Amz-Cf-Id": "<cf-id:9>",
+          "X-Amzn-Trace-Id": "<trace-id:9>",
+          "X-Forwarded-For": "<X-Forwarded-For>",
+          "X-Forwarded-Port": "<X-Forwarded-Port>",
+          "X-Forwarded-Proto": "<X-Forwarded-Proto>",
+          "tEsT-HEADeR": "aValUE"
+        },
+        "httpMethod": "GET",
+        "isBase64Encoded": false,
+        "multiValueHeaders": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "random-value"
+          ],
+          "CloudFront-Forwarded-Proto": [
+            "https"
+          ],
+          "CloudFront-Is-Desktop-Viewer": [
+            "true"
+          ],
+          "CloudFront-Is-Mobile-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-SmartTV-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-Tablet-Viewer": [
+            "false"
+          ],
+          "CloudFront-Viewer-ASN": [
+            "<cloudfront-asn:1>"
+          ],
+          "CloudFront-Viewer-Country": [
+            "<cloudfront-country:1>"
+          ],
+          "Host": [
+            "<host:1>"
+          ],
+          "User-Agent": [
+            "python-requests/testing"
+          ],
+          "Via": [
+            "<via:9>"
+          ],
+          "X-Amz-Cf-Id": [
             "<cf-id:9>"
           ],
           "X-Amzn-Trace-Id": [
@@ -1056,9 +1056,9 @@
             "abort/"
           ]
         },
-        "path": "/test-path/api",
+        "path": "/proxy-value/api",
         "pathParameters": {
-          "proxy": "test-path/api"
+          "proxy": "proxy-value/api"
         },
         "queryStringParameters": {
           "dateTimeOffset": "2023-06-12T18:05:10.123456 00:00",
@@ -1090,14 +1090,14 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test/test-path/api",
+          "path": "/stage/proxy-value/api",
           "protocol": "HTTP/1.1",
           "requestId": "<uuid:9>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
           "resourcePath": "/{proxy+}",
-          "stage": "test"
+          "stage": "stage"
         },
         "resource": "/{proxy+}",
         "stageVariables": null
@@ -1120,7 +1120,7 @@
           "Content-Type": "application/json;charset=utf-8",
           "Host": "<host:1>",
           "User-Agent": "python-requests/testing",
-          "Via": "<via:8>",
+          "Via": "<via:10>",
           "X-Amz-Cf-Id": "<cf-id:10>",
           "X-Amzn-Trace-Id": "<trace-id:10>",
           "X-Forwarded-For": "<X-Forwarded-For>",
@@ -1170,7 +1170,7 @@
             "python-requests/testing"
           ],
           "Via": [
-            "<via:8>"
+            "<via:10>"
           ],
           "X-Amz-Cf-Id": [
             "<cf-id:10>"
@@ -1193,9 +1193,9 @@
             "30"
           ]
         },
-        "path": "/test-path",
+        "path": "/proxy-value",
         "pathParameters": {
-          "proxy": "test-path"
+          "proxy": "proxy-value"
         },
         "queryStringParameters": {
           "category": "books",
@@ -1223,16 +1223,132 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test/test-path",
+          "path": "/stage/proxy-value",
           "protocol": "HTTP/1.1",
           "requestId": "<uuid:10>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
           "resourcePath": "/{proxy+}",
-          "stage": "test"
+          "stage": "stage"
         },
         "resource": "/{proxy+}",
+        "stageVariables": null
+      },
+      "invocation-hardcoded": {
+        "body": null,
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "random-value",
+          "CloudFront-Forwarded-Proto": "https",
+          "CloudFront-Is-Desktop-Viewer": "true",
+          "CloudFront-Is-Mobile-Viewer": "false",
+          "CloudFront-Is-SmartTV-Viewer": "false",
+          "CloudFront-Is-Tablet-Viewer": "false",
+          "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
+          "CloudFront-Viewer-Country": "<cloudfront-country:1>",
+          "Host": "<host:1>",
+          "User-Agent": "python-requests/testing",
+          "Via": "<via:11>",
+          "X-Amz-Cf-Id": "<cf-id:11>",
+          "X-Amzn-Trace-Id": "<trace-id:11>",
+          "X-Forwarded-For": "<X-Forwarded-For>",
+          "X-Forwarded-Port": "<X-Forwarded-Port>",
+          "X-Forwarded-Proto": "<X-Forwarded-Proto>",
+          "tEsT-HEADeR": "aValUE"
+        },
+        "httpMethod": "GET",
+        "isBase64Encoded": false,
+        "multiValueHeaders": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "random-value"
+          ],
+          "CloudFront-Forwarded-Proto": [
+            "https"
+          ],
+          "CloudFront-Is-Desktop-Viewer": [
+            "true"
+          ],
+          "CloudFront-Is-Mobile-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-SmartTV-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-Tablet-Viewer": [
+            "false"
+          ],
+          "CloudFront-Viewer-ASN": [
+            "<cloudfront-asn:1>"
+          ],
+          "CloudFront-Viewer-Country": [
+            "<cloudfront-country:1>"
+          ],
+          "Host": [
+            "<host:1>"
+          ],
+          "User-Agent": [
+            "python-requests/testing"
+          ],
+          "Via": [
+            "<via:11>"
+          ],
+          "X-Amz-Cf-Id": [
+            "<cf-id:11>"
+          ],
+          "X-Amzn-Trace-Id": [
+            "<trace-id:11>"
+          ],
+          "X-Forwarded-For": "<X-Forwarded-For>",
+          "X-Forwarded-Port": "<X-Forwarded-Port>",
+          "X-Forwarded-Proto": "<X-Forwarded-Proto>",
+          "tEsT-HEADeR": [
+            "aValUE"
+          ]
+        },
+        "multiValueQueryStringParameters": null,
+        "path": "/hardcoded",
+        "pathParameters": null,
+        "queryStringParameters": null,
+        "requestContext": {
+          "accountId": "111111111111",
+          "apiId": "<api-id>",
+          "deploymentId": "<deployment-id:1>",
+          "domainName": "<host:1>",
+          "domainPrefix": "<api-id>",
+          "extendedRequestId": "<extended-request-id:11>",
+          "httpMethod": "GET",
+          "identity": {
+            "accessKey": null,
+            "accountId": null,
+            "caller": null,
+            "cognitoAuthenticationProvider": null,
+            "cognitoAuthenticationType": null,
+            "cognitoIdentityId": null,
+            "cognitoIdentityPoolId": null,
+            "principalOrgId": null,
+            "sourceIp": "<source-ip:1>",
+            "user": null,
+            "userAgent": "python-requests/testing",
+            "userArn": null
+          },
+          "path": "/stage//hardcoded",
+          "protocol": "HTTP/1.1",
+          "requestId": "<uuid:11>",
+          "requestTime": "<request-time>",
+          "requestTimeEpoch": "<request-time-epoch>",
+          "resourceId": "<resource-id:2>",
+          "resourcePath": "/hardcoded",
+          "stage": "stage"
+        },
+        "resource": "/hardcoded",
         "stageVariables": null
       }
     }

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -9,7 +9,7 @@
     "last_validated_date": "2023-05-31T21:09:38+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
-    "last_validated_date": "2024-07-25T20:18:13+00:00"
+    "last_validated_date": "2024-08-02T23:34:43+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration_non_post_method": {
     "last_validated_date": "2024-07-10T15:43:36+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #11268, the first fix only fixed one part of the issue where for greedy matching, but it did not address the original issue which was multiple slashes between the stage and the path. 

```
2024-08-02T11:22:49.052 DEBUG --- [et.reactor-5] l.s.apigateway.helpers     : No match found for path: '//orders' and method: 'GET'
2024-08-02T11:22:49.052  INFO --- [et.reactor-5] localstack.request.http    : GET /prod//orders => 404
```

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a new case in the existing test for hardcoded path
- rewrite a bit the test to have better test value, following a good comment from @cloutierMat that everything is "test" "test" and that is was a bit unclear
- fix the value for `pathParameters` in APIGW NG (if there are no values, it's `None` for AWS_PROXY)
- fix how we remove the leading slashes for a path in order to properly route a request, but keep them for the `requestContext.path` value which is stage + path

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
