### PR TITLE
[SFN] Support for Singleton Literal Array Access Unpacking

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/common/path/input_path.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/common/path/input_path.py
@@ -3,7 +3,7 @@ from typing import Final, Optional
 
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class InputPath(EvalComponent):
@@ -21,5 +21,5 @@ class InputPath(EvalComponent):
             case InputPath.DEFAULT_PATH:
                 value = env.inp
             case _:
-                value = JSONPathUtils.extract_json(self.input_path_src, env.inp)
+                value = extract_json(self.input_path_src, env.inp)
         env.stack.append(copy.deepcopy(value))

--- a/localstack-core/localstack/services/stepfunctions/asl/component/common/path/items_path.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/common/path/items_path.py
@@ -3,7 +3,7 @@ from typing import Final
 
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class ItemsPath(EvalComponent):
@@ -15,5 +15,5 @@ class ItemsPath(EvalComponent):
     def _eval_body(self, env: Environment) -> None:
         value = copy.deepcopy(env.stack[-1])
         if self.items_path_src != ItemsPath.DEFAULT_PATH:
-            value = JSONPathUtils.extract_json(self.items_path_src, value)
+            value = extract_json(self.items_path_src, value)
         env.stack.append(value)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/common/path/output_path.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/common/path/output_path.py
@@ -2,7 +2,7 @@ from typing import Final, Optional
 
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class OutputPath(EvalComponent):
@@ -18,5 +18,5 @@ class OutputPath(EvalComponent):
             env.inp = dict()
         else:
             current_output = env.stack.pop()
-            state_output = JSONPathUtils.extract_json(self.output_path, current_output)
+            state_output = extract_json(self.output_path, current_output)
             env.inp = state_output

--- a/localstack-core/localstack/services/stepfunctions/asl/component/common/payload/payloadvalue/payloadbinding/payload_binding_path.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/common/payload/payloadvalue/payloadbinding/payload_binding_path.py
@@ -17,7 +17,7 @@ from localstack.services.stepfunctions.asl.component.common.payload.payloadvalue
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.eval.event.event_detail import EventDetails
 from localstack.services.stepfunctions.asl.utils.encoding import to_json_str
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class PayloadBindingPath(PayloadBinding):
@@ -33,7 +33,7 @@ class PayloadBindingPath(PayloadBinding):
     def _eval_val(self, env: Environment) -> Any:
         inp = env.stack[-1]
         try:
-            value = JSONPathUtils.extract_json(self.path, inp)
+            value = extract_json(self.path, inp)
         except RuntimeError:
             failure_event = FailureEvent(
                 env=env,

--- a/localstack-core/localstack/services/stepfunctions/asl/component/common/payload/payloadvalue/payloadbinding/payload_binding_path_context_obj.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/common/payload/payloadvalue/payloadbinding/payload_binding_path_context_obj.py
@@ -4,7 +4,7 @@ from localstack.services.stepfunctions.asl.component.common.payload.payloadvalue
     PayloadBinding,
 )
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class PayloadBindingPathContextObj(PayloadBinding):
@@ -19,7 +19,5 @@ class PayloadBindingPathContextObj(PayloadBinding):
         return cls(field=field, path_context_obj=path_context_obj)
 
     def _eval_val(self, env: Environment) -> Any:
-        value = JSONPathUtils.extract_json(
-            self.path_context_obj, env.context_object_manager.context_object
-        )
+        value = extract_json(self.path_context_obj, env.context_object_manager.context_object)
         return value

--- a/localstack-core/localstack/services/stepfunctions/asl/component/common/timeouts/heartbeat.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/common/timeouts/heartbeat.py
@@ -3,7 +3,7 @@ from typing import Final
 
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class Heartbeat(EvalComponent, abc.ABC):
@@ -37,7 +37,7 @@ class HeartbeatSecondsPath(Heartbeat):
 
     def _eval_seconds(self, env: Environment) -> int:
         inp = env.stack[-1]
