### PR TITLE
fix APIGW CFN Stage with Stage Variables casing

### DIFF
--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -1257,12 +1257,10 @@ def import_api_from_openapi_spec(
                 case "AWS_PROXY":
                     # if the integration is AWS_PROXY with lambda, the only accepted integration method is POST
                     integration_method = "POST"
-                case "AWS":
+                case _:
                     integration_method = (
                         method_integration.get("httpMethod") or method_name
                     ).upper()
-                case _:
-                    integration_method = method_name
 
             connection_type = (
                 ConnectionType.INTERNET

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
@@ -39,7 +39,9 @@ def freeze_rest_api(
     )
 
 
-def render_uri_with_stage_variables(uri: str | None, stage_variables: dict[str, str]) -> str | None:
+def render_uri_with_stage_variables(
+    uri: str | None, stage_variables: dict[str, str] | None
+) -> str | None:
     """
     https://docs.aws.amazon.com/apigateway/latest/developerguide/aws-api-gateway-stage-variables-reference.html#stage-variables-in-integration-HTTP-uris
     URI=https://${stageVariables.<variable_name>}
@@ -48,9 +50,10 @@ def render_uri_with_stage_variables(uri: str | None, stage_variables: dict[str, 
     """
     if not uri:
         return uri
+    stage_vars = stage_variables or {}
 
     def replace_match(match_obj: re.Match) -> str:
-        return stage_variables.get(match_obj.group("varName"), "")
+        return stage_vars.get(match_obj.group("varName"), "")
 
     return _stage_variable_pattern.sub(replace_match, uri)
 

--- a/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_stage.py
+++ b/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_stage.py
@@ -99,7 +99,7 @@ class ApiGatewayStageProvider(ResourceProvider[ApiGatewayStageProperties]):
         apigw = request.aws_client_factory.apigateway
 
         stage_name = model.get("StageName", "default")
-        stage_variables = model.get("Variables", {})
+        stage_variables = model.get("Variables")
         # we need to deep copy as several fields are nested dict and arrays
         params = keys_to_lower(copy.deepcopy(model))
         # TODO: add methodSettings

--- a/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_stage.py
+++ b/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_stage.py
@@ -1,6 +1,7 @@
 # LocalStack Resource Provider Scaffolding v2
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 from typing import Optional, TypedDict
 
@@ -98,14 +99,17 @@ class ApiGatewayStageProvider(ResourceProvider[ApiGatewayStageProperties]):
         apigw = request.aws_client_factory.apigateway
 
         stage_name = model.get("StageName", "default")
-        params = keys_to_lower(model.copy())
+        stage_variables = model.get("Variables", {})
+        # we need to deep copy as several fields are nested dict and arrays
+        params = keys_to_lower(copy.deepcopy(model))
+        # TODO: add methodSettings
+        # TODO: add custom CfN tags
         param_names = [
             "restApiId",
             "deploymentId",
             "description",
             "cacheClusterEnabled",
             "cacheClusterSize",
-            "variables",
             "documentationVersion",
             "canarySettings",
             "tracingEnabled",
@@ -114,6 +118,8 @@ class ApiGatewayStageProvider(ResourceProvider[ApiGatewayStageProperties]):
         params = util.select_attributes(params, param_names)
         params["tags"] = {t["key"]: t["value"] for t in params.get("tags", [])}
         params["stageName"] = stage_name
+        if stage_variables:
+            params["variables"] = stage_variables
 
         result = apigw.create_stage(**params)
         model["StageName"] = result["stageName"]

--- a/tests/aws/files/openapi.spec.stage-variables.json
+++ b/tests/aws/files/openapi.spec.stage-variables.json
@@ -11,7 +11,7 @@
           "httpMethod":"POST",
           "payloadFormatVersion":"1.0",
           "type":"HTTP_PROXY",
-          "uri": "http://${stageVariables.url}"
+          "uri": "https://${stageVariables.TestHost}/${stageVariables.testPath}?${stageVariables.querystring}"
         },
         "responses": {
           "200": {

--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -739,6 +739,9 @@ class TestApiGatewayImportRestApi:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..origin"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_next_gen_api(), paths=["$..method"]
+    )
     def test_import_with_stage_variables(
         self, import_apigw, aws_client, create_echo_http_server, snapshot
     ):

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -4792,7 +4792,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_stage_variables": {
-    "recorded-date": "12-08-2024, 12:48:55",
+    "recorded-date": "12-08-2024, 13:42:20",
     "recorded-content": {
       "get-resp-from-http": {
         "args": {
@@ -4803,6 +4803,9 @@
         "method": "POST",
         "origin": "<origin:1>",
         "path": "/test-path"
+      },
+      "get-error-resp-from-http": {
+        "message": "Internal server error"
       }
     }
   }

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -4792,7 +4792,18 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_stage_variables": {
-    "recorded-date": "15-04-2024, 21:38:55",
-    "recorded-content": {}
+    "recorded-date": "12-08-2024, 12:48:55",
+    "recorded-content": {
+      "get-resp-from-http": {
+        "args": {
+          "qs_key": "qs_value"
+        },
+        "data": "",
+        "domain": "<domain:1>",
+        "method": "POST",
+        "origin": "<origin:1>",
+        "path": "/test-path"
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -42,6 +42,6 @@
     "last_validated_date": "2024-04-15T21:38:57+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_stage_variables": {
-    "last_validated_date": "2024-04-15T21:38:14+00:00"
+    "last_validated_date": "2024-08-12T12:48:54+00:00"
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -42,6 +42,6 @@
     "last_validated_date": "2024-04-15T21:38:57+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_stage_variables": {
-    "last_validated_date": "2024-08-12T12:48:54+00:00"
+    "last_validated_date": "2024-08-12T13:42:13+00:00"
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -107,7 +107,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "recorded-date": "17-06-2024, 21:54:27",
+    "recorded-date": "12-08-2024, 13:13:34",
     "recorded-content": {
       "rest-api": {
         "apiKeySource": "HEADER",
@@ -157,6 +157,44 @@
             }
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "Test Stage 123",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {
+          "*/*": {
+            "cacheDataEncrypted": false,
+            "cacheTtlInSeconds": 300,
+            "cachingEnabled": false,
+            "dataTraceEnabled": true,
+            "loggingLevel": "ERROR",
+            "metricsEnabled": true,
+            "requireAuthorizationForCacheControl": true,
+            "throttlingBurstLimit": 5000,
+            "throttlingRateLimit": 10000.0,
+            "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"
+          }
+        },
+        "stageName": "local",
+        "tags": {
+          "aws:cloudformation:logical-id": "ApiGWStage",
+          "aws:cloudformation:stack-id": "arn:<partition>:cloudformation:<region>:111111111111:stack/stack-name/<resource:1>",
+          "aws:cloudformation:stack-name": "stack-name"
+        },
+        "tracingEnabled": true,
+        "variables": {
+          "TestCasing": "myvar",
+          "testCasingTwo": "myvar2",
+          "testlowcasing": "myvar3"
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
@@ -9,7 +9,7 @@
     "last_validated_date": "2024-06-25T18:12:55+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "last_validated_date": "2024-06-17T21:54:26+00:00"
+    "last_validated_date": "2024-08-12T13:13:32+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_integration": {
     "last_validated_date": "2024-02-21T12:54:34+00:00"

--- a/tests/aws/templates/apigateway_integration_from_s3.yml
+++ b/tests/aws/templates/apigateway_integration_from_s3.yml
@@ -30,11 +30,6 @@ Resources:
       Description: foobar
       RestApiId:
         Ref: ApiGatewayRestApi
-      StageName: local
-      StageDescription:
-        TracingEnabled: true
-        LoggingLevel: ERROR
-        DataTraceEnabled: true
 
   ApiGWStage:
     Type: AWS::ApiGateway::Stage
@@ -44,6 +39,20 @@ Resources:
         Ref: ApiGWDeployment
       RestApiId:
         Ref: ApiGatewayRestApi
+      StageName: local
+      TracingEnabled: true
+      MethodSettings:
+        - LoggingLevel: ERROR
+          DataTraceEnabled: true
+          HttpMethod: "*"
+          MetricsEnabled: true
+          ResourcePath: "/*"
+      Variables:
+        TestCasing: "myvar"
+        testCasingTwo: "myvar2"
+        testlowcasing: "myvar3"
+
+
 Outputs:
   RestApiId:
     Value:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by a user, we had an issue with stage variables when declared via CloudFormation. 

Setting a stage variable to be `TestCasing` would save it as `testCasing`. As stage variables are case sensitive, this is quite an issue. 

I've tracked down the issue to be because we would call `keys_to_lower` on the parameters, which would change the casing.

In the meantime, I've added more tests around stage variables and their casing without CFN, and more validation about what the user was encoutering (the stage variable wouldn't be found, which would create an HTTP integration URI to not have a host). 

I've also found a small issue with how we would import OpenAPI/Swagger files for the method used for the integration for HTTP/HTTP_PROXY.

Resources:
- https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-variables

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix the CloudFormation `Stage` resource for APIGW, picking up the stage variables before the `keys_to_lower` call and using deep copy because of the nested dicts
- update a validated test to check the fix and casing
- update another test related to Stage Variables but not CFN, just to check behavior (also add a negative test for NextGen only)
- add better exception handler for `HTTP` & `HTTP_PROXY` NextGen integrations, can still be improved with negative testing, we just need to find how to trigger them

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
