### PR TITLE
implement IfNoneMatch for PutObject and CompleteMultipartUpload

### DIFF
--- a/localstack-core/localstack/aws/api/s3/__init__.py
+++ b/localstack-core/localstack/aws/api/s3/__init__.py
@@ -185,6 +185,8 @@ HttpMethod = str
 ResourceType = str
 MissingHeaderName = str
 KeyLength = str
+Header = str
+additionalMessage = str
 
 
 class AnalyticsS3ExportFileFormat(StrEnum):
@@ -949,6 +951,22 @@ class InvalidEncryptionAlgorithmError(ServiceException):
     status_code: int = 400
     ArgumentName: Optional[ArgumentName]
     ArgumentValue: Optional[ArgumentValue]
+
+
+class NotImplemented(ServiceException):
+    code: str = "NotImplemented"
+    sender_fault: bool = False
+    status_code: int = 501
+    Header: Optional[Header]
+    additionalMessage: Optional[additionalMessage]
+
+
+class ConditionalRequestConflict(ServiceException):
+    code: str = "ConditionalRequestConflict"
+    sender_fault: bool = False
+    status_code: int = 409
+    Condition: Optional[IfCondition]
+    Key: Optional[ObjectKey]
 
 
 AbortDate = datetime

--- a/localstack-core/localstack/aws/spec-patches.json
+++ b/localstack-core/localstack/aws/spec-patches.json
@@ -1243,6 +1243,60 @@
         "documentation": "<p>The Encryption request you specified is not valid.</p>",
         "exception": true
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/Header",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/additionalMessage",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/NotImplemented",
+      "value": {
+        "type": "structure",
+        "members": {
+          "Header": {
+            "shape": "Header"
+          },
+          "additionalMessage": {
+            "shape": "additionalMessage"
+          }
+        },
+        "error": {
+          "httpStatusCode": 501
+        },
+        "documentation": "<p>A header you provided implies functionality that is not implemented.</p>",
+        "exception": true
+      }
+    },
+        {
+      "op": "add",
+      "path": "/shapes/ConditionalRequestConflict",
+      "value": {
+        "type": "structure",
+        "members": {
+          "Condition": {
+            "shape": "IfCondition"
+          },
+          "Key": {
+            "shape": "ObjectKey"
+          }
+        },
+        "error": {
+          "httpStatusCode": 409
+        },
+        "documentation": "<p>The conditional request cannot succeed due to a conflicting operation against this resource.</p>",
+        "exception": true
+      }
     }
   ],
   "apigatewayv2/2018-11-29/service-2": [

--- a/localstack-core/localstack/aws/spec-patches.json
+++ b/localstack-core/localstack/aws/spec-patches.json
@@ -1278,7 +1278,7 @@
         "exception": true
       }
     },