-        seconds = JSONPathUtils.extract_json(self.path, inp)
+        seconds = extract_json(self.path, inp)
         if not isinstance(seconds, int) and seconds <= 0:
             raise ValueError(
                 f"Expected non-negative integer for HeartbeatSecondsPath, got '{seconds}' instead."

--- a/localstack-core/localstack/services/stepfunctions/asl/component/common/timeouts/timeout.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/common/timeouts/timeout.py
@@ -3,7 +3,7 @@ from typing import Final, Optional
 
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class Timeout(EvalComponent, abc.ABC):
@@ -51,7 +51,7 @@ class TimeoutSecondsPath(Timeout):
 
     def _eval_seconds(self, env: Environment) -> int:
         inp = env.stack[-1]
-        seconds = JSONPathUtils.extract_json(self.path, inp)
+        seconds = extract_json(self.path, inp)
         if not isinstance(seconds, int) and seconds <= 0:
             raise ValueError(
                 f"Expected non-negative integer for TimeoutSecondsPath, got '{seconds}' instead."

--- a/localstack-core/localstack/services/stepfunctions/asl/component/intrinsic/argument/function_argument_context_path.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/intrinsic/argument/function_argument_context_path.py
@@ -2,7 +2,7 @@ from localstack.services.stepfunctions.asl.component.intrinsic.argument.function
     FunctionArgument,
 )
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class FunctionArgumentContextPath(FunctionArgument):
@@ -13,7 +13,5 @@ class FunctionArgumentContextPath(FunctionArgument):
         self._json_path: str = json_path
 
     def _eval_body(self, env: Environment) -> None:
-        self._value = JSONPathUtils.extract_json(
-            self._json_path, env.context_object_manager.context_object
-        )
+        self._value = extract_json(self._json_path, env.context_object_manager.context_object)
         super()._eval_body(env=env)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/intrinsic/argument/function_argument_json_path.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/intrinsic/argument/function_argument_json_path.py
@@ -2,7 +2,7 @@ from localstack.services.stepfunctions.asl.component.intrinsic.argument.function
     FunctionArgument,
 )
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class FunctionArgumentJsonPath(FunctionArgument):
@@ -14,5 +14,5 @@ class FunctionArgumentJsonPath(FunctionArgument):
 
     def _eval_body(self, env: Environment) -> None:
         inp = env.stack[-1]
-        self._value = JSONPathUtils.extract_json(self._json_path, inp)
+        self._value = extract_json(self._json_path, inp)
         super()._eval_body(env=env)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/operator/implementations/boolean_equals.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/operator/implementations/boolean_equals.py
@@ -7,7 +7,7 @@ from localstack.services.stepfunctions.asl.component.state.state_choice.comparis
     Operator,
 )
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class BooleanEquals(Operator):
@@ -34,7 +34,7 @@ class BooleanEqualsPath(Operator):
         variable = env.stack.pop()
 
         inp = env.stack[-1]
-        comp_value: bool = JSONPathUtils.extract_json(value, inp)
+        comp_value: bool = extract_json(value, inp)
         if not isinstance(comp_value, bool):
             raise TypeError(f"Expected type bool, but got '{comp_value}' from path '{value}'.")
 

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/operator/implementations/numeric.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/operator/implementations/numeric.py
@@ -7,7 +7,7 @@ from localstack.services.stepfunctions.asl.component.state.state_choice.comparis
     Operator,
 )
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 def _is_numeric(variable: Any) -> bool:
@@ -42,7 +42,7 @@ class NumericEqualsPath(NumericEquals):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = NumericEquals._compare(variable, comp_value)
         env.stack.append(res)
 
@@ -75,7 +75,7 @@ class NumericGreaterThanPath(NumericGreaterThan):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = NumericGreaterThanPath._compare(variable, comp_value)
         env.stack.append(res)
 
@@ -108,7 +108,7 @@ class NumericGreaterThanEqualsPath(NumericGreaterThanEquals):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = NumericGreaterThanEqualsPath._compare(variable, comp_value)
         env.stack.append(res)
 
@@ -141,7 +141,7 @@ class NumericLessThanPath(NumericLessThan):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = NumericLessThanPath._compare(variable, comp_value)
         env.stack.append(res)
 
@@ -174,6 +174,6 @@ class NumericLessThanEqualsPath(NumericLessThanEquals):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = NumericLessThanEqualsPath._compare(variable, comp_value)
         env.stack.append(res)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/operator/implementations/string_operators.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/operator/implementations/string_operators.py
