### PR TITLE
Add new flag for mounting dependencies into the container

### DIFF
--- a/localstack-core/localstack/testing/pytest/container.py
+++ b/localstack-core/localstack/testing/pytest/container.py
@@ -23,7 +23,10 @@ from localstack.utils.sync import poll_condition
 LOG = logging.getLogger(__name__)
 
 ENV_TEST_CONTAINER_MOUNT_SOURCES = "TEST_CONTAINER_MOUNT_SOURCES"
-"""Environment variable used to indicate that we should mount localstack source files into the container."""
+"""Environment variable used to indicate that we should mount LocalStack  source files into the container."""
+
+ENV_TEST_CONTAINER_MOUNT_DEPENDENCIES = "TEST_CONTAINER_MOUNT_DEPENDENCIES"
+"""Environment variable used to indicate that we should mount dependencies into the container."""
 
 
 class ContainerFactory:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When using `TEST_CONTAINER_MOUNT_SOURCES`, this includes mounting dependencies as well as the sources, which may not be what we want.

Specifically when the host OS is different to the container OS (e.g. macOS host, Linux container) and dependences include compiled code, the container fails to start.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Add a new flag to choose whether we mount dependencies into the container compared to the sources.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