-        {
+    {
       "op": "add",
       "path": "/shapes/ConditionalRequestConflict",
       "value": {

--- a/localstack-core/localstack/services/s3/models.py
+++ b/localstack-core/localstack/services/s3/models.py
@@ -427,6 +427,7 @@ class S3Multipart:
     upload_id: MultipartUploadId
     checksum_value: Optional[str]
     initiated: datetime
+    precondition: bool
 
     def __init__(
         self,
@@ -449,6 +450,7 @@ class S3Multipart:
         initiator: Optional[Owner] = None,
         tagging: Optional[dict[str, str]] = None,
         owner: Optional[Owner] = None,
+        precondition: Optional[bool] = None,
     ):
         self.id = token_urlsafe(96)  # MultipartUploadId is 128 characters long
         self.initiated = datetime.now(tz=_gmt_zone_info)
@@ -456,6 +458,7 @@ class S3Multipart:
         self.initiator = initiator
         self.tagging = tagging
         self.checksum_value = None
+        self.precondition = precondition
         self.object = S3Object(
             key=key,
             user_metadata=user_metadata,

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -1832,3 +1832,156 @@ class TestS3BucketAccelerateConfiguration:
                 AccelerateConfiguration={"Status": "random"},
             )
         snapshot.match("put-bucket-accelerate-config-dot-bucket", e.value.response)
+
+
+class TestS3ObjectWritePrecondition:
+    @pytest.fixture(autouse=True)
+    def add_snapshot_transformers(self, snapshot):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("Bucket"),
+                snapshot.transform.key_value("UploadId"),
+                snapshot.transform.key_value("VersionId"),
+                snapshot.transform.key_value("DisplayName"),
+                snapshot.transform.key_value("ID"),
+                snapshot.transform.key_value("Name"),
+            ]
+        )
+        snapshot.add_transformer(snapshot.transform.key_value("Location"), priority=-1)
+
+    @markers.aws.validated
+    def test_put_object_if_none_match(self, s3_bucket, aws_client, snapshot):
+        key = "test-precondition"
+        put_obj = aws_client.s3.put_object(Bucket=s3_bucket, Key=key, IfNoneMatch="*")
+        snapshot.match("put-obj", put_obj)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object(Bucket=s3_bucket, Key=key, IfNoneMatch="*")
+        snapshot.match("put-obj-if-none-match", e.value.response)
+
+        del_obj = aws_client.s3.delete_object(Bucket=s3_bucket, Key=key)
+        snapshot.match("del-obj", del_obj)
+
+        put_obj_after_del = aws_client.s3.put_object(Bucket=s3_bucket, Key=key, IfNoneMatch="*")
+        snapshot.match("put-obj-after-del", put_obj_after_del)
+
+    @markers.aws.validated
+    def test_put_object_if_none_match_validation(self, s3_bucket, aws_client, snapshot):
+        key = "test-precondition-validation"
+        put_obj = aws_client.s3.put_object(Bucket=s3_bucket, Key=key)
+        snapshot.match("put-obj", put_obj)
+        obj_etag = put_obj["ETag"]
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object(Bucket=s3_bucket, Key=key, IfNoneMatch=obj_etag)
+        snapshot.match("put-obj-if-none-match-bad-value", e.value.response)
+
+    @markers.aws.validated
+    def test_multipart_if_none_match_with_delete(self, s3_bucket, aws_client, snapshot):
+        key = "test-precondition"
+        put_obj = aws_client.s3.put_object(Bucket=s3_bucket, Key=key, IfNoneMatch="*")
+        snapshot.match("put-obj", put_obj)
+
+        create_multipart = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=key)
+        snapshot.match("create-multipart", create_multipart)
+        upload_id = create_multipart["UploadId"]
+
+        upload_part = aws_client.s3.upload_part(
+            Bucket=s3_bucket, Key=key, UploadId=upload_id, Body="test", PartNumber=1
+        )
+        parts = [{"ETag": upload_part["ETag"], "PartNumber": 1}]
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.complete_multipart_upload(
+                Bucket=s3_bucket,
+                Key=key,
+                MultipartUpload={"Parts": parts},
+                UploadId=upload_id,
+                IfNoneMatch="*",
+            )
+        snapshot.match("complete-multipart-if-none-match", e.value.response)
+
+        del_obj = aws_client.s3.delete_object(Bucket=s3_bucket, Key=key)
+        snapshot.match("del-obj", del_obj)
+
+        # the previous DeleteObject request was done between the CreateMultipartUpload and completion, so it takes
+        # precedence
+        # you need to restart the whole multipart for it to work
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.complete_multipart_upload(
+                Bucket=s3_bucket,
+                Key=key,
+                MultipartUpload={"Parts": parts},
+                UploadId=upload_id,
+                IfNoneMatch="*",
+            )
+        snapshot.match("complete-multipart-after-del", e.value.response)
+
+        create_multipart = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=key)
+        upload_id = create_multipart["UploadId"]
+
+        upload_part = aws_client.s3.upload_part(
+            Bucket=s3_bucket, Key=key, UploadId=upload_id, Body="test", PartNumber=1
+        )
+        parts = [{"ETag": upload_part["ETag"], "PartNumber": 1}]
+        complete_multipart = aws_client.s3.complete_multipart_upload(
+            Bucket=s3_bucket,
+            Key=key,
+            MultipartUpload={"Parts": parts},
+            UploadId=upload_id,
+            IfNoneMatch="*",
+        )
+        snapshot.match("complete-multipart-after-del-restart", complete_multipart)
+
+    @markers.aws.validated
+    def test_multipart_if_none_match_with_put(self, s3_bucket, aws_client, snapshot):
+        key = "test-precondition"
+
+        create_multipart = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=key)
+        snapshot.match("create-multipart", create_multipart)
+        upload_id = create_multipart["UploadId"]
+
+        upload_part = aws_client.s3.upload_part(
+            Bucket=s3_bucket, Key=key, UploadId=upload_id, Body="test", PartNumber=1
+        )
+        parts = [{"ETag": upload_part["ETag"], "PartNumber": 1}]
+
+        put_obj = aws_client.s3.put_object(Bucket=s3_bucket, Key=key, IfNoneMatch="*")
+        snapshot.match("put-obj", put_obj)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.complete_multipart_upload(
+                Bucket=s3_bucket,
+                Key=key,
+                MultipartUpload={"Parts": parts},
+                UploadId=upload_id,
+                IfNoneMatch="*",
+            )
+        snapshot.match("complete-multipart-if-none-match-put-during", e.value.response)
+
+    @markers.aws.validated
+    def test_put_object_if_none_match_versioned_bucket(self, s3_bucket, aws_client, snapshot):
+        #  For buckets with versioning enabled, S3 checks for the presence of a current object version with the same
+        #  name as part of the conditional evaluation. If there is no current object version with the same name, or
+        #  if the current object version is a delete marker, then the write operation succeeds.
+        aws_client.s3.put_bucket_versioning(
+            Bucket=s3_bucket, VersioningConfiguration={"Status": "Enabled"}
+        )
+        key = "test-precondition"
+        put_obj = aws_client.s3.put_object(Bucket=s3_bucket, Key=key, IfNoneMatch="*")
+        snapshot.match("put-obj", put_obj)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object(Bucket=s3_bucket, Key=key, IfNoneMatch="*")
+        snapshot.match("put-obj-if-none-match", e.value.response)
+
+        del_obj = aws_client.s3.delete_object(Bucket=s3_bucket, Key=key)
+        snapshot.match("del-obj", del_obj)
+
+        # if the last object is a delete marker, then we can use IfNoneMatch
+        put_obj_after_del = aws_client.s3.put_object(Bucket=s3_bucket, Key=key, IfNoneMatch="*")
+        snapshot.match("put-obj-after-del", put_obj_after_del)
+
+        list_object_versions = aws_client.s3.list_object_versions(Bucket=s3_bucket)
+        snapshot.match("list-object-versions", list_object_versions)

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -1834,6 +1834,10 @@ class TestS3BucketAccelerateConfiguration:
         snapshot.match("put-bucket-accelerate-config-dot-bucket", e.value.response)
 
 