@@ -8,7 +8,7 @@ from localstack.services.stepfunctions.asl.component.state.state_choice.comparis
     Operator,
 )
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class StringEquals(Operator):
@@ -39,7 +39,7 @@ class StringEqualsPath(StringEquals):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = StringEqualsPath._compare(variable, comp_value)
         env.stack.append(res)
 
@@ -72,7 +72,7 @@ class StringGreaterThanPath(StringGreaterThan):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = StringGreaterThanPath._compare(variable, comp_value)
         env.stack.append(res)
 
@@ -105,7 +105,7 @@ class StringGreaterThanEqualsPath(StringGreaterThanEquals):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = StringGreaterThanEqualsPath._compare(variable, comp_value)
         env.stack.append(res)
 
@@ -138,7 +138,7 @@ class StringLessThanPath(StringLessThan):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = StringLessThanPath._compare(variable, comp_value)
         env.stack.append(res)
 
@@ -171,7 +171,7 @@ class StringLessThanEqualsPath(StringLessThanEquals):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = StringLessThanEqualsPath._compare(variable, comp_value)
         env.stack.append(res)
 

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/operator/implementations/timestamp_operators.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/operator/implementations/timestamp_operators.py
@@ -10,7 +10,7 @@ from localstack.services.stepfunctions.asl.component.state.state_choice.comparis
     Operator,
 )
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class TimestampEquals(Operator):
@@ -44,7 +44,7 @@ class TimestampEqualsPath(TimestampEquals):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = TimestampEqualsPath._compare(variable, comp_value)
         env.stack.append(res)
 
@@ -80,7 +80,7 @@ class TimestampGreaterThanPath(TimestampGreaterThan):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = TimestampGreaterThanPath._compare(variable, comp_value)
         env.stack.append(res)
 
@@ -116,7 +116,7 @@ class TimestampGreaterThanEqualsPath(TimestampGreaterThanEquals):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = TimestampGreaterThanEqualsPath._compare(variable, comp_value)
         env.stack.append(res)
 
@@ -152,7 +152,7 @@ class TimestampLessThanPath(TimestampLessThan):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = TimestampLessThanPath._compare(variable, comp_value)
         env.stack.append(res)
 
@@ -188,6 +188,6 @@ class TimestampLessThanEqualsPath(TimestampLessThanEquals):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         inp = env.stack[-1]
-        comp_value = JSONPathUtils.extract_json(value, inp)
+        comp_value = extract_json(value, inp)
         res = TimestampLessThanEqualsPath._compare(variable, comp_value)
         env.stack.append(res)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/variable.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/variable.py
@@ -2,7 +2,7 @@ from typing import Final
 
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 from localstack.services.stepfunctions.asl.eval.environment import Environment
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class NoSuchVariable:
@@ -17,7 +17,7 @@ class Variable(EvalComponent):
     def _eval_body(self, env: Environment) -> None:
         try:
             inp = env.stack[-1]
-            value = JSONPathUtils.extract_json(self.value, inp)
+            value = extract_json(self.value, inp)
         except Exception as ex:
             value = NoSuchVariable(f"{self.value}, {ex}")
         env.stack.append(value)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/reader_config/max_items_decl.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/reader_config/max_items_decl.py
@@ -15,7 +15,7 @@ from localstack.services.stepfunctions.asl.component.common.error_name.states_er
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.eval.event.event_detail import EventDetails
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class MaxItemsDecl(EvalComponent, abc.ABC):
@@ -104,6 +104,6 @@ class MaxItemsPath(MaxItemsDecl):
 
     def _get_value(self, env: Environment) -> int:
         inp = env.stack[-1]
-        max_items = JSONPathUtils.extract_json(self.path, inp)
+        max_items = extract_json(self.path, inp)
         self._validate_value(env=env, value=max_items)
         return max_items

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/max_concurrency.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/max_concurrency.py
@@ -16,7 +16,7 @@ from localstack.services.stepfunctions.asl.component.eval_component import EvalC
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.eval.event.event_detail import EventDetails
 from localstack.services.stepfunctions.asl.utils.encoding import to_json_str
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 DEFAULT_MAX_CONCURRENCY_VALUE: Final[int] = 0  # No limit.
 
