### PR TITLE
Modify certificate download URL to new endpoint

### DIFF
--- a/localstack-core/localstack/constants.py
+++ b/localstack-core/localstack/constants.py
@@ -28,7 +28,7 @@ MAVEN_REPO_URL = "https://repo1.maven.org/maven2"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 
 # Artifacts endpoint
-ARTIFACTS_ENDPOINT = "https://analytics.localstack.cloud"
+ASSETS_ENDPOINT = "https://assets.localstack.cloud"
 
 # host to bind to when starting the services
 BIND_HOST = "0.0.0.0"

--- a/localstack-core/localstack/constants.py
+++ b/localstack-core/localstack/constants.py
@@ -27,9 +27,8 @@ MAVEN_REPO_URL = "https://repo1.maven.org/maven2"
 # URL of localstack's artifacts repository on GitHub
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 
-# Download URLs
-SSL_CERT_URL = f"{ARTIFACTS_REPO}/raw/master/local-certs/server.key"
-SSL_CERT_URL_FALLBACK = "{api_endpoint}/proxy/localstack.cert.key"
+# Artifacts endpoint
+ARTIFACTS_ENDPOINT = "https://analytics.localstack.cloud"
 
 # host to bind to when starting the services
 BIND_HOST = "0.0.0.0"

--- a/localstack-core/localstack/utils/ssl.py
+++ b/localstack-core/localstack/utils/ssl.py
@@ -6,12 +6,13 @@ from localstack.constants import API_ENDPOINT, ARTIFACTS_ENDPOINT
 from localstack.utils.crypto import generate_ssl_cert
 from localstack.utils.http import download, download_github_artifact
 from localstack.utils.time import now
+from localstack.version import __version__ as version
 
 LOG = logging.getLogger(__name__)
 
 # Download URLs
-SSL_CERT_URL = f"{ARTIFACTS_ENDPOINT}/local-certs/server.key"
-SSL_CERT_URL_FALLBACK = "{api_endpoint}/proxy/localstack.cert.key"
+SSL_CERT_URL = f"{ARTIFACTS_ENDPOINT}/local-certs/server.key?version={version}"
+SSL_CERT_URL_FALLBACK = "{api_endpoint}/proxy/localstack.cert.key?version={version}"
 
 # path for test certificate
 _SERVER_CERT_PEM_FILE = "server.test.pem"
@@ -32,7 +33,7 @@ def setup_ssl_cert():
 
     # cache file for 6 hours (non-enterprise) or forever (enterprise)
     if os.path.exists(target_file):
-        cache_duration_secs = 6 * 60 * 60
+        cache_duration_secs = 24 * 60 * 60
         mod_time = os.path.getmtime(target_file)
         if mod_time > (now() - cache_duration_secs):
             LOG.debug("Using cached SSL certificate (less than 6hrs since last update).")
@@ -48,7 +49,7 @@ def setup_ssl_cert():
         return download_github_artifact(SSL_CERT_URL, target_file, timeout=timeout_gh)
     except Exception:
         # try fallback URL, directly from our API proxy
-        url = SSL_CERT_URL_FALLBACK.format(api_endpoint=API_ENDPOINT)
+        url = SSL_CERT_URL_FALLBACK.format(api_endpoint=API_ENDPOINT, version=version)
         try:
             return download(url, target_file, timeout=timeout_proxy)
         except Exception as e:

--- a/localstack-core/localstack/utils/ssl.py
+++ b/localstack-core/localstack/utils/ssl.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from localstack import config
-from localstack.constants import API_ENDPOINT, ARTIFACTS_ENDPOINT
+from localstack.constants import API_ENDPOINT, ASSETS_ENDPOINT
 from localstack.utils.crypto import generate_ssl_cert
 from localstack.utils.http import download, download_github_artifact
 from localstack.utils.time import now
@@ -11,8 +11,8 @@ from localstack.version import __version__ as version
 LOG = logging.getLogger(__name__)
 
 # Download URLs
-SSL_CERT_URL = f"{ARTIFACTS_ENDPOINT}/local-certs/server.key?version={version}"
-SSL_CERT_URL_FALLBACK = "{api_endpoint}/proxy/localstack.cert.key?version={version}"
+SSL_CERT_URL = f"{ASSETS_ENDPOINT}/local-certs/server.key?version={version}"
+SSL_CERT_URL_FALLBACK = f"{API_ENDPOINT}/proxy/localstack.cert.key?version={version}"
 
 # path for test certificate
 _SERVER_CERT_PEM_FILE = "server.test.pem"
