### PR TITLE
Fix SQS handling of empty Redrive Policy attribute

### DIFF
--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -1349,6 +1349,10 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             del queue.attributes[QueueAttributeName.Policy]
 
         redrive_policy = queue.attributes.get(QueueAttributeName.RedrivePolicy)
+        if redrive_policy == "":
+            del queue.attributes[QueueAttributeName.RedrivePolicy]
+            return
+
         if redrive_policy:
             _redrive_policy = json.loads(redrive_policy)
             dl_target_arn = _redrive_policy.get("deadLetterTargetArn")

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3621,5 +3621,13 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_set_empty_redrive_policy[sqs]": {
+    "recorded-date": "20-08-2024, 14:14:08",
+    "recorded-content": {}
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_set_empty_redrive_policy[sqs_query]": {
+    "recorded-date": "20-08-2024, 14:14:11",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -320,6 +320,12 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_message_multiple_queues": {
     "last_validated_date": "2024-04-30T13:40:05+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_set_empty_redrive_policy[sqs]": {
+    "last_validated_date": "2024-08-20T14:14:08+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_set_empty_redrive_policy[sqs_query]": {
+    "last_validated_date": "2024-08-20T14:14:11+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_set_unsupported_attribute_fifo[sqs]": {
     "last_validated_date": "2024-05-14T22:23:46+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Handle the case where setting a `RedrivePolicy` attribute to an empty string removes the `RedrivePolicy` from an SQS queue's attribute map. This should be identical to how LocalStack handles an empty `Policy` attribute.

Currently, this behavior is causing Terraform deletions to initially fail. Terraform attempts to remove a queue's `aws_sqs_queue_redrive_policy` resource by setting the `RedrivePolicy` attribute value to an empty string. However, LocalStack was not removing this empty value, leading to the failure.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Setting an SQS queue's `RedrivePolicy` to an empty string now deletes it from the internal `QueueAttributeMap`
- Added a test for this case at `TestSqsProvider::test_set_empty_redrive_policy`

## Testing
- Validated with Terraform & CLI against LocalStack and AWS

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