@@ -50,7 +50,7 @@ class MaxConcurrencyPath(MaxConcurrency):
 
     def _eval_max_concurrency(self, env: Environment) -> int:
         inp = env.stack[-1]
-        max_concurrency_value = JSONPathUtils.extract_json(self.max_concurrency_path, inp)
+        max_concurrency_value = extract_json(self.max_concurrency_path, inp)
 
         error_cause = None
         if not isinstance(max_concurrency_value, int):

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/tolerated_failure.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/tolerated_failure.py
@@ -16,7 +16,7 @@ from localstack.services.stepfunctions.asl.component.eval_component import EvalC
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.eval.event.event_detail import EventDetails
 from localstack.services.stepfunctions.asl.utils.encoding import to_json_str
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 TOLERATED_FAILURE_COUNT_MIN: Final[int] = 0
 TOLERATED_FAILURE_COUNT_DEFAULT: Final[int] = 0
@@ -52,7 +52,7 @@ class ToleratedFailureCountPath(ToleratedFailureCountDecl):
 
     def _eval_tolerated_failure_count(self, env: Environment) -> int:
         inp = env.stack[-1]
-        tolerated_failure_count = JSONPathUtils.extract_json(self.tolerated_failure_count_path, inp)
+        tolerated_failure_count = extract_json(self.tolerated_failure_count_path, inp)
 
         error_cause = None
         if not isinstance(tolerated_failure_count, int):
@@ -113,9 +113,7 @@ class ToleratedFailurePercentagePath(ToleratedFailurePercentageDecl):
 
     def _eval_tolerated_failure_percentage(self, env: Environment) -> float:
         inp = env.stack[-1]
-        tolerated_failure_percentage = JSONPathUtils.extract_json(
-            self.tolerate_failure_percentage_path, inp
-        )
+        tolerated_failure_percentage = extract_json(self.tolerate_failure_percentage_path, inp)
 
         if isinstance(tolerated_failure_percentage, int):
             tolerated_failure_percentage = float(tolerated_failure_percentage)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_fail/cause_path.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_fail/cause_path.py
@@ -7,7 +7,7 @@ from localstack.services.stepfunctions.asl.component.intrinsic.functionname.stat
 from localstack.services.stepfunctions.asl.component.state.state_fail.cause_decl import CauseDecl
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.parse.intrinsic.intrinsic_parser import IntrinsicParser
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 _STRING_RETURN_FUNCTIONS: Final[set[str]] = {
     typ.name()
@@ -29,7 +29,7 @@ class CausePath(CauseDecl): ...
 class CausePathJsonPath(CausePath):
     def _eval_body(self, env: Environment) -> None:
         current_output = env.stack[-1]
-        cause = JSONPathUtils.extract_json(self.value, current_output)
+        cause = extract_json(self.value, current_output)
         env.stack.append(cause)
 
 

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_fail/error_path.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_fail/error_path.py
@@ -7,7 +7,7 @@ from localstack.services.stepfunctions.asl.component.intrinsic.functionname.stat
 from localstack.services.stepfunctions.asl.component.state.state_fail.error_decl import ErrorDecl
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.parse.intrinsic.intrinsic_parser import IntrinsicParser
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 _STRING_RETURN_FUNCTIONS: Final[set[str]] = {
     typ.name()
@@ -29,7 +29,7 @@ class ErrorPath(ErrorDecl): ...
 class ErrorPathJsonPath(ErrorPath):
     def _eval_body(self, env: Environment) -> None:
         current_output = env.stack[-1]
-        cause = JSONPathUtils.extract_json(self.value, current_output)
+        cause = extract_json(self.value, current_output)
         env.stack.append(cause)
 
 

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/seconds_path.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/seconds_path.py
@@ -16,7 +16,7 @@ from localstack.services.stepfunctions.asl.component.state.state_wait.wait_funct
 )
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.eval.event.event_detail import EventDetails
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class SecondsPath(WaitFunction):
@@ -56,6 +56,6 @@ class SecondsPath(WaitFunction):
 
     def _get_wait_seconds(self, env: Environment) -> int:
         inp = env.stack[-1]
-        seconds = JSONPathUtils.extract_json(self.path, inp)
+        seconds = extract_json(self.path, inp)
         self._validate_seconds_value(env=env, seconds=seconds)
         return seconds

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/timestamp_path.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/timestamp_path.py
@@ -21,7 +21,7 @@ from localstack.services.stepfunctions.asl.component.state.state_wait.wait_funct
 )
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.eval.event.event_detail import EventDetails
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 
 
 class TimestampPath(WaitFunction):
