### PR TITLE
Feature/Eventbridge v2: Support extending available targets

### DIFF
--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -376,9 +376,9 @@ class BatchTargetSender(TargetSender):
         pass
 
 
-class ContainerTargetSender(TargetSender):
+class ECSTargetSender(TargetSender):
     def send_event(self, event):
-        raise NotImplementedError("ECS target is not yet implemented")
+        raise NotImplementedError("ECS target is a pro feature, please use LocalStack Pro")
 
     def _validate_input(self, target: Target):
         super()._validate_input(target)
@@ -572,7 +572,7 @@ class TargetSenderFactory:
         "apigateway": ApiGatewayTargetSender,
         "appsync": AppSyncTargetSender,
         "batch": BatchTargetSender,
-        "ecs": ContainerTargetSender,
+        "ecs": ECSTargetSender,
         "events": EventsTargetSender,
         "firehose": FirehoseTargetSender,
         "kinesis": KinesisTargetSender,

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -4,7 +4,7 @@ import logging
 import re
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Set
+from typing import Any, Dict, Set, Type
 from urllib.parse import urlencode
 
 import requests
@@ -596,6 +596,10 @@ class TargetSenderFactory:
         self.rule_name = rule_name
         self.region = region
         self.account_id = account_id
+
+    @classmethod
+    def register_target_sender(cls, service_name: str, sender_class: Type[TargetSender]):
+        cls.target_map[service_name] = sender_class
 
     def get_target_sender(self) -> TargetSender:
         service = extract_service_from_arn(self.target["Arn"])

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -1808,40 +1808,6 @@ def firehose_create_delivery_stream(wait_for_delivery_stream_ready, aws_client):
 
 
 @pytest.fixture
-def events_create_rule(aws_client):
-    rules = []
-
-    def _create_rule(**kwargs):
-        rule_name = kwargs["Name"]
-        bus_name = kwargs.get("EventBusName", "")
-        pattern = kwargs.get("EventPattern", {})
-        schedule = kwargs.get("ScheduleExpression", "")
-        rule_arn = aws_client.events.put_rule(
-            Name=rule_name,
-            EventBusName=bus_name,
-            EventPattern=json.dumps(pattern),
-            ScheduleExpression=schedule,
-        )["RuleArn"]
-        rules.append({"name": rule_name, "bus": bus_name})
-        return rule_arn
-
-    yield _create_rule
-
-    for rule in rules:
-        targets = aws_client.events.list_targets_by_rule(
-            Rule=rule["name"], EventBusName=rule["bus"]
-        )["Targets"]
-
-        targetIds = [target["Id"] for target in targets]
-        if len(targetIds) > 0:
-            aws_client.events.remove_targets(
-                Rule=rule["name"], EventBusName=rule["bus"], Ids=targetIds
-            )
-
-        aws_client.events.delete_rule(Name=rule["name"], EventBusName=rule["bus"])
-
-
-@pytest.fixture
 def ses_configuration_set(aws_client):
     configuration_set_names = []
 
@@ -2313,48 +2279,6 @@ def hosted_zone(aws_client):
 
 
 @pytest.fixture