+@pytest.mark.skipif(
+    condition=config.LEGACY_V2_S3_PROVIDER,
+    reason="Not implemented in legacy",
+)
 class TestS3ObjectWritePrecondition:
     @pytest.fixture(autouse=True)
     def add_snapshot_transformers(self, snapshot):

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -3370,5 +3370,260 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3ObjectWritePrecondition::test_put_object_if_none_match": {
+    "recorded-date": "21-08-2024, 22:26:22",
+    "recorded-content": {
+      "put-obj": {
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-if-none-match": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "If-None-Match",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "del-obj": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "put-obj-after-del": {
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3ObjectWritePrecondition::test_put_object_if_none_match_validation": {
+    "recorded-date": "21-08-2024, 22:26:24",
+    "recorded-content": {
+      "put-obj": {
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-if-none-match-bad-value": {
+        "Error": {
+          "Code": "NotImplemented",
+          "Header": "If-None-Match",
+          "Message": "A header you provided implies functionality that is not implemented",
+          "additionalMessage": "We don't accept the provided value of If-None-Match header for this API"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 501
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3ObjectWritePrecondition::test_put_object_if_none_match_versioned_bucket": {
+    "recorded-date": "21-08-2024, 22:26:32",
+    "recorded-content": {
+      "put-obj": {
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-if-none-match": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "If-None-Match",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "del-obj": {
+        "DeleteMarker": true,
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "put-obj-after-del": {
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-object-versions": {
+        "DeleteMarkers": [
+          {
+            "IsLatest": false,
+            "Key": "test-precondition",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name:1>",
+              "ID": "<i-d:1>"
+            },
+            "VersionId": "<version-id:2>"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxKeys": 1000,
+        "Name": "<name:1>",
+        "Prefix": "",
+        "VersionIdMarker": "",
+        "Versions": [
+          {
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": true,
+            "Key": "test-precondition",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name:1>",
+              "ID": "<i-d:1>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:3>"
+          },
+          {
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "test-precondition",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name:1>",
+              "ID": "<i-d:1>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3ObjectWritePrecondition::test_multipart_if_none_match_with_delete": {
+    "recorded-date": "21-08-2024, 22:26:27",
+    "recorded-content": {
+      "put-obj": {
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-multipart": {
+        "Bucket": "<bucket:1>",
+        "Key": "test-precondition",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-if-none-match": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "If-None-Match",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "del-obj": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "complete-multipart-after-del": {
+        "Error": {
+          "Code": "ConditionalRequestConflict",
+          "Condition": "If-None-Match",
+          "Key": "test-precondition",
+          "Message": "The conditional request cannot succeed due to a conflicting operation against this resource."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "complete-multipart-after-del-restart": {
+        "Bucket": "<bucket:1>",
+        "ETag": "\"60cd54a928cbbcbb6e7b5595bab46a9e-1\"",
+        "Key": "test-precondition",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3ObjectWritePrecondition::test_multipart_if_none_match_with_put": {
+    "recorded-date": "21-08-2024, 22:26:29",
+    "recorded-content": {
+      "create-multipart": {
+        "Bucket": "<bucket:1>",
+        "Key": "test-precondition",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj": {
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-if-none-match-put-during": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "If-None-Match",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -116,6 +116,21 @@
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectLock::test_put_object_lock_configuration_on_existing_bucket": {
     "last_validated_date": "2024-01-15T03:13:25+00:00"
   },
+  "tests/aws/services/s3/test_s3_api.py::TestS3ObjectWritePrecondition::test_multipart_if_none_match_with_delete": {
+    "last_validated_date": "2024-08-21T22:26:26+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3ObjectWritePrecondition::test_multipart_if_none_match_with_put": {
+    "last_validated_date": "2024-08-21T22:26:28+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3ObjectWritePrecondition::test_put_object_if_none_match": {
+    "last_validated_date": "2024-08-21T22:26:21+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3ObjectWritePrecondition::test_put_object_if_none_match_validation": {
+    "last_validated_date": "2024-08-21T22:26:23+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3ObjectWritePrecondition::test_put_object_if_none_match_versioned_bucket": {
+    "last_validated_date": "2024-08-21T22:26:31+00:00"
+  },
   "tests/aws/services/s3/test_s3_api.py::TestS3PublicAccessBlock::test_crud_public_access_block": {
     "last_validated_date": "2023-08-10T01:29:18+00:00"
   }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
AWS just [released yesterday Conditional Writes for S3](https://aws.amazon.com/about-aws/whats-new/2024/08/amazon-s3-conditional-writes/), which is a pretty big thing (and nice!)

This PR implements the behavior as documented in https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html and tested with snapshots. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement behavior in PutObject: use the lock to be sure only the first write to succeed and block others, making them raise an exception once they acquire the lock if the object exists
- implement behavior in CompleteMultipartObject: from the documentation it seems that if an object exists when completing you should raise a Precondition error, and if something existed before but got deleted, you need to raise a Conflict. Did that by attaching the original existence when creating, and checking again when completing
- patch the specs for the new exceptions

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
