### PR TITLE
Update lambda init binary to v0.1.29-pre

### DIFF
--- a/localstack-core/localstack/services/lambda_/packages.py
+++ b/localstack-core/localstack/services/lambda_/packages.py
@@ -13,7 +13,7 @@ from localstack.utils.platform import get_arch
 """Customized LocalStack version of the AWS Lambda Runtime Interface Emulator (RIE).
 https://github.com/localstack/lambda-runtime-init/blob/localstack/README-LOCALSTACK.md
 """
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.28-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.29-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
In the most recent update of the lambda runtime init, we included the latest upstream changes, and updated the go version to version 1.22, which should fix the CVE https://avd.aquasec.com/nvd/2024/cve-2024-24790/ .

For more information see localstack/lambda-runtime-init#35.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Update lambda runtime init to `v0.1.29`

## TODO

What's left to do:

- [ ] Update k8s images

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->