### PR TITLE
enable integration between EventsBridge and Stepfunctions

### DIFF
--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -408,7 +408,9 @@ class StatesTargetSender(TargetSender):
 
     def send_event(self, event):
         self.service = "stepfunctions"
-        self.client.start_execution(stateMachineArn=self.target["Arn"], input=to_json_str(event))
+        self.client.start_execution(
+            stateMachineArn=self.target["Arn"], name=event["id"], input=to_json_str(event)
+        )
 
     def _validate_input(self, target: Target):
         super()._validate_input(target)

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -407,6 +407,7 @@ class StatesTargetSender(TargetSender):
     """Step Functions Target Sender"""
 
     def send_event(self, event):
+        self.service = "stepfunctions"
         self.client.start_execution(stateMachineArn=self.target["Arn"], input=to_json_str(event))
 
     def _validate_input(self, target: Target):
@@ -456,6 +457,7 @@ class TargetSenderFactory:
         "sqs": SqsTargetSender,
         "sagemaker": SagemakerTargetSender,
         "ssm": SystemsManagerSender,
+        "states": StatesTargetSender,
         # TODO custom endpoints via http target
     }
 

--- a/tests/aws/cdk_templates/EventsTests/stack-events-target-stepfunctions.json
+++ b/tests/aws/cdk_templates/EventsTests/stack-events-target-stepfunctions.json
@@ -1,0 +1,175 @@
+{
+  "Resources": {
+    "MyEventBus251E60F8": {
+      "Type": "AWS::Events::EventBus",
+      "Properties": {
+        "Name": "MyEventBus"
+      }
+    },
+    "MyQueueE6CA6235": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {
+        "QueueName": "MyQueue"
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "MyStateMachineRoleD59FFEBC": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "states.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      }
+    },
+    "MyStateMachineRoleDefaultPolicyE468EB18": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "MyQueueE6CA6235",
+                  "Arn"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "MyStateMachineRoleDefaultPolicyE468EB18",
+        "Roles": [
+          {
+            "Ref": "MyStateMachineRoleD59FFEBC"
+          }
+        ]
+      }
+    },
+    "MyStateMachine6C968CA5": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "",
+            [
+              "{\"StartAt\":\"SendToQueue\",\"States\":{\"SendToQueue\":{\"End\":true,\"Type\":\"Task\",\"Resource\":\"arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":states:::sqs:sendMessage\",\"Parameters\":{\"QueueUrl\":\"",
+              {
+                "Ref": "MyQueueE6CA6235"
+              },
+              "\",\"MessageBody\":{\"message.$\":\"$\"}}}}}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRoleD59FFEBC",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine"
+      },
+      "DependsOn": [
+        "MyStateMachineRoleDefaultPolicyE468EB18",
+        "MyStateMachineRoleD59FFEBC"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "MyStateMachineEventsRole7C46BBB5": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      }
+    },
+    "MyStateMachineEventsRoleDefaultPolicy6422AE18": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "MyStateMachine6C968CA5"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "MyStateMachineEventsRoleDefaultPolicy6422AE18",
+        "Roles": [
+          {
+            "Ref": "MyStateMachineEventsRole7C46BBB5"
+          }
+        ]
+      }
+    },
+    "MyRuleA44AB831": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventBusName": {
+          "Ref": "MyEventBus251E60F8"
+        },
+        "EventPattern": {
+          "detail-type": [
+            "myDetailType"
+          ]
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine6C968CA5"
+            },
+            "Id": "Target0",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "MyStateMachineEventsRole7C46BBB5",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "MachineArn": {
+      "Value": {
+        "Ref": "MyStateMachine6C968CA5"
+      }
+    },
+    "QueueUrl": {
+      "Value": {
+        "Ref": "MyQueueE6CA6235"
+      }
+    }
+  }
+}

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -806,6 +806,7 @@ class TestEventsTargetSqs:
 
 class TestEventsTargetStepFunctions:
     @markers.aws.validated
