### PR TITLE
add support for `Number` type param in `!Sub` in cfn templates

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -404,6 +404,7 @@ def _resolve_refs_recursively(
                     parameters,
                     val,
                 )
+
                 if not isinstance(resolved_val, str):
                     # We don't have access to the resource that's a dependency in this case,
                     # so do the best we can with the resource ids
@@ -770,6 +771,8 @@ def resolve_placeholders_in_string(
 
                 if parameter_type in ["CommaDelimitedList"] or parameter_type.startswith("List<"):
                     return [p.strip() for p in parameter_value.split(",")]
+                elif parameter_type == "Number":
+                    return str(parameter_value)
                 else:
                     return parameter_value
             else:
@@ -782,7 +785,7 @@ def resolve_placeholders_in_string(
 
     regex = r"\$\{([^\}]+)\}"
     result = re.sub(regex, _replace, result)
-    return result
+    return int(result) if result.isdigit() else result
 
 
 def evaluate_resource_condition(conditions: dict[str, bool], resource: dict) -> bool:

--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -716,6 +716,16 @@ def resolve_placeholders_in_string(
     Variables can be template parameter names, resource logical IDs, resource attributes, or a variable in a key-value map
     """
 
+    def _validate_result_type(value: str):
+        if value.isdigit():
+            return int(value)
+        else:
+            try:
+                res = float(value)
+                return res
+            except ValueError:
+                return value
+
     def _replace(match):
         ref_expression = match.group(1)
         parts = ref_expression.split(".")
@@ -785,7 +795,7 @@ def resolve_placeholders_in_string(
 
     regex = r"\$\{([^\}]+)\}"
     result = re.sub(regex, _replace, result)
-    return int(result) if result.isdigit() else result
+    return _validate_result_type(result)
 
 
 def evaluate_resource_condition(conditions: dict[str, bool], resource: dict) -> bool:

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -245,16 +245,23 @@ class TestIntrinsicFunctions:
 
     @markers.aws.validated
     def test_sub_number_type(self, deploy_cfn_template):
-        alarm_name = "alarm-test-latency-preemptive"
+        alarm_name_prefix = "alarm-test-latency-preemptive"
+        threshold = "1000.0"
+        period = "60"
         stack = deploy_cfn_template(
             template_path=os.path.join(
                 os.path.dirname(__file__), "../../templates/sub_number_type.yml"
             ),
-            parameters={"ResourceNamePrefix": alarm_name},
+            parameters={
+                "ResourceNamePrefix": alarm_name_prefix,
+                "RestLatencyPreemptiveAlarmThreshold": threshold,
+                "RestLatencyPreemptiveAlarmPeriod": period,
+            },
         )
 
-        result = stack.outputs["Result"]
-        assert result == alarm_name
+        assert stack.outputs["AlarmName"] == alarm_name_prefix
+        assert stack.outputs["Threshold"] == threshold
+        assert stack.outputs["Period"] == period
 
 
 class TestImports:

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -243,6 +243,19 @@ class TestIntrinsicFunctions:
         result = stack.outputs["Result"]
         assert result == "test"
 
+    @markers.aws.validated
+    def test_sub_number_type(self, deploy_cfn_template):
+        alarm_name = "alarm-test-latency-preemptive"
+        stack = deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__), "../../templates/sub_number_type.yml"
+            ),
+            parameters={"ResourceNamePrefix": alarm_name},
+        )
+
+        result = stack.outputs["Result"]
+        assert result == alarm_name
+
 
 class TestImports:
     @markers.aws.validated

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -259,7 +259,7 @@ class TestIntrinsicFunctions:
             },
         )
 
-        assert stack.outputs["AlarmName"] == alarm_name_prefix
+        assert stack.outputs["AlarmName"] == f"{alarm_name_prefix}-{period}"
         assert stack.outputs["Threshold"] == threshold
         assert stack.outputs["Period"] == period
 

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -36,7 +36,7 @@
     "last_validated_date": "2024-05-09T08:33:45+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_sub_number_type": {
-    "last_validated_date": "2024-08-05T08:53:33+00:00"
+    "last_validated_date": "2024-08-06T18:16:15+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_capabilities_requirements": {
     "last_validated_date": "2023-01-30T19:15:46+00:00"

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -35,6 +35,9 @@
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[us-west-2]": {
     "last_validated_date": "2024-05-09T08:33:45+00:00"
   },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_sub_number_type": {
+    "last_validated_date": "2024-08-05T08:53:33+00:00"
+  },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_capabilities_requirements": {
     "last_validated_date": "2023-01-30T19:15:46+00:00"
   },

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -36,7 +36,7 @@
     "last_validated_date": "2024-05-09T08:33:45+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_sub_number_type": {
-    "last_validated_date": "2024-08-06T18:16:15+00:00"
+    "last_validated_date": "2024-08-09T06:55:16+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_capabilities_requirements": {
     "last_validated_date": "2023-01-30T19:15:46+00:00"

--- a/tests/aws/templates/sub_number_type.yml
+++ b/tests/aws/templates/sub_number_type.yml
@@ -1,0 +1,40 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  ResourceNamePrefix:
+    Type: String
+  RestLatencyPreemptiveAlarmPeriod:
+    Type: Number
+    Default: 60
+  RestLatencyPreemptiveAlarmEvaluationPeriods:
+    Type: Number
+    Default: 1
+  RestLatencyPreemptiveAlarmThreshold:
+    Type: Number
+    Default: 1000
+
+Resources:
+  RestLatencyPreemptiveAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - Fn::Sub: arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:opsitem:2
+      AlarmDescription: Test alarm
+      AlarmName: !Ref ResourceNamePrefix
+      Namespace: AWS/ApiGateway
+      MetricName: Latency
+      Dimensions:
+        - Name: ApiName
+          Value: dummy-api
+      Statistic: Average
+      Period:
+        Fn::Sub: ${RestLatencyPreemptiveAlarmPeriod}
+      EvaluationPeriods:
+        Fn::Sub: ${RestLatencyPreemptiveAlarmEvaluationPeriods}
+      Threshold:
+        Fn::Sub: ${RestLatencyPreemptiveAlarmThreshold}
+      ComparisonOperator: GreaterThanThreshold
+
+Outputs:
+  Result:
+    Value: !Ref RestLatencyPreemptiveAlarm

--- a/tests/aws/templates/sub_number_type.yml
+++ b/tests/aws/templates/sub_number_type.yml
@@ -19,7 +19,7 @@ Resources:
         - Fn::Sub: arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:opsitem:2
       AlarmDescription: Test alarm
       AlarmName:
-        Fn::Sub: ${ResourceNamePrefix}
+        Fn::Sub: "${ResourceNamePrefix}-${RestLatencyPreemptiveAlarmPeriod}"
       Namespace: AWS/ApiGateway
       MetricName: Latency
       Dimensions:

--- a/tests/aws/templates/sub_number_type.yml
+++ b/tests/aws/templates/sub_number_type.yml
@@ -4,13 +4,11 @@ Parameters:
     Type: String
   RestLatencyPreemptiveAlarmPeriod:
     Type: Number
-    Default: 60
   RestLatencyPreemptiveAlarmEvaluationPeriods:
     Type: Number
     Default: 1
   RestLatencyPreemptiveAlarmThreshold:
     Type: Number
-    Default: 1000
 
 Resources:
   RestLatencyPreemptiveAlarm:
@@ -20,7 +18,8 @@ Resources:
       AlarmActions:
         - Fn::Sub: arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:opsitem:2
       AlarmDescription: Test alarm
-      AlarmName: !Ref ResourceNamePrefix
+      AlarmName:
+        Fn::Sub: ${ResourceNamePrefix}
       Namespace: AWS/ApiGateway
       MetricName: Latency
       Dimensions:
@@ -36,5 +35,9 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
 
 Outputs:
-  Result:
+  AlarmName:
     Value: !Ref RestLatencyPreemptiveAlarm
+  Threshold:
+    Value: !Ref RestLatencyPreemptiveAlarmThreshold
+  Period:
+    Value: !Ref RestLatencyPreemptiveAlarmPeriod


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Whenever we use `!Sub` for `Type: Number` param in cfn templates it fails with the following error message: 

```
DEBUG --- [functhread91] l.s.c.e.template_deployer  : Error applying changes for CloudFormation stack "lm-test": sequence item 0: expected str instance, int found Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/cloudformation/engine/template_deployer.py", line 1102, in _run
    self.do_apply_changes_in_loop(changes, stack)
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/cloudformation/engine/template_deployer.py", line 1392, in do_apply_changes_in_loop
    should_deploy = self.prepare_should_deploy_change(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/cloudformation/engine/template_deployer.py", line 1145, in prepare_should_deploy_change
    resolve_refs_recursively(
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack_ext/services/cloudformation/cloudformation_extended.py.enc", line 13, in resolve_refs_recursively
    G='name';B=resolve_refs_recursively_orig(*H,**I)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/utils/functions.py", line 81, in func
    return wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/cloudformation/engine/template_deployer.py", line 190, in resolve_refs_recursively
    result = _resolve_refs_recursively(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/utils/functions.py", line 81, in func
    return wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/cloudformation/engine/template_deployer.py", line 645, in _resolve_refs_recursively
    value[key] = resolve_refs_recursively(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack_ext/services/cloudformation/cloudformation_extended.py.enc", line 13, in resolve_refs_recursively
    G='name';B=resolve_refs_recursively_orig(*H,**I)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/utils/functions.py", line 81, in func
    return wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/cloudformation/engine/template_deployer.py", line 190, in resolve_refs_recursively
    result = _resolve_refs_recursively(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/utils/functions.py", line 81, in func
    return wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/cloudformation/engine/template_deployer.py", line 645, in _resolve_refs_recursively
    value[key] = resolve_refs_recursively(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack_ext/services/cloudformation/cloudformation_extended.py.enc", line 13, in resolve_refs_recursively
    G='name';B=resolve_refs_recursively_orig(*H,**I)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/utils/functions.py", line 81, in func
    return wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/cloudformation/engine/template_deployer.py", line 190, in resolve_refs_recursively
    result = _resolve_refs_recursively(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/utils/functions.py", line 81, in func
    return wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/cloudformation/engine/template_deployer.py", line 401, in _resolve_refs_recursively
    result = resolve_placeholders_in_string(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/cloudformation/engine/template_deployer.py", line 769, in resolve_placeholders_in_string
    result = re.sub(regex, _replace, result)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/__init__.py", line 185, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: sequence item 0: expected str instance, int found

2024-08-06T09:13:10.479  WARN --- [functhread91] l.s.c.engine.entities      : CFn resource failed to deploy: RestLatencyPreemptiveAlarm (sequence item 0: expected str instance, int found)
```

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This PR: 
- adds the support `Number` type param in `!Sub` in cloudformation templates. 
- adds an AWS validated test to verify the changes. 

Closes https://github.com/localstack/localstack/issues/11159

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
