### PR TITLE
Filter by active stack when executing a cloudformation changeset

### DIFF
--- a/localstack-core/localstack/services/cloudformation/provider.py
+++ b/localstack-core/localstack/services/cloudformation/provider.py
@@ -856,7 +856,11 @@ class CloudformationProvider(CloudformationApi):
         **kwargs,
     ) -> ExecuteChangeSetOutput:
         change_set = find_change_set(
-            context.account_id, context.region, change_set_name, stack_name=stack_name
+            context.account_id,
+            context.region,
+            change_set_name,
+            stack_name=stack_name,
+            active_only=True,
         )
         if not change_set:
             raise ChangeSetNotFoundException(f"ChangeSet [{change_set_name}] does not exist")

--- a/localstack-core/localstack/services/cloudformation/stores.py
+++ b/localstack-core/localstack/services/cloudformation/stores.py
@@ -103,10 +103,12 @@ def find_active_stack_by_name_or_id(
 
 
 def find_change_set(
-    account_id: str, region_name: str, cs_name: str, stack_name: Optional[str] = None
+    account_id: str, region_name: str, cs_name: str, stack_name: Optional[str] = None, active_only: bool = False
 ) -> Optional[StackChangeSet]:
     store = get_cloudformation_store(account_id, region_name)
     for stack in store.stacks.values():
+        if active_only and stack.status == "DELETE_COMPLETE":
+            continue
         if stack_name in (stack.stack_name, stack.stack_id, None):
             for change_set in stack.change_sets:
                 if cs_name in (change_set.change_set_id, change_set.change_set_name):

--- a/localstack-core/localstack/services/cloudformation/stores.py
+++ b/localstack-core/localstack/services/cloudformation/stores.py
@@ -103,16 +103,19 @@ def find_active_stack_by_name_or_id(
 
 
 def find_change_set(
-    account_id: str, region_name: str, cs_name: str, stack_name: Optional[str] = None, active_only: bool = False
+    account_id: str,
+    region_name: str,
+    cs_name: str,
+    stack_name: Optional[str] = None,
+    active_only: bool = False,
 ) -> Optional[StackChangeSet]:
-    store = get_cloudformation_store(account_id, region_name)
-    for stack in store.stacks.values():
-        if active_only and stack.status == "DELETE_COMPLETE":
-            continue
-        if stack_name in (stack.stack_name, stack.stack_id, None):
-            for change_set in stack.change_sets:
-                if cs_name in (change_set.change_set_id, change_set.change_set_name):
-                    return change_set
+    if active_only:
+        stack = find_active_stack_by_name_or_id(account_id, region_name, stack_name)
+    else:
+        stack = find_stack(account_id, region_name, stack_name)
+    for change_set in stack.change_sets:
+        if cs_name in (change_set.change_set_id, change_set.change_set_name):
+            return change_set
     return None
 
 

--- a/localstack-core/localstack/services/cloudformation/stores.py
+++ b/localstack-core/localstack/services/cloudformation/stores.py
@@ -109,15 +109,14 @@ def find_change_set(
     stack_name: Optional[str] = None,
     active_only: bool = False,
 ) -> Optional[StackChangeSet]:
-    if active_only:
-        stack = find_active_stack_by_name_or_id(account_id, region_name, stack_name)
-    else:
-        stack = find_stack(account_id, region_name, stack_name)
-    if not stack:
-        return None
-    for change_set in stack.change_sets:
-        if cs_name in (change_set.change_set_id, change_set.change_set_name):
-            return change_set
+    store = get_cloudformation_store(account_id, region_name)
+    for stack in store.stacks.values():
+        if active_only and stack.status == "DELETE_COMPLETE":
+            continue
+        if stack_name in (stack.stack_name, stack.stack_id, None):
+            for change_set in stack.change_sets:
+                if cs_name in (change_set.change_set_id, change_set.change_set_name):
+                    return change_set
     return None
 
 

--- a/localstack-core/localstack/services/cloudformation/stores.py
+++ b/localstack-core/localstack/services/cloudformation/stores.py
@@ -113,6 +113,8 @@ def find_change_set(
         stack = find_active_stack_by_name_or_id(account_id, region_name, stack_name)
     else:
         stack = find_stack(account_id, region_name, stack_name)
+    if not stack:
+        return None
     for change_set in stack.change_sets:
         if cs_name in (change_set.change_set_id, change_set.change_set_name):
             return change_set


### PR DESCRIPTION

## Motivation
This PR fixes the behaviour of the cloudformation api, when deleting and recreating a stack with the same name. 
Now stacks which have the status `DELETE_COMPLETE` are filtered out when a changeset execution is requested for a stack, which closes #11333

## Changes

The `find_changeset` function in `stores.py` of the cloudformation package now accepts an additional optional parameter `active_only` which filters the stacks by their status when set. This parameter is set to true only in `execute_changeset` handler of the cloudformation provider.

## Testing
TODO
## TODO
What's left to do:

- [ ] Proper testing for this functionality
