### PR TITLE
improve X-Amz-Trace-Id to APIGW NG

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -88,6 +88,8 @@ class RestApiInvocationContext(RequestContext):
     """The region the REST API is living in."""
     account_id: Optional[str]
     """The account the REST API is living in."""
+    trace_id: Optional[str]
+    """The X-Ray trace ID for the request."""
     resource: Optional[Resource]
     """The resource the invocation matched"""
     resource_method: Optional[Method]
@@ -126,3 +128,4 @@ class RestApiInvocationContext(RequestContext):
         self.integration_request = None
         self.endpoint_response = None
         self.invocation_response = None
+        self.trace_id = None

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -7,7 +7,7 @@ from localstack.aws.api.apigateway import Integration, IntegrationType
 from localstack.constants import APPLICATION_JSON
 from localstack.http import Request, Response
 from localstack.utils.collections import merge_recursive
-from localstack.utils.strings import short_uid, to_bytes, to_str
+from localstack.utils.strings import to_bytes, to_str
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import IntegrationRequest, InvocationRequest, RestApiInvocationContext
@@ -282,7 +282,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
             default_headers["Content-Type"] = content_type
 
         set_default_headers(headers, default_headers)
-        headers.set("X-Amzn-Trace-Id", short_uid())  # TODO
+        headers.set("X-Amzn-Trace-Id", context.trace_id)
         if integration_type not in (IntegrationType.AWS_PROXY, IntegrationType.AWS):
             headers.set("X-Amzn-Apigateway-Api-Id", context.api_id)
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -15,6 +15,7 @@ from localstack.utils.time import timestamp
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import InvocationRequest, RestApiInvocationContext
 from ..header_utils import should_drop_header_from_invocation
+from ..helpers import generate_trace_id
 from ..moto_helpers import get_stage_variables
 from ..variables import ContextVariables, ContextVarsIdentity
 
@@ -43,6 +44,9 @@ class InvocationRequestParser(RestApiGatewayHandler):
         # then populate the stage variables
         context.stage_variables = self.fetch_stage_variables(context)
         LOG.debug("Initializing $stageVariables='%s'", context.stage_variables)
+
+        # TODO: improve the logic here, maybe there's already a X-Amz-Trace-Id header we should take from?
+        context.trace_id = f"Root={generate_trace_id()}"
 
     def create_invocation_request(self, context: RestApiInvocationContext) -> InvocationRequest:
         request = context.request

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/response_enricher.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/response_enricher.py
@@ -26,4 +26,4 @@ class InvocationResponseEnricher(RestApiGatewayHandler):
             and context.integration["type"] != IntegrationType.HTTP_PROXY
             and not context.context_variables.get("error")
         ):
-            headers.set("X-Amzn-Trace-Id", short_uid())  # TODO
+            headers.set("X-Amzn-Trace-Id", context.trace_id)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
@@ -1,6 +1,8 @@
 import copy
 import logging
 import re
+import time
+from secrets import token_hex
 from typing import Type, TypedDict
 
 from moto.apigateway.models import RestAPI as MotoRestAPI
@@ -113,3 +115,12 @@ def validate_sub_dict_of_typed_dict(typed_dict: Type[TypedDict], obj: dict) -> b
     typed_dict_keys = {*typed_dict.__required_keys__, *typed_dict.__optional_keys__}
 
     return not bool(set(obj) - typed_dict_keys)
+
+
+def generate_trace_id():
+    """https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids"""
+    original_request_epoch = int(time.time())
+    timestamp_hex = hex(original_request_epoch)[2:]
+    version_number = "1"
+    unique_id = token_hex(12)
+    return f"{version_number}-{timestamp_hex}-{unique_id}"

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -117,6 +117,8 @@ class TestParsingHandler:
         assert context.context_variables["domainPrefix"] == TEST_API_ID
         assert context.context_variables["path"] == f"/{TEST_API_STAGE}/normal-path"
 
+        assert "Root=" in context.trace_id
+
     def test_parse_raw_path(self, dummy_deployment, parse_handler_chain, get_invocation_context):
         request = Request(
             "GET",

--- a/tests/unit/services/apigateway/test_helpers.py
+++ b/tests/unit/services/apigateway/test_helpers.py
@@ -1,0 +1,15 @@
+import datetime
+import time
+
+from localstack.services.apigateway.next_gen.execute_api.helpers import generate_trace_id
+
+
+def test_generate_trace_id():
+    # See https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids for the format
+    trace_id = generate_trace_id()
+    version, hex_time, unique_id = trace_id.split("-")
+    assert version == "1"
+    trace_time = datetime.datetime.fromtimestamp(int(hex_time, 16), tz=datetime.UTC)
+    now = time.time()
+    assert now - 10 <= trace_time.timestamp() <= now
+    assert len(unique_id) == 24


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As talked about in https://github.com/localstack/localstack/issues/11253#issuecomment-2271700499, we could use the same trace-id throughout the invocation, this was left as a TODO. I have a bit of time, so I implemented it quickly. 

It seems the Lambda integration is overwriting the trace header for now, so it is hard to test. It might be done with a regular AWS integration, to SQS for example. We can work on this as a follow-up. 
The implementation is very naive for now, as it does not take into account possible AWS callers already passing a trace-id header? My knowledge of X-Ray is not great, so we can build on that! 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement a trace-id field to the context so that it is accessible throughout the invocation
- add a util to generate a trace and some unit tests around it
- adding the newly generated trace-id field where we would generate a random id before

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
