### PR TITLE
Refactor/Events: add localstack_only test markers for v1 only tests

### DIFF
--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -101,8 +101,7 @@ class TestEvents:
         response = aws_client.events.put_events(Entries=entries)
         snapshot.match("put-events", response)
 
-    @markers.aws.only_localstack
-    # tests for legacy v1 provider delete once v1 provider is removed, v2 covered in separate tests
+    @markers.aws.validated
     @pytest.mark.skipif(
         is_old_provider(),
         reason="V1 provider does not support this feature",

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -101,7 +101,8 @@ class TestEvents:
         response = aws_client.events.put_events(Entries=entries)
         snapshot.match("put-events", response)
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
+    # tests for legacy v1 provider delete once v1 provider is removed, v2 covered in separate tests
     @pytest.mark.skipif(
         is_old_provider(),
         reason="V1 provider does not support this feature",
@@ -189,7 +190,8 @@ class TestEvents:
         snapshot.add_transformer(snapshot.transform.regex(bus_name, "<bus-name>"))
         snapshot.match("put-events-exceed-limit-error", e.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
+    # tests for legacy v1 provider delete once v1 provider is removed
     @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_events_written_to_disk_are_timestamp_prefixed_for_chronological_ordering(
         self, aws_client
@@ -223,8 +225,8 @@ class TestEvents:
 
         assert [json.loads(event["Detail"]) for event in sorted_events] == event_details_to_publish
 
-    @markers.aws.unknown
-    # TODO move to schedule
+    @markers.aws.only_localstack
+    # tests for legacy v1 provider delete once v1 provider is removed, v2 covered in separate tests
     @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_scheduled_expression_events(
         self,
@@ -363,7 +365,8 @@ class TestEvents:
         clean_up(rule_name=rule_name, target_ids=target_ids, queue_url=queue_url)
         aws_client.stepfunctions.delete_state_machine(stateMachineArn=state_machine_arn)
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
+    # tests for legacy v1 provider delete once v1 provider is removed, v2 covered in separate tests
     @pytest.mark.parametrize("auth", API_DESTINATION_AUTHS)
     @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_api_destinations(self, httpserver: HTTPServer, auth, aws_client, clean_up):
@@ -523,7 +526,8 @@ class TestEvents:
                 assert oauth_request.headers["oauthheader"] == "value2"
                 assert oauth_request.args["oauthquery"] == "value3"
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
+    # tests for legacy v1 provider delete once v1 provider is removed, v2 covered in separate tests
     @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_create_connection_validations(self, aws_client):
         connection_name = "This should fail with two errors 123467890123412341234123412341234"

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -36,7 +36,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_time": {
-    "recorded-date": "19-06-2024, 10:40:53",
+    "recorded-date": "27-08-2024, 10:02:33",
     "recorded-content": {
       "messages": [
         {

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -123,7 +123,7 @@
     "last_validated_date": "2024-06-19T10:40:55+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_time": {
-    "last_validated_date": "2024-06-19T10:40:53+00:00"
+    "last_validated_date": "2024-08-27T10:02:33+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_without_source": {
     "last_validated_date": "2024-06-19T10:40:50+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Some tests are only relevant for the v1 provider, since they are covered in separate tests or the functionality is not supported in v2 provider. 
They will be removed once the v1 provider is removed.
Some of these tests are not validated and it is not worth the effort to validate them, to clearly indicate that they are not to be validated the marker `localstack_only` with an explanation is added.

