### PR TITLE
CloudWatch: Add missing response fields

### DIFF
--- a/localstack-core/localstack/services/cloudwatch/provider.py
+++ b/localstack-core/localstack/services/cloudwatch/provider.py
@@ -364,6 +364,8 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                 "v": r.value,
                 "t": r.timestamp,
                 "d": [{"n": d.name, "v": d.value} for d in r.dimensions],
+                "account": account_id,
+                "region": region,
             }
             for r in result
         ]


### PR DESCRIPTION
## Background

CloudWatch has the `/_aws/cloudwatch/metrics/raw` endpoint that returns the raw metrics. It was noticed that the [v1](https://github.com/localstack/localstack/blame/0063912ad5e984692e83e615a7b38021bc15e9c2/localstack-core/localstack/services/cloudwatch/provider.py#L345C9-L370) and [v2](https://github.com/localstack/localstack/blob/0063912ad5e984692e83e615a7b38021bc15e9c2/localstack-core/localstack/services/cloudwatch/cloudwatch_database_helper.py#L424-L454) providers do not have the same API response spec. To be specific, the `account` and `region` fields were missing in the v1 provider.

## Changes

In order to keep the spec consistent and simplify #11025, this PR adds the missing fields to the v1 provider response.