### PR TITLE
implement SSE-C encryption for S3

### DIFF
--- a/localstack-core/localstack/aws/api/s3/__init__.py
+++ b/localstack-core/localstack/aws/api/s3/__init__.py
@@ -942,6 +942,14 @@ class EntityTooLarge(ServiceException):
     ProposedSize: Optional[ProposedSize]
 
 
+class InvalidEncryptionAlgorithmError(ServiceException):
+    code: str = "InvalidEncryptionAlgorithmError"
+    sender_fault: bool = False
+    status_code: int = 400
+    ArgumentName: Optional[ArgumentName]
+    ArgumentValue: Optional[ArgumentValue]
+
+
 AbortDate = datetime
 
 

--- a/localstack-core/localstack/aws/spec-patches.json
+++ b/localstack-core/localstack/aws/spec-patches.json
@@ -1223,6 +1223,26 @@
         "documentation":"<p>Container for version information.</p>",
         "locationName":"Version"
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/InvalidEncryptionAlgorithmError",
+      "value": {
+        "type": "structure",
+        "members": {
+          "ArgumentName": {
+            "shape": "ArgumentName"
+          },
+          "ArgumentValue": {
+            "shape": "ArgumentValue"
+          }
+        },
+        "error": {
+          "httpStatusCode": 400
+        },
+        "documentation": "<p>The Encryption request you specified is not valid.</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack-core/localstack/services/s3/models.py
+++ b/localstack-core/localstack/services/s3/models.py
@@ -58,6 +58,7 @@ from localstack.aws.api.s3 import (
     ServerSideEncryption,
     ServerSideEncryptionRule,
     Size,
+    SSECustomerKeyMD5,
     SSEKMSKeyId,
     StorageClass,
     WebsiteConfiguration,
@@ -245,7 +246,6 @@ class S3Bucket:
         return s3_object
 
 
-# note: might be migrated to dataclass once the full API is set
 class S3Object:
     key: ObjectKey
     version_id: Optional[ObjectVersionId]
@@ -262,6 +262,7 @@ class S3Object:
     encryption: Optional[ServerSideEncryption]  # inherit bucket
     kms_key_id: Optional[SSEKMSKeyId]  # inherit bucket
     bucket_key_enabled: Optional[bool]  # inherit bucket
+    sse_key_hash: Optional[SSECustomerKeyMD5]
     checksum_algorithm: ChecksumAlgorithm
     checksum_value: str
     lock_mode: Optional[ObjectLockMode | ObjectLockRetentionMode]
@@ -289,6 +290,7 @@ class S3Object:
         checksum_value: Optional[str] = None,
         encryption: Optional[ServerSideEncryption] = None,
         kms_key_id: Optional[SSEKMSKeyId] = None,
+        sse_key_hash: Optional[SSECustomerKeyMD5] = None,
         bucket_key_enabled: bool = False,
         lock_mode: Optional[ObjectLockMode | ObjectLockRetentionMode] = None,
         lock_legal_status: Optional[ObjectLockLegalHoldStatus] = None,
@@ -312,6 +314,7 @@ class S3Object:
         self.encryption = encryption
         self.kms_key_id = kms_key_id
         self.bucket_key_enabled = bucket_key_enabled
+        self.sse_key_hash = sse_key_hash
         self.lock_mode = lock_mode
         self.lock_legal_status = lock_legal_status
         self.lock_until = lock_until
@@ -435,6 +438,7 @@ class S3Multipart:
         encryption: Optional[ServerSideEncryption] = None,  # inherit bucket
         kms_key_id: Optional[SSEKMSKeyId] = None,  # inherit bucket
         bucket_key_enabled: bool = False,  # inherit bucket
+        sse_key_hash: Optional[SSECustomerKeyMD5] = None,
         lock_mode: Optional[ObjectLockMode] = None,
         lock_legal_status: Optional[ObjectLockLegalHoldStatus] = None,
         lock_until: Optional[datetime] = None,
@@ -463,6 +467,7 @@ class S3Multipart:
             encryption=encryption,
             kms_key_id=kms_key_id,
             bucket_key_enabled=bucket_key_enabled,
+            sse_key_hash=sse_key_hash,
             lock_mode=lock_mode,
             lock_legal_status=lock_legal_status,
             lock_until=lock_until,

--- a/localstack-core/localstack/services/s3/validation.py
+++ b/localstack-core/localstack/services/s3/validation.py
@@ -428,6 +428,17 @@ def validate_sse_c(
     encryption_key_md5: SSECustomerKeyMD5,
     server_side_encryption: ServerSideEncryption = None,
 ):
+    """
+    This method validates the SSE Customer parameters for different requests.
+    :param algorithm: the SSECustomerAlgorithm parameter of the incoming Request, can only be AES256
+    :param encryption_key: the SSECustomerKey of the incoming Request, represent the base64 encoded encryption key
+    :param encryption_key_md5: the SSECustomerKeyMD5 of the request, represents the base64 encoded MD5 hash of the
+    encryption key
+    :param server_side_encryption: when the incoming request is a "write" request (PutObject, CopyObject,
+     CreateMultipartUpload), the user can specify the encryption. Customer encryption and AWS SSE can't both be set.
+    :raises: InvalidArgument if the request is invalid
+    :raises: InvalidEncryptionAlgorithmError if the given algorithm is different from AES256
+    """
     if not encryption_key and not algorithm:
         return
     elif server_side_encryption:

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -12121,5 +12121,606 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_put_object_validation_sse_c": {
+    "recorded-date": "14-08-2024, 18:09:54",
+    "recorded-content": {
+      "put-obj-sse-c-both-encryption": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "AES256",
+          "Code": "InvalidArgument",
+          "Message": "Server Side Encryption with Customer provided key is incompatible with the encryption method specified"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-sse-c-wrong-algo": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "KMS",
+          "Code": "InvalidEncryptionAlgorithmError",
+          "Message": "The Encryption request you specified is not valid. Supported value: AES256."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-sse-c-no-algo": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "null",
+          "Code": "InvalidArgument",
+          "Message": "Requests specifying Server Side Encryption with Customer provided keys must provide a valid encryption algorithm."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-sse-c-no-key": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "null",
+          "Code": "InvalidArgument",
+          "Message": "Requests specifying Server Side Encryption with Customer provided keys must provide an appropriate secret key."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-sse-c-no-md5": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "null",
+          "Code": "InvalidArgument",
+          "Message": "The secret key was invalid for the specified algorithm."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-sse-c-wrong-key-size": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "null",
+          "Code": "InvalidArgument",
+          "Message": "The secret key was invalid for the specified algorithm."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-sse-c-bad-md5": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "null",
+          "Code": "InvalidArgument",
+          "Message": "The calculated MD5 hash of the key did not match the hash that was provided."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_object_retrieval_sse_c": {
+    "recorded-date": "14-08-2024, 17:16:18",
+    "recorded-content": {
+      "put-obj-sse-c": {
+        "ETag": "\"6e1dd38f1774369f29f29865959f470f\"",
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-sse-c": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The object was stored using a form of Server Side Encryption. The correct parameters must be provided to retrieve the object."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-obj-sse-c-wrong-key": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "get-obj-sse-c-wrong-algo": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "KMS",
+          "Code": "InvalidEncryptionAlgorithmError",
+          "Message": "The Encryption request you specified is not valid. Supported value: AES256."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "head-obj-sse-c-wrong-algo": {
+        "Error": {
+          "Code": "400",
+          "Message": "Bad Request"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-obj-attrs-sse-c-wrong-algo": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "KMS",
+          "Code": "InvalidEncryptionAlgorithmError",
+          "Message": "The Encryption request you specified is not valid. Supported value: AES256."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-obj-sse-c-no-md5": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "get-obj-sse-c-wrong-key-size": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "null",
+          "Code": "InvalidArgument",
+          "Message": "The secret key was invalid for the specified algorithm."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-obj-sse-c-bad-md5": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "null",
+          "Code": "InvalidArgument",
+          "Message": "The calculated MD5 hash of the key did not match the hash that was provided."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_copy_object_with_sse_c": {
+    "recorded-date": "14-08-2024, 18:24:33",
+    "recorded-content": {
+      "put-obj-sse-c": {
+        "ETag": "\"92fb632f684d80423159ba897667fd57\"",
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-obj-sse-c-target-no-sse-c": {
+        "CopyObjectResult": {
+          "ETag": "\"6af8307c2460f2d208ad254f04be4b0d\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-obj-sse-c": {
+        "CopyObjectResult": {
+          "ETag": "\"3bea172833358f13bb322acea379c087\"",
+          "LastModified": "datetime"
+        },
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-sse-c-param": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The object was stored using a form of Server Side Encryption. The correct parameters must be provided to retrieve the object."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "copy-obj-no-src-sse-c": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The object was stored using a form of Server Side Encryption. The correct parameters must be provided to retrieve the object."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "copy-obj-wrong-src-sse-c-algo": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "KMS",
+          "Code": "InvalidEncryptionAlgorithmError",
+          "Message": "The Encryption request you specified is not valid. Supported value: AES256."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "copy-obj-wrong-target-sse-c-algo": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "KMS",
+          "Code": "InvalidEncryptionAlgorithmError",
+          "Message": "The Encryption request you specified is not valid. Supported value: AES256."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "copy-obj-target-double-encryption": {
+        "Error": {
+          "ArgumentName": "x-amz-server-side-encryption",
+          "ArgumentValue": "AES256",
+          "Code": "InvalidArgument",
+          "Message": "Server Side Encryption with Customer provided key is incompatible with the encryption method specified"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_multipart_upload_sse_c": {
+    "recorded-date": "14-08-2024, 17:17:30",
+    "recorded-content": {
+      "create-mpu-sse-c": {
+        "Bucket": "bucket",
+        "Key": "test-sse-c-multipart",
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-0": {
+        "ETag": "\"d1a74530ea27e17609ab0f7ba95f4498\"",
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-1": {
+        "ETag": "\"d72af240c64a953f679f4611fca532df\"",
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-2": {
+        "ETag": "\"61a9eeda93b38aea8abfddd51b4c3cef\"",
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-sse-c-multipart",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 3,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "\"d1a74530ea27e17609ab0f7ba95f4498\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 5242881
+          },
+          {
+            "ETag": "\"d72af240c64a953f679f4611fca532df\"",
+            "LastModified": "datetime",
+            "PartNumber": 2,
+            "Size": 5242881
+          },
+          {
+            "ETag": "\"61a9eeda93b38aea8abfddd51b4c3cef\"",
+            "LastModified": "datetime",
+            "PartNumber": 3,
+            "Size": 5242881
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-checksum": {
+        "Bucket": "bucket",
+        "ETag": "\"2e8e089c9b6734ded1545d08dbf5b88c-3\"",
+        "Key": "test-sse-c-multipart",
+        "Location": "<location:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-sse-c-param": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The object was stored using a form of Server Side Encryption. The correct parameters must be provided to retrieve the object."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-obj-sse-c": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ContentLength": 15728643,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"2e8e089c9b6734ded1545d08dbf5b88c-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_multipart_upload_sse_c_validation": {
+    "recorded-date": "14-08-2024, 18:46:26",
+    "recorded-content": {
+      "create-mpu-no-sse-c": {
+        "Bucket": "bucket",
+        "Key": "test-sse-c-multipart",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "mpu-no-sse-c-upload-part-with-sse-c": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The multipart upload initiate requested encryption. Subsequent part requests must include the appropriate encryption parameters."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-mpu-sse-c": {
+        "Bucket": "bucket",
+        "Key": "test-sse-c-multipart",
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "UploadId": "<upload-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "mpu-sse-c-upload-part-no-sse-c": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The multipart upload initiate requested encryption. Subsequent part requests must include the appropriate encryption parameters."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "mpu-sse-c-upload-part-wrong-sse-c": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The provided encryption parameters did not match the ones used originally."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_put_object_lifecycle_with_sse_c": {
+    "recorded-date": "14-08-2024, 17:16:11",
+    "recorded-content": {
+      "put-obj-sse-c": {
+        "ETag": "\"c064b33e9ee3f003d3066b620a0158dc\"",
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-obj-sse-c": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 9,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"c064b33e9ee3f003d3066b620a0158dc\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-sse-c": {
+        "AcceptRanges": "bytes",
+        "Body": "test_data",
+        "ContentLength": 9,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"c064b33e9ee3f003d3066b620a0158dc\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-attrs-sse-c": {
+        "ETag": "c064b33e9ee3f003d3066b620a0158dc",
+        "LastModified": "datetime",
+        "ObjectSize": 9,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "del-obj-sse-c": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_sse_c_with_versioning": {
+    "recorded-date": "14-08-2024, 18:38:47",
+    "recorded-content": {
+      "put-obj-sse-c-version-1": {
+        "ETag": "\"ad407de6a7cc4cea54fb43c329dcb32d\"",
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-sse-c-version-2": {
+        "ETag": "\"a10681b6f0bd60688a37bd45ffc4b326\"",
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "KoitZ78ZSAQHz4+gxDpJqQ==",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-sse-c-last-version": {
+        "AcceptRanges": "bytes",
+        "Body": "version2",
+        "ContentLength": 8,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"a10681b6f0bd60688a37bd45ffc4b326\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "KoitZ78ZSAQHz4+gxDpJqQ==",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-sse-c-version-2": {
+        "AcceptRanges": "bytes",
+        "Body": "version2",
+        "ContentLength": 8,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"a10681b6f0bd60688a37bd45ffc4b326\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "KoitZ78ZSAQHz4+gxDpJqQ==",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-sse-c-last-version-wrong-key": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "get-obj-sse-c-version-1": {
+        "AcceptRanges": "bytes",
+        "Body": "version1",
+        "ContentLength": 8,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"ad407de6a7cc4cea54fb43c329dcb32d\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSECustomerAlgorithm": "AES256",
+        "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -680,6 +680,27 @@
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_s3_put_presigned_url_with_different_headers[s3v4]": {
     "last_validated_date": "2023-08-04T21:59:38+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_copy_object_with_sse_c": {
+    "last_validated_date": "2024-08-14T18:24:33+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_multipart_upload_sse_c": {
+    "last_validated_date": "2024-08-14T17:17:30+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_multipart_upload_sse_c_validation": {
+    "last_validated_date": "2024-08-14T18:46:26+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_object_retrieval_sse_c": {
+    "last_validated_date": "2024-08-14T17:16:18+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_put_object_lifecycle_with_sse_c": {
+    "last_validated_date": "2024-08-14T17:16:11+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_put_object_validation_sse_c": {
+    "last_validated_date": "2024-08-14T18:09:54+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_sse_c_with_versioning": {
+    "last_validated_date": "2024-08-14T18:38:47+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3StaticWebsiteHosting::test_crud_website_configuration": {
     "last_validated_date": "2023-08-25T22:29:24+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #11356, we did not support SSE-C for S3. This PR implements it, we still don't encrypt the files locally, but this is irrelevant for the usage, as AWS decrypts objects on the fly, and for now we don't really have a use-case for it.

I've implemented it following the documentation page: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html

And tried to think of most use-cases, as this is needed for the object-store Rust crate (see https://github.com/apache/arrow-rs/pull/6230) . 

I haven't implemented it for the pre-signed POST yet, this can be done in a follow-up. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement SSE-C parameter validation for `PutObject`, `GetObject`, `HeadObject`, `GetObjectAttributes`, `CopyObject`, `CreateMultipartUpload` and `UploadPart`. 
- add some tests around it, positive and negative
- properly return the right fields

Note: test failure unrelated, it's an OpenSearch failure, not blocking the merge

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
