### PR TITLE
Apigw ng refactor deployment store

### DIFF
--- a/localstack-core/localstack/services/apigateway/models.py
+++ b/localstack-core/localstack/services/apigateway/models.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from typing import Any, Dict, List
 
 from requests.structures import CaseInsensitiveDict
@@ -127,12 +126,12 @@ class ApiGatewayStore(BaseStore):
     # TODO: make sure API ID are unique across all accounts
     # maps ApiID to a map of deploymentId and RestApiDeployment, an executable/snapshot of a REST API
     internal_deployments: dict[str, dict[str, RestApiDeployment]] = CrossAccountAttribute(
-        default=lambda: defaultdict(dict)
+        default=dict
     )
 
     # active deployments, mapping API ID to a map of Stage and deployment ID
     # TODO: make sure API ID are unique across all accounts
-    active_deployments: dict[str, dict[str, str]] = CrossAccountAttribute(lambda: defaultdict(dict))
+    active_deployments: dict[str, dict[str, str]] = CrossAccountAttribute(dict)
 
     def __init__(self):
         super().__init__()

--- a/localstack-core/localstack/services/apigateway/models.py
+++ b/localstack-core/localstack/services/apigateway/models.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import Any, Dict, List
 
 from requests.structures import CaseInsensitiveDict
@@ -126,12 +127,12 @@ class ApiGatewayStore(BaseStore):
     # TODO: make sure API ID are unique across all accounts
     # maps ApiID to a map of deploymentId and RestApiDeployment, an executable/snapshot of a REST API
     internal_deployments: dict[str, dict[str, RestApiDeployment]] = CrossAccountAttribute(
-        default=dict
+        default=lambda: defaultdict(dict)
     )
 
     # active deployments, mapping API ID to a map of Stage and deployment ID
     # TODO: make sure API ID are unique across all accounts
-    active_deployments: dict[str, dict[str, str]] = CrossAccountAttribute(dict)
+    active_deployments: dict[str, dict[str, str]] = CrossAccountAttribute(lambda: defaultdict(dict))
 
     def __init__(self):
         super().__init__()

--- a/localstack-core/localstack/services/apigateway/models.py
+++ b/localstack-core/localstack/services/apigateway/models.py
@@ -124,12 +124,14 @@ class ApiGatewayStore(BaseStore):
 
     # internal deployments, represents a frozen REST API for a deployment, used in our router
     # TODO: make sure API ID are unique across all accounts
-    # maps ApiID + deploymentId to a RestApiDeployment, an executable/snapshot of a REST API
-    internal_deployments: dict[(str, str), RestApiDeployment] = CrossAccountAttribute(default=dict)
+    # maps ApiID to a map of deploymentId and RestApiDeployment, an executable/snapshot of a REST API
+    internal_deployments: dict[str, dict[str, RestApiDeployment]] = CrossAccountAttribute(
+        default=dict
+    )
 
-    # active deployments, mapping API ID + Stage to deployment ID
+    # active deployments, mapping API ID to a map of Stage and deployment ID
     # TODO: make sure API ID are unique across all accounts
-    active_deployments: dict[(str, str), str] = CrossAccountAttribute(dict)
+    active_deployments: dict[str, dict[str, str]] = CrossAccountAttribute(dict)
 
     def __init__(self):
         super().__init__()

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -78,8 +78,8 @@ class ApiGatewayEndpoint:
         self, context: RestApiInvocationContext, api_id: str, stage: str
     ):
         try:
-            deployment_id = self._global_store.active_deployments[(api_id, stage)]
-            frozen_deployment = self._global_store.internal_deployments[(api_id, deployment_id)]
+            deployment_id = self._global_store.active_deployments[api_id][stage]
+            frozen_deployment = self._global_store.internal_deployments[api_id][deployment_id]
 
         except KeyError:
             # TODO: find proper error when trying to hit an API with no deployment/stage linked

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -72,7 +72,7 @@ class ApiGatewayEndpoint:
         return context, response
 
     def is_rest_api(self, api_id: str, stage: str):
