### PR TITLE
Add MessageAttributes to SQS messages when executed via Step Function

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sqs.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sqs.py
@@ -29,7 +29,7 @@ _ERROR_NAME_AWS: Final[str] = "SQS.AmazonSQSException"
 _SUPPORTED_API_PARAM_BINDINGS: Final[dict[str, set[str]]] = {
     "sendmessage": {
         "DelaySeconds",
-        "MessageAttribute",
+        "MessageAttributes",
         "MessageBody",
         "MessageDeduplicationId",
         "MessageGroupId",
@@ -75,10 +75,14 @@ class StateTaskServiceSqs(StateTaskServiceCallback):
             boto_service_name=boto_service_name,
             service_action_name=service_action_name,
         )
-        # Normalise output value key to SFN standard for Md5OfMessageBody.
+        # Normalise output value keys to SFN standard for Md5OfMessageBody and Md5OfMessageAttributes
         if response and "Md5OfMessageBody" in response:
             md5_message_body = response.pop("Md5OfMessageBody")
             response["MD5OfMessageBody"] = md5_message_body
+
+        if response and "Md5OfMessageAttributes" in response:
+            md5_message_attributes = response.pop("Md5OfMessageAttributes")
+            response["MD5OfMessageAttributes"] = md5_message_attributes
 
     def _eval_service_task(
         self,

--- a/localstack-core/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack-core/localstack/testing/snapshots/transformer_utility.py
@@ -705,6 +705,7 @@ class TransformerUtility:
             # Transform MD5OfMessageBody value bindings as in StepFunctions these are not deterministic
             # about the input message.
             TransformerUtility.key_value("MD5OfMessageBody"),
+            TransformerUtility.key_value("MD5OfMessageAttributes"),
         ]
 
     @staticmethod

--- a/tests/aws/services/stepfunctions/templates/services/services_templates.py
+++ b/tests/aws/services/stepfunctions/templates/services/services_templates.py
@@ -54,6 +54,9 @@ class ServicesTemplates(TemplateLoader):
     SQS_SEND_MESSAGE_AND_WAIT: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/sqs_send_msg_and_wait.json5"
     )
+    SQS_SEND_MESSAGE_ATTRIBUTES: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/sqs_send_msg_attributes.json5"
+    )
     SNS_PUBLISH: Final[str] = os.path.join(_THIS_FOLDER, "statemachines/sns_publish.json5")
     SNS_FIFO_PUBLISH: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/sns_fifo_publish.json5"

