### PR TITLE
CFn: show CDK stack events

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -1240,7 +1240,7 @@ class TemplateDeployerBase(ABC):
             action, logical_resource_id=resource_id
         )
 
-        resource_provider = executor.load_resource_provider(resource["Type"])
+        resource_provider = executor.try_load_resource_provider(resource["Type"])
         if resource_provider is not None:
             resource_status = f"{get_action_name_for_resource_change(action)}_IN_PROGRESS"
             physical_resource_id = None
@@ -1405,7 +1405,7 @@ class TemplateDeployerV2(TemplateDeployerBase):
                     len(resources),
                     resource["ResourceType"],
                 )
-                resource_provider = executor.load_resource_provider(resource["Type"])
+                resource_provider = executor.try_load_resource_provider(resource["Type"])
                 if resource_provider is not None:
                     event = executor.deploy_loop(
                         resource_provider, resource, resource_provider_payload
@@ -1580,7 +1580,7 @@ class TemplateDeployerLegacy(TemplateDeployerBase):
                             resource["ResourceType"],
                             iteration_cycle,
                         )
-                        resource_provider = executor.load_resource_provider(resource["Type"])
+                        resource_provider = executor.try_load_resource_provider(resource["Type"])
                         if resource_provider is not None:
                             event = executor.deploy_loop(
                                 resource_provider, resource, resource_provider_payload

--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -1381,7 +1381,8 @@ class TemplateDeployerV2(TemplateDeployerBase):
                     len(resources),
                     resource["ResourceType"],
                 )
-                event = executor.deploy_loop(resource, resource_provider_payload)
+                resource_provider = executor.load_resource_provider(resource["Type"])
+                event = executor.deploy_loop(resource_provider, resource, resource_provider_payload)
                 match event.status:
                     case OperationStatus.SUCCESS:
                         self.stack.set_resource_status(resource_id, "DELETE_COMPLETE")
@@ -1550,7 +1551,10 @@ class TemplateDeployerLegacy(TemplateDeployerBase):
                             resource["ResourceType"],
                             iteration_cycle,
                         )
-                        event = executor.deploy_loop(resource, resource_provider_payload)
+                        resource_provider = executor.load_resource_provider(resource["Type"])
+                        event = executor.deploy_loop(
+                            resource_provider, resource, resource_provider_payload
+                        )
                         match event.status:
                             case OperationStatus.SUCCESS:
                                 self.stack.set_resource_status(resource_id, "DELETE_COMPLETE")

--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -1242,6 +1242,7 @@ class TemplateDeployerBase(ABC):
 
         resource_provider = executor.try_load_resource_provider(resource["Type"])
         if resource_provider is not None:
+            # add in-progress event
             resource_status = f"{get_action_name_for_resource_change(action)}_IN_PROGRESS"
             physical_resource_id = None
             if action in ("Modify", "Remove"):
@@ -1259,6 +1260,8 @@ class TemplateDeployerBase(ABC):
                 physical_res_id=physical_resource_id,
                 status=resource_status,
             )
+
+            # perform the deploy
             progress_event = executor.deploy_loop(
                 resource_provider, resource, resource_provider_payload
             )

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -203,6 +203,8 @@ class ResourceProvider(Generic[Properties]):
     This provides a base class onto which service-specific resource providers are built.
     """
 
+    SCHEMA: dict
+
     def create(self, request: ResourceRequest[Properties]) -> ProgressEvent[Properties]:
         raise NotImplementedError
 

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -424,6 +424,7 @@ class ResourceProviderExecutor:
 
     def deploy_loop(
         self,
+        resource_provider: ResourceProvider,
         resource: dict,
         raw_payload: ResourceProviderPayload,
         max_timeout: int = config.CFN_PER_RESOURCE_TIMEOUT,
@@ -438,8 +439,6 @@ class ResourceProviderExecutor:
                 {"Type": raw_payload["resourceType"]}
             )  # TODO: simplify signature of get_resource_type to just take the type
             try:
-                resource_provider = self.load_resource_provider(resource_type)
-
                 resource["SpecifiedProperties"] = raw_payload["requestData"]["resourceProperties"]
 
                 try:

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -555,7 +555,8 @@ class ResourceProviderExecutor:
             case _:
                 raise NotImplementedError(change_type)  # TODO: change error type
 
-    def load_resource_provider(self, resource_type: str) -> ResourceProvider | None:
+    @staticmethod
+    def load_resource_provider(resource_type: str) -> ResourceProvider | None:
         # TODO: unify namespace of plugins
 
         # 1. try to load pro resource provider

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -556,7 +556,7 @@ class ResourceProviderExecutor:
                 raise NotImplementedError(change_type)  # TODO: change error type
 
     @staticmethod
-    def load_resource_provider(resource_type: str) -> ResourceProvider | None:
+    def try_load_resource_provider(resource_type: str) -> ResourceProvider | None:
         # TODO: unify namespace of plugins
 
         # 1. try to load pro resource provider


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

CDK shows a nice progress indicator when deploying a stack, however our implementation does not do this. This is because we don't emit `*_IN_PROGRESS` events.

![image](https://github.com/user-attachments/assets/7f527012-c80f-4a4d-b062-52a760b5f3e1)


https://github.com/user-attachments/assets/beccc4ae-7a7f-4569-80af-7ae0a8814edc




<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Emit `*_IN_PROGRESS` events on resource operations
- Move the instanciation of the resource provider to outside the `ResourceProviderExecutor` 
  - this was needed because on update we need to provider the physical resource id of the resource, and our handy `extract_physical_resource_id_from_model_with_schema` function requires the schema

## Final result

_Running a CDK deploy with SQS queue and SSM parameter with artificial sleep for the SQS queue shows the in-progress event_


https://github.com/user-attachments/assets/13b9d3db-929d-4a5e-9f5b-c274b0477560



<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
