### PR TITLE
fix ASF upgrades by upgrading botocore pins and dependency locks

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -76,7 +76,6 @@ jobs:
           echo "Pinning botocore, boto3, and boto3-stubs to version $BOTOCORE_VERSION"
           bin/release-helper.sh set-dep-ver botocore "==$BOTOCORE_VERSION"
           bin/release-helper.sh set-dep-ver boto3 "==$BOTOCORE_VERSION"
-          bin/release-helper.sh set-dep-ver boto3-stubs "==$BOTOCORE_VERSION"
 
           # upgrade the requirements files only for the botocore package
           pip install pip-tools
@@ -84,7 +83,7 @@ jobs:
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli" --extra runtime -o requirements-runtime.txt pyproject.toml
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli" --extra test -o requirements-test.txt pyproject.toml
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli" --extra dev -o requirements-dev.txt pyproject.toml
-          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli" --upgrade-package "boto3-stubs==$BOTOCORE_VERSION" --extra typehint -o requirements-typehint.txt pyproject.toml
+          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli" --extra typehint -o requirements-typehint.txt pyproject.toml
 
       - name: Read PR markdown template
         if: ${{ success() && steps.check-for-changes.outputs.diff-count != '0' && steps.check-for-changes.outputs.diff-count != '' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,9 @@ Issues = "https://github.com/localstack/localstack/issues"
 # minimal required to actually run localstack on the host for services natively implemented in python
 base-runtime = [
     # pinned / updated by ASF update action
-    "boto3==1.34.158",
+    "boto3==1.35.2",
     # pinned / updated by ASF update action
-    "botocore==1.34.158",
+    "botocore==1.35.2",
     "awscrt>=0.13.14",
     "cbor2>=5.2.0",
     "dnspython>=1.16.0",
@@ -129,7 +129,7 @@ typehint = [
     # typehint is an optional extension of the dev dependencies
     "localstack-core[dev]",
     # pinned / updated by ASF update action
-    "boto3-stubs[acm,acm-pca,amplify,apigateway,apigatewayv2,appconfig,appconfigdata,application-autoscaling,appsync,athena,autoscaling,backup,batch,ce,cloudcontrol,cloudformation,cloudfront,cloudtrail,cloudwatch,codecommit,cognito-identity,cognito-idp,dms,docdb,dynamodb,dynamodbstreams,ec2,ecr,ecs,efs,eks,elasticache,elasticbeanstalk,elbv2,emr,emr-serverless,es,events,firehose,fis,glacier,glue,iam,identitystore,iot,iot-data,iotanalytics,iotwireless,kafka,kinesis,kinesisanalytics,kinesisanalyticsv2,kms,lakeformation,lambda,logs,managedblockchain,mediaconvert,mediastore,mq,mwaa,neptune,opensearch,organizations,pi,pipes,qldb,qldb-session,rds,rds-data,redshift,redshift-data,resource-groups,resourcegroupstaggingapi,route53,route53resolver,s3,s3control,sagemaker,sagemaker-runtime,secretsmanager,serverlessrepo,servicediscovery,ses,sesv2,sns,sqs,ssm,sso-admin,stepfunctions,sts,timestream-query,timestream-write,transcribe,wafv2,xray]==1.34.158",
+    "boto3-stubs[acm,acm-pca,amplify,apigateway,apigatewayv2,appconfig,appconfigdata,application-autoscaling,appsync,athena,autoscaling,backup,batch,ce,cloudcontrol,cloudformation,cloudfront,cloudtrail,cloudwatch,codecommit,cognito-identity,cognito-idp,dms,docdb,dynamodb,dynamodbstreams,ec2,ecr,ecs,efs,eks,elasticache,elasticbeanstalk,elbv2,emr,emr-serverless,es,events,firehose,fis,glacier,glue,iam,identitystore,iot,iot-data,iotanalytics,iotwireless,kafka,kinesis,kinesisanalytics,kinesisanalyticsv2,kms,lakeformation,lambda,logs,managedblockchain,mediaconvert,mediastore,mq,mwaa,neptune,opensearch,organizations,pi,pipes,qldb,qldb-session,rds,rds-data,redshift,redshift-data,resource-groups,resourcegroupstaggingapi,route53,route53resolver,s3,s3control,sagemaker,sagemaker-runtime,secretsmanager,serverlessrepo,servicediscovery,ses,sesv2,sns,sqs,ssm,sso-admin,stepfunctions,sts,timestream-query,timestream-write,transcribe,wafv2,xray]",
 ]
 
 [tool.setuptools]

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -8,9 +8,9 @@ attrs==24.2.0
     # via localstack-twisted
 awscrt==0.21.2
     # via localstack-core (pyproject.toml)
-boto3==1.34.158
+boto3==1.35.2
     # via localstack-core (pyproject.toml)
-botocore==1.34.158
+botocore==1.35.2
     # via
     #   boto3
     #   localstack-core (pyproject.toml)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -41,17 +41,17 @@ aws-sam-translator==1.91.0
     #   localstack-core
 aws-xray-sdk==2.14.0
     # via moto-ext
-awscli==1.33.40
+awscli==1.34.2
     # via localstack-core
 awscrt==0.21.2
     # via localstack-core
-boto3==1.34.158
+boto3==1.35.2
     # via
     #   amazon-kclpy
     #   aws-sam-translator
     #   localstack-core
     #   moto-ext
-botocore==1.34.158
+botocore==1.35.2
     # via
     #   aws-xray-sdk
     #   awscli
@@ -261,7 +261,7 @@ openapi-schema-validator==0.6.2
     # via openapi-spec-validator
 openapi-spec-validator==0.7.1
     # via moto-ext
-opensearch-py==2.6.0
+opensearch-py==2.7.0
     # via localstack-core
 ordered-set==4.1.0
     # via deepdiff
@@ -426,7 +426,6 @@ six==1.16.0
     # via
     #   airspeed-ext
     #   jsonpath-rw
-    #   opensearch-py
     #   python-dateutil
     #   rfc3339-validator
 sniffio==1.3.1

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -29,17 +29,17 @@ aws-sam-translator==1.91.0
     #   localstack-core (pyproject.toml)
 aws-xray-sdk==2.14.0
     # via moto-ext
-awscli==1.33.40
+awscli==1.34.2
     # via localstack-core (pyproject.toml)
 awscrt==0.21.2
     # via localstack-core
-boto3==1.34.158
+boto3==1.35.2
     # via
     #   amazon-kclpy
     #   aws-sam-translator
     #   localstack-core
     #   moto-ext
-botocore==1.34.158
+botocore==1.35.2
     # via
     #   aws-xray-sdk
     #   awscli
@@ -194,7 +194,7 @@ openapi-schema-validator==0.6.2
     # via openapi-spec-validator
 openapi-spec-validator==0.7.1
     # via moto-ext
-opensearch-py==2.6.0
+opensearch-py==2.7.0
     # via localstack-core (pyproject.toml)
 packaging==24.1
     # via
@@ -311,7 +311,6 @@ six==1.16.0
     # via
     #   airspeed-ext
     #   jsonpath-rw
-    #   opensearch-py
     #   python-dateutil
     #   rfc3339-validator
 sympy==1.13.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -41,17 +41,17 @@ aws-sam-translator==1.91.0
     #   localstack-core
 aws-xray-sdk==2.14.0
     # via moto-ext
-awscli==1.33.40
+awscli==1.34.2
     # via localstack-core
 awscrt==0.21.2
     # via localstack-core
-boto3==1.34.158
+boto3==1.35.2
     # via
     #   amazon-kclpy
     #   aws-sam-translator
     #   localstack-core
     #   moto-ext
-botocore==1.34.158
+botocore==1.35.2
     # via
     #   aws-xray-sdk
     #   awscli
@@ -241,7 +241,7 @@ openapi-schema-validator==0.6.2
     # via openapi-spec-validator
 openapi-spec-validator==0.7.1
     # via moto-ext
-opensearch-py==2.6.0
+opensearch-py==2.7.0
     # via localstack-core
 ordered-set==4.1.0
     # via deepdiff
@@ -389,7 +389,6 @@ six==1.16.0
     # via
     #   airspeed-ext
     #   jsonpath-rw
-    #   opensearch-py
     #   python-dateutil
     #   rfc3339-validator
 sniffio==1.3.1

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -41,19 +41,19 @@ aws-sam-translator==1.91.0
     #   localstack-core
 aws-xray-sdk==2.14.0
     # via moto-ext
-awscli==1.33.40
+awscli==1.34.2
     # via localstack-core
 awscrt==0.21.2
     # via localstack-core
-boto3==1.34.158
+boto3==1.35.2
     # via
     #   amazon-kclpy
     #   aws-sam-translator
     #   localstack-core
     #   moto-ext
-boto3-stubs==1.34.158
+boto3-stubs==1.35.2
     # via localstack-core (pyproject.toml)
-botocore==1.34.158
+botocore==1.35.2
     # via
     #   aws-xray-sdk
     #   awscli
@@ -62,7 +62,7 @@ botocore==1.34.158
     #   localstack-snapshot
     #   moto-ext
     #   s3transfer
-botocore-stubs==1.35.1
+botocore-stubs==1.35.2
     # via boto3-stubs
 build==1.2.1
     # via
@@ -255,197 +255,197 @@ mpmath==1.3.0
     # via sympy
 multipart==0.2.5
     # via moto-ext
-mypy-boto3-acm==1.34.140
+mypy-boto3-acm==1.35.0
     # via boto3-stubs
-mypy-boto3-acm-pca==1.34.145
+mypy-boto3-acm-pca==1.35.0
     # via boto3-stubs
-mypy-boto3-amplify==1.34.160
+mypy-boto3-amplify==1.35.0
     # via boto3-stubs
-mypy-boto3-apigateway==1.34.137
+mypy-boto3-apigateway==1.35.0
     # via boto3-stubs
-mypy-boto3-apigatewayv2==1.34.0
+mypy-boto3-apigatewayv2==1.35.0
     # via boto3-stubs
-mypy-boto3-appconfig==1.34.58
+mypy-boto3-appconfig==1.35.0
     # via boto3-stubs
-mypy-boto3-appconfigdata==1.34.24
+mypy-boto3-appconfigdata==1.35.0
     # via boto3-stubs
-mypy-boto3-application-autoscaling==1.34.149
+mypy-boto3-application-autoscaling==1.35.0
     # via boto3-stubs
-mypy-boto3-appsync==1.34.147
+mypy-boto3-appsync==1.35.0
     # via boto3-stubs
-mypy-boto3-athena==1.34.130
+mypy-boto3-athena==1.35.0
     # via boto3-stubs
-mypy-boto3-autoscaling==1.34.151
+mypy-boto3-autoscaling==1.35.0
     # via boto3-stubs
-mypy-boto3-backup==1.34.64
+mypy-boto3-backup==1.35.0
     # via boto3-stubs
-mypy-boto3-batch==1.34.143
+mypy-boto3-batch==1.35.0
     # via boto3-stubs
-mypy-boto3-ce==1.34.90
+mypy-boto3-ce==1.35.0
     # via boto3-stubs
-mypy-boto3-cloudcontrol==1.34.0
+mypy-boto3-cloudcontrol==1.35.0
     # via boto3-stubs
-mypy-boto3-cloudformation==1.34.111
+mypy-boto3-cloudformation==1.35.0
     # via boto3-stubs
-mypy-boto3-cloudfront==1.34.135
+mypy-boto3-cloudfront==1.35.0
     # via boto3-stubs
-mypy-boto3-cloudtrail==1.34.129
+mypy-boto3-cloudtrail==1.35.0
     # via boto3-stubs
-mypy-boto3-cloudwatch==1.34.153
+mypy-boto3-cloudwatch==1.35.0
     # via boto3-stubs
-mypy-boto3-codecommit==1.34.149
+mypy-boto3-codecommit==1.35.0
     # via boto3-stubs
-mypy-boto3-cognito-identity==1.34.137
+mypy-boto3-cognito-identity==1.35.0
     # via boto3-stubs
-mypy-boto3-cognito-idp==1.34.158
+mypy-boto3-cognito-idp==1.35.0
     # via boto3-stubs
-mypy-boto3-dms==1.34.141
+mypy-boto3-dms==1.35.0
     # via boto3-stubs
-mypy-boto3-docdb==1.34.162
+mypy-boto3-docdb==1.35.0
     # via boto3-stubs
-mypy-boto3-dynamodb==1.34.148
+mypy-boto3-dynamodb==1.35.0
     # via boto3-stubs
-mypy-boto3-dynamodbstreams==1.34.0
+mypy-boto3-dynamodbstreams==1.35.0
     # via boto3-stubs
-mypy-boto3-ec2==1.34.159
+mypy-boto3-ec2==1.35.0
     # via boto3-stubs
-mypy-boto3-ecr==1.34.154
+mypy-boto3-ecr==1.35.0
     # via boto3-stubs
-mypy-boto3-ecs==1.34.162
+mypy-boto3-ecs==1.35.2
     # via boto3-stubs
-mypy-boto3-efs==1.34.128
+mypy-boto3-efs==1.35.0
     # via boto3-stubs
-mypy-boto3-eks==1.34.159
+mypy-boto3-eks==1.35.0
     # via boto3-stubs
-mypy-boto3-elasticache==1.34.151
+mypy-boto3-elasticache==1.35.0
     # via boto3-stubs
-mypy-boto3-elasticbeanstalk==1.34.141
+mypy-boto3-elasticbeanstalk==1.35.0
     # via boto3-stubs
-mypy-boto3-elbv2==1.34.149
+mypy-boto3-elbv2==1.35.0
     # via boto3-stubs
-mypy-boto3-emr==1.34.136
+mypy-boto3-emr==1.35.0
     # via boto3-stubs
-mypy-boto3-emr-serverless==1.34.116
+mypy-boto3-emr-serverless==1.35.0
     # via boto3-stubs
-mypy-boto3-es==1.34.141
+mypy-boto3-es==1.35.0
     # via boto3-stubs
-mypy-boto3-events==1.34.151
+mypy-boto3-events==1.35.0
     # via boto3-stubs
-mypy-boto3-firehose==1.34.145
+mypy-boto3-firehose==1.35.0
     # via boto3-stubs
-mypy-boto3-fis==1.34.160
+mypy-boto3-fis==1.35.0
     # via boto3-stubs
-mypy-boto3-glacier==1.34.0
+mypy-boto3-glacier==1.35.0
     # via boto3-stubs
-mypy-boto3-glue==1.34.160
+mypy-boto3-glue==1.35.0
     # via boto3-stubs
-mypy-boto3-iam==1.34.162
+mypy-boto3-iam==1.35.0
     # via boto3-stubs
-mypy-boto3-identitystore==1.34.0
+mypy-boto3-identitystore==1.35.0
     # via boto3-stubs
-mypy-boto3-iot==1.34.52
+mypy-boto3-iot==1.35.0
     # via boto3-stubs
-mypy-boto3-iot-data==1.34.0
+mypy-boto3-iot-data==1.35.0
     # via boto3-stubs
-mypy-boto3-iotanalytics==1.34.0
+mypy-boto3-iotanalytics==1.35.0
     # via boto3-stubs
-mypy-boto3-iotwireless==1.34.126
+mypy-boto3-iotwireless==1.35.0
     # via boto3-stubs
-mypy-boto3-kafka==1.34.114
+mypy-boto3-kafka==1.35.0
     # via boto3-stubs
-mypy-boto3-kinesis==1.34.153
+mypy-boto3-kinesis==1.35.0
     # via boto3-stubs
-mypy-boto3-kinesisanalytics==1.34.0
+mypy-boto3-kinesisanalytics==1.35.0
     # via boto3-stubs
-mypy-boto3-kinesisanalyticsv2==1.34.136
+mypy-boto3-kinesisanalyticsv2==1.35.0
     # via boto3-stubs
-mypy-boto3-kms==1.34.126
+mypy-boto3-kms==1.35.0
     # via boto3-stubs
-mypy-boto3-lakeformation==1.34.108
+mypy-boto3-lakeformation==1.35.0
     # via boto3-stubs
-mypy-boto3-lambda==1.34.77
+mypy-boto3-lambda==1.35.1
     # via boto3-stubs
-mypy-boto3-logs==1.34.151
+mypy-boto3-logs==1.35.0
     # via boto3-stubs
-mypy-boto3-managedblockchain==1.34.113
+mypy-boto3-managedblockchain==1.35.0
     # via boto3-stubs
-mypy-boto3-mediaconvert==1.34.128
+mypy-boto3-mediaconvert==1.35.0
     # via boto3-stubs
-mypy-boto3-mediastore==1.34.0
+mypy-boto3-mediastore==1.35.0
     # via boto3-stubs
-mypy-boto3-mq==1.34.135
+mypy-boto3-mq==1.35.0
     # via boto3-stubs
-mypy-boto3-mwaa==1.34.107
+mypy-boto3-mwaa==1.35.0
     # via boto3-stubs
-mypy-boto3-neptune==1.34.0
+mypy-boto3-neptune==1.35.0
     # via boto3-stubs
-mypy-boto3-opensearch==1.34.142
+mypy-boto3-opensearch==1.35.0
     # via boto3-stubs
-mypy-boto3-organizations==1.34.139
+mypy-boto3-organizations==1.35.0
     # via boto3-stubs
-mypy-boto3-pi==1.34.154
+mypy-boto3-pi==1.35.0
     # via boto3-stubs
-mypy-boto3-pipes==1.34.119
+mypy-boto3-pipes==1.35.0
     # via boto3-stubs
-mypy-boto3-qldb==1.34.49
+mypy-boto3-qldb==1.35.0
     # via boto3-stubs
-mypy-boto3-qldb-session==1.34.0
+mypy-boto3-qldb-session==1.35.0
     # via boto3-stubs
-mypy-boto3-rds==1.34.152
+mypy-boto3-rds==1.35.0
     # via boto3-stubs
-mypy-boto3-rds-data==1.34.6
+mypy-boto3-rds-data==1.35.0
     # via boto3-stubs
-mypy-boto3-redshift==1.34.125
+mypy-boto3-redshift==1.35.0
     # via boto3-stubs
-mypy-boto3-redshift-data==1.34.0
+mypy-boto3-redshift-data==1.35.0
     # via boto3-stubs
-mypy-boto3-resource-groups==1.34.79
+mypy-boto3-resource-groups==1.35.0
     # via boto3-stubs
-mypy-boto3-resourcegroupstaggingapi==1.34.0
+mypy-boto3-resourcegroupstaggingapi==1.35.0
     # via boto3-stubs
-mypy-boto3-route53==1.34.153
+mypy-boto3-route53==1.35.0
     # via boto3-stubs
-mypy-boto3-route53resolver==1.34.141
+mypy-boto3-route53resolver==1.35.0
     # via boto3-stubs
-mypy-boto3-s3==1.34.162
+mypy-boto3-s3==1.35.2
     # via boto3-stubs
-mypy-boto3-s3control==1.34.83
+mypy-boto3-s3control==1.35.0
     # via boto3-stubs
-mypy-boto3-sagemaker==1.34.159
+mypy-boto3-sagemaker==1.35.0
     # via boto3-stubs
-mypy-boto3-sagemaker-runtime==1.34.0
+mypy-boto3-sagemaker-runtime==1.35.0
     # via boto3-stubs
-mypy-boto3-secretsmanager==1.34.145
+mypy-boto3-secretsmanager==1.35.0
     # via boto3-stubs
-mypy-boto3-serverlessrepo==1.34.0
+mypy-boto3-serverlessrepo==1.35.0
     # via boto3-stubs
-mypy-boto3-servicediscovery==1.34.89
+mypy-boto3-servicediscovery==1.35.0
     # via boto3-stubs
-mypy-boto3-ses==1.34.141
+mypy-boto3-ses==1.35.0
     # via boto3-stubs
-mypy-boto3-sesv2==1.34.125
+mypy-boto3-sesv2==1.35.0
     # via boto3-stubs
-mypy-boto3-sns==1.34.121
+mypy-boto3-sns==1.35.0
     # via boto3-stubs
-mypy-boto3-sqs==1.34.121
+mypy-boto3-sqs==1.35.0
     # via boto3-stubs
-mypy-boto3-ssm==1.34.158
+mypy-boto3-ssm==1.35.0
     # via boto3-stubs
-mypy-boto3-sso-admin==1.34.0
+mypy-boto3-sso-admin==1.35.0
     # via boto3-stubs
-mypy-boto3-stepfunctions==1.34.149
+mypy-boto3-stepfunctions==1.35.0
     # via boto3-stubs
-mypy-boto3-sts==1.34.0
+mypy-boto3-sts==1.35.0
     # via boto3-stubs
-mypy-boto3-timestream-query==1.34.145
+mypy-boto3-timestream-query==1.35.0
     # via boto3-stubs
-mypy-boto3-timestream-write==1.34.0
+mypy-boto3-timestream-write==1.35.0
     # via boto3-stubs
-mypy-boto3-transcribe==1.34.94
+mypy-boto3-transcribe==1.35.0
     # via boto3-stubs
-mypy-boto3-wafv2==1.34.137
+mypy-boto3-wafv2==1.35.0
     # via boto3-stubs
-mypy-boto3-xray==1.34.0
+mypy-boto3-xray==1.35.0
     # via boto3-stubs
 networkx==3.3
     # via
@@ -457,7 +457,7 @@ openapi-schema-validator==0.6.2
     # via openapi-spec-validator
 openapi-spec-validator==0.7.1
     # via moto-ext
-opensearch-py==2.6.0
+opensearch-py==2.7.0
     # via localstack-core
 ordered-set==4.1.0
     # via deepdiff
@@ -622,7 +622,6 @@ six==1.16.0
     # via
     #   airspeed-ext
     #   jsonpath-rw
-    #   opensearch-py
     #   python-dateutil
     #   rfc3339-validator
 sniffio==1.3.1


### PR DESCRIPTION
## Motivation
`botocore` recently performed a minor version bump to `1.35`, and so did the `boto3-stubs`.
It turns out that the upgrade of the exact pin of `boto3-stubs` breaks the ASF update because:
- `boto3-stubs` is explicitly set to `1.35.2` (the latest version as of today):
  https://github.com/localstack/localstack/blob/c3cd60f70b49ce0486ca9c9b8b3d7bd270cf61c3/.github/workflows/asf-updates.yml#L79
- Afterwards, we explicitly upgrade the package version in the `requirements-typehint.txt`:
  https://github.com/localstack/localstack/blob/c3cd60f70b49ce0486ca9c9b8b3d7bd270cf61c3/.github/workflows/asf-updates.yml#L87C97-L87C106
- This failed in the last attempts:
  - https://github.com/localstack/localstack/actions/runs/10447444855
  - https://github.com/localstack/localstack/actions/runs/10487561864
  ```
  2024-08-21T09:51:15.5105378Z   ERROR: Cannot install boto3-stubs[acm,acm-pca,amplify,apigateway,apigatewayv2,appconfig,appconfigdata,application-autoscaling,appsync,athena,autoscaling,backup,batch,ce,cloudcontrol,cloudformation,cloudfront,cloudtrail,cloudwatch,codecommit,cognito-identity,cognito-idp,dms,docdb,dynamodb,dynamodbstreams,ec2,ecr,ecs,efs,eks,elasticache,elasticbeanstalk,elbv2,emr,emr-serverless,es,events,firehose,fis,glacier,glue,iam,identitystore,iot,iot-data,iotanalytics,iotwireless,kafka,kinesis,kinesisanalytics,kinesisanalyticsv2,kms,lakeformation,lambda,logs,managedblockchain,mediaconvert,mediastore,mq,mwaa,neptune,opensearch,organizations,pi,pipes,qldb,qldb-session,rds,rds-data,redshift,redshift-data,resource-groups,resourcegroupstaggingapi,route53,route53resolver,s3,s3control,sagemaker,sagemaker-runtime,secretsmanager,serverlessrepo,servicediscovery,ses,sesv2,sns,sqs,ssm,sso-admin,stepfunctions,sts,timestream-query,timestream-write,transcribe,wafv2,xray]==1.35.2 because these package versions have conflicting dependencies.
  ```

This is because `boto3-stubs` has transitive dependencies on the minor versions (f.e. `mypy-boto3-s3`), which was bumped from `>=1.34,<1.5` to `>=1.35,<1.36`.
This ends in a conflict, because we do not explicitly list every single transitive dependency of `boto3-stubs` in the upgrade command, and these transitive dependencies are then conflicting.
Unfortunately, `pip-compile` does not support any wildcards or transitive package upgrades (without upgrading _everything_), which is why this PR actually removes the pin completely.

## Changes
- Removes the pin on `boto3-stubs` in the `pyproject.toml`.
- Upgrades the pins of `boto3`, `botocore` in the `pyproject.toml`.
- Upgrades all `requirements-*.txt` dependency lock files.

## Testing
- Triggered an ASF update workflow run from this branch: https://github.com/localstack/localstack/actions/runs/10489221940
  - The run was successful and created this PR (which was closed because it has the wrong base): https://github.com/localstack/localstack/pull/11395