-def clean_up(
-    aws_client,
-):  # TODO: legacy clean up fixtures for eventbridge - remove and use individual fixtures for creating resources instead
-    def _clean_up(
-        bus_name=None,
-        rule_name=None,
-        target_ids=None,
-        queue_url=None,
-        log_group_name=None,
-    ):
-        events_client = aws_client.events
-        kwargs = {"EventBusName": bus_name} if bus_name else {}
-        if target_ids:
-            target_ids = target_ids if isinstance(target_ids, list) else [target_ids]
-            call_safe(
-                events_client.remove_targets,
-                kwargs=dict(Rule=rule_name, Ids=target_ids, Force=True, **kwargs),
-            )
-        if rule_name:
-            call_safe(events_client.delete_rule, kwargs=dict(Name=rule_name, Force=True, **kwargs))
-        if bus_name:
-            call_safe(events_client.delete_event_bus, kwargs=dict(Name=bus_name))
-        if queue_url:
-            sqs_client = aws_client.sqs
-            call_safe(sqs_client.delete_queue, kwargs=dict(QueueUrl=queue_url))
-        if log_group_name:
-            logs_client = aws_client.logs
-
-            def _delete_log_group():
-                log_streams = logs_client.describe_log_streams(logGroupName=log_group_name)
-                for log_stream in log_streams["logStreams"]:
-                    logs_client.delete_log_stream(
-                        logGroupName=log_group_name, logStreamName=log_stream["logStreamName"]
-                    )
-                logs_client.delete_log_group(logGroupName=log_group_name)
-
-            call_safe(_delete_log_group)
-
-    yield _clean_up
-
-
-@pytest.fixture
 def openapi_validate(monkeypatch):
     monkeypatch.setattr(config, "OPENAPI_VALIDATE_RESPONSE", "true")
     monkeypatch.setattr(config, "OPENAPI_VALIDATE_REQUEST", "true")
@@ -2417,7 +2341,7 @@ def events_create_event_bus(aws_client, region_name, account_id):
 
                     aws_client.events.delete_rule(Name=rule, EventBusName=event_bus_name)
                 except Exception as e:
