### PR TITLE
Provide regions to various inter-service communication clients

### DIFF
--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -318,7 +318,7 @@ class ClientFactory(ABC):
         :return: Service Level Client Factory
         """
         session_name = session_name or f"session-{short_uid()}"
-        sts_client = self(endpoint_url=endpoint_url, config=config).sts
+        sts_client = self(endpoint_url=endpoint_url, config=config, region_name=region_name).sts
 
         metadata = {}
         if service_principal:

--- a/localstack-core/localstack/services/apigateway/integration.py
+++ b/localstack-core/localstack/services/apigateway/integration.py
@@ -168,7 +168,7 @@ def get_internal_mocked_headers(
 ) -> dict[str, str]:
     if role_arn:
         access_key_id = (
-            connect_to()
+            connect_to(region_name=region_name)
             .sts.request_metadata(service_principal=ServicePrincipal.apigateway)
             .assume_role(RoleArn=role_arn, RoleSessionName="BackplaneAssumeRoleSession")[
                 "Credentials"

--- a/localstack-core/localstack/services/apigateway/provider.py
+++ b/localstack-core/localstack/services/apigateway/provider.py
@@ -428,7 +428,10 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
         # find matching hosted zone
         zone_id = None
-        route53 = connect_to().route53
+        # TODO check if this call is IAM enforced
+        route53 = connect_to(
+            region_name=context.region, aws_access_key_id=context.account_id
+        ).route53
         hosted_zones = route53.list_hosted_zones().get("HostedZones", [])
         hosted_zones = [hz for hz in hosted_zones if domain_name.endswith(hz["Name"].strip("."))]
         zone_id = hosted_zones[0]["Id"].replace("/hostedzone/", "") if hosted_zones else zone_id


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Until recently, we did not provide a proper region to various clients around LocalStack.
This worked somewhat well, especially with global services like IAM/STS.

However, with the recent advancement in partition support, the proper region has to be provided for those clients as well.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Provide correct regions for various internal clients

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
