### PR TITLE
Automatically convert props in resource provider botocore calls

### DIFF
--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -110,7 +110,7 @@ ResourceProperties = TypeVar("ResourceProperties")
 
 def _handler_provide_client_params(event_name: str, params: dict, model: OperationModel, **kwargs):
     """
-    A botocore hook handler that will convert the passed parameters according to the corresponding operation model
+    A botocore hook handler that will try to convert the passed parameters according to the given operation model
     """
     return convert_request_kwargs(params, model.input_shape)
 
@@ -118,16 +118,14 @@ def _handler_provide_client_params(event_name: str, params: dict, model: Operati
 class ConvertingInternalClientFactory(InternalClientFactory):
     def _get_client_post_hook(self, client: BaseClient) -> BaseClient:
         """
-        Register handlers that enable internal data object transfer mechanism
-        for internal clients.
+        Register handlers that modify the passed properties to make them compatible with the API structure
         """
 
         client.meta.events.register(
             "provide-client-params.*.*", handler=_handler_provide_client_params
         )
 
-        super()._get_client_post_hook(client)
-        return client
+        return super()._get_client_post_hook(client)
 
 
 _cfn_resource_client_factory = ConvertingInternalClientFactory(use_ssl=config.DISTRIBUTED_MODE)

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -12,10 +12,12 @@ from math import ceil
 from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Type, TypedDict, TypeVar
 
 import botocore
+from botocore.client import BaseClient
+from botocore.model import OperationModel
 from plux import Plugin, PluginManager
 
 from localstack import config
-from localstack.aws.connect import ServiceLevelClientFactory, connect_to
+from localstack.aws.connect import InternalClientFactory, ServiceLevelClientFactory
 from localstack.services.cloudformation import usage
 from localstack.services.cloudformation.deployment_utils import (
     check_not_found_exception,
@@ -26,6 +28,7 @@ from localstack.services.cloudformation.deployment_utils import (
     remove_none_values,
 )
 from localstack.services.cloudformation.engine.quirks import PHYSICAL_RESOURCE_ID_SPECIAL_CASES
+from localstack.services.cloudformation.provider_utils import convert_request_kwargs
 from localstack.services.cloudformation.service_models import KEY_RESOURCE_STATE
 
 PRO_RESOURCE_PROVIDERS = False
@@ -105,10 +108,35 @@ class ResourceProviderPayload(TypedDict):
 ResourceProperties = TypeVar("ResourceProperties")
 
 
+def _handler_provide_client_params(event_name: str, params: dict, model: OperationModel, **kwargs):
+    """
+    A botocore hook handler that will convert the passed parameters according to the corresponding operation model
+    """
+    return convert_request_kwargs(params, model.input_shape)
+
+
+class ConvertingInternalClientFactory(InternalClientFactory):
+    def _get_client_post_hook(self, client: BaseClient) -> BaseClient:
+        """
+        Register handlers that enable internal data object transfer mechanism
+        for internal clients.
+        """
+
+        client.meta.events.register(
+            "provide-client-params.*.*", handler=_handler_provide_client_params
+        )
+
+        super()._get_client_post_hook(client)
+        return client
+
+
+_cfn_resource_client_factory = ConvertingInternalClientFactory(use_ssl=config.DISTRIBUTED_MODE)
+
+
 def convert_payload(
     stack_name: str, stack_id: str, payload: ResourceProviderPayload
 ) -> ResourceRequest[Properties]:
-    client_factory = connect_to(
+    client_factory = _cfn_resource_client_factory(
         aws_access_key_id=payload["requestData"]["callerCredentials"]["accessKeyId"],
         aws_session_token=payload["requestData"]["callerCredentials"]["sessionToken"],
         aws_secret_access_key=payload["requestData"]["callerCredentials"]["secretAccessKey"],


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/localstack/localstack/pull/11178

Resource properties are now automatically converted for any boto calls issues through the clients in resource providers are now automatically corrected according to the operation model.

## Changes

- The internal client factory used when creating resource providers now automatically registers a botocore hook that  performs parameter conversion according to the operation model on all requests.

## Todo

This PR still keeps the old utils around, so in most cases this is purely a fall back, which at least shouldn't break any existing functionality. Follow-up PRs will handle the refactoring of the util usage & cleaning up the utils.


## Testing

I've also already tested refactoring the covered utils into NO-OPs. Both Community and -ext need minor adjustments to some providers for that to work which I'll do in follow-up PRs. Seems to be working quite nicely though. :+1: 