@@ -49,13 +49,12 @@ def setup_ssl_cert():
         return download_github_artifact(SSL_CERT_URL, target_file, timeout=timeout_gh)
     except Exception:
         # try fallback URL, directly from our API proxy
-        url = SSL_CERT_URL_FALLBACK.format(api_endpoint=API_ENDPOINT, version=version)
         try:
-            return download(url, target_file, timeout=timeout_proxy)
+            return download(SSL_CERT_URL_FALLBACK, target_file, timeout=timeout_proxy)
         except Exception as e:
             LOG.info(
                 "Unable to download local test SSL certificate from %s to %s (using self-signed cert as fallback): %s",
-                url,
+                SSL_CERT_URL_FALLBACK,
                 target_file,
                 e,
             )

--- a/localstack-core/localstack/utils/ssl.py
+++ b/localstack-core/localstack/utils/ssl.py
@@ -2,13 +2,16 @@ import logging
 import os
 
 from localstack import config
-from localstack.constants import API_ENDPOINT, SSL_CERT_URL, SSL_CERT_URL_FALLBACK
+from localstack.constants import API_ENDPOINT, ARTIFACTS_ENDPOINT
 from localstack.utils.crypto import generate_ssl_cert
 from localstack.utils.http import download, download_github_artifact
 from localstack.utils.time import now
 
 LOG = logging.getLogger(__name__)
 
+# Download URLs
+SSL_CERT_URL = f"{ARTIFACTS_ENDPOINT}/local-certs/server.key"
+SSL_CERT_URL_FALLBACK = "{api_endpoint}/proxy/localstack.cert.key"
 
 # path for test certificate
 _SERVER_CERT_PEM_FILE = "server.test.pem"

--- a/localstack-core/localstack/utils/ssl.py
+++ b/localstack-core/localstack/utils/ssl.py
@@ -4,7 +4,7 @@ import os
 from localstack import config
 from localstack.constants import API_ENDPOINT, ASSETS_ENDPOINT
 from localstack.utils.crypto import generate_ssl_cert
-from localstack.utils.http import download, download_github_artifact
+from localstack.utils.http import download
 from localstack.utils.time import now
 from localstack.version import __version__ as version
 
@@ -43,14 +43,13 @@ def setup_ssl_cert():
     LOG.debug("Attempting to download local SSL certificate file")
 
     # apply timeout (and fall back to using self-signed certs)
-    timeout_gh = 3  # short timeout for GitHub (default download)
-    timeout_proxy = 5  # slightly higher timeout for our proxy
+    timeout = 5  # slightly higher timeout for our proxy
     try:
-        return download_github_artifact(SSL_CERT_URL, target_file, timeout=timeout_gh)
+        return download(SSL_CERT_URL, target_file, timeout=timeout)
     except Exception:
         # try fallback URL, directly from our API proxy
         try:
-            return download(SSL_CERT_URL_FALLBACK, target_file, timeout=timeout_proxy)
+            return download(SSL_CERT_URL_FALLBACK, target_file, timeout=timeout)
         except Exception as e:
             LOG.info(
                 "Unable to download local test SSL certificate from %s to %s (using self-signed cert as fallback): %s",

--- a/localstack-core/localstack/utils/ssl.py
+++ b/localstack-core/localstack/utils/ssl.py
@@ -11,7 +11,7 @@ from localstack.version import __version__ as version
 LOG = logging.getLogger(__name__)
 
 # Download URLs
-SSL_CERT_URL = f"{ASSETS_ENDPOINT}/local-certs/server.key?version={version}"
+SSL_CERT_URL = f"{ASSETS_ENDPOINT}/local-certs/localstack.cert.key?version={version}"
 SSL_CERT_URL_FALLBACK = f"{API_ENDPOINT}/proxy/localstack.cert.key?version={version}"
 
 # path for test certificate


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With recent certificate issues, we need to change to a new endpoint where certificates are served from.

Also, to alleviate load on that endpoint, we should cache it for 24 hours, instead of 6 hours.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Download certificate from new endpoint
* Increase caching duration for the certificate to 24h

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
