### PR TITLE
fix test_import_with_stage_variables for multi account

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -753,8 +753,8 @@ class TestApiGatewayImportRestApi:
         )
         spec_file = load_file(OAS_30_STAGE_VARIABLES)
         if not is_aws_cloud():
-            # to make sure we return the test without https
-            spec_file.replace("https://", "http://")
+            # to make sure we return the endpoint without https to avoid cert issues
+            spec_file = spec_file.replace("https://", "http://")
 
         import_resp, root_id = import_apigw(body=spec_file, failOnWarnings=True)
         rest_api_id = import_resp["id"]


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Recently updated test `test_import_with_stage_variables` [broke the multi account pipeline](https://app.circleci.com/pipelines/github/localstack/localstack/27318/workflows/6163beb5-f542-4d1c-836e-7385d6ffe7bc/jobs/234706) because we used a lambda URL function in a non default region which doesn't have certificates. We however need HTTPS by default in the OpenAPI file because AWS does not accept HTTP only requests to lambda URL. 


There was a condition to replace the https scheme by http when running against LocalStack, but I've done a small mistake and did not assign the result 😅 
Anyway, this now works, you can validate the fix by running the same test with `TEST_AWS_REGION_NAME=ap-northeast-1` and see it is fixed.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- assign the result of the `str.replace`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
