### PR TITLE
cloudwatch: check amount of datapoints, refactor database-locks

### DIFF
--- a/localstack-core/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack-core/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -44,10 +44,9 @@ class CloudwatchDatabase:
             return
 
         mkdir(self.CLOUDWATCH_DATA_ROOT)
-        with self.DATABASE_LOCK:
-            with sqlite3.connect(self.METRICS_DB) as conn:
-                cur = conn.cursor()
-                common_columns = """
+        with self.DATABASE_LOCK, sqlite3.connect(self.METRICS_DB) as conn:
+            cur = conn.cursor()
+            common_columns = """
                     "id"	                INTEGER,
                     "account_id"	        TEXT,
                     "region"	            TEXT,
@@ -58,18 +57,18 @@ class CloudwatchDatabase:
                     "unit"	                TEXT,
                     "storage_resolution"	INTEGER
                 """
-                cur.execute(
-                    f"""
+            cur.execute(
+                f"""
                 CREATE TABLE "{self.TABLE_SINGLE_METRICS}" (
                     {common_columns},
                     "value"	                NUMERIC,
                     PRIMARY KEY("id")
                 );
                 """
-                )
+            )
 
-                cur.execute(
-                    f"""
+            cur.execute(
+                f"""
                 CREATE TABLE "{self.TABLE_AGGREGATED_METRICS}" (
                     {common_columns},
                     "sample_count"          NUMERIC,
@@ -79,15 +78,15 @@ class CloudwatchDatabase:
                     PRIMARY KEY("id")
                 );
                 """
-                )
-                # create indexes
-                cur.executescript(
-                    """
+            )
+            # create indexes
+            cur.executescript(
+                """
                 CREATE INDEX idx_single_metrics_comp ON SINGLE_METRICS (metric_name, namespace);
                 CREATE INDEX idx_aggregated_metrics_comp ON AGGREGATED_METRICS (metric_name, namespace);
                 """
-                )
-                conn.commit()
+            )
+            conn.commit()
 
     def add_metric_data(
         self, account_id: str, region: str, namespace: str, metric_data: MetricData
@@ -112,15 +111,38 @@ class CloudwatchDatabase:
                     {"Value": value, "TimesToInsert": int(counts[indexValue])}
                     for indexValue, value in enumerate(metric.get("Values"))
                 ]
-            with self.DATABASE_LOCK:
-                with sqlite3.connect(self.METRICS_DB) as conn:
+            all_data = []
+            for insert in inserts:
+                times_to_insert = insert.get("TimesToInsert")
+
+                data = (
+                    account_id,
+                    region,
+                    metric.get("MetricName"),
+                    namespace,
+                    unix_timestamp,
+                    self._get_ordered_dimensions_with_separator(metric.get("Dimensions")),
+                    metric.get("Unit"),
+                    metric.get("StorageResolution"),
+                    insert.get("Value"),
+                )
+                all_data.extend([data] * times_to_insert)
+
+            if all_data:
+                with self.DATABASE_LOCK, sqlite3.connect(self.METRICS_DB) as conn:
                     cur = conn.cursor()