@@ -47,7 +47,7 @@ class TimestampPath(WaitFunction):
 
     def _get_wait_seconds(self, env: Environment) -> int:
         inp = env.stack[-1]
-        timestamp_str: str = JSONPathUtils.extract_json(self.path, inp)
+        timestamp_str: str = extract_json(self.path, inp)
         try:
             if not re.match(Timestamp.TIMESTAMP_PATTERN, timestamp_str):
                 raise FailureEventException(self._create_failure_event(env, timestamp_str))

--- a/localstack-core/localstack/services/stepfunctions/asl/utils/json_path.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/utils/json_path.py
@@ -1,25 +1,37 @@
 import json
+import re
+from typing import Final
 
 from jsonpath_ng.ext import parse
 from jsonpath_ng.jsonpath import Index
 
 from localstack.services.stepfunctions.asl.utils.encoding import to_json_str
 
+_PATTERN_SINGLETON_ARRAY_ACCESS_OUTPUT: Final[str] = r"\[\d+\]$"
 
-class JSONPathUtils:
-    @staticmethod
-    def extract_json(path: str, data: json) -> json:
-        input_expr = parse(path)
 
-        matches = input_expr.find(data)
-        if not matches:
-            raise RuntimeError(
-                f"The JSONPath {path} could not be found in the input {to_json_str(data)}"
-            )
+def _is_singleton_array_access(path: str) -> bool:
+    # Returns true if the json path terminates with a literal singleton array access.
+    return bool(re.search(_PATTERN_SINGLETON_ARRAY_ACCESS_OUTPUT, path))
 
-        if len(matches) > 1 or isinstance(matches[0].path, Index):
-            value = [match.value for match in matches]
-        else:
-            value = matches[0].value
 
-        return value
+def extract_json(path: str, data: json) -> json:
+    input_expr = parse(path)
+
+    matches = input_expr.find(data)
+    if not matches:
+        raise RuntimeError(
+            f"The JSONPath {path} could not be found in the input {to_json_str(data)}"
+        )
+
+    if len(matches) > 1 or isinstance(matches[0].path, Index):
+        value = [match.value for match in matches]
+
+        # AWS StepFunctions breaks jsonpath specifications and instead
+        # unpacks literal singleton array accesses.
+        if _is_singleton_array_access(path=path) and len(value) == 1:
+            value = value[0]
+    else:
+        value = matches[0].value
+
+    return value

--- a/localstack-core/localstack/testing/pytest/stepfunctions/utils.py
+++ b/localstack-core/localstack/testing/pytest/stepfunctions/utils.py
@@ -26,7 +26,7 @@ from localstack.aws.api.stepfunctions import (
 )
 from localstack.services.stepfunctions.asl.eval.event.logging import is_logging_enabled_for
 from localstack.services.stepfunctions.asl.utils.encoding import to_json_str
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import poll_condition
@@ -391,7 +391,7 @@ def launch_and_record_execution(
 
     # Transform all map runs if any.
     try:
-        map_run_arns = JSONPathUtils.extract_json("$..mapRunArn", get_execution_history)
+        map_run_arns = extract_json("$..mapRunArn", get_execution_history)
         if isinstance(map_run_arns, str):
             map_run_arns = [map_run_arns]
         for i, map_run_arn in enumerate(list(set(map_run_arns))):

--- a/tests/aws/services/stepfunctions/templates/base/base_templates.py
+++ b/tests/aws/services/stepfunctions/templates/base/base_templates.py
@@ -46,3 +46,6 @@ class BaseTemplate(TemplateLoader):
     WAIT_SECONDS_PATH: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/wait_seconds_path.json5"
     )
+    JSON_PATH_ARRAY_ACCESS: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/json_path_array_access.json5"
+    )

