### PR TITLE
CFn: support importing existing EC2 SSH keys

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_ec2.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.snapshot.json
@@ -287,5 +287,16 @@
         "SGWithoutVpcIdRef": "<without-vpcid-group-name>"
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_ec2.py::test_keypair_create_import": {
+    "recorded-date": "12-08-2024, 21:51:36",
+    "recorded-content": {
+      "outputs": {
+        "GeneratedKeyPairFingerprint": "<fingerprint>",
+        "GeneratedKeyPairName": "<generated-key-name>",
+        "ImportedKeyPairFingerprint": "4LmcYnyBOqlloHZ5TKAxfa8BgMK2wL6WeOOTvXVdhmw=",
+        "ImportedKeyPairName": "<imported-key-name>"
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_ec2.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.validation.json
@@ -14,6 +14,9 @@
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_internet_gateway_ref_and_attr": {
     "last_validated_date": "2023-02-13T16:13:41+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_ec2.py::test_keypair_create_import": {
+    "last_validated_date": "2024-08-12T21:51:36+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_simple_route_table_creation": {
     "last_validated_date": "2024-07-01T20:13:48+00:00"
   },

--- a/tests/aws/templates/ec2_import_keypair.yaml
+++ b/tests/aws/templates/ec2_import_keypair.yaml
@@ -1,0 +1,33 @@
+Parameters:
+  GeneratedKeyName:
+    Type: String
+  ImportedKeyName:
+    Type: String
+
+Resources:
+
+  GeneratedKeyPair:
+    Type: AWS::EC2::KeyPair
+    Properties:
+      KeyName: !Ref GeneratedKeyName
+      KeyFormat: pem
+      KeyType: rsa
+
+  ImportedKeyPair:
+    Type: AWS::EC2::KeyPair
+    Properties:
+      KeyName: !Ref ImportedKeyName
+      KeyFormat: pem
+      KeyType: rsa
+      # generated from a throwaway key
+      PublicKeyMaterial: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILR+zNQbYY5ORuhYXGMTSnjRLzS9C5dUdWRKdlqi20q2
+
+Outputs:
+  GeneratedKeyPairName:
+    Value: !Ref GeneratedKeyPair
+  GeneratedKeyPairFingerprint:
+    Value: !GetAtt GeneratedKeyPair.KeyFingerprint
+  ImportedKeyPairName:
+    Value: !Ref ImportedKeyPair
+  ImportedKeyPairFingerprint:
+    Value: !GetAtt ImportedKeyPair.KeyFingerprint


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While exploring EC2 CloudFormation resources (via CDK) I found that when providing `PublicKeyMaterial` that the deployment failed, since this is not a valid parameter to `create_ssh_key`.

In this case, we should use `import_ssh_key`.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* If `PublicKeyMaterial` is present in incoming resource definition, call `import_ssh_key` instead of `create_ssh_key`
* Add test to capture both behaviours

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