+    @pytest.mark.skipif(is_old_provider(), reason="not supported by the old provider")
     def test_put_events_with_target_statefunction_machine(self, infrastructure_setup, aws_client):
         infra = infrastructure_setup(namespace="EventsTests")
         stack_name = "stack-events-target-stepfunctions"

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -5,6 +5,7 @@ Classes are ordered alphabetically."""
 import json
 import time
 
+import aws_cdk as cdk
 import pytest
 
 from localstack import config
@@ -801,3 +802,88 @@ class TestEventsTargetSqs:
             ],
         )
         snapshot.match("messages", messages)
+
+
+class TestEventsTargetStepFunctions:
+    @markers.aws.validated
+    def test_put_events_with_target_statefunction_machine(self, infrastructure_setup, aws_client):
+        infra = infrastructure_setup(namespace="EventsTests")
+        stack_name = f"stack-events-target-stepfunctions"
+        stack = cdk.Stack(infra.cdk_app, stack_name=stack_name)
+
+        bus_name = "MyEventBus"
+        bus = cdk.aws_events.EventBus(stack, "MyEventBus", event_bus_name=bus_name)
+
+        queue = cdk.aws_sqs.Queue(stack, "MyQueue", queue_name="MyQueue")
+
+        send_to_sqs_task = cdk.aws_stepfunctions_tasks.SqsSendMessage(
+            stack,
+            "SendToQueue",
+            queue=queue,
+            message_body=cdk.aws_stepfunctions.TaskInput.from_object(
+                {"message": cdk.aws_stepfunctions.JsonPath.entire_payload}
+            ),
+        )
+
+        state_machine = cdk.aws_stepfunctions.StateMachine(
+            stack,
+            "MyStateMachine",
+            definition=send_to_sqs_task,
+            state_machine_name="MyStateMachine",
+        )
+
+        detail_type = "myDetailType"
+        rule = cdk.aws_events.Rule(
+            stack,
+            "MyRule",
+            event_bus=bus,
+            event_pattern=cdk.aws_events.EventPattern(detail_type=[detail_type]),
+        )
+
+        rule.add_target(cdk.aws_events_targets.SfnStateMachine(state_machine))
+
+        cdk.CfnOutput(stack, "MachineArn", value=state_machine.state_machine_arn)
+        cdk.CfnOutput(stack, "QueueUrl", value=queue.queue_url)
+
+        with infra.provisioner() as prov:
+            outputs = prov.get_stack_outputs(stack_name=stack_name)
+
+            entries = [
+                {
+                    "Source": "com.sample.resource",
+                    "DetailType": detail_type,
+                    "Detail": json.dumps({"Key1": "Value"}),
+                    "EventBusName": bus_name,
+                }
+                for i in range(5)
+            ]
+            aws_client.events.put_events(Entries=entries)
+
+            state_machine_arn = outputs["MachineArn"]
+
+            def _assert_executions():
+                exec = (
+                    aws_client.stepfunctions.get_paginator("list_executions")
+                    .paginate(stateMachineArn=state_machine_arn)
+                    .build_full_result()
+                )
+                assert len(exec["executions"]) > 0
+
+            retry_config = {
+                "retries": (20 if is_aws_cloud() else 5),
+                "sleep": (2 if is_aws_cloud() else 1),
+                "sleep_before": (2 if is_aws_cloud() else 0),
+            }
+            retry(_assert_executions, **retry_config)
+
+            messages = []
+            queue_url = outputs["QueueUrl"]
+
+            def _assert_messages():
+                queue_msgs = aws_client.sqs.receive_message(QueueUrl=queue_url)
+                for msg in queue_msgs.get("Messages", []):
+                    messages.append(msg)
+
+                assert len(messages) > 0
+
+            retry(_assert_messages, **retry_config)

--- a/tests/aws/services/events/test_events_targets.validation.json
+++ b/tests/aws/services/events/test_events_targets.validation.json
@@ -38,6 +38,9 @@
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetSqs::test_put_events_with_target_sqs_event_detail_match": {
     "last_validated_date": "2024-07-11T09:05:43+00:00"
   },
+  "tests/aws/services/events/test_events_targets.py::TestEventsTargetStepFunctions::test_put_events_with_target_statefunction_machine": {
+    "last_validated_date": "2024-08-29T17:39:41+00:00"
+  },
   "tests/aws/services/events/test_events_targets.py::test_put_events_with_target_lambda_list_entries_partial_match": {
     "last_validated_date": "2024-04-08T17:36:24+00:00"
   },

--- a/tests/aws/services/events/test_events_targets.validation.json
+++ b/tests/aws/services/events/test_events_targets.validation.json
@@ -39,7 +39,7 @@
     "last_validated_date": "2024-07-11T09:05:43+00:00"
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetStepFunctions::test_put_events_with_target_statefunction_machine": {
-    "last_validated_date": "2024-08-29T17:39:41+00:00"
+    "last_validated_date": "2024-08-29T18:06:56+00:00"
   },
   "tests/aws/services/events/test_events_targets.py::test_put_events_with_target_lambda_list_entries_partial_match": {
     "last_validated_date": "2024-04-08T17:36:24+00:00"


### PR DESCRIPTION
## Motivation

For some reason the integration between EventsBridge and StepFunctions service was not being used. With this PR the integration is used with certain changes so the execution name of the machine uses the event ID as it happens in AWS.

## Changes

- Enable integration
- Add Event ID to Execution Name

## Testing 
- New CDK test that asserts the integration. It basically combines EventBridge, StepFunctions and SQS. The test consists on putting an event in to the bus. A rule will execute the state machine with the event as input. And the machine will send the message to an SQS Queue.