--- a/tests/aws/services/stepfunctions/templates/base/statemachines/json_path_array_access.json5
+++ b/tests/aws/services/stepfunctions/templates/base/statemachines/json_path_array_access.json5
@@ -1,0 +1,13 @@
+{
+  "Comment": "JSON_PATH_ARRAY_ACCESS",
+  "StartAt": "EntryState",
+  "States": {
+    "EntryState": {
+      "Type": "Pass",
+      "Parameters": {
+        "item.$": "$.items[0]"
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/base/test_base.py
+++ b/tests/aws/services/stepfunctions/v2/base/test_base.py
@@ -396,3 +396,30 @@ class TestSnfBase:
             definition,
             exec_input,
         )
+
+    @markers.aws.validated
+    @pytest.mark.parametrize(
+        "json_path_string",
+        ["$.items[0]", "$.items[10]"],
+    )
+    def test_json_path_array_access(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+        json_path_string,
+    ):
+        template = BaseTemplate.load_sfn_template(BaseTemplate.JSON_PATH_ARRAY_ACCESS)
+        template["States"]["EntryState"]["Parameters"]["item.$"] = json_path_string
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"items": [{"item_key": i} for i in range(11)]})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )

--- a/tests/aws/services/stepfunctions/v2/base/test_base.py
+++ b/tests/aws/services/stepfunctions/v2/base/test_base.py
@@ -397,6 +397,8 @@ class TestSnfBase:
             exec_input,
         )
 
