### PR TITLE
add support for default tags AWS::EC2::SecurityGroup

### DIFF
--- a/localstack-core/localstack/services/ec2/resource_providers/aws_ec2_securitygroup.py
+++ b/localstack-core/localstack/services/ec2/resource_providers/aws_ec2_securitygroup.py
@@ -101,9 +101,17 @@ class EC2SecurityGroupProvider(ResourceProvider[EC2SecurityGroupProperties]):
             params["VpcId"] = vpc_id
 
         params["Description"] = model.get("GroupDescription", "")
-        if model.get("Tags"):
-            tags = [{"ResourceType": "security-group", "Tags": model.get("Tags")}]
-            params["TagSpecifications"] = tags
+
+        tags = [
+            {"Key": "aws:cloudformation:logical-id", "Value": request.logical_resource_id},
+            {"Key": "aws:cloudformation:stack-id", "Value": request.stack_id},
+            {"Key": "aws:cloudformation:stack-name", "Value": request.stack_name},
+        ]
+
+        if model_tags := model.get("Tags"):
+            tags += model_tags
+
+        params["TagSpecifications"] = [{"ResourceType": "security-group", "Tags": tags}]
 
         response = ec2.create_security_group(**params)
         model["GroupId"] = response["GroupId"]

--- a/tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.py
+++ b/tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.py
@@ -68,13 +68,11 @@ def test_deploy_security_group_with_tags(deploy_cfn_template, aws_client, snapsh
     snapshot.add_transformer(snapshot.transform.key_value("GroupId"))
     snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
     snapshot.add_transformer(snapshot.transform.key_value("VpcId"))
+    snapshot.add_transformer(snapshot.transform.regex(stack.stack_id, "<stack-id>"))
+    snapshot.add_transformer(snapshot.transform.regex(stack.stack_name, "<stack-name>"))
     snapshot.add_transformer(SortingTransformer("Tags", lambda tag: tag["Key"]))
     response = aws_client.ec2.describe_security_groups(GroupIds=[stack.outputs["SecurityGroupId"]])
     security_group = response["SecurityGroups"][0]
-
-    security_group["Tags"] = [
-        tag for tag in security_group["Tags"] if not tag["Key"].startswith("aws:cloudformation")
-    ]
 
     snapshot.match("security-group", security_group)
 

--- a/tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.snapshot.json
+++ b/tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.snapshot.json
@@ -224,7 +224,7 @@
     }
   },
   "tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.py::test_deploy_security_group_with_tags": {
-    "recorded-date": "28-06-2024, 19:04:12",
+    "recorded-date": "16-08-2024, 19:09:00",
     "recorded-content": {
       "security-group": {
         "Description": "Security Group",
@@ -246,6 +246,18 @@
         ],
         "OwnerId": "111111111111",
         "Tags": [
+          {
+            "Key": "aws:cloudformation:logical-id",
+            "Value": "SecurityGroup"
+          },
+          {
+            "Key": "aws:cloudformation:stack-id",
+            "Value": "<stack-id>"
+          },
+          {
+            "Key": "aws:cloudformation:stack-name",
+            "Value": "<stack-name>"
+          },
           {
             "Key": "key1",
             "Value": "value1"

--- a/tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.validation.json
+++ b/tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.validation.json
@@ -6,7 +6,7 @@
     "last_validated_date": "2024-04-26T16:18:18+00:00"
   },
   "tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.py::test_deploy_security_group_with_tags": {
-    "last_validated_date": "2024-06-28T19:04:12+00:00"
+    "last_validated_date": "2024-08-16T19:09:00+00:00"
   },
   "tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.py::test_deploy_vpc_endpoint": {
     "last_validated_date": "2024-04-30T20:01:19+00:00"


### PR DESCRIPTION
## Motivation
This PR adds the default tags that CFn adds to a Security group. Fixes #11119.

## Changes
- tags generation in the Create method of the resource provider

## Testing
- extended a previous test for security group tags.