-                    for insert in inserts:
-                        times_to_insert = insert.get("TimesToInsert")
-                        prepared_placeholder = ",".join(
-                            ["(?, ?, ?, ?, ?, ?, ?, ?, ?)" for _ in range(times_to_insert)]
-                        )
-                        data = (
+                    query = f"INSERT INTO {self.TABLE_SINGLE_METRICS} (account_id, region, metric_name, namespace, timestamp, dimensions, unit, storage_resolution, value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                    cur.executemany(query, all_data)
+                    conn.commit()
+
+            if statistic_values := metric.get("StatisticValues"):
+                with self.DATABASE_LOCK, sqlite3.connect(self.METRICS_DB) as conn:
+                    cur = conn.cursor()
+                    cur.execute(
+                        f"""INSERT INTO {self.TABLE_AGGREGATED_METRICS}
+                    ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "sample_count", "sum", "min", "max")
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                        (
                             account_id,
                             region,
                             metric.get("MetricName"),
@@ -129,38 +151,12 @@ class CloudwatchDatabase:
                             self._get_ordered_dimensions_with_separator(metric.get("Dimensions")),
                             metric.get("Unit"),
                             metric.get("StorageResolution"),
-                            insert.get("Value"),
-                        ) * times_to_insert
-
-                        cur.execute(
-                            f"""INSERT INTO {self.TABLE_SINGLE_METRICS}
-                    ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "value")
-                    VALUES {prepared_placeholder}""",
-                            data,
-                        )
-
-                    if statistic_values := metric.get("StatisticValues"):
-                        cur.execute(
-                            f"""INSERT INTO {self.TABLE_AGGREGATED_METRICS}
-                        ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "sample_count", "sum", "min", "max")
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                            (
-                                account_id,
-                                region,
-                                metric.get("MetricName"),
-                                namespace,
-                                unix_timestamp,
-                                self._get_ordered_dimensions_with_separator(
-                                    metric.get("Dimensions")
-                                ),
-                                metric.get("Unit"),
-                                metric.get("StorageResolution"),
-                                statistic_values.get("SampleCount"),
-                                statistic_values.get("Sum"),
-                                statistic_values.get("Minimum"),
-                                statistic_values.get("Maximum"),
-                            ),
-                        )
+                            statistic_values.get("SampleCount"),
+                            statistic_values.get("Sum"),
+                            statistic_values.get("Minimum"),
+                            statistic_values.get("Maximum"),
+                        ),
+                    )
 
                     conn.commit()
 
@@ -205,15 +201,14 @@ class CloudwatchDatabase:
             AND timestamp >= ? AND timestamp < ?
         ) AS subquery
         """
-        with self.DATABASE_LOCK:
-            with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
-                cur = conn.cursor()
-                cur.execute(
-                    sql_query,
-                    data,
-                )
-                result_row = cur.fetchone()
-                return result_row[0].split(",") if result_row[0] else ["NULL_VALUE"]
+        with self.DATABASE_LOCK, sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                sql_query,
+                data,
+            )
+            result_row = cur.fetchone()
+            return result_row[0].split(",") if result_row[0] else ["NULL_VALUE"]
 
     def get_metric_data_stat(
         self,
@@ -278,39 +273,53 @@ class CloudwatchDatabase:
         AND timestamp >= ? AND timestamp < ?
         ORDER BY timestamp ASC
         """
-        with self.DATABASE_LOCK:
-            with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
-                cur = conn.cursor()
-                timestamps = []
-                values = []
-                while start_time_unix < end_time_unix:
-                    next_start_time = start_time_unix + period
-                    cur.execute(
-                        sql_query,
-                        data + (start_time_unix, next_start_time),
-                    )
-                    result_row = cur.fetchone()
 
-                    if result_row[1]:
-                        calculated_result = (
-                            result_row[0] / result_row[1] if stat == "Average" else result_row[0]
-                        )
-                        timestamps.append(start_time_unix)
-                        values.append(calculated_result)
+        timestamps = []
+        values = []
+        query_params = []
 
-                    start_time_unix = next_start_time
+        # Prepare all the query parameters
+        while start_time_unix < end_time_unix:
+            next_start_time = start_time_unix + period
+            query_params.append(data + (start_time_unix, next_start_time))
+            start_time_unix = next_start_time
 
-                # The while loop while always give us the timestamps in ascending order as we start with the start_time
-                # and increase it by the period until we reach the end_time
-                # If we want the timestamps in descending order we need to reverse the list
-                if scan_by is None or scan_by == ScanBy.TimestampDescending:
-                    timestamps = timestamps[::-1]
-                    values = values[::-1]
+        all_results = []
+        with self.DATABASE_LOCK, sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
+            cur = conn.cursor()
+            batch_size = 500
+            for i in range(0, len(query_params), batch_size):
+                batch = query_params[i : i + batch_size]
+                cur.execute(
+                    f"""
+                            SELECT * FROM (
+                                {' UNION ALL '.join(['SELECT * FROM (' + sql_query + ')'] * len(batch))}
+                            )
+                        """,
+                    sum(batch, ()),  # flatten the list of tuples in batch into a single tuple
+                )
+                all_results.extend(cur.fetchall())
 