+    # TODO: the jsonpath library used in the SFN v2 interpreter does not support indexing features available in
+    #  AWS SFN such as: negative ([-1]) and list ([1,2]) indexing.
     @markers.aws.validated
     @pytest.mark.parametrize(
         "json_path_string",

--- a/tests/aws/services/stepfunctions/v2/base/test_base.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/base/test_base.snapshot.json
@@ -1108,5 +1108,293 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_json_path_array_access[$.items[0]]": {
+    "recorded-date": "16-08-2024, 15:52:50",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "items": [
+                  {
+                    "item_key": 0
+                  },
+                  {
+                    "item_key": 1
+                  },
+                  {
+                    "item_key": 2
+                  },
+                  {
+                    "item_key": 3
+                  },
+                  {
+                    "item_key": 4
+                  },
+                  {
+                    "item_key": 5
+                  },
+                  {
+                    "item_key": 6
+                  },
+                  {
+                    "item_key": 7
+                  },
+                  {
+                    "item_key": 8
+                  },
+                  {
+                    "item_key": 9
+                  },
+                  {
+                    "item_key": 10
+                  }
+                ]
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "items": [
+                  {
+                    "item_key": 0
+                  },
+                  {
+                    "item_key": 1
+                  },
+                  {
+                    "item_key": 2
+                  },
+                  {
+                    "item_key": 3
+                  },
+                  {
+                    "item_key": 4
+                  },
+                  {
+                    "item_key": 5
+                  },
+                  {
+                    "item_key": 6
+                  },
+                  {
+                    "item_key": 7
+                  },
+                  {
+                    "item_key": 8
+                  },
+                  {
+                    "item_key": 9
+                  },
+                  {
+                    "item_key": 10
+                  }
+                ]
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "EntryState"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "EntryState",
+              "output": {
+                "item": {
+                  "item_key": 0
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "item": {
+                  "item_key": 0
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_json_path_array_access[$.items[10]]": {
+    "recorded-date": "16-08-2024, 15:53:06",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "items": [
+                  {
+                    "item_key": 0
+                  },
+                  {
+                    "item_key": 1
+                  },
+                  {
+                    "item_key": 2
+                  },
+                  {
+                    "item_key": 3
+                  },
+                  {
+                    "item_key": 4
+                  },
+                  {
+                    "item_key": 5
+                  },
+                  {
+                    "item_key": 6
+                  },
+                  {
+                    "item_key": 7
+                  },
+                  {
+                    "item_key": 8
+                  },
+                  {
+                    "item_key": 9
+                  },
+                  {
+                    "item_key": 10
+                  }
+                ]
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "items": [
+                  {
+                    "item_key": 0
+                  },
+                  {
+                    "item_key": 1
+                  },
+                  {
+                    "item_key": 2
+                  },
+                  {
+                    "item_key": 3
+                  },
+                  {
+                    "item_key": 4
+                  },
+                  {
+                    "item_key": 5
+                  },
+                  {
+                    "item_key": 6
+                  },
+                  {
+                    "item_key": 7
+                  },
+                  {
+                    "item_key": 8
+                  },
+                  {
+                    "item_key": 9
+                  },
+                  {
+                    "item_key": 10
+                  }
+                ]
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "EntryState"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "EntryState",
+              "output": {
+                "item": {
+                  "item_key": 10
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "item": {
+                  "item_key": 10
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/base/test_base.validation.json
+++ b/tests/aws/services/stepfunctions/v2/base/test_base.validation.json
@@ -5,6 +5,12 @@
   "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_event_bridge_events_base": {
     "last_validated_date": "2024-02-07T13:56:58+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_json_path_array_access[$.items[0]]": {
+    "last_validated_date": "2024-08-16T15:52:50+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_json_path_array_access[$.items[10]]": {
+    "last_validated_date": "2024-08-16T15:53:06+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_query_context_object_values": {
     "last_validated_date": "2024-07-15T13:00:19+00:00"
   },

--- a/tests/aws/services/stepfunctions/v2/choice_operators/utils.py
+++ b/tests/aws/services/stepfunctions/v2/choice_operators/utils.py
@@ -3,7 +3,7 @@ from typing import Any, Final
 
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 from localstack.testing.pytest.stepfunctions.utils import await_execution_success
 from localstack.utils.strings import short_uid
 from tests.aws.services.stepfunctions.templates.choiceoperators.choice_operators_templates import (
@@ -94,8 +94,6 @@ def create_and_test_comparison_function(
         )
 
         exec_hist_resp = stepfunctions_client.get_execution_history(executionArn=execution_arn)
-        output = JSONPathUtils.extract_json(
-            "$.events[*].executionSucceededEventDetails.output", exec_hist_resp
-        )
+        output = extract_json("$.events[*].executionSucceededEventDetails.output", exec_hist_resp)
         input_output_cases.append({"input": exec_input, "output": output})
     sfn_snapshot.match("cases", input_output_cases)

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_unique_id_generation.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_unique_id_generation.py
@@ -2,7 +2,7 @@ import json
 
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.stepfunctions.utils import await_execution_success
 from localstack.utils.strings import short_uid
@@ -37,9 +37,7 @@ class TestUniqueIdGeneration:
         )
 
         exec_hist_resp = aws_client.stepfunctions.get_execution_history(executionArn=execution_arn)
-        output = JSONPathUtils.extract_json(
-            "$..executionSucceededEventDetails..output", exec_hist_resp
-        )
+        output = extract_json("$..executionSucceededEventDetails..output", exec_hist_resp)
         uuid = json.loads(output)[IFT.FUNCTION_OUTPUT_KEY]
         sfn_snapshot.add_transformer(RegexTransformer(uuid, "generated-uuid"))
 

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
@@ -5,7 +5,7 @@ import pytest
 from localstack_snapshot.snapshots.transformer import JsonpathTransformer, RegexTransformer
 
 from localstack.aws.api.lambda_ import Runtime
-from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
+from localstack.services.stepfunctions.asl.utils.json_path import extract_json
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.stepfunctions.utils import (
     SfnNoneRecursiveParallelTransformer,
@@ -1207,9 +1207,7 @@ class TestBaseScenarios:
         execution_history = aws_client.stepfunctions.get_execution_history(
             executionArn=execution_arn
         )
-        map_run_arn = JSONPathUtils.extract_json(
-            "$..mapRunStartedEventDetails.mapRunArn", execution_history
-        )
+        map_run_arn = extract_json("$..mapRunStartedEventDetails.mapRunArn", execution_history)
         sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_map_run_arn(map_run_arn, 0))
 
         # Normalise s3 ListObjectV2 response in the execution events output to ensure variable fields such as


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
AWS StepFunctions automatically unpacks singleton JsonPath results obtained through singleton literal array access, such as `$.items[0]`. These changes add support for such behaviour. Addresses: #11321

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Support for singleton literal array access and unpacking
- Removed unnecessary packing of json util function in the SFN package
- Added related snapshot test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
