### PR TITLE
Lambda: improve function name and qualifier validation

### DIFF
--- a/localstack-core/localstack/services/lambda_/api_utils.py
+++ b/localstack-core/localstack/services/lambda_/api_utils.py
@@ -8,7 +8,7 @@ import re
 import string
 from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-from localstack.aws.api import RequestContext
+from localstack.aws.api import CommonServiceException, RequestContext
 from localstack.aws.api import lambda_ as api_spec
 from localstack.aws.api.lambda_ import (
     AliasConfiguration,
@@ -27,6 +27,7 @@ from localstack.aws.api.lambda_ import (
     TracingConfig,
     VpcConfigResponse,
 )
+from localstack.services.lambda_.invocation import AccessDeniedException
 from localstack.services.lambda_.runtimes import ALL_RUNTIMES, VALID_LAYER_RUNTIMES, VALID_RUNTIMES
 from localstack.utils.aws.arns import ARN_PARTITION_REGEX, get_partition
 from localstack.utils.collections import merge_recursive
@@ -48,7 +49,7 @@ FULL_FN_ARN_PATTERN = re.compile(
     rf"{ARN_PARTITION_REGEX}:lambda:(?P<region_name>[^:]+):(?P<account_id>\d{{12}}):function:(?P<function_name>[^:]+)(:(?P<qualifier>.*))?$"
 )
 
-# Pattern for a full (both with and without qualifier) lambda function ARN
+# Pattern for a full (both with and without qualifier) lambda layer ARN
 LAYER_VERSION_ARN_PATTERN = re.compile(
     rf"{ARN_PARTITION_REGEX}:lambda:(?P<region_name>[^:]+):(?P<account_id>\d{{12}}):layer:(?P<layer_name>[^:]+)(:(?P<layer_version>\d+))?$"
 )
@@ -101,6 +102,65 @@ LAMBDA_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f+0000"
 
 # An unordered list of all Lambda CPU architectures supported by LocalStack.
 ARCHITECTURES = [Architecture.arm64, Architecture.x86_64]
+
+# ARN pattern returned in validation exception messages.
+# Some excpetions from AWS return a '\.' in the function name regex
+# pattern therefore we can sub this value in when appropriate.
+ARN_NAME_PATTERN_VALIDATION_TEMPLATE = "(arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{{2}}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{{1}}:)?(\\d{{12}}:)?(function:)?([a-zA-Z0-9-_{0}]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+
+
+def validate_function_name(function_name_or_arn: str, operation_type: str):
+    function_name, *_ = function_locators_from_arn(function_name_or_arn)
+    arn_name_pattern = ARN_NAME_PATTERN_VALIDATION_TEMPLATE.format("")
+    max_length = 170
+
+    match operation_type:
+        case "GetFunction" | "Invoke":
+            arn_name_pattern = ARN_NAME_PATTERN_VALIDATION_TEMPLATE.format(r"\.")
+        case "CreateFunction" if function_name == function_name_or_arn:  # only a function name
+            max_length = 64
+        case "CreateFunction" | "DeleteFunction":
+            max_length = 140
+
+    validations = []
+    if len(function_name_or_arn) > max_length:
+        constraint = f"Member must have length less than or equal to {max_length}"
+        validation_msg = f"Value '{function_name_or_arn}' at 'functionName' failed to satisfy constraint: {constraint}"
+        validations.append(validation_msg)
+
+    if not AWS_FUNCTION_NAME_REGEX.match(function_name_or_arn) or not function_name:
+        constraint = f"Member must satisfy regular expression pattern: {arn_name_pattern}"
+        validation_msg = f"Value '{function_name_or_arn}' at 'functionName' failed to satisfy constraint: {constraint}"
+        validations.append(validation_msg)
+
+    return validations
+
+
+def validate_qualifier(qualifier: str):
+    validations = []
+
+    if len(qualifier) > 128:
+        constraint = "Member must have length less than or equal to 128"
+        validation_msg = (
+            f"Value '{qualifier}' at 'qualifier' failed to satisfy constraint: {constraint}"
+        )
+        validations.append(validation_msg)
+
+    if not QUALIFIER_REGEX.match(qualifier):
+        constraint = "Member must satisfy regular expression pattern: (|[a-zA-Z0-9$_-]+)"
+        validation_msg = (
+            f"Value '{qualifier}' at 'qualifier' failed to satisfy constraint: {constraint}"
+        )
+        validations.append(validation_msg)
+
+    return validations
+
+
+def construct_validation_exception_message(validation_errors):
+    if validation_errors:
+        return f"{len(validation_errors)} validation error{'s' if len(validation_errors) > 1 else ''} detected: {'; '.join(validation_errors)}"
+
+    return None
 
 
 def map_function_url_config(model: "FunctionUrlConfig") -> api_spec.FunctionUrlConfig:
@@ -185,14 +245,22 @@ def get_function_name(function_arn_or_name: str, context: RequestContext) -> str
     return name
 
 
-def function_locators_from_arn(arn: str) -> tuple[str, str | None, str | None, str | None]:
+def function_locators_from_arn(arn: str) -> tuple[str | None, str | None, str | None, str | None]:
     """
     Takes a full or partial arn, or a name
 
     :param arn: Given arn (or name)
     :return: tuple with (name, qualifier, account, region). Qualifier and region are none if missing
     """
-    return FUNCTION_NAME_REGEX.match(arn).group("name", "qualifier", "account", "region")
+
+    if matched := FUNCTION_NAME_REGEX.match(arn):
+        name = matched.group("name")
+        qualifier = matched.group("qualifier")
+        account = matched.group("account")
+        region = matched.group("region")
+        return (name, qualifier, account, region)
+
+    return None, None, None, None
 
 
 def get_account_and_region(function_arn_or_name: str, context: RequestContext) -> Tuple[str, str]:
@@ -210,25 +278,57 @@ def get_name_and_qualifier(
     function_arn_or_name: str, qualifier: str | None, context: RequestContext
 ) -> tuple[str, str | None]:
     """
-    Takes a full or partial arn, or a name and a qualifier
-    Will raise exception if a qualified arn is provided and the qualifier does not match (but is given)
+    Takes a full or partial arn, or a name and a qualifier.
 
     :param function_arn_or_name: Given arn (or name)
     :param qualifier: A qualifier for the function (or None)
     :param context: Request context
     :return: tuple with (name, qualifier). Qualifier is none if missing
+    :raises: `ResourceNotFoundException` when the context's region differs from the ARN's region
+    :raises: `AccessDeniedException` when the context's account ID differs from the ARN's account ID
+    :raises: `ValidationExcpetion` when a function ARN/name or qualifier fails validation checks
+    :raises: `InvalidParameterValueException` when a qualified arn is provided and the qualifier does not match (but is given)
     """
-    function_name, arn_qualifier, _, arn_region = function_locators_from_arn(function_arn_or_name)
+    function_name, arn_qualifier, account, region = function_locators_from_arn(function_arn_or_name)
+    operation_type = context.operation.name
+
+    if operation_type not in _supported_resource_based_operations:
+        if account and account != context.account_id:
+            raise AccessDeniedException(None)
+
+    # TODO: should this only run if operation type is unsupported?
+    if region and region != context.region:
+        raise ResourceNotFoundException(
+            f"Functions from '{region}' are not reachable in this region ('{context.region}')",
+            Type="User",
+        )
+
+    validation_errors = []
+    if function_arn_or_name:
+        validation_errors.extend(validate_function_name(function_arn_or_name, operation_type))
+
+    if qualifier:
+        validation_errors.extend(validate_qualifier(qualifier))
+
+    is_only_function_name = function_arn_or_name == function_name
+    if validation_errors:
+        message = construct_validation_exception_message(validation_errors)
+        # Edge-case where the error type is not ValidationException
+        if (
+            operation_type == "CreateFunction"
+            and is_only_function_name
+            and arn_qualifier is None
+            and region is None
+        ):  # just name OR partial
+            raise InvalidParameterValueException(message=message, Type="User")
+        raise CommonServiceException(message=message, code="ValidationException")
+
     if qualifier and arn_qualifier and arn_qualifier != qualifier:
         raise InvalidParameterValueException(
             "The derived qualifier from the function name does not match the specified qualifier.",
             Type="User",
         )
-    if arn_region and arn_region != context.region:
-        raise ResourceNotFoundException(
-            f"Functions from '{arn_region}' are not reachable in this region ('{context.region}')",
-            Type="User",
-        )
+
     qualifier = qualifier or arn_qualifier
     return function_name, qualifier
 
@@ -627,5 +727,35 @@ def is_layer_arn(layer_name: str) -> bool:
     return LAYER_VERSION_ARN_PATTERN.match(layer_name) is not None
 
 
-def validate_function_name(function_name):
-    return AWS_FUNCTION_NAME_REGEX.match(function_name)
+# See Lambda API actions that support resource-based IAM policies
+# https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html#permissions-resource-api
+_supported_resource_based_operations = {
+    "CreateAlias",
+    "DeleteAlias",
+    "DeleteFunction",
+    "DeleteFunctionConcurrency",
+    "DeleteFunctionEventInvokeConfig",
+    "DeleteProvisionedConcurrencyConfig",
+    "GetAlias",
+    "GetFunction",
+    "GetFunctionConcurrency",
+    "GetFunctionConfiguration",
+    "GetFunctionEventInvokeConfig",
+    "GetPolicy",
+    "GetProvisionedConcurrencyConfig",
+    "Invoke",
+    "ListAliases",
+    "ListFunctionEventInvokeConfigs",
+    "ListProvisionedConcurrencyConfigs",
+    "ListTags",
+    "ListVersionsByFunction",
+    "PublishVersion",
+    "PutFunctionConcurrency",
+    "PutFunctionEventInvokeConfig",
+    "PutProvisionedConcurrencyConfig",
+    "TagResource",
+    "UntagResource",
+    "UpdateAlias",
+    "UpdateFunctionCode",
+    "UpdateFunctionEventInvokeConfig",
+}

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -14049,7 +14049,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_arns": {
-    "recorded-date": "10-04-2024, 09:00:25",
+    "recorded-date": "22-08-2024, 15:53:32",
     "recorded-content": {
       "create-function-arn-response": {
         "CreateEventSourceMappingResponse": null,
@@ -14152,7 +14152,7 @@
       "invalid_function_name_exc": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'invalid:function:name' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+          "Message": "1 validation error detected: Value 'invalid:function:name' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -14316,7 +14316,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaAlias::test_alias_naming": {
-    "recorded-date": "10-04-2024, 09:12:45",
+    "recorded-date": "22-08-2024, 16:08:22",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -16418,6 +16418,942 @@
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestPartialARNMatching::test_cross_region_arn_function_access": {
     "recorded-date": "11-06-2024, 13:06:45",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:25",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value '*' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:26",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value '*' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:26",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value '*' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:26",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value '*' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:24",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'my-function!' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:24",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'my-function!' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:25",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'my-function!' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:25",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'my-function!' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:27",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'invalid!' at 'qualifier' failed to satisfy constraint: Member must satisfy regular expression pattern: (|[a-zA-Z0-9$_-]+)"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:27",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'invalid!' at 'qualifier' failed to satisfy constraint: Member must satisfy regular expression pattern: (|[a-zA-Z0-9$_-]+)"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:27",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'invalid!' at 'qualifier' failed to satisfy constraint: Member must satisfy regular expression pattern: (|[a-zA-Z0-9$_-]+)"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:27",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'my-function:invalid!' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long0-get_function]": {
+    "recorded-date": "22-08-2024, 15:07:09",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value '<a:len(129)>' at 'qualifier' failed to satisfy constraint: Member must have length less than or equal to 128"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long0-delete_function]": {
+    "recorded-date": "22-08-2024, 15:07:10",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value '<a:len(129)>' at 'qualifier' failed to satisfy constraint: Member must have length less than or equal to 128"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long0-invoke]": {
+    "recorded-date": "22-08-2024, 15:07:10",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value '<a:len(129)>' at 'qualifier' failed to satisfy constraint: Member must have length less than or equal to 128"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long0-create_function]": {
+    "recorded-date": "22-08-2024, 15:07:10",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'my-function:<a:len(129)>' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:29",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'invalid-account:function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:29",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'invalid-account:function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:29",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'invalid-account:function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:30",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'invalid-account:function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:30",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:30",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:31",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:31",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:31",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:ec2:<region>:111111111111:instance:i-1234567890abcdef0' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:31",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:ec2:<region>:111111111111:instance:i-1234567890abcdef0' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:32",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:ec2:<region>:111111111111:instance:i-1234567890abcdef0' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:32",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:ec2:<region>:111111111111:instance:i-1234567890abcdef0' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:32",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ResourceNotFoundException",
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:<a:len(65)>"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:33",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ResourceNotFoundException",
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:<a:len(65)>"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:33",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ResourceNotFoundException",
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:<a:len(65)>:$LATEST"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:33",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "InvalidParameterValueException",
+        "Count": 1,
+        "Errors": [
+          "Value '<a:len(65)>' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 64"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:34",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 2,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function<a:len(170)>' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 170",
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function<a:len(170)>' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:34",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 2,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function<a:len(140)>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140",
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function<a:len(140)>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:34",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 2,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function<a:len(170)>' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 170",
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function<a:len(170)>' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:35",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 2,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function<a:len(140)>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140",
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function<a:len(140)>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:35",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 3,
+        "Errors": [
+          "Value '<a:len(129)>' at 'qualifier' failed to satisfy constraint: Member must have length less than or equal to 128",
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function-<a:len(170)>' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 170",
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function-<a:len(170)>' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:35",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 3,
+        "Errors": [
+          "Value '<a:len(129)>' at 'qualifier' failed to satisfy constraint: Member must have length less than or equal to 128",
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function-<a:len(140)>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140",
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function-<a:len(140)>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:36",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 3,
+        "Errors": [
+          "Value '<a:len(129)>' at 'qualifier' failed to satisfy constraint: Member must have length less than or equal to 128",
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function-<a:len(170)>' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 170",
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function-<a:len(170)>' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:36",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 2,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function-<a:len(140)>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:<a:len(129)>' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140",
+          "Value 'arn:<partition>:lambda:invalid-region:111111111111:function:my-function-<a:len(140)>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:<a:len(129)>' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long1-get_function]": {
+    "recorded-date": "22-08-2024, 15:07:18",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ResourceNotFoundException",
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:my-function:<a:len(65)>"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long1-delete_function]": {
+    "recorded-date": "22-08-2024, 15:07:18",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "InvalidParameterValueException",
+        "Message": "Deletion of aliases is not currently supported."
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long1-invoke]": {
+    "recorded-date": "22-08-2024, 15:07:18",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ResourceNotFoundException",
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:my-function:<a:len(65)>"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long1-create_function]": {
+    "recorded-date": "22-08-2024, 15:07:19",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:36",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>:111111111111:function:my-function:1:2' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:36",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>:111111111111:function:my-function:1:2' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:37",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>:111111111111:function:my-function:1:2' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:37",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>:111111111111:function:my-function:1:2' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:37",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ResourceNotFoundException",
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:function"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:38",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ResourceNotFoundException",
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:function"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:38",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ResourceNotFoundException",
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:function:$LATEST"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:38",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:38",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'function:my-function:$LATEST:extra' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:39",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'function:my-function:$LATEST:extra' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:39",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'function:my-function:$LATEST:extra' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:39",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'function:my-function:$LATEST:extra' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:39",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "InvalidParameterValueException",
+        "Message": "The derived qualifier from the function name does not match the specified qualifier."
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:40",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "InvalidParameterValueException",
+        "Message": "The derived qualifier from the function name does not match the specified qualifier."
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:40",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "InvalidParameterValueException",
+        "Message": "The derived qualifier from the function name does not match the specified qualifier."
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:40",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>:111111111111:function:my-function:$LATEST:1' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:41",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ResourceNotFoundException",
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:my-function:$latest"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:41",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:41",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ResourceNotFoundException",
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:my-function:$latest"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:41",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>:111111111111:function:my-function:$latest' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:42",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda::111111111111:function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:42",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda::111111111111:function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:42",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda::111111111111:function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:43",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda::111111111111:function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:43",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>::function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:43",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>::function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:44",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>::function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:44",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>::function:my-function' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:44",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>:111111111111:function:my-function:$LATES' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:44",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>:111111111111:function:my-function:$LATES' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:45",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>:111111111111:function:my-function:$LATES' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:45",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'arn:<partition>:lambda:<region>:111111111111:function:my-function:$LATES' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-get_function]": {
+    "recorded-date": "22-08-2024, 15:20:28",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value '<a:len(129)>' at 'qualifier' failed to satisfy constraint: Member must have length less than or equal to 128"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-delete_function]": {
+    "recorded-date": "22-08-2024, 15:20:28",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value '<a:len(129)>' at 'qualifier' failed to satisfy constraint: Member must have length less than or equal to 128"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-invoke]": {
+    "recorded-date": "22-08-2024, 15:20:28",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value '<a:len(129)>' at 'qualifier' failed to satisfy constraint: Member must have length less than or equal to 128"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-create_function]": {
+    "recorded-date": "22-08-2024, 15:20:29",
+    "recorded-content": {
+      "create_function_exception": {
+        "Code": "ValidationException",
+        "Count": 1,
+        "Errors": [
+          "Value 'my-function:<a:len(129)>' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_and_qualifier_too_long-get_function]": {
+    "recorded-date": "22-08-2024, 15:10:43",
+    "recorded-content": {
+      "get_function_exception": {
+        "Code": "ResourceNotFoundException",
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:my-function:<a:len(65)>"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_and_qualifier_too_long-delete_function]": {
+    "recorded-date": "22-08-2024, 15:10:43",
+    "recorded-content": {
+      "delete_function_exception": {
+        "Code": "InvalidParameterValueException",
+        "Message": "Deletion of aliases is not currently supported."
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_and_qualifier_too_long-invoke]": {
+    "recorded-date": "22-08-2024, 15:10:44",
+    "recorded-content": {
+      "invoke_exception": {
+        "Code": "ResourceNotFoundException",
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:my-function:<a:len(65)>"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_and_qualifier_too_long-create_function]": {
+    "recorded-date": "22-08-2024, 15:10:45",
     "recorded-content": {}
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -18,7 +18,7 @@
     "last_validated_date": "2024-04-10T09:12:27+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaAlias::test_alias_naming": {
-    "last_validated_date": "2024-07-26T13:07:55+00:00"
+    "last_validated_date": "2024-08-22T16:08:21+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaAlias::test_notfound_and_invalid_routingconfigs": {
     "last_validated_date": "2024-04-10T09:12:41+00:00"
@@ -57,10 +57,250 @@
     "last_validated_date": "2024-04-10T08:59:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_arns": {
-    "last_validated_date": "2024-04-10T09:00:24+00:00"
+    "last_validated_date": "2024-08-22T15:53:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_lifecycle": {
     "last_validated_date": "2024-04-10T08:59:22+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:36+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:35+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:35+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:36+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:37+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:36+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:36+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:37+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_and_qualifier_too_long-delete_function]": {
+    "last_validated_date": "2024-08-22T15:10:43+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_and_qualifier_too_long-get_function]": {
+    "last_validated_date": "2024-08-22T15:10:43+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_and_qualifier_too_long-invoke]": {
+    "last_validated_date": "2024-08-22T15:10:44+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:26+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:26+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:25+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:26+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:33+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:33+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:32+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:33+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:35+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:34+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:34+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:34+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:38+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:37+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:38+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:30+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:29+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:29+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:29+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:25+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:24+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:24+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:25+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:27+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:27+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:27+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:27+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:31+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:30+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:30+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:31+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:40+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:40+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:39+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:40+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:41+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:41+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:41+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:44+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:43+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:43+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:44+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:43+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:42+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:42+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:42+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:45+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:44+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:44+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:45+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:32+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:31+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:31+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:32+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:39+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:38+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:38+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:39+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-create_function]": {
+    "last_validated_date": "2024-08-22T15:20:29+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-delete_function]": {
+    "last_validated_date": "2024-08-22T15:20:28+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-get_function]": {
+    "last_validated_date": "2024-08-22T15:20:28+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-invoke]": {
+    "last_validated_date": "2024-08-22T15:20:28+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long0-create_function]": {
+    "last_validated_date": "2024-08-22T15:07:10+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long0-delete_function]": {
+    "last_validated_date": "2024-08-22T15:07:10+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long0-get_function]": {
+    "last_validated_date": "2024-08-22T15:07:09+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long0-invoke]": {
+    "last_validated_date": "2024-08-22T15:07:10+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long1-delete_function]": {
+    "last_validated_date": "2024-08-22T15:07:18+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long1-get_function]": {
+    "last_validated_date": "2024-08-22T15:07:18+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long1-invoke]": {
+    "last_validated_date": "2024-08-22T15:07:18+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_partial_advanced_logging_configuration_update[partial_config0]": {
     "last_validated_date": "2024-04-10T08:58:53+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Current validation checks for Lambda function names did not account for some invalid regex combinations as well as length limits for `FunctionName` differing between request types. This will add tests ensuring a wider range of invalid `FunctionName` and `Qualfier` combinations are caught.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
The Lambda Provider:
- Remove validation checks from `create_function` in favour of `api_utils.get_name_and_qualifier`
- Use improved qualifier validation and better account for invalid qualifier edge-case for `DeleteFunction`

The API utils `api_utils.py`:
- Conduct name validations in the `get_name_and_qualifier` -- which is ubiquitously used across the Lambda provider and should enact these checks.
- Account for operation type when running `validate_function_name` (accounting specifically for `CreateFunction`, `DeleteFunction`, `Invoke`, and `GetFunction`) with sensible defaults being used elsewhere.
- Add new `validate_qualifier` and `construct_validation_exception_message`

The Lambda API tests:
- Added new test `test_function_name_and_qualifier_validation` which accounts for a wide range of possible exception cases when attempting validation. 

## Testing

The below is a test table showing all scenarios tested for `CreateFunction`, `DeleteFunction` `GetFunction` and `Invoke` test types.

Some considerations:
- The "Negative Version Number" and "Incomplete ARN" test skips the `create_function` request.
- The "Function Name Too Long" test will only fail validation for `create_function` request -- with `ResourceNotFoundException` being thrown for othe types. None are skipped to ensure parity with AWS.

| Name | Function Name | Qualifier | Skipped Requests |
|------|---------------|-----------|------------------|
| Invalid Function Name | `my-function!` | N/A | None |
| Invalid Qualifier | `my-function` | `invalid!` | None |
| Invalid Account ID | `invalid-account:function:my-function` | N/A | None |
| Invalid Region in ARN | `arn:aws:lambda:invalid-region:{account_id}:function:my-function` | N/A | None |
| Non-Lambda ARN | `arn:aws:ec2:{region_name}:{account_id}:instance:i-1234567890abcdef0` | N/A | None |
| Function Name Too Long | `"a" * max_length` | N/A | None |
| Long Name, Invalid Region | `arn:aws:lambda:invalid-region:{account_id}:function:my-function["a" * max_length]` | N/A | None |
| Long ARN & Qualifier, Invalid Region | `arn:aws:lambda:invalid-region:{account_id}:function:my-function-["a" * max_length]` | `"a" * max_length` | None |
| Long Qualifier | `my-function` | `"a" * max_length` | None |
| Multiple Qualifiers in ARN | `arn:aws:lambda:{region_name}:{account_id}:function:my-function:1:2` | N/A | None |
| Negative Version Number | `my-function` | `-1` | `create_function` |
| Incomplete ARN | `arn:aws:lambda:{region_name}:{account_id}:function` | N/A | `create_function` |
| Partial ARN, Extra Qualifier | `function:my-function:$LATEST:extra` | N/A | None |
| Latest Ver, Add'l Qualifier | `arn:aws:lambda:{region_name}:{account_id}:function:my-function:$LATEST` | `1` | None |
| Lowercase Latest Qualifier | `arn:aws:lambda:{region_name}:{account_id}:function:my-function` | `$latest` | None |
| Missing Region in ARN | `arn:aws:lambda::{account_id}:function:my-function` | N/A | None |
| Missing Account ID in ARN | `arn:aws:lambda:{region_name}::function:my-function` | N/A | None |
| Misspelled Latest in ARN | `arn:aws:lambda:{region_name}:{account_id}:function:my-function:$LATES` | N/A | None |

### Additional Pipelines

#### LocalStack Pro: IAM Policies Enforced
- `ext`: Partial run against tests in `aws/tests/lambda_` and with `ENFORCE_IAM` enabled at [GitHub workflow](https://github.com/localstack/localstack-ext/actions/runs/10457344427)
- `ENV: ENFORCE_IAM=1`
#### LocalStack Community: Multi-Account and Multi-Region
- `multi`: Multi-region/account build at [CircleCI](https://app.circleci.com/pipelines/github/localstack/localstack/27405) pipeline.

## TODO

What's left to do:

- [x] Ensure a multi-account and multi-region test can run for this PR
- [ ] Runs against LocalStack Pro version with IAM enforcement enabled

## Potential future works
- Extend the operations being tested beyond `CreateFunction`, `DeleteFunction`, `GetFunction`, and `Invoke`
- Look into improving test-coverage and support for multi-account and multi-region operations for the provider.