--- a/tests/aws/services/stepfunctions/templates/services/statemachines/sqs_send_msg_attributes.json5
+++ b/tests/aws/services/stepfunctions/templates/services/statemachines/sqs_send_msg_attributes.json5
@@ -1,0 +1,25 @@
+{
+  "Comment": "SQS_SEND_MESSAGE_ATTRIBUTES",
+  "StartAt": "SendSQS",
+  "States": {
+    "SendSQS": {
+      "Type": "Task",
+     "Resource": "arn:aws:states:::sqs:sendMessage",
+     "Parameters": {
+        "QueueUrl.$": "$.QueueUrl",
+        "MessageBody.$": "$.Message",
+        "MessageAttributes": {
+          "my_attribute_no_1": {
+            "DataType": "String",
+            "StringValue.$": "$.MessageAttributeValue1"
+          },
+          "my_attribute_no_2": {
+            "DataType": "String",
+            "StringValue.$": "$.MessageAttributeValue2"
+          }
+        }
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/services/test_sqs_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_sqs_task_service.py
@@ -95,3 +95,60 @@ class TestTaskServiceSqs:
             definition,
             exec_input,
         )
+
+    @markers.aws.validated
+    def test_send_message_attributes(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sqs_create_queue,
+        sfn_snapshot,
+    ):
+        sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sqs_integration())
+
+        queue_name = f"queue-{short_uid()}"
+        queue_url = sqs_create_queue(QueueName=queue_name)
+        sfn_snapshot.add_transformer(RegexTransformer(queue_url, "<sqs_queue_url>"))
+        sfn_snapshot.add_transformer(RegexTransformer(queue_name, "<sqs_queue_name>"))
+
+        template = ST.load_sfn_template(ST.SQS_SEND_MESSAGE_ATTRIBUTES)
+        definition = json.dumps(template)
+
+        message_body = "test_message_body"
+        message_attr_1 = "Hello"
+        message_attr_2 = "World"
+
+        exec_input = json.dumps(
+            {
+                "QueueUrl": queue_url,
+                "Message": message_body,
+                "MessageAttributeValue1": message_attr_1,
+                "MessageAttributeValue2": message_attr_2,
+            }
+        )
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+        receive_message_res = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, MessageAttributeNames=["All"]
+        )
+        assert len(receive_message_res["Messages"]) == 1
+
+        sqs_message = receive_message_res["Messages"][0]
+        assert sqs_message["Body"] == message_body
+
+        sqs_message_attributes = sqs_message["MessageAttributes"]
+        assert len(sqs_message_attributes) == 2
+
+        assert sqs_message_attributes["my_attribute_no_1"]["StringValue"] == message_attr_1
+        assert sqs_message_attributes["my_attribute_no_1"]["DataType"] == "String"
+
+        assert sqs_message_attributes["my_attribute_no_2"]["StringValue"] == message_attr_2
+        assert sqs_message_attributes["my_attribute_no_2"]["DataType"] == "String"

--- a/tests/aws/services/stepfunctions/v2/services/test_sqs_task_service.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_sqs_task_service.snapshot.json
@@ -408,5 +408,224 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_sqs_task_service.py::TestTaskServiceSqs::test_send_message_attributes": {
+    "recorded-date": "22-08-2024, 10:04:56",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_body",
+                "MessageAttributeValue1": "Hello",
+                "MessageAttributeValue2": "World"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:<partition>:iam::111111111111:role/<resource:1>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_body",
+                "MessageAttributeValue1": "Hello",
+                "MessageAttributeValue2": "World"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "SendSQS"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "MessageAttributes": {
+                  "my_attribute_no_1": {
+                    "DataType": "String",
+                    "StringValue": "Hello"
+                  },
+                  "my_attribute_no_2": {
+                    "DataType": "String",
+                    "StringValue": "World"
+                  }
+                },
+                "QueueUrl": "<sqs_queue_url>",
+                "MessageBody": "test_message_body"
+              },
+              "region": "<region>",
+              "resource": "sendMessage",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "sendMessage",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSucceededEventDetails": {
+              "output": {
+                "MD5OfMessageAttributes": "<m-d5-of-message-attributes:1>",
+                "MD5OfMessageBody": "<m-d5-of-message-body:1>",
+                "MessageId": "<uuid:1>",
+                "SdkHttpMetadata": {
+                  "AllHttpHeaders": {
+                    "x-amzn-RequestId": [
+                      "<uuid:2>"
+                    ],
+                    "connection": [
+                      "keep-alive"
+                    ],
+                    "Content-Length": [
+                      "166"
+                    ],
+                    "Date": "date",
+                    "Content-Type": [
+                      "application/x-amz-json-1.0"
+                    ]
+                  },
+                  "HttpHeaders": {
+                    "connection": "keep-alive",
+                    "Content-Length": "166",
+                    "Content-Type": "application/x-amz-json-1.0",
+                    "Date": "date",
+                    "x-amzn-RequestId": "<uuid:2>"
+                  },
+                  "HttpStatusCode": 200
+                },
+                "SdkResponseMetadata": {
+                  "RequestId": "<uuid:2>"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "sendMessage",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "SendSQS",
+              "output": {
+                "MD5OfMessageAttributes": "<m-d5-of-message-attributes:1>",
+                "MD5OfMessageBody": "<m-d5-of-message-body:1>",
+                "MessageId": "<uuid:1>",
+                "SdkHttpMetadata": {
+                  "AllHttpHeaders": {
+                    "x-amzn-RequestId": [
+                      "<uuid:2>"
+                    ],
+                    "connection": [
+                      "keep-alive"
+                    ],
+                    "Content-Length": [
+                      "166"
+                    ],
+                    "Date": "date",
+                    "Content-Type": [
+                      "application/x-amz-json-1.0"
+                    ]
+                  },
+                  "HttpHeaders": {
+                    "connection": "keep-alive",
+                    "Content-Length": "166",
+                    "Content-Type": "application/x-amz-json-1.0",
+                    "Date": "date",
+                    "x-amzn-RequestId": "<uuid:2>"
+                  },
+                  "HttpStatusCode": 200
+                },
+                "SdkResponseMetadata": {
+                  "RequestId": "<uuid:2>"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "MD5OfMessageAttributes": "<m-d5-of-message-attributes:1>",
+                "MD5OfMessageBody": "<m-d5-of-message-body:1>",
+                "MessageId": "<uuid:1>",
+                "SdkHttpMetadata": {
+                  "AllHttpHeaders": {
+                    "x-amzn-RequestId": [
+                      "<uuid:2>"
+                    ],
+                    "connection": [
+                      "keep-alive"
+                    ],
+                    "Content-Length": [
+                      "166"
+                    ],
+                    "Date": "date",
+                    "Content-Type": [
+                      "application/x-amz-json-1.0"
+                    ]
+                  },
+                  "HttpHeaders": {
+                    "connection": "keep-alive",
+                    "Content-Length": "166",
+                    "Content-Type": "application/x-amz-json-1.0",
+                    "Date": "date",
+                    "x-amzn-RequestId": "<uuid:2>"
+                  },
+                  "HttpStatusCode": 200
+                },
+                "SdkResponseMetadata": {
+                  "RequestId": "<uuid:2>"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/services/test_sqs_task_service.validation.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_sqs_task_service.validation.json
@@ -1,6 +1,9 @@
 {
   "tests/aws/services/stepfunctions/v2/services/test_sqs_task_service.py::TestTaskServiceSqs::test_send_message": {
-    "last_validated_date": "2024-04-18T06:37:09+00:00"
+    "last_validated_date": "2024-08-21T15:47:00+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_sqs_task_service.py::TestTaskServiceSqs::test_send_message_attributes": {
+    "last_validated_date": "2024-08-22T10:04:56+00:00"
   },
   "tests/aws/services/stepfunctions/v2/services/test_sqs_task_service.py::TestTaskServiceSqs::test_send_message_unsupported_parameters": {
     "last_validated_date": "2024-04-18T06:37:24+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
- The Step Functions' SQS provider did not fully support the `MessageAttributes` field during a `SendMessage` since the initial implementation used the incorrect field name provided by the AWS docs. 
- This PR fixes the fieldname and adds a parity test to ensure a `MessageAttributes` JSON object and `Md5OfMessageAttributes` hash is correctly returned.
- Raised by https://github.com/localstack/localstack/issues/11109

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Renames `"MessageAttribute" => "MessageAttributes"`
- Normalises field `"MD5OfMessageAttributes" => "Md5OfMessageAttributes"` to ensure PascalCase for SFN output
- Add new stepfunction template for SQS message with attributes

## Testing
- New parity test `test_send_message_attributes`
- Manually validated the original issue input now passes following these changes https://github.com/localstack/localstack/issues/11109

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