-                return {
-                    "timestamps": timestamps,
-                    "values": values,
-                }
+        # Process results outside the lock
+        for i, result_row in enumerate(all_results):
+            if result_row[1]:
+                calculated_result = (
+                    result_row[0] / result_row[1] if stat == "Average" else result_row[0]
+                )
+                timestamps.append(query_params[i][-2])  # start_time_unix
+                values.append(calculated_result)
+
+        # The while loop while always give us the timestamps in ascending order as we start with the start_time
+        # and increase it by the period until we reach the end_time
+        # If we want the timestamps in descending order we need to reverse the list
+        if scan_by is None or scan_by == ScanBy.TimestampDescending:
+            timestamps = timestamps[::-1]
+            values = values[::-1]
+
+        return {
+            "timestamps": timestamps,
+            "values": values,
+        }
 
     def list_metrics(
         self,
@@ -353,34 +362,32 @@ class CloudwatchDatabase:
             {dimension_filter}
             ORDER BY timestamp DESC
         """
-        with self.DATABASE_LOCK:
-            with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
-                cur = conn.cursor()
+        with self.DATABASE_LOCK, sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
+            cur = conn.cursor()
 
-                cur.execute(
-                    query,
-                    data,
-                )
-                metrics_result = [
-                    {
-                        "metric_name": r[0],
-                        "namespace": r[1],
-                        "dimensions": self._restore_dimensions_from_string(r[2]),
-                    }
-                    for r in cur.fetchall()
-                ]
+            cur.execute(
+                query,
+                data,
+            )
+            metrics_result = [
+                {
+                    "metric_name": r[0],
+                    "namespace": r[1],
+                    "dimensions": self._restore_dimensions_from_string(r[2]),
+                }
+                for r in cur.fetchall()
+            ]
 
-                return {"metrics": metrics_result}
+            return {"metrics": metrics_result}
 
     def clear_tables(self):
-        with self.DATABASE_LOCK:
-            with sqlite3.connect(self.METRICS_DB) as conn:
-                cur = conn.cursor()
-                cur.execute(f"DELETE FROM {self.TABLE_SINGLE_METRICS}")
-                cur.execute(f"DELETE FROM {self.TABLE_AGGREGATED_METRICS}")
-                conn.commit()
-                cur.execute("VACUUM")
-                conn.commit()
+        with self.DATABASE_LOCK, sqlite3.connect(self.METRICS_DB) as conn:
+            cur = conn.cursor()
+            cur.execute(f"DELETE FROM {self.TABLE_SINGLE_METRICS}")
+            cur.execute(f"DELETE FROM {self.TABLE_AGGREGATED_METRICS}")
+            conn.commit()
+            cur.execute("VACUUM")
+            conn.commit()
 
     def _get_ordered_dimensions_with_separator(self, dims: Optional[List[Dict]], for_search=False):
         """
@@ -422,10 +429,9 @@ class CloudwatchDatabase:
         return int(timestamp.timestamp())
 
     def get_all_metric_data(self):
-        with self.DATABASE_LOCK:
-            with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
-                cur = conn.cursor()
-                """ shape for each data entry:
+        with self.DATABASE_LOCK, sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
+            cur = conn.cursor()
+            """ shape for each data entry:
                     {
                         "ns": r.namespace,
                         "n": r.name,
@@ -436,19 +442,19 @@ class CloudwatchDatabase:
                         "region": region_name, # new for v2
                     }
                     """
-                query = f"SELECT namespace, metric_name, value, timestamp, dimensions, account_id, region from {self.TABLE_SINGLE_METRICS}"
-                cur.execute(query)
-                metrics_result = [
-                    {
-                        "ns": r[0],
-                        "n": r[1],
-                        "v": r[2],
-                        "t": r[3],
-                        "d": r[4],
-                        "account": r[5],
-                        "region": r[6],
-                    }
-                    for r in cur.fetchall()
-                ]
-                # TODO add aggregated metrics (was not handled by v1 either)
-                return metrics_result
+            query = f"SELECT namespace, metric_name, value, timestamp, dimensions, account_id, region from {self.TABLE_SINGLE_METRICS}"
+            cur.execute(query)
+            metrics_result = [
+                {
+                    "ns": r[0],
+                    "n": r[1],
+                    "v": r[2],
+                    "t": r[3],
+                    "d": r[4],
+                    "account": r[5],
+                    "region": r[6],
+                }
+                for r in cur.fetchall()
+            ]
+            # TODO add aggregated metrics (was not handled by v1 either)
+            return metrics_result

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -11,6 +11,7 @@ from urllib.request import Request, urlopen
 
 import pytest
 import requests
+from botocore.exceptions import ClientError
 
 from localstack import config
 from localstack.services.cloudwatch.provider import PATH_GET_RAW_METRICS
@@ -2601,6 +2602,44 @@ class TestCloudwatch:
 
         sort_dimensions(list_metrics_res)
         snapshot.match("list-metrics", list_metrics_res)
+
+    @markers.aws.validated
+    def test_invalid_amount_of_datapoints(self, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.cloudwatch_api())
+        utc_now = datetime.now(tz=timezone.utc)
+        with pytest.raises(ClientError) as ex:
+            aws_client.cloudwatch.get_metric_statistics(
+                Namespace="namespace",
+                MetricName="metric_name",
+                StartTime=utc_now,
+                EndTime=utc_now + timedelta(days=1),
+                Period=1,
+                Statistics=["SampleCount"],
+            )
+
+        snapshot.match("error-invalid-amount-datapoints", ex.value.response)
+        with pytest.raises(ClientError) as ex:
+            aws_client.cloudwatch.get_metric_statistics(
+                Namespace="namespace",
+                MetricName="metric_name",
+                StartTime=utc_now,
+                EndTime=utc_now,
+                Period=1,
+                Statistics=["SampleCount"],
+            )
+
+        snapshot.match("error-invalid-time-frame", ex.value.response)
+
+        response = aws_client.cloudwatch.get_metric_statistics(
+            Namespace=f"namespace_{short_uid()}",
+            MetricName="metric_name",
+            StartTime=utc_now,
+            EndTime=utc_now + timedelta(days=1),
+            Period=60,
+            Statistics=["SampleCount"],
+        )
+
+        snapshot.match("get-metric-statitics", response)
 
 
 def _get_lambda_logs(logs_client: "CloudWatchLogsClient", fn_name: str):

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -2604,6 +2604,7 @@ class TestCloudwatch:
         snapshot.match("list-metrics", list_metrics_res)
 
     @markers.aws.validated
+    @pytest.mark.skipif(is_old_provider(), reason="New test for v2 provider")
     def test_invalid_amount_of_datapoints(self, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.cloudwatch_api())
         utc_now = datetime.now(tz=timezone.utc)

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -2045,5 +2045,40 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_invalid_amount_of_datapoints": {
+    "recorded-date": "23-08-2024, 14:14:54",
+    "recorded-content": {
+      "error-invalid-amount-datapoints": {
+        "Error": {
+          "Code": "InvalidParameterCombination",
+          "Message": "You have requested up to 86400 datapoints, which exceeds the limit of 1440. You may reduce the datapoints requested by increasing Period, or decreasing the time range.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-invalid-time-frame": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "The parameter StartTime must be less than the parameter EndTime.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-metric-statitics": {
+        "Datapoints": [],
+        "Label": "metric_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -44,6 +44,9 @@
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_insight_rule": {
     "last_validated_date": "2023-10-26T08:07:59+00:00"
   },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_invalid_amount_of_datapoints": {
+    "last_validated_date": "2024-08-23T14:16:44+00:00"
+  },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_multiple_dimensions_statistics": {
     "last_validated_date": "2024-07-29T07:56:05+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When requesting `get-metric-statistics` LocalStack didn't have any checks on the amount of datapoints. 
Therefore, it would accept large queries, e.g. with a timeframe of over a year and a period of 1 second, which would mean that the data is aggregated for each second in that timeframe. 

AWS only accepts up to 1440 datapoints, and raises an error if those are exceeded.

As LocalStack was running queries in a loop, with a lock on the database, it basically made the cloudwatch provider unresponsive for any other requests (as the lock wasn't released).

In this PR we are trying to address two issues:
1) don't allow more than 1440 datapoints in one request (also being in parity with AWS)
2) refactor the database locks that we currently have in place: by keeping sql queries to a limited amount, and only use the database lock for query-execution

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* added new aws-validated test for the amount of expected datapoints
* refactored code and database locks

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
