### PR TITLE
APIGW NG: introduce new unified path style

### DIFF
--- a/localstack-core/localstack/aws/handlers/cors.py
+++ b/localstack-core/localstack/aws/handlers/cors.py
@@ -155,8 +155,10 @@ def should_enforce_self_managed_service(context: RequestContext) -> bool:
     if not config.DISABLE_CUSTOM_CORS_APIGATEWAY:
         # we don't check for service_name == "apigw" here because ``.execute-api.`` can be either apigw v1 or v2
         path = context.request.path
-        is_user_request = ".execute-api." in context.request.host or (
-            path.startswith("/restapis/") and f"/{PATH_USER_REQUEST}" in context.request.path
+        is_user_request = (
+            ".execute-api." in context.request.host
+            or (path.startswith("/restapis/") and f"/{PATH_USER_REQUEST}" in context.request.path)
+            or (path.startswith("/_aws/apigateway/execute-api"))
         )
         if is_user_request:
             return False

--- a/localstack-core/localstack/aws/handlers/cors.py
+++ b/localstack-core/localstack/aws/handlers/cors.py
@@ -158,7 +158,7 @@ def should_enforce_self_managed_service(context: RequestContext) -> bool:
         is_user_request = (
             ".execute-api." in context.request.host
             or (path.startswith("/restapis/") and f"/{PATH_USER_REQUEST}" in context.request.path)
-            or (path.startswith("/_aws/apigateway/execute-api"))
+            or (path.startswith("/_aws/execute-api"))
         )
         if is_user_request:
             return False

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -660,6 +660,13 @@ def path_based_url(api_id: str, stage_name: str, path: str) -> str:
     return pattern.format(api_id=api_id, stage_name=stage_name, path=path)
 
 
+def localstack_path_based_url(api_id: str, stage_name: str, path: str) -> str:
+    """Return URL for inbound API gateway for given API ID, stage name, and path on the _aws namespace"""
+    return (
+        f"{config.external_service_url()}/_aws/apigateway/execute-api/{api_id}/{stage_name}{path}"
+    )
+
+
 def host_based_url(rest_api_id: str, path: str, stage_name: str = None):
     """Return URL for inbound API gateway for given API ID, stage name, and path with custom dns
     format"""

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -662,9 +662,7 @@ def path_based_url(api_id: str, stage_name: str, path: str) -> str:
 
 def localstack_path_based_url(api_id: str, stage_name: str, path: str) -> str:
     """Return URL for inbound API gateway for given API ID, stage name, and path on the _aws namespace"""
-    return (
-        f"{config.external_service_url()}/_aws/apigateway/execute-api/{api_id}/{stage_name}{path}"
-    )
+    return f"{config.external_service_url()}/_aws/execute-api/{api_id}/{stage_name}{path}"
 
 
 def host_based_url(rest_api_id: str, path: str, stage_name: str = None):

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -77,10 +77,10 @@ class InvocationRequestParser(RestApiGatewayHandler):
             # in this format, the stage is before `_user_request_`, so we don't need to remove it
             raw_uri = raw_uri.partition("_user_request_")[2]
         else:
-            if raw_uri.startswith("/_aws/apigateway/execute-api"):
+            if raw_uri.startswith("/_aws/execute-api"):
                 # the API can be cased in the path, so we need to ignore it to remove it
                 raw_uri = re.sub(
-                    f"^/_aws/apigateway/execute-api/{context.api_id}",
+                    f"^/_aws/execute-api/{context.api_id}",
                     "",
                     raw_uri,
                     flags=re.IGNORECASE,

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -104,6 +104,7 @@ class ApiGatewayEndpoint:
 class ApiGatewayRouter:
     router: Router[Handler]
     handler: ApiGatewayEndpoint
+    EXECUTE_API_INTERNAL_PATH = "/_aws/apigateway/execute-api"
 
     def __init__(self, router: Router[Handler] = None, handler: ApiGatewayEndpoint = None):
         self.router = router or ROUTER
@@ -134,7 +135,7 @@ class ApiGatewayRouter:
                 endpoint=self.handler,
                 strict_slashes=True,
             ),
-            # add the localstack-specific _user_request_ routes
+            # add the deprecated localstack-specific _user_request_ routes
             self.router.add(
                 path="/restapis/<api_id>/<stage>/_user_request_",
                 endpoint=self.handler,
@@ -142,6 +143,24 @@ class ApiGatewayRouter:
             ),
             self.router.add(
                 path="/restapis/<api_id>/<stage>/_user_request_/<greedy_path:path>",
+                endpoint=self.handler,
+                strict_slashes=True,
+            ),
+            # add the localstack-specific so-called "path-style" routes when DNS resolving is not possible
+            self.router.add(
+                path=f"{self.EXECUTE_API_INTERNAL_PATH}/<api_id>/",
+                endpoint=self.handler,
+                defaults={"path": "", "stage": None},
+                strict_slashes=True,
+            ),
+            self.router.add(
+                path=f"{self.EXECUTE_API_INTERNAL_PATH}/<api_id>/<stage>/",
+                endpoint=self.handler,
+                defaults={"path": ""},
+                strict_slashes=False,
+            ),
+            self.router.add(
+                path=f"{self.EXECUTE_API_INTERNAL_PATH}/<api_id>/<stage>/<greedy_path:path>",
                 endpoint=self.handler,
                 strict_slashes=True,
             ),

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -118,7 +118,7 @@ class ApiGatewayRouter:
         deprecated_route_endpoint = deprecated_endpoint(
             endpoint=self.handler,
             previous_path="/restapis/<api_id>/<stage>/_user_request_",
-            deprecation_version="3.7.0",
+            deprecation_version="3.8.0",
             new_path=f"{self.EXECUTE_API_INTERNAL_PATH}/<api_id>/<stage>",
         )
         rules = [
@@ -146,7 +146,7 @@ class ApiGatewayRouter:
             self.router.add(
                 path="/restapis/<api_id>/<stage>/_user_request_",
                 endpoint=deprecated_route_endpoint,
-                defaults={"path": ""},
+                defaults={"path": "", "random": "?"},
             ),
             self.router.add(
                 path="/restapis/<api_id>/<stage>/_user_request_/<greedy_path:path>",

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -105,7 +105,7 @@ class ApiGatewayEndpoint:
 class ApiGatewayRouter:
     router: Router[Handler]
     handler: ApiGatewayEndpoint
-    EXECUTE_API_INTERNAL_PATH = "/_aws/apigateway/execute-api"
+    EXECUTE_API_INTERNAL_PATH = "/_aws/execute-api"
 
     def __init__(self, router: Router[Handler] = None, handler: ApiGatewayEndpoint = None):
         self.router = router or ROUTER

--- a/tests/aws/services/apigateway/apigateway_fixtures.py
+++ b/tests/aws/services/apigateway/apigateway_fixtures.py
@@ -1,7 +1,11 @@
 from enum import Enum
 from typing import Dict
 
-from localstack.services.apigateway.helpers import host_based_url, path_based_url
+from localstack.services.apigateway.helpers import (
+    host_based_url,
+    localstack_path_based_url,
+    path_based_url,
+)
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.aws import aws_stack
 
@@ -195,6 +199,7 @@ def delete_cognito_user_pool_client(cognito_idp, **kwargs):
 class UrlType(Enum):
     HOST_BASED = 0
     PATH_BASED = 1
+    LS_PATH_BASED = 2
 
 
 def api_invoke_url(
@@ -209,6 +214,10 @@ def api_invoke_url(
             region = aws_stack.get_boto3_region()
         stage = f"/{stage}" if stage else ""
         return f"https://{api_id}.execute-api.{region}.amazonaws.com{stage}{path}"
+
     if url_type == UrlType.HOST_BASED:
         return host_based_url(api_id, stage_name=stage, path=path)
-    return path_based_url(api_id, stage_name=stage, path=path)
+    elif url_type == UrlType.PATH_BASED:
+        return path_based_url(api_id, stage_name=stage, path=path)
+    else:
+        return localstack_path_based_url(api_id, stage_name=stage, path=path)

--- a/tests/unit/services/apigateway/test_handler_request.py
+++ b/tests/unit/services/apigateway/test_handler_request.py
@@ -165,8 +165,8 @@ class TestParsingHandler:
         # simulate a path request
         request = Request(
             "GET",
-            path=f"/_aws/apigateway/execute-api/{TEST_API_ID}/{TEST_API_STAGE}/foo/bar/ed",
-            raw_path=f"/_aws/apigateway/execute-api/{TEST_API_ID}/{TEST_API_STAGE}//foo%2Fbar/ed",
+            path=f"/_aws/execute-api/{TEST_API_ID}/{TEST_API_STAGE}/foo/bar/ed",
+            raw_path=f"/_aws/execute-api/{TEST_API_ID}/{TEST_API_STAGE}//foo%2Fbar/ed",
         )
 
         context = get_invocation_context(request)
@@ -186,7 +186,7 @@ class TestParsingHandler:
         if addressing == "host":
             full_path = f"/{TEST_API_STAGE}/{path}"
         elif addressing == "path_style":
-            full_path = f"/_aws/apigateway/execute-api/{TEST_API_ID}/{TEST_API_STAGE}/{path}"
+            full_path = f"/_aws/execute-api/{TEST_API_ID}/{TEST_API_STAGE}/{path}"
         else:
             full_path = f"/restapis/{TEST_API_ID}/{TEST_API_STAGE}/_user_request_/{path}"
 
@@ -207,7 +207,7 @@ class TestParsingHandler:
         self, dummy_deployment, parse_handler_chain, get_invocation_context, addressing
     ):
         if addressing == "path_style":
-            full_path = f"/_aws/apigateway/execute-api/TestApi/{TEST_API_STAGE}/test"
+            full_path = f"/_aws/execute-api/TestApi/{TEST_API_STAGE}/test"
         else:
             full_path = f"/restapis/{TEST_API_ID}/TestApi/_user_request_/test"
 
@@ -382,7 +382,7 @@ class TestRoutingHandler:
             return f"/restapis/{TEST_API_ID}/{TEST_API_STAGE}/_user_request_/{path}"
         else:
             # this new style allows following the regular order in an easier way, stage is always before path
-            return f"/_aws/apigateway/execute-api/{TEST_API_ID}/{TEST_API_STAGE}{path}"
+            return f"/_aws/execute-api/{TEST_API_ID}/{TEST_API_STAGE}{path}"
 
     @pytest.mark.parametrize("addressing", ["host", "user_request", "path_style"])
     def test_route_request_no_param(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation


In LocalStack API Gateway, we currently have a specific path-style format to call `execute-api`: `http(s)://<your-domain>:<port>/restapis/<api_id>/<stage>/_user_request_/<your-path>`.
The actual AWS format is this, with the host: `http(s)://<api-id>.execute-api.<domain>/<stage>/<your-path>`

There are multiple problems with our current "path style" format:
- it has `restapis` in the name but is shared with HTTP and WebSockets API in APIGW v2
- for HTTP APIs, <stage> can be optional. That format does not work with that case
- there is the custom _user_request_ between  <stage> and <your-path> , which looks weird and necessitate to re-organize the parts for the user

This PR introduces a new path format for API Gateway, available with the "Next Gen" provider:
`http(s)://<your-domain>:<port>/_aws/execute-api/<api-id>/<stage>/<your-path>`

This new format follows the same order as AWS, is clearer about the LocalStack-only part, is on the `_aws` namespace, and has `execute-api` in the name, which maps to the URL people are used to see.

It also sets up a deprecation path for the previous "path style" and log a message when people uses it with the new provider. We will also need to update the documentation accordingly.


Deprecation message:
```
2024-08-14T03:10:10.517 WARNING --- [PoolThread-twisted.internet.reactor-0] localstack.deprecations    : /restapis/<api_id>/<stage>/_user_request_ is deprecated (since 3.7.0) and will be removed in upcoming releases of LocalStack! Use /_aws/execute-api/<api_id>/<stage> instead.
```

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- register new routes for the APIGW NG router
- update the CORS handler to recognize this new router
- add deprecation on the `_user_request_` endpoint when using the NG provder
- update the tests to use this new endpoint too 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
