### PR TITLE
Simplify publishing analytics of new LocalStack editions

### DIFF
--- a/localstack-core/localstack/utils/analytics/metadata.py
+++ b/localstack-core/localstack/utils/analytics/metadata.py
@@ -107,16 +107,18 @@ def get_machine_id() -> str:
 
 
 def get_localstack_edition() -> Optional[str]:
-    version_dir = "/usr/lib/localstack"
-
     # Generator expression to find the first hidden file ending with '-version'
     version_file = next(
-        (f for f in os.listdir(version_dir) if f.startswith(".") and f.endswith("-version")),
+        (
+            f
+            for f in os.listdir(config.dirs.static_libs)
+            if f.startswith(".") and f.endswith("-version")
+        ),
         None,
     )
 
     # Return the base name of the version file, or None if no file is found
-    return version_file.removesuffix("-version") if version_file else None
+    return version_file.removesuffix("-version").removeprefix(".") if version_file else None
 
 
 def is_license_activated() -> bool:

--- a/localstack-core/localstack/utils/analytics/metadata.py
+++ b/localstack-core/localstack/utils/analytics/metadata.py
@@ -106,13 +106,15 @@ def get_machine_id() -> str:
     return doc["machine_id"]
 
 
-def get_localstack_edition() -> Optional[Literal["enterprise", "pro", "community"]]:
+def get_localstack_edition() -> Optional[Literal["enterprise", "pro", "community", "azure-alpha"]]:
     if os.path.exists("/usr/lib/localstack/.enterprise-version"):
         return "enterprise"
     elif os.path.exists("/usr/lib/localstack/.pro-version"):
         return "pro"
     elif os.path.exists("/usr/lib/localstack/.community-version"):
         return "community"
+    elif os.path.exists("/usr/lib/localstack/.azure-alpha-version"):
+        return "azure-alpha"
 
     return None
 

--- a/localstack-core/localstack/utils/analytics/metadata.py
+++ b/localstack-core/localstack/utils/analytics/metadata.py
@@ -2,7 +2,7 @@ import dataclasses
 import logging
 import os
 import platform
-from typing import Literal, Optional
+from typing import Optional
 
 from localstack import config
 from localstack.constants import VERSION
@@ -106,17 +106,17 @@ def get_machine_id() -> str:
     return doc["machine_id"]
 
 
-def get_localstack_edition() -> Optional[Literal["enterprise", "pro", "community", "azure-alpha"]]:
-    if os.path.exists("/usr/lib/localstack/.enterprise-version"):
-        return "enterprise"
-    elif os.path.exists("/usr/lib/localstack/.pro-version"):
-        return "pro"
-    elif os.path.exists("/usr/lib/localstack/.community-version"):
-        return "community"
-    elif os.path.exists("/usr/lib/localstack/.azure-alpha-version"):
-        return "azure-alpha"
+def get_localstack_edition() -> Optional[str]:
+    version_dir = "/usr/lib/localstack"
 
-    return None
+    # Generator expression to find the first hidden file ending with '-version'
+    version_file = next(
+        (f for f in os.listdir(version_dir) if f.startswith(".") and f.endswith("-version")),
+        None,
+    )
+
+    # Return the base name of the version file, or None if no file is found
+    return version_file.removesuffix("-version") if version_file else None
 
 
 def is_license_activated() -> bool:

--- a/tests/unit/utils/analytics/test_metadata.py
+++ b/tests/unit/utils/analytics/test_metadata.py
@@ -1,8 +1,16 @@
 import multiprocessing
+import os.path
 import threading
 from queue import Queue
 
-from localstack.utils.analytics.metadata import get_client_metadata, get_session_id
+import pytest
+
+from localstack import config
+from localstack.utils.analytics.metadata import (
+    get_client_metadata,
+    get_localstack_edition,
+    get_session_id,
+)
 
 
 def test_get_client_metadata_cache():
@@ -47,3 +55,27 @@ def test_get_session_id_cache_not_process_local():
         # fix for MacOS (and potentially other systems) where local functions cannot be used for multiprocessing
         if "Can't pickle local object" not in str(e):
             raise
+
+
+@pytest.mark.parametrize(
+    "expected_edition, version_file",
+    [
+        ("enterprise", ".enterprise-version"),
+        ("pro", ".pro-version"),
+        ("community", ".community-version"),
+        ("azure-alpha", ".azure-alpha-version"),
+        (None, "non-hidden-version"),
+        (None, ".hidden-file"),
+        (None, "not-a-version-file"),
+    ],
+)
+def test_get_localstack_edition(expected_edition, version_file):
+    # put the version file in the expected location
+    file_location = os.path.join(config.dirs.static_libs, version_file)
+    with open(file_location, "w") as f:
+        f.write("")
+
+    assert get_localstack_edition() == expected_edition
+
+    # cleanup
+    os.remove(file_location)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

With adding a new edition of LocalStack we need to add its marker to the analytics events

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Generalizes the parsing of markers to give out `xyz` for any `.xyz-version` file in the static libs (`/usr/lib/localstack`)
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