-                    LOG.warning(f"Failed to delete rule {rule}: {e}")
+                    LOG.warning("Failed to delete rule %s: %s", rule, e)
 
             # Delete archives for event bus
             event_source_arn = (
@@ -2429,11 +2353,11 @@ def events_create_event_bus(aws_client, region_name, account_id):
                 try:
                     aws_client.events.delete_archive(ArchiveName=archive)
                 except Exception as e:
-                    LOG.warning(f"Failed to delete archive {archive}: {e}")
+                    LOG.warning("Failed to delete archive %s: %s", archive, e)
 
             aws_client.events.delete_event_bus(Name=event_bus_name)
         except Exception as e:
-            LOG.warning(f"Failed to delete event bus {event_bus_name}: {e}")
+            LOG.warning("Failed to delete event bus %s: %s", event_bus_name, e)
 
 
 @pytest.fixture
@@ -2466,7 +2390,41 @@ def events_put_rule(aws_client):
 
             aws_client.events.delete_rule(Name=rule, EventBusName=event_bus_name)
         except Exception as e:
-            LOG.warning(f"Failed to delete rule {rule}: {e}")
+            LOG.warning("Failed to delete rule %s: %s", rule, e)
+
+
+@pytest.fixture
+def events_create_rule(aws_client):
+    rules = []
+
+    def _create_rule(**kwargs):
+        rule_name = kwargs["Name"]
+        bus_name = kwargs.get("EventBusName", "")
+        pattern = kwargs.get("EventPattern", {})
+        schedule = kwargs.get("ScheduleExpression", "")
+        rule_arn = aws_client.events.put_rule(
+            Name=rule_name,
+            EventBusName=bus_name,
+            EventPattern=json.dumps(pattern),
+            ScheduleExpression=schedule,
+        )["RuleArn"]
+        rules.append({"name": rule_name, "bus": bus_name})
+        return rule_arn
+
+    yield _create_rule
+
+    for rule in rules:
+        targets = aws_client.events.list_targets_by_rule(
+            Rule=rule["name"], EventBusName=rule["bus"]
+        )["Targets"]
+
+        targetIds = [target["Id"] for target in targets]
+        if len(targetIds) > 0:
+            aws_client.events.remove_targets(
+                Rule=rule["name"], EventBusName=rule["bus"], Ids=targetIds
+            )
+
+        aws_client.events.delete_rule(Name=rule["name"], EventBusName=rule["bus"])
 
 
 @pytest.fixture
@@ -2505,3 +2463,45 @@ def sqs_as_events_target(aws_client, sqs_get_queue_arn):
             aws_client.sqs.delete_queue(QueueUrl=queue_url)
         except Exception as e:
             LOG.debug("error cleaning up queue %s: %s", queue_url, e)
+
+
+@pytest.fixture
+def clean_up(
+    aws_client,
+):  # TODO: legacy clean up fixtures for eventbridge - remove and use individual fixtures for creating resources instead
+    def _clean_up(
+        bus_name=None,
+        rule_name=None,
+        target_ids=None,
+        queue_url=None,
+        log_group_name=None,
+    ):
+        events_client = aws_client.events
+        kwargs = {"EventBusName": bus_name} if bus_name else {}
+        if target_ids:
+            target_ids = target_ids if isinstance(target_ids, list) else [target_ids]
+            call_safe(
+                events_client.remove_targets,
+                kwargs=dict(Rule=rule_name, Ids=target_ids, Force=True, **kwargs),
+            )
+        if rule_name:
+            call_safe(events_client.delete_rule, kwargs=dict(Name=rule_name, Force=True, **kwargs))
+        if bus_name:
+            call_safe(events_client.delete_event_bus, kwargs=dict(Name=bus_name))
+        if queue_url:
+            sqs_client = aws_client.sqs
+            call_safe(sqs_client.delete_queue, kwargs=dict(QueueUrl=queue_url))
+        if log_group_name:
+            logs_client = aws_client.logs
+
+            def _delete_log_group():
+                log_streams = logs_client.describe_log_streams(logGroupName=log_group_name)
+                for log_stream in log_streams["logStreams"]:
+                    logs_client.delete_log_stream(
+                        logGroupName=log_group_name, logStreamName=log_stream["logStreamName"]
+                    )
+                logs_client.delete_log_group(logGroupName=log_group_name)
+
+            call_safe(_delete_log_group)
+
+    yield _clean_up

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -1386,7 +1386,8 @@ def create_echo_http_server(aws_client, create_lambda_function):
     from localstack.aws.api.lambda_ import Runtime
 
     lambda_client = aws_client.lambda_
-    handler_code = textwrap.dedent("""
+    handler_code = textwrap.dedent(
+        """
     import json
     import os
 
@@ -1419,7 +1420,8 @@ def create_echo_http_server(aws_client, create_lambda_function):
             "origin": event["requestContext"]["http"].get("sourceIp", ""),
             "path": event["requestContext"]["http"].get("path", ""),
         }
-        return make_response(response)""")
+        return make_response(response)"""
+    )
 
     def _create_echo_http_server(trim_x_headers: bool = False) -> str:
         """Creates a server that will echo any request. Any request will be returned with the
@@ -2372,3 +2374,134 @@ def set_resource_custom_id():
 
     for resource_identifier in set_ids:
         localstack_id_manager.unset_custom_id(resource_identifier)
+
+
+###############################
+# Events (EventBridge) fixtures
+###############################
+
+
+@pytest.fixture
+def events_create_event_bus(aws_client, region_name, account_id):
+    event_bus_names = []
+
+    def _create_event_bus(**kwargs):
+        if "Name" not in kwargs:
+            kwargs["Name"] = f"test-event-bus-{short_uid()}"
+
+        response = aws_client.events.create_event_bus(**kwargs)
+        event_bus_names.append(kwargs["Name"])
+        return response
+
+    yield _create_event_bus
+
+    for event_bus_name in event_bus_names:
+        try:
+            response = aws_client.events.list_rules(EventBusName=event_bus_name)
+            rules = [rule["Name"] for rule in response["Rules"]]
+
+            # Delete all rules for the current event bus
+            for rule in rules:
+                try:
+                    response = aws_client.events.list_targets_by_rule(
+                        Rule=rule, EventBusName=event_bus_name
+                    )
+                    targets = [target["Id"] for target in response["Targets"]]
+
+                    # Remove all targets for the current rule
+                    if targets:
+                        for target in targets:
+                            aws_client.events.remove_targets(
+                                Rule=rule, EventBusName=event_bus_name, Ids=[target]
+                            )
+
+                    aws_client.events.delete_rule(Name=rule, EventBusName=event_bus_name)
+                except Exception as e:
+                    LOG.warning(f"Failed to delete rule {rule}: {e}")
+
+            # Delete archives for event bus
+            event_source_arn = (
+                f"arn:aws:events:{region_name}:{account_id}:event-bus/{event_bus_name}"
+            )
+            response = aws_client.events.list_archives(EventSourceArn=event_source_arn)
+            archives = [archive["ArchiveName"] for archive in response["Archives"]]
+            for archive in archives:
+                try:
+                    aws_client.events.delete_archive(ArchiveName=archive)
+                except Exception as e:
+                    LOG.warning(f"Failed to delete archive {archive}: {e}")
+
+            aws_client.events.delete_event_bus(Name=event_bus_name)
+        except Exception as e:
+            LOG.warning(f"Failed to delete event bus {event_bus_name}: {e}")
+
+
+@pytest.fixture
+def events_put_rule(aws_client):
+    rules = []
+
+    def _put_rule(**kwargs):
+        if "Name" not in kwargs:
+            kwargs["Name"] = f"rule-{short_uid()}"
+
+        response = aws_client.events.put_rule(**kwargs)
+        rules.append((kwargs["Name"], kwargs.get("EventBusName", "default")))
+        return response
+
+    yield _put_rule
+
+    for rule, event_bus_name in rules:
+        try:
+            response = aws_client.events.list_targets_by_rule(
+                Rule=rule, EventBusName=event_bus_name
+            )
+            targets = [target["Id"] for target in response["Targets"]]
+
+            # Remove all targets for the current rule
+            if targets:
+                for target in targets:
+                    aws_client.events.remove_targets(
+                        Rule=rule, EventBusName=event_bus_name, Ids=[target]
+                    )
+
+            aws_client.events.delete_rule(Name=rule, EventBusName=event_bus_name)
+        except Exception as e:
+            LOG.warning(f"Failed to delete rule {rule}: {e}")
+
+
+@pytest.fixture
+def sqs_as_events_target(aws_client, sqs_get_queue_arn):
+    queue_urls = []
+
+    def _sqs_as_events_target(queue_name: str | None = None) -> tuple[str, str]:
+        if not queue_name:
+            queue_name = f"tests-queue-{short_uid()}"
+        sqs_client = aws_client.sqs
+        queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
+        queue_urls.append(queue_url)
+        queue_arn = sqs_get_queue_arn(queue_url)
+        policy = {
+            "Version": "2012-10-17",
+            "Id": f"sqs-eventbridge-{short_uid()}",
+            "Statement": [
+                {
+                    "Sid": f"SendMessage-{short_uid()}",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "events.amazonaws.com"},
+                    "Action": "sqs:SendMessage",
+                    "Resource": queue_arn,
+                }
+            ],
+        }
+        sqs_client.set_queue_attributes(
+            QueueUrl=queue_url, Attributes={"Policy": json.dumps(policy)}
+        )
+        return queue_url, queue_arn
+
+    yield _sqs_as_events_target
+
+    for queue_url in queue_urls:
+        try:
+            aws_client.sqs.delete_queue(QueueUrl=queue_url)
+        except Exception as e:
+            LOG.debug("error cleaning up queue %s: %s", queue_url, e)

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -11,74 +11,6 @@ from tests.aws.services.events.helper_functions import put_entries_assert_result
 
 LOG = logging.getLogger(__name__)
 
-
-@pytest.fixture
-def events_create_event_bus(aws_client, region_name, account_id):
-    event_bus_names = []
-
-    def _create_event_bus(**kwargs):
-        if "Name" not in kwargs:
-            kwargs["Name"] = f"test-event-bus-{short_uid()}"
-
-        response = aws_client.events.create_event_bus(**kwargs)
-        event_bus_names.append(kwargs["Name"])
-        return response
-
-    yield _create_event_bus
-
-    for event_bus_name in event_bus_names:
-        try:
-            response = aws_client.events.list_rules(EventBusName=event_bus_name)
-            rules = [rule["Name"] for rule in response["Rules"]]
-
-            # Delete all rules for the current event bus
-            for rule in rules:
-                try:
-                    response = aws_client.events.list_targets_by_rule(
-                        Rule=rule, EventBusName=event_bus_name
-                    )
-                    targets = [target["Id"] for target in response["Targets"]]
-
-                    # Remove all targets for the current rule
-                    if targets:
-                        for target in targets:
-                            aws_client.events.remove_targets(
-                                Rule=rule, EventBusName=event_bus_name, Ids=[target]
-                            )
-
-                    aws_client.events.delete_rule(Name=rule, EventBusName=event_bus_name)
-                except Exception as e:
-                    LOG.warning(
-                        "Failed to delete rule %s: %s",
-                        rule,
-                        e,
-                    )
-
-            # Delete archives for event bus
-            event_source_arn = (
-                f"arn:aws:events:{region_name}:{account_id}:event-bus/{event_bus_name}"
-            )
-            response = aws_client.events.list_archives(EventSourceArn=event_source_arn)
-            archives = [archive["ArchiveName"] for archive in response["Archives"]]
-            for archive in archives:
-                try:
-                    aws_client.events.delete_archive(ArchiveName=archive)
-                except Exception as e:
-                    LOG.warning(
-                        "Failed to delete archive %s: %s",
-                        archive,
-                        e,
-                    )
-
-            aws_client.events.delete_event_bus(Name=event_bus_name)
-        except Exception as e:
-            LOG.warning(
-                "Failed to delete event bus %s: %s",
-                event_bus_name,
-                e,
-            )
-
-
 # some fixtures are shared in localstack/testing/pytest/fixtures.py
 
 
@@ -131,43 +63,6 @@ def create_role_event_bus_source_to_bus_target(create_iam_role_with_policy):
         return role_arn_bus_source_to_bus_target
 
     yield _create_role_event_bus_to_bus
-
-
-@pytest.fixture
-def events_put_rule(aws_client):
-    rules = []
-
-    def _put_rule(**kwargs):
-        if "Name" not in kwargs:
-            kwargs["Name"] = f"rule-{short_uid()}"
-
-        response = aws_client.events.put_rule(**kwargs)
-        rules.append((kwargs["Name"], kwargs.get("EventBusName", "default")))
-        return response
-
-    yield _put_rule
-
-    for rule, event_bus_name in rules:
-        try:
-            response = aws_client.events.list_targets_by_rule(
-                Rule=rule, EventBusName=event_bus_name
-            )
-            targets = [target["Id"] for target in response["Targets"]]
-
-            # Remove all targets for the current rule
-            if targets:
-                for target in targets:
-                    aws_client.events.remove_targets(
-                        Rule=rule, EventBusName=event_bus_name, Ids=[target]
-                    )
-
-            aws_client.events.delete_rule(Name=rule, EventBusName=event_bus_name)
-        except Exception as e:
-            LOG.warning(
-                "Failed to delete rule %s: %s",
-                rule,
-                e,
-            )
 
 
 @pytest.fixture

--- a/tests/aws/services/events/test_archive_and_replay.py
+++ b/tests/aws/services/events/test_archive_and_replay.py
@@ -374,7 +374,7 @@ class TestReplay:
         event_bus_type,
         events_create_default_or_custom_event_bus,
         events_put_rule,
-        create_sqs_events_target,
+        sqs_as_events_target,
         put_event_to_archive,
         aws_client,
         snapshot,
@@ -395,7 +395,7 @@ class TestReplay:
         rule_arn = response["RuleArn"]
 
         # setup sqs target
-        queue_url, queue_arn = create_sqs_events_target()
+        queue_url, queue_arn = sqs_as_events_target()
         target_id = f"target-{short_uid()}"
         aws_client.events.put_targets(
             Rule=rule_name,

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -1026,7 +1026,7 @@ class TestEventBus:
         self,
         strategy,
         monkeypatch,
-        create_sqs_events_target,
+        sqs_as_events_target,
         events_create_event_bus,
         events_put_rule,
         aws_client,
@@ -1102,7 +1102,7 @@ class TestEventBus:
         )
 
         # Create sqs target
-        queue_url, queue_arn = create_sqs_events_target()
+        queue_url, queue_arn = sqs_as_events_target()
 
         # Rule and target bus 2 to sqs
         rule_name_bus_two = f"rule-{short_uid()}"

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -440,12 +440,12 @@ class TestEvents:
 
     @markers.aws.validated
     def test_put_events_response_entries_order(
-        self, events_put_rule, create_sqs_events_target, aws_client, snapshot, clean_up
+        self, events_put_rule, sqs_as_events_target, aws_client, snapshot, clean_up
     ):
         """Test that put_events response contains each EventId only once, even with multiple targets."""
 
-        queue_url_1, queue_arn_1 = create_sqs_events_target()
-        queue_url_2, queue_arn_2 = create_sqs_events_target()
+        queue_url_1, queue_arn_1 = sqs_as_events_target()
+        queue_url_2, queue_arn_2 = sqs_as_events_target()
 
         rule_name = f"test-rule-{short_uid()}"
 
@@ -601,11 +601,11 @@ class TestEvents:
     @markers.aws.validated
     @pytest.mark.skipif(is_old_provider(), reason="Test specific for v2 provider")
     def test_put_events_with_time_field(
-        self, events_put_rule, create_sqs_events_target, aws_client, snapshot
+        self, events_put_rule, sqs_as_events_target, aws_client, snapshot
     ):
         """Test that EventBridge correctly handles datetime serialization in events."""
         rule_name = f"test-rule-{short_uid()}"
-        queue_url, queue_arn = create_sqs_events_target()
+        queue_url, queue_arn = sqs_as_events_target()
 
         snapshot.add_transformers_list(
             [

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -29,9 +29,9 @@ INPUT_TEMPLATE_PREDEFINED_VARIABLES_JSON = '{"originalEvent": <aws.events.event>
     reason="V1 provider does not support this feature",
 )
 def test_put_event_input_path_and_input_transformer(
-    create_sqs_events_target, events_create_event_bus, events_put_rule, aws_client, snapshot
+    sqs_as_events_target, events_create_event_bus, events_put_rule, aws_client, snapshot
 ):
-    _, queue_arn = create_sqs_events_target()
+    _, queue_arn = sqs_as_events_target()
     bus_name = f"test-bus-{short_uid()}"
     events_create_event_bus(Name=bus_name)
 
@@ -153,14 +153,14 @@ class TestInputPath:
     def test_put_events_with_input_path_multiple_targets(
         self,
         aws_client,
-        create_sqs_events_target,
+        sqs_as_events_target,
         events_create_event_bus,
         events_put_rule,
         snapshot,
     ):
         # prepare target queues
-        queue_url_1, queue_arn_1 = create_sqs_events_target()
-        queue_url_2, queue_arn_2 = create_sqs_events_target()
+        queue_url_1, queue_arn_1 = sqs_as_events_target()
+        queue_url_2, queue_arn_2 = sqs_as_events_target()
 
         bus_name = f"test-bus-{short_uid()}"
         events_create_event_bus(Name=bus_name)
@@ -344,13 +344,13 @@ class TestInputTransformer:
     )
     def test_put_events_with_input_transformer_missing_keys(
         self,
-        create_sqs_events_target,
+        sqs_as_events_target,
         events_create_event_bus,
         events_put_rule,
         aws_client_factory,
         snapshot,
     ):
-        _, queue_arn = create_sqs_events_target()
+        _, queue_arn = sqs_as_events_target()
 
         bus_name = f"test-bus-{short_uid()}"
         events_create_event_bus(Name=bus_name)
@@ -400,7 +400,7 @@ class TestInputTransformer:
     def test_input_transformer_predefined_variables(
         self,
         input_template,
-        create_sqs_events_target,
+        sqs_as_events_target,
         events_create_event_bus,
         events_put_rule,
         aws_client,
@@ -409,7 +409,7 @@ class TestInputTransformer:
         # https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-transform-target-input.html#eb-transform-input-predefined
 
         # prepare target queues
-        queue_url, queue_arn = create_sqs_events_target()
+        queue_url, queue_arn = sqs_as_events_target()
 
         bus_name = f"test-bus-{short_uid()}"
         events_create_event_bus(Name=bus_name)

--- a/tests/aws/services/events/test_events_patterns.py
+++ b/tests/aws/services/events/test_events_patterns.py
@@ -367,13 +367,13 @@ class TestRuleWithPattern:
     @markers.aws.validated
     def test_put_event_with_content_base_rule_in_pattern(
         self,
-        create_sqs_events_target,
+        sqs_as_events_target,
         events_create_event_bus,
         events_put_rule,
         snapshot,
         aws_client,
     ):
-        queue_url, queue_arn = create_sqs_events_target()
+        queue_url, queue_arn = sqs_as_events_target()
 
         # Create event bus
         event_bus_name = f"event-bus-{short_uid()}"

--- a/tests/aws/services/events/test_events_schedule.py
+++ b/tests/aws/services/events/test_events_schedule.py
@@ -83,13 +83,13 @@ class TestScheduleRate:
     @markers.aws.validated
     def tests_schedule_rate_target_sqs(
         self,
-        create_sqs_events_target,
+        sqs_as_events_target,
         events_put_rule,
         aws_client,
         snapshot,
     ):
         queue_name = f"test-queue-{short_uid()}"
-        queue_url, queue_arn = create_sqs_events_target(queue_name)
+        queue_url, queue_arn = sqs_as_events_target(queue_name)
 
         bus_name = "default"
         rule_name = f"test-rule-{short_uid()}"
@@ -143,9 +143,9 @@ class TestScheduleRate:
 
     @markers.aws.validated
     def tests_schedule_rate_custom_input_target_sqs(
-        self, create_sqs_events_target, events_put_rule, aws_client, snapshot
+        self, sqs_as_events_target, events_put_rule, aws_client, snapshot
     ):
-        queue_url, queue_arn = create_sqs_events_target()
+        queue_url, queue_arn = sqs_as_events_target()
 
         bus_name = "default"
         rule_name = f"test-rule-{short_uid()}"
@@ -306,12 +306,12 @@ class TestScheduleCron:
     @pytest.mark.skip("Flaky, target time can be 1min off message time")
     def test_schedule_cron_target_sqs(
         self,
-        create_sqs_events_target,
+        sqs_as_events_target,
         events_put_rule,
         aws_client,
         snapshot,
     ):
-        queue_url, queue_arn = create_sqs_events_target()
+        queue_url, queue_arn = sqs_as_events_target()
 
         schedule_cron, target_datetime = get_cron_expression(
             1

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -403,7 +403,7 @@ class TestEventsTargetEvents:
         account_id,
         events_put_rule,
         create_role_event_bus_source_to_bus_target,
-        create_sqs_events_target,
+        sqs_as_events_target,
         aws_client,
         snapshot,
     ):
@@ -467,7 +467,7 @@ class TestEventsTargetEvents:
             EventPattern=json.dumps(TEST_EVENT_PATTERN),
         )
 
-        queue_url, queue_arn = create_sqs_events_target()
+        queue_url, queue_arn = sqs_as_events_target()
         target_id = f"target-{short_uid()}"
         aws_client.events.put_targets(
             Rule=rule_name_target_to_sqs,

--- a/tests/aws/services/ssm/test_ssm.py
+++ b/tests/aws/services/ssm/test_ssm.py
@@ -169,7 +169,7 @@ class TestSSM:
 
     @markers.aws.needs_fixing
     # TODO: remove parameters, set correct parameter prefix name, use events_create_event_bus and events_put_rule fixture,
-    # remove clean_up, use create_sqs_events_target fixture, use snapshot
+    # remove clean_up, use sqs_as_events_target fixture, use snapshot
     @pytest.mark.parametrize("strategy", ["standard", "domain", "path"])
     def test_trigger_event_on_systems_manager_change(
         self, monkeypatch, aws_client, clean_up, strategy


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds the ability to extend the TargetSenderFactory by targets defined in localstack-pro.
Furthermore, it makes testing fixtures available to localstack-pro

## Testing
Since ECS is a pro feature, the aws validated test can be found in the companion branch.
