### PR TITLE
add APIGW NG workaround for AccessDenied exception

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/gateway_exception.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/gateway_exception.py
@@ -11,6 +11,7 @@ from localstack.services.apigateway.next_gen.execute_api.api import (
 )
 from localstack.services.apigateway.next_gen.execute_api.context import RestApiInvocationContext
 from localstack.services.apigateway.next_gen.execute_api.gateway_response import (
+    AccessDeniedError,
     BaseGatewayException,
     get_gateway_response_or_default,
 )
@@ -81,6 +82,13 @@ class GatewayExceptionHandler(RestApiGatewayExceptionHandler):
     def _build_response_content(exception: BaseGatewayException) -> str:
         # TODO apply responseTemplates to the content. We should also handle the default simply by managing the default
         #  template body `{"message":$context.error.messageString}`
+
+        # TODO: remove this workaround by properly managing the responseTemplate for UnauthorizedError
+        #  on the CRUD level, it returns the same template as all other errors but in reality the message field is
+        #  capitalized
+        if isinstance(exception, AccessDeniedError):
+            return json.dumps({"Message": exception.message})
+
         return json.dumps({"message": exception.message})
 
     @staticmethod


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While testing against the real AWS, it seems the `AccessDenied` exception is special, and the `message` field in the default JSON response is capitalized, even though the default template for the `ACCESS_DENIED` GatewayResponse is the same as all others: `{"message":$context.error.messageString}`, so the CRUD layer is once again wrong for the default values. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a special case until we handle the `responseTemplate` where we will override the default value for `AccessDenied `
- add a unit test to prevent regression 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
