### PR TITLE
add support for ArchivePolicy in AWS::SNS::Topic

### DIFF
--- a/localstack-core/localstack/services/sns/provider.py
+++ b/localstack-core/localstack/services/sns/provider.py
@@ -163,6 +163,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 moto_response["Attributes"][key] = getattr(moto_topic_model, attr)
             elif attr == "signature_version":
                 moto_response["Attributes"]["SignatureVersion"] = moto_topic_model.signature_version
+            elif attr == "archive_policy":
+                moto_response["Attributes"]["ArchivePolicy"] = moto_topic_model.archive_policy
         return moto_response
 
     def publish_batch(

--- a/localstack-core/localstack/services/sns/resource_providers/aws_sns_topic.py
+++ b/localstack-core/localstack/services/sns/resource_providers/aws_sns_topic.py
@@ -102,7 +102,7 @@ class SNSTopicProvider(ResourceProvider[SNSTopicProperties]):
         model["TopicArn"] = create_sns_response["TopicArn"]
 
         # now we add subscriptions if they exists
-        for subscription in model.get("Subscriptions", []):
+        for subscription in model.get("Subscription", []):
             sns.subscribe(
                 TopicArn=model["TopicArn"],
                 Protocol=subscription["Protocol"],

--- a/localstack-core/localstack/services/sns/resource_providers/aws_sns_topic.py
+++ b/localstack-core/localstack/services/sns/resource_providers/aws_sns_topic.py
@@ -80,7 +80,7 @@ class SNSTopicProvider(ResourceProvider[SNSTopicProperties]):
             k: v
             for k, v in model.items()
             if v is not None
-            if k not in ["TopicName", "Subscriptions", "Tags"]
+            if k not in ["TopicName", "Subscription", "Tags"]
         }
         if (fifo_topic := attributes.get("FifoTopic")) is not None:
             attributes["FifoTopic"] = canonicalize_bool_to_str(fifo_topic)

--- a/localstack-core/localstack/services/sns/resource_providers/aws_sns_topic.py
+++ b/localstack-core/localstack/services/sns/resource_providers/aws_sns_topic.py
@@ -1,6 +1,7 @@
 # LocalStack Resource Provider Scaffolding v2
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Optional, TypedDict
 
@@ -74,44 +75,40 @@ class SNSTopicProvider(ResourceProvider[SNSTopicProperties]):
         """
         model = request.desired_state
         sns = request.aws_client_factory.sns
-        # TODO: validations and iam checks
 
-        attributes = {k: v for k, v in model.items() if v is not None if k != "TopicName"}
-
-        # following attributes need to be str instead of bool for boto to work
+        attributes = {
+            k: v
+            for k, v in model.items()
+            if v is not None
+            if k not in ["TopicName", "Subscriptions", "Tags"]
+        }
         if (fifo_topic := attributes.get("FifoTopic")) is not None:
             attributes["FifoTopic"] = canonicalize_bool_to_str(fifo_topic)
+
+        if archive_policy := attributes.get("ArchivePolicy"):
+            archive_policy["MessageRetentionPeriod"] = str(archive_policy["MessageRetentionPeriod"])
+            attributes["ArchivePolicy"] = json.dumps(archive_policy)
 
         if (content_based_dedup := attributes.get("ContentBasedDeduplication")) is not None:
             attributes["ContentBasedDeduplication"] = canonicalize_bool_to_str(content_based_dedup)
 
-        subscriptions = []
-        if attributes.get("Subscription") is not None:
-            subscriptions = attributes["Subscription"]
-            del attributes["Subscription"]
-
-        tags = []
-        if attributes.get("Tags") is not None:
-            tags = attributes["Tags"]
-            del attributes["Tags"]
-
-        # in case cloudformation didn't provide topic name
+        # Default name
         if model.get("TopicName") is None:
-            name = f"topic-{short_uid()}" if not fifo_topic else f"topic-{short_uid()}.fifo"
-            model["TopicName"] = name
+            model["TopicName"] = (
+                f"topic-{short_uid()}.fifo" if fifo_topic else f"topic-{short_uid()}"
+            )
 
         create_sns_response = sns.create_topic(Name=model["TopicName"], Attributes=attributes)
-        request.custom_context[REPEATED_INVOCATION] = True
         model["TopicArn"] = create_sns_response["TopicArn"]
 
         # now we add subscriptions if they exists
-        for subscription in subscriptions:
+        for subscription in model.get("Subscriptions", []):
             sns.subscribe(
                 TopicArn=model["TopicArn"],
                 Protocol=subscription["Protocol"],
                 Endpoint=subscription["Endpoint"],
             )
-        if tags:
+        if tags := model.get("Tags"):
             sns.tag_resource(ResourceArn=model["TopicArn"], Tags=tags)
 
         return ProgressEvent(

--- a/tests/aws/services/cloudformation/resources/test_sns.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_sns.snapshot.json
@@ -104,5 +104,13 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_with_attributes": {
+    "recorded-date": "16-08-2024, 15:44:50",
+    "recorded-content": {
+      "topic-archive-policy": {
+        "MessageRetentionPeriod": "30"
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_sns.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_sns.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_fifo_with_deduplication": {
     "last_validated_date": "2023-11-27T20:27:29+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_with_attributes": {
+    "last_validated_date": "2024-08-16T15:44:50+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_sns.py::test_update_subscription": {
     "last_validated_date": "2024-03-29T21:16:21+00:00"
   }


### PR DESCRIPTION
## Motivation
With this PR now an user can define an ArchivePolicy attribute without the stack deployment crashing. Fixes #11289

## Changes
- Resource provider now converts the dict into a json string as the service requires
-  The service provider now returns the attribute if it exists in the model
- A bit of refactoring in the Create Method op.

## Testing
- new cdk test
