### PR TITLE
Use the correct image for diagnostic endpoint

### DIFF
--- a/localstack-core/localstack/utils/diagnose.py
+++ b/localstack-core/localstack/utils/diagnose.py
@@ -12,7 +12,7 @@ from localstack.services.lambda_.runtimes import IMAGE_MAPPING
 from localstack.utils import bootstrap
 from localstack.utils.analytics import usage
 from localstack.utils.container_networking import get_main_container_name
-from localstack.utils.container_utils.container_client import NoSuchImage
+from localstack.utils.container_utils.container_client import ContainerException, NoSuchImage
 from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.files import load_file
 
@@ -138,7 +138,13 @@ def traverse_file_tree(root: str) -> List[str]:
 
 
 def get_docker_image_details() -> Dict[str, str]:
-    return bootstrap.get_docker_image_details()
+    image = os.environ.get("IMAGE_NAME")
+    if not image:
+        try:
+            image = DOCKER_CLIENT.inspect_container(get_main_container_name())["Config"]["Image"]
+        except ContainerException:
+            image = None
+    return bootstrap.get_docker_image_details(image_name=image)
 
 
 def get_host_kernel_version() -> str:

--- a/localstack-core/localstack/utils/diagnose.py
+++ b/localstack-core/localstack/utils/diagnose.py
@@ -138,12 +138,13 @@ def traverse_file_tree(root: str) -> List[str]:
 
 
 def get_docker_image_details() -> Dict[str, str]:
-    image = os.environ.get("IMAGE_NAME")
-    if not image:
-        try:
-            image = DOCKER_CLIENT.inspect_container(get_main_container_name())["Config"]["Image"]
-        except ContainerException:
-            return {}
+    try:
+        image = DOCKER_CLIENT.inspect_container(get_main_container_name())["Config"]["Image"]
+    except ContainerException:
+        return {}
+    # The default bootstrap image detection does not take custom images into account.
+    # Also, the patches to correctly detect a `-pro` image are only applied on the host, so the detection fails
+    # at runtime. The bootstrap detection is mostly used for the CLI, so having a different logic here makes sense.
     return bootstrap.get_docker_image_details(image_name=image)
 
 

--- a/localstack-core/localstack/utils/diagnose.py
+++ b/localstack-core/localstack/utils/diagnose.py
@@ -143,7 +143,7 @@ def get_docker_image_details() -> Dict[str, str]:
         try:
             image = DOCKER_CLIENT.inspect_container(get_main_container_name())["Config"]["Image"]
         except ContainerException:
-            image = None
+            return {}
     return bootstrap.get_docker_image_details(image_name=image)
 
 

--- a/tests/unit/utils/test_diagnose.py
+++ b/tests/unit/utils/test_diagnose.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+
+from localstack.utils.diagnose import get_docker_image_details
+from localstack.utils.docker_utils import DOCKER_CLIENT
+
+
+class TestDiagnoseEndpoint:
+    @patch.object(
+        DOCKER_CLIENT, "inspect_container", return_value={"Config": {"Image": "mocked-image"}}
+    )
+    @patch.object(
+        DOCKER_CLIENT,
+        "inspect_image",
+        return_value={
+            "RepoDigests": [
+                "mocked-image@sha256:ee339698cadbee0f7ec7057407973c944e0b834798b1b54829f074aff288388c"
+            ],
+            "Id": "sha256:ababababababd18ca91ec21fe09b5cb77ec3959f0623d9c8b24006d5c59bd391",
+            "RepoTags": ["mocked-image:latest"],
+            "Created": "2024-08-25T10:41:47.724301163Z",
+        },
+    )
+    def test_diagnose_non_default_image(self, mocked_image, mocked_inspect):
+        image_details = get_docker_image_details()
+        assert image_details["id"] == "abababababab"
+        assert (
+            image_details["sha256"]
+            == "ee339698cadbee0f7ec7057407973c944e0b834798b1b54829f074aff288388c"
+        )
+        assert image_details["tag"] == "latest"
+        assert image_details["created"] == "2024-08-25T10:41:47"
+
+        mocked_inspect.assert_called_once()
+        mocked_image.assert_called_once_with("mocked-image")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, when using the new `LOCALSTACK_AUTH_TOKEN`s instead of `LOCALSTACK_API_KEY`, the diagnostic endpoint will pull the `localstack/localstack` image instead of inspecting the current image, most likely `localstack/localstack-pro`.

To avoid issues like this, we should always inspect the docker image returned when inspecting the own container.
If no docker socket is available, we cannot inspect the image anyway, and if there is, we should be able to check the current container for the image. This way we always match the right image, no matter if an api key or auth token is set.

Note that there is a patch to the `is_api_key_configured` method in `localstack.utils.bootstrap` from -ext, but it is only applied on the host within the CLI, and is therefore ineffective within the container.
We might want to adapt that method as well in the future, but for now it is only used for the CLI, where it is patched anyway.

/cc @MarcelStranak

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Calling the diagnose endpoint should no longer pull the `localstack/localstack` image and return information for it if an auth token is used.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