-        return (api_id, stage) in self._global_store.active_deployments
+        return (api := self._global_store.active_deployments[api_id]) and stage in api
 
     def populate_rest_api_invocation_context(
         self, context: RestApiInvocationContext, api_id: str, stage: str

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -72,7 +72,7 @@ class ApiGatewayEndpoint:
         return context, response
 
     def is_rest_api(self, api_id: str, stage: str):
-        return (api := self._global_store.active_deployments[api_id]) and stage in api
+        return stage in self._global_store.active_deployments.get(api_id)
 
     def populate_rest_api_invocation_context(
         self, context: RestApiInvocationContext, api_id: str, stage: str

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -72,7 +72,7 @@ class ApiGatewayEndpoint:
         return context, response
 
     def is_rest_api(self, api_id: str, stage: str):
-        return stage in self._global_store.active_deployments.get(api_id)
+        return stage in self._global_store.active_deployments.get(api_id, {})
 
     def populate_rest_api_invocation_context(
         self, context: RestApiInvocationContext, api_id: str, stage: str

--- a/localstack-core/localstack/services/apigateway/next_gen/provider.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/provider.py
@@ -55,11 +55,18 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
         apply_patches()
         self.router.register_routes()
 
+    @handler("DeleteRestApi")
+    def delete_rest_api(self, context: RequestContext, rest_api_id: String, **kwargs) -> None:
+        super().delete_rest_api(context, rest_api_id, **kwargs)
+        store = get_apigateway_store(context=context)
+        store.active_deployments.pop(rest_api_id)
+        store.internal_deployments.pop(rest_api_id)
+
     @handler("CreateStage", expand=False)
     def create_stage(self, context: RequestContext, request: CreateStageRequest) -> Stage:
         response = super().create_stage(context, request)
         store = get_apigateway_store(context=context)
-        store.active_deployments[(request["restApiId"].lower(), request["stageName"])] = request[
+        store.active_deployments[request["restApiId"].lower()][request["stageName"]] = request[
             "deploymentId"
         ]
         return response
@@ -83,7 +90,7 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
             if patch_path == "/deploymentId" and patch_operation["op"] == "replace":
                 if deployment_id := patch_operation.get("value"):
                     store = get_apigateway_store(context=context)
-                    store.active_deployments[(rest_api_id.lower(), stage_name)] = deployment_id
+                    store.active_deployments[rest_api_id.lower()][stage_name] = deployment_id
 
         return response
 
@@ -92,7 +99,7 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
     ) -> None:
         call_moto(context)
         store = get_apigateway_store(context=context)
-        store.active_deployments.pop((rest_api_id.lower(), stage_name), None)
+        store.active_deployments[rest_api_id.lower()].pop(stage_name, None)
 
     def create_deployment(
         self,
@@ -123,10 +130,10 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
             localstack_rest_api=rest_api_container,
         )
         router_api_id = rest_api_id.lower()
-        store.internal_deployments[(router_api_id, deployment["id"])] = frozen_deployment
+        store.internal_deployments[router_api_id][deployment["id"]] = frozen_deployment
 
         if stage_name:
-            store.active_deployments[(router_api_id, stage_name)] = deployment["id"]
+            store.active_deployments[router_api_id][stage_name] = deployment["id"]
 
         return deployment
 
@@ -135,7 +142,7 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
     ) -> None:
         call_moto(context)
         store = get_apigateway_store(context=context)
-        store.internal_deployments.pop((rest_api_id.lower(), deployment_id), None)
+        store.internal_deployments[rest_api_id.lower()].pop(deployment_id, None)
 
     def put_gateway_response(
         self,

--- a/localstack-core/localstack/services/apigateway/next_gen/provider.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/provider.py
@@ -59,8 +59,8 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
     def delete_rest_api(self, context: RequestContext, rest_api_id: String, **kwargs) -> None:
         super().delete_rest_api(context, rest_api_id, **kwargs)
         store = get_apigateway_store(context=context)
-        store.active_deployments.pop(rest_api_id)
-        store.internal_deployments.pop(rest_api_id)
+        store.active_deployments.pop(rest_api_id, None)
+        store.internal_deployments.pop(rest_api_id, None)
 
     @handler("CreateStage", expand=False)
     def create_stage(self, context: RequestContext, request: CreateStageRequest) -> Stage:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

As discussed with @bentsku, we are changing the structure of internals and actives deployment dict in the store. This will facilitate access to the resources when only the api id is known. Notably when entirely deleting a rest api.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Also fixed in this PR. When deleting a rest api, we were not deleting it's deployment from the store, leading to memory leaks.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
