### PR TITLE
APIGW: add better validation for PutIntegration and PutIntegrationResponse

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -2498,3 +2498,77 @@ class TestApigatewayIntegration:
                 restApiId=api_id, resourceId=root_resource_id, httpMethod="GET", type="HTTPS_PROXY"
             )
         snapshot.match("put-integration-wrong-type", e.value.response)
+
+    @markers.aws.validated
+    def test_put_integration_response_validation(
+        self, aws_client, apigw_create_rest_api, aws_client_factory, snapshot
+    ):
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}", description="testing PutIntegrationResponse method exc"
+        )
+        api_id = response["id"]
+        root_id = response["rootResourceId"]
+
+        aws_client.apigateway.put_method(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="POST",
+            authorizationType="NONE",
+        )
+
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.put_integration(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="GET",
+                integrationHttpMethod="GET",
+                type="MOCK",
+                requestTemplates={"application/json": '{"statusCode": 200}'},
+            )
+        snapshot.match("put-integration-wrong-method", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.put_integration(
+                restApiId=api_id,
+                resourceId="badresource",
+                httpMethod="GET",
+                integrationHttpMethod="GET",
+                type="MOCK",
+                requestTemplates={"application/json": '{"statusCode": 200}'},
+            )
+        snapshot.match("put-integration-wrong-resource", e.value.response)
+
+        aws_client.apigateway.put_integration(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="POST",
+            integrationHttpMethod="GET",
+            type="MOCK",
+            requestTemplates={"application/json": '{"statusCode": 200}'},
+        )
+
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.put_integration_response(
+                restApiId=api_id,
+                resourceId=root_id,
+                # put the integrationHttpMethod instead of the `httpMethod` should result in an error
+                httpMethod="GET",
+                statusCode="200",
+                selectionPattern="",
+                responseTemplates={"application/json": json.dumps({})},
+            )
+
+        snapshot.match("put-integration-response-wrong-method", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.put_integration_response(
+                restApiId=api_id,
+                resourceId="badresource",
+                # put the integrationHttpMethod instead of the `httpMethod` should result in an error
+                httpMethod="GET",
+                statusCode="200",
+                selectionPattern="",
+                responseTemplates={"application/json": json.dumps({})},
+            )
+
+        snapshot.match("put-integration-response-wrong-resource", e.value.response)

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -3507,5 +3507,54 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_put_integration_response_validation": {
+    "recorded-date": "21-08-2024, 15:09:28",
+    "recorded-content": {
+      "put-integration-wrong-method": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Method identifier specified"
+        },
+        "message": "Invalid Method identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-integration-wrong-resource": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-integration-response-wrong-method": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Method identifier specified"
+        },
+        "message": "Invalid Method identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-integration-response-wrong-resource": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -128,6 +128,9 @@
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_update_gateway_response": {
     "last_validated_date": "2024-04-15T20:47:11+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_put_integration_response_validation": {
+    "last_validated_date": "2024-08-21T15:09:28+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_put_integration_wrong_type": {
     "last_validated_date": "2024-04-15T20:48:47+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in our Slack Community channel with https://localstack-community.slack.com/archives/CMAFN2KSP/p1724147479425329, we raised a bad error when using the wrong `httpMethod` with `PutIntegrationResponse`. This PR adds better exception handling for `PutIntegration` and `PutIntegrationResponse`

`api error InternalError: exception while calling apigateway.PutIntegrationResponse: 'dict' object has no attribute 'method_integration'`

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add test for bad resourceId and bad httpMethod for those 2 operations
- improve the exceptions in the provider

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
