### PR TITLE
docs: Add workaround for amazon-ion issue in contributing docs

### DIFF
--- a/docs/development-environment-setup/README.md
+++ b/docs/development-environment-setup/README.md
@@ -58,6 +58,10 @@ Refer to our official [Dockerfile](https://github.com/localstack/localstack/blob
 * [JPype1](https://pypi.org/project/JPype1/) might require `g++` to fix a compile error on ARM Linux `gcc: fatal error: cannot execute ‘cc1plus’`
   * Used in EventBridge, EventBridge Pipes, and Lambda Event Source Mapping for a Java-based event ruler via the opt-in configuration `EVENT_RULE_ENGINE=java`
   * Introduced in [#10615](https://github.com/localstack/localstack/pull/10615)
+* [Amazon Ion Python](https://github.com/amazon-ion/ion-python) might fail to compile on more recent versions of `gcc` where the diagnostics [`incompatible-pointer-types`](https://gcc.gnu.org/pipermail/gcc-cvs/2023-December/394351.html) and [`int-conversion`](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106416) were promoted from warnings to errors. This is more likely to affect Mac OSX ARM users since there are no build wheels available for [`amazon-ion==0.9.3`](https://pypi.org/project/amazon.ion/0.9.3/#files).
+  * Used by the Python driver for Amazon QLDB `pyqldb` and pinned to `amazon-ion==0.9.3` since later versions of `amazon-ion` have introduced [breaking changes](https://github.com/awslabs/amazon-qldb-driver-python/issues/164).
+  * As a workaround, installation can be done with `CFLAGS="-Wno-incompatible-pointer-types -Wno-int-conversion" pip install --no-cache amazon-ion==0.9.3` which prevents the aforementioned diagnostics entirely.
+  * Alternatively, remove `cmake` from `$PATH` to ensure a pure Python wheel gets built.
 
 #### Test Dependencies
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
- Workaround for issue encountered when compiling `amazon-ion==0.9.3` dependency using `gcc/cmake`.
- Updates to the C compiler now interpret some warnings as errors, so the dependency wheel will fail to build. In addition, there is no Mac OSX ARM64 build wheel available for this version on PyPi.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added changes to `CONTRIBUTING.md` with workaround steps. 
- A user can either suppress the C warnings/errors OR remove `cmake` from their `PATH` variable causing pip to build the wheel using pure Python instead of C.
