### PR TITLE
Fix CFn bug when loading custom resources

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -1408,7 +1408,7 @@ class TemplateDeployerV2(TemplateDeployerBase):
                     len(resources),
                     resource["ResourceType"],
                 )
-                resource_provider = executor.try_load_resource_provider(resource["Type"])
+                resource_provider = executor.try_load_resource_provider(get_resource_type(resource))
                 if resource_provider is not None:
                     event = executor.deploy_loop(
                         resource_provider, resource, resource_provider_payload
@@ -1583,7 +1583,9 @@ class TemplateDeployerLegacy(TemplateDeployerBase):
                             resource["ResourceType"],
                             iteration_cycle,
                         )
-                        resource_provider = executor.try_load_resource_provider(resource["Type"])
+                        resource_provider = executor.try_load_resource_provider(
+                            get_resource_type(resource)
+                        )
                         if resource_provider is not None:
                             event = executor.deploy_loop(
                                 resource_provider, resource, resource_provider_payload

--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -1240,7 +1240,7 @@ class TemplateDeployerBase(ABC):
             action, logical_resource_id=resource_id
         )
 
-        resource_provider = executor.try_load_resource_provider(resource["Type"])
+        resource_provider = executor.try_load_resource_provider(get_resource_type(resource))
         if resource_provider is not None:
             # add in-progress event
             resource_status = f"{get_action_name_for_resource_change(action)}_IN_PROGRESS"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

With https://github.com/localstack/localstack/pull/11406 we added support for `*_IN_PROGRESS` events however we broke custom resource support in -ext.

The issue is that we perform a custom type mapping in -ext that we do not do in this repository. This means that the tests passed in isolation, but the -ext pipeline broke.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Map the resource type with `get_resource_type`, which is overridden in -ext to support custom resources

## Testing

- Trigger a manual -ext pipeline against this branch name
  - manual CI run is 🟢 apart from unrelated issue likely caused by our recent code restructuring

<!-- Optional section: How to test these changes? -->
<!--

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
