### PR TITLE
fix Lambda custom aliased URL flaky test

### DIFF
--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -4169,9 +4169,9 @@ class TestLambdaUrl:
         assert function_v1_sha256 == function_latest_sha256
 
         # Assert that update actually did occur
-        rev_id_v1 = update_function_code_v1_resp.get("RevisionId")
-        rev_id_latest = update_function_code_latest_resp.get("RevisionId")
-        assert rev_id_latest > rev_id_v1
+        last_modified_v1 = update_function_code_v1_resp.get("LastModified")
+        last_modified_latest = update_function_code_latest_resp.get("LastModified")
+        assert last_modified_latest > last_modified_v1
 
         # Create a URL for an unpublished function
         _assert_create_function_url(qualifier=None, expected_url_id=custom_id_value)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
- Test case introduced in #11272 is flaky since `RevisionID` values are UUIDs and therefore not suited for comparison.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Compare the [`LastModified` (in ISO-8601 format) response values](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionCode.html#lambda-UpdateFunctionCode-response-LastModified) to assert that the second `UpdateFunctionCode` request occurs after the first.
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
