### PR TITLE
ESM-v2: Fix failure destination context difference between ESM and Pipes

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_event_processor.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_event_processor.py
@@ -49,7 +49,6 @@ class EsmEventProcessor(EventProcessor):
                 messageType="ExecutionSucceeded",
                 logLevel=LogLevel.INFO,
             )
-
         except PartialFailureSenderError as e:
             self.logger.log(
                 messageType="ExecutionFailed",
@@ -77,8 +76,6 @@ class EsmEventProcessor(EventProcessor):
             raise e
 
     def process_target_stage(self, events: list[dict]) -> None:
-        payload = {}
-
         try:
             self.logger.log(
                 messageType="TargetStageEntered",
@@ -91,10 +88,12 @@ class EsmEventProcessor(EventProcessor):
                     logLevel=LogLevel.TRACE,
                 )
                 # TODO: handle and log target invocation + stage skipped (when no records present)
-                if response_payload := self.sender.send_events(events):
+                payload = self.sender.send_events(events)
+                if payload:
                     # TODO: test unserializable content (e.g., byte strings)
-                    payload = response_payload
-
+                    payload = json.dumps(payload)
+                else:
+                    payload = ""
                 self.logger.log(
                     messageType="TargetInvocationSucceeded",
                     logLevel=LogLevel.TRACE,
@@ -116,7 +115,7 @@ class EsmEventProcessor(EventProcessor):
             self.logger.log(
                 messageType="TargetStageSucceeded",
                 logLevel=LogLevel.INFO,
-                payload=json.dumps(payload),
+                payload=payload,
             )
         except PartialFailureSenderError as e:
             self.logger.log(

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_event_processor.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_event_processor.py
@@ -21,15 +21,13 @@ LOG = logging.getLogger(__name__)
 
 class EsmEventProcessor(EventProcessor):
     sender: Sender
-    # TODO: Why have a pipe logger here if pipes is not implemented in community?
     logger: PipeLogger
 
     def __init__(self, sender, logger):
         self.sender = sender
         self.logger = logger
 
-    # TODO: This error handling can be simplified
-    def process_events_batch(self, input_events: list[dict]) -> dict | None:
+    def process_events_batch(self, input_events: list[dict]) -> None:
         execution_id = uuid.uuid4()
         # Create a copy of the original input events
         events = input_events.copy()
@@ -46,12 +44,11 @@ class EsmEventProcessor(EventProcessor):
                 logLevel=LogLevel.TRACE,
             )
             # Target Stage
-            payload = self.process_target_stage(events)
+            self.process_target_stage(events)
             self.logger.log(
                 messageType="ExecutionSucceeded",
                 logLevel=LogLevel.INFO,
             )
-            return payload
 
         except PartialFailureSenderError as e:
             self.logger.log(
@@ -79,7 +76,7 @@ class EsmEventProcessor(EventProcessor):
             )
             raise e
 
-    def process_target_stage(self, events: list[dict]) -> dict | None:
+    def process_target_stage(self, events: list[dict]) -> None:
         payload = {}
 
         try:
@@ -135,8 +132,6 @@ class EsmEventProcessor(EventProcessor):
                 error=e.error,
             )
             raise e
-
-        return payload
 
     def generate_event_failure_context(self, abort_condition: str, **kwargs) -> dict:
         error_payload: dict = kwargs.get("error")

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
@@ -41,6 +41,7 @@ class EsmWorkerFactory:
         self.function_role_arn = function_role
         self.enabled = enabled
 
+    # TODO Should we split up each Poller creation to a separate static function?
     def get_esm_worker(self) -> EsmWorker:
         # Sender (always Lambda)
         function_arn = self.esm_config["FunctionArn"]

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
@@ -41,7 +41,6 @@ class EsmWorkerFactory:
         self.function_role_arn = function_role
         self.enabled = enabled
 
-    # TODO Should we split up each Poller creation to a separate static function?
     def get_esm_worker(self) -> EsmWorker:
         # Sender (always Lambda)
         function_arn = self.esm_config["FunctionArn"]

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/event_processor.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/event_processor.py
@@ -27,7 +27,8 @@ class CustomerInvocationError(EventProcessorError):
 class BatchFailureError(EventProcessorError):
     """The entire batch failed."""
 
-    pass
+    def __init__(self, error=None) -> None:
+        self.error = error
 
 
 class PartialFailurePayload(TypedDict, total=False):
@@ -57,3 +58,14 @@ class EventProcessor(ABC):
         """Processes a batch of `input_events`.
         Throws an error upon full or partial batch failure.
         """
+
+    @abstractmethod
+    def generate_event_failure_context(self, abort_condition: str, **kwargs) -> dict:
+        """
+        Generates a context object for a failed event processing invocation.
+
+        This method is used to create a standardized failure context for both
+        event source mapping and pipes processing scenarios. The resulting
+        context will be passed to a Dead Letter Queue (DLQ).
+        """
+        pass

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pipe_utils.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pipe_utils.py
@@ -66,10 +66,6 @@ def get_datetime_from_timestamp(timestamp: float) -> datetime:
     # return datetime.fromtimestamp(timestamp, tz=timezone.utc)
 
 
-def format_time_iso_8601_z(time: datetime) -> str:
-    return f"{time.isoformat()[:-3]}Z"
-
-
 def to_json_str(obj: any) -> str:
     """Custom JSON encoding for events with potentially unserializable fields (e.g., byte string).
     JSON encoders in LocalStack:

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/dynamodb_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/dynamodb_poller.py
@@ -105,5 +105,8 @@ class DynamoDBPoller(StreamPoller):
         # TODO: parse float properly if present from ApproximateCreationDateTime -> now works, compare via debug!
         return record["dynamodb"].get("todo", datetime.utcnow().timestamp())
 
+    def format_datetime(self, time: datetime) -> str:
+        return f"{time.isoformat(timespec='seconds')}Z"
+
     def get_sequence_number(self, record: dict) -> str:
         return record["dynamodb"]["SequenceNumber"]

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/kinesis_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/kinesis_poller.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 from copy import deepcopy
+from datetime import datetime
 
 from botocore.client import BaseClient
 
@@ -135,6 +136,9 @@ class KinesisPoller(StreamPoller):
             return record["kinesis"]["approximateArrivalTimestamp"]
         else:
             return record["approximateArrivalTimestamp"]
+
+    def format_datetime(self, time: datetime) -> str:
+        return f"{time.isoformat(timespec='milliseconds')}Z"
 
     def get_sequence_number(self, record: dict) -> str:
         if self.kinesis_namespace:

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -18,7 +18,6 @@ from localstack.services.lambda_.event_source_mapping.event_processor import (
     PipeInternalError,
 )
 from localstack.services.lambda_.event_source_mapping.pipe_utils import (
-    format_time_iso_8601_z,
     get_current_time,
     get_datetime_from_timestamp,
     get_internal_client,
@@ -90,6 +89,11 @@ class StreamPoller(Poller):
 
     @abstractmethod
     def get_approximate_arrival_time(self, record: dict) -> float:
+        pass
+
+    @abstractmethod
+    def format_datetime(self, time: datetime) -> str:
+        """Formats a datetime in the correct format for DynamoDB (with ms) or Kinesis (without ms)"""
         pass
 
     @abstractmethod
@@ -198,21 +202,15 @@ class StreamPoller(Poller):
                     )
                 error_payload = ex.partial_failure_payload
                 # let entire batch fail (ideally raise BatchFailureError)
-            except (SenderError, PartialFailureSenderError, BatchFailureError) as ex:
-                error_payload = ex.error
-                LOG.warning(
-                    f"Attempt {attempts} failed while processing {self.partner_resource_arn} with events: {events}"
-                )
-                attempts += 1
-                # Retry polling until the record expires at the source
-                if self.stream_parameters.get("MaximumRetryAttempts", -1) == -1:
-                    # TODO: handle iterator expired scenario
-                    return
-            except Exception:
-                LOG.warning(
-                    "Attempt %s failed unexpectedly while processing %s with events: %s",
+            except (SenderError, PartialFailureSenderError, BatchFailureError, Exception) as ex:
+                if isinstance(ex, (SenderError, PartialFailureSenderError, BatchFailureError)):
+                    error_payload = ex.error
+
+                # FIXME partner_resource_arn is not defined in ESM
+                LOG.debug(
+                    "Attempt %d failed while processing %s with events: %s",
                     attempts,
-                    self.partner_resource_arn,
+                    self.partner_resource_arn or self.source_arn,
                     events,
                 )
                 attempts += 1
@@ -229,7 +227,6 @@ class StreamPoller(Poller):
             attempts_count=attempts,
             partner_resource_arn=self.partner_resource_arn,
         )
-        LOG.warning(f"failure context: {failure_context}")
         self.send_events_to_dlq(events, context=failure_context)
         # Update shard iterator if the execution failed but the events are sent to a DLQ
         self.shards[shard_id] = get_records_response["NextShardIterator"]
@@ -308,15 +305,17 @@ class StreamPoller(Poller):
         return {
             **context,
             self.failure_payload_details_field_name(): {
-                "approximateArrivalOfFirstRecord": format_time_iso_8601_z(first_record_arrival),
-                "approximateArrivalOfLastRecord": format_time_iso_8601_z(last_record_arrival),
+                "approximateArrivalOfFirstRecord": self.format_datetime(first_record_arrival),
+                "approximateArrivalOfLastRecord": self.format_datetime(last_record_arrival),
                 "batchSize": len(events),
                 "endSequenceNumber": self.get_sequence_number(last_record),
                 "shardId": shard_id,
                 "startSequenceNumber": self.get_sequence_number(first_record),
                 "streamArn": self.source_arn,
             },
-            "timestamp": format_time_iso_8601_z(datetime.utcnow()),
+            "timestamp": get_current_time()
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z"),
             "version": "1.0",
         }
 

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/senders/lambda_sender.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/senders/lambda_sender.py
@@ -63,8 +63,10 @@ class LambdaSender(Sender):
                 "awsService": "lambda",
                 "requestId": invoke_result["ResponseMetadata"]["RequestId"],
                 # TODO: fix hardcoded value by figuring out what other exception types exist
-                "exceptionType": "BadRequest",
+                "exceptionType": "BadRequest",  # TODO: Is this actually used anywhere?
                 "resourceArn": self.target_arn,
+                "functionError": function_error,
+                "executedVersion": invoke_result.get("ExecutedVersion", "$LATEST"),
             }
             raise SenderError(
                 f"Error during sending events {events} due to FunctionError {function_error}.",
@@ -83,6 +85,8 @@ class LambdaSender(Sender):
                 "requestId": invoke_result["ResponseMetadata"]["RequestId"],
                 "exceptionType": "BadRequest",
                 "resourceArn": self.target_arn,
+                "functionError": function_error,
+                "executedVersion": invoke_result.get("ExecutedVersion", "$LATEST"),
             }
             raise PartialFailureSenderError(error=error, partial_failure_payload=payload)
 

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/senders/lambda_sender.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/senders/lambda_sender.py
@@ -63,7 +63,7 @@ class LambdaSender(Sender):
                 "awsService": "lambda",
                 "requestId": invoke_result["ResponseMetadata"]["RequestId"],
                 # TODO: fix hardcoded value by figuring out what other exception types exist
-                "exceptionType": "BadRequest",  # TODO: Is this actually used anywhere?
+                "exceptionType": "BadRequest",  # Currently only used in Pipes
                 "resourceArn": self.target_arn,
                 "functionError": function_error,
                 "executedVersion": invoke_result.get("ExecutedVersion", "$LATEST"),

--- a/tests/aws/services/lambda_/event_source_mapping/conftest.py
+++ b/tests/aws/services/lambda_/event_source_mapping/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+from localstack_snapshot.snapshots import SnapshotSession
+from localstack_snapshot.snapshots.transformer import RegexTransformer
+
+from localstack.testing.snapshots.transformer_utility import (
+    SNAPSHOT_BASIC_TRANSFORMER_NEW,
+    TransformerUtility,
+)
+from localstack.utils.aws.arns import get_partition
+
+
+# Here, we overwrite the snapshot fixture to allow the event_source_mapping subdir
+# to use the newer basic transformer.
+@pytest.fixture(scope="function")
+def snapshot(request, _snapshot_session: SnapshotSession, account_id, region_name):
+    _snapshot_session.transform = TransformerUtility
+
+    _snapshot_session.add_transformer(RegexTransformer(account_id, "1" * 12), priority=2)
+    _snapshot_session.add_transformer(RegexTransformer(region_name, "<region>"), priority=2)
+    _snapshot_session.add_transformer(
+        RegexTransformer(f"arn:{get_partition(region_name)}:", "arn:<partition>:"), priority=2
+    )
+
+    _snapshot_session.add_transformer(SNAPSHOT_BASIC_TRANSFORMER_NEW, priority=2)
+
+    return _snapshot_session

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -330,17 +330,6 @@ class TestDynamoDBEventSourceMapping:
         list_esm = aws_client.lambda_.list_event_source_mappings(EventSourceArn=latest_stream_arn)
         snapshot.match("list_event_source_mapping_result", list_esm)
 
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        condition=is_v2_esm,
-        paths=[
-            # Pipe uses "context" (extra)
-            "$..context",
-            # ESM uses "requestContext" and "responseContext" (not implemented yet)
-            "$..requestContext",
-            "$..responseContext",
-        ],
-    )
     # FIXME last three skip verification entries are purely due to numbering mismatches
     @markers.snapshot.skip_snapshot_verify(
         paths=[
@@ -354,6 +343,7 @@ class TestDynamoDBEventSourceMapping:
             "$..UUID",
         ],
     )
+    @markers.aws.validated
     def test_dynamodb_event_source_mapping_with_on_failure_destination_config(
         self,
         create_lambda_function,

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.snapshot.json
@@ -295,7 +295,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_on_failure_destination_config": {
-    "recorded-date": "08-08-2024, 20:50:27",
+    "recorded-date": "26-08-2024, 13:18:23",
     "recorded-content": {
       "update_table_response": {
         "TableDescription": {

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping": {
-    "recorded-date": "26-04-2023, 10:48:20",
+    "recorded-date": "03-09-2024, 14:52:49",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -13,7 +13,7 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
           "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
@@ -47,7 +47,7 @@
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -99,7 +99,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_disabled_dynamodb_event_source_mapping": {
-    "recorded-date": "27-02-2023, 18:34:59",
+    "recorded-date": "03-09-2024, 15:51:32",
     "recorded-content": {
       "dynamodb_create_table_result": {
         "TableDescription": {
@@ -112,7 +112,8 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
+          "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
             {
@@ -151,7 +152,7 @@
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -176,7 +177,7 @@
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "OK",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -195,7 +196,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_deletion_event_source_mapping_with_dynamodb": {
-    "recorded-date": "27-02-2023, 18:35:29",
+    "recorded-date": "03-09-2024, 14:55:15",
     "recorded-content": {
       "create_dynamodb_table_response": {
         "TableDescription": {
@@ -208,7 +209,8 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
+          "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
             {
@@ -247,7 +249,7 @@
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 0,
         "MaximumRecordAgeInSeconds": -1,
@@ -274,7 +276,7 @@
             "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
             "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
             "FunctionResponseTypes": [],
-            "LastModified": "datetime",
+            "LastModified": "<datetime>",
             "LastProcessingResult": "No records processed",
             "MaximumBatchingWindowInSeconds": 0,
             "MaximumRecordAgeInSeconds": -1,
@@ -295,8 +297,44 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_on_failure_destination_config": {
-    "recorded-date": "26-08-2024, 13:18:23",
+    "recorded-date": "03-09-2024, 14:58:10",
     "recorded-content": {
+      "create_table_response": {
+        "TableDescription": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "my_partition_key",
+              "AttributeType": "S"
+            }
+          ],
+          "BillingModeSummary": {
+            "BillingMode": "PAY_PER_REQUEST"
+          },
+          "CreationDateTime": "<datetime>",
+          "DeletionProtectionEnabled": false,
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "my_partition_key",
+              "KeyType": "HASH"
+            }
+          ],
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 0,
+            "WriteCapacityUnits": 0
+          },
+          "TableArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<resource:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "update_table_response": {
         "TableDescription": {
           "AttributeDefinitions": [
@@ -307,9 +345,9 @@
           ],
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST",
-            "LastUpdateToPayPerRequestDateTime": "datetime"
+            "LastUpdateToPayPerRequestDateTime": "<datetime>"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
           "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
@@ -318,8 +356,8 @@
               "KeyType": "HASH"
             }
           ],
-          "LatestStreamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
-          "LatestStreamLabel": "<resource:1>",
+          "LatestStreamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+          "LatestStreamLabel": "<resource:2>",
           "ProvisionedThroughput": {
             "NumberOfDecreasesToday": 0,
             "ReadCapacityUnits": 0,
@@ -329,9 +367,9 @@
             "StreamEnabled": true,
             "StreamViewType": "NEW_IMAGE"
           },
-          "TableArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>",
+          "TableArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>",
           "TableId": "<uuid:1>",
-          "TableName": "<resource:2>",
+          "TableName": "<resource:1>",
           "TableSizeBytes": 0,
           "TableStatus": "UPDATING"
         },
@@ -348,10 +386,10 @@
             "Destination": "arn:<partition>:sqs:<region>:111111111111:<resource:3>"
           }
         },
-        "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
+        "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:4>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -383,15 +421,15 @@
                 "functionError": "Unhandled"
               },
               "version": "1.0",
-              "timestamp": "date",
+              "timestamp": "<timestamp:2022-07-13T13:48:01.000Z>",
               "DDBStreamBatchInfo": {
                 "shardId": "<shard-id:1>",
                 "startSequenceNumber": "<start-sequence-number:1>",
                 "endSequenceNumber": "<start-sequence-number:1>",
-                "approximateArrivalOfFirstRecord": "date",
-                "approximateArrivalOfLastRecord": "date",
+                "approximateArrivalOfFirstRecord": "<timestamp:2022-07-13T13:48:01Z>",
+                "approximateArrivalOfLastRecord": "<timestamp:2022-07-13T13:48:01Z>",
                 "batchSize": 1,
-                "streamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>"
+                "streamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>"
               }
             },
             "MD5OfBody": "<m-d5-of-body:1>",
@@ -407,7 +445,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_invalid_event_filter[single-string]": {
-    "recorded-date": "27-02-2023, 18:44:12",
+    "recorded-date": "03-09-2024, 15:10:19",
     "recorded-content": {
       "exception_event_source_creation": {
         "Error": {
@@ -424,7 +462,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_invalid_event_filter[[{\"eventName\": [\"INSERT\"=123}]]": {
-    "recorded-date": "27-02-2023, 18:44:25",
+    "recorded-date": "03-09-2024, 15:10:37",
     "recorded-content": {
       "exception_event_source_creation": {
         "Error": {
@@ -441,7 +479,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_duplicate_event_source_mappings": {
-    "recorded-date": "04-01-2024, 17:25:30",
+    "recorded-date": "03-09-2024, 14:53:08",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -454,7 +492,7 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
           "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
@@ -488,7 +526,7 @@
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -519,7 +557,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[insert_same_entry_twice]": {
-    "recorded-date": "31-07-2024, 12:38:15",
+    "recorded-date": "03-09-2024, 14:59:51",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -532,7 +570,7 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
           "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
@@ -577,7 +615,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -662,7 +700,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[content_or_filter]": {
-    "recorded-date": "31-07-2024, 12:39:42",
+    "recorded-date": "03-09-2024, 15:01:39",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -675,7 +713,7 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
           "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
@@ -721,7 +759,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -836,7 +874,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[content_multiple_filters]": {
-    "recorded-date": "31-07-2024, 12:41:06",
+    "recorded-date": "03-09-2024, 15:03:30",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -849,7 +887,7 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
           "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
@@ -897,7 +935,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -976,7 +1014,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[content_filter_type]": {
-    "recorded-date": "31-07-2024, 12:42:14",
+    "recorded-date": "03-09-2024, 15:05:31",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -989,7 +1027,7 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
           "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
@@ -1040,7 +1078,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -1125,7 +1163,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[exists_filter_type]": {
-    "recorded-date": "31-07-2024, 12:44:08",
+    "recorded-date": "03-09-2024, 15:06:46",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -1138,7 +1176,7 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
           "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
@@ -1191,7 +1229,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -1607,7 +1645,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[prefix_filter]": {
-    "recorded-date": "31-07-2024, 12:45:08",
+    "recorded-date": "03-09-2024, 15:08:36",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -1620,7 +1658,7 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
           "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
@@ -1673,7 +1711,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -1758,7 +1796,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[date_time_conversion]": {
-    "recorded-date": "31-07-2024, 12:47:15",
+    "recorded-date": "03-09-2024, 15:10:02",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -1771,7 +1809,7 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
           "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
@@ -1816,7 +1854,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.validation.json
@@ -1,50 +1,50 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_deletion_event_source_mapping_with_dynamodb": {
-    "last_validated_date": "2023-02-27T17:35:29+00:00"
+    "last_validated_date": "2024-09-03T14:54:58+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_disabled_dynamodb_event_source_mapping": {
-    "last_validated_date": "2023-02-27T17:34:59+00:00"
+    "last_validated_date": "2024-09-03T15:51:30+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_duplicate_event_source_mappings": {
-    "last_validated_date": "2024-01-04T23:38:14+00:00"
+    "last_validated_date": "2024-09-03T14:53:04+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[content_filter_type]": {
-    "last_validated_date": "2024-07-31T12:42:14+00:00"
+    "last_validated_date": "2024-09-03T15:05:30+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[content_multiple_filters]": {
-    "last_validated_date": "2024-07-31T12:41:05+00:00"
+    "last_validated_date": "2024-09-03T15:03:28+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[content_or_filter]": {
-    "last_validated_date": "2024-07-31T12:39:41+00:00"
+    "last_validated_date": "2024-09-03T15:01:38+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[date_time_conversion]": {
-    "last_validated_date": "2024-07-31T12:47:14+00:00"
+    "last_validated_date": "2024-09-03T15:10:01+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[exists_false_filter]": {
     "last_validated_date": "2024-04-11T20:56:30+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[exists_filter_type]": {
-    "last_validated_date": "2024-07-31T12:44:07+00:00"
+    "last_validated_date": "2024-09-03T15:06:44+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[insert_same_entry_twice]": {
-    "last_validated_date": "2024-07-31T12:38:14+00:00"
+    "last_validated_date": "2024-09-03T14:59:49+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[numeric_filter]": {
     "last_validated_date": "2024-04-11T20:57:38+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[prefix_filter]": {
-    "last_validated_date": "2024-07-31T12:45:07+00:00"
+    "last_validated_date": "2024-09-03T15:08:34+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping": {
-    "last_validated_date": "2023-04-26T08:48:20+00:00"
+    "last_validated_date": "2024-09-03T14:52:46+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_on_failure_destination_config": {
-    "last_validated_date": "2024-08-26T13:18:18+00:00"
+    "last_validated_date": "2024-09-03T14:58:05+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_invalid_event_filter[[{\"eventName\": [\"INSERT\"=123}]]": {
-    "last_validated_date": "2023-02-27T17:44:25+00:00"
+    "last_validated_date": "2024-09-03T15:10:35+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_invalid_event_filter[single-string]": {
-    "last_validated_date": "2023-02-27T17:44:12+00:00"
+    "last_validated_date": "2024-09-03T15:10:17+00:00"
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.validation.json
@@ -39,7 +39,7 @@
     "last_validated_date": "2023-04-26T08:48:20+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_on_failure_destination_config": {
-    "last_validated_date": "2024-08-08T20:50:25+00:00"
+    "last_validated_date": "2024-08-26T13:18:18+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_invalid_event_filter[[{\"eventName\": [\"INSERT\"=123}]]": {
     "last_validated_date": "2023-02-27T17:44:25+00:00"

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -18,7 +18,7 @@ from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid, to_bytes
 from localstack.utils.sync import ShortCircuitWaitException, retry, wait_until
-from tests.aws.services.lambda_.event_source_mapping.utils import is_v2_esm
+from tests.aws.services.lambda_.event_source_mapping.utils import is_old_esm, is_v2_esm
 from tests.aws.services.lambda_.functions import FUNCTIONS_PATH, lambda_integration
 from tests.aws.services.lambda_.test_lambda import (
     TEST_LAMBDA_PYTHON,
@@ -34,6 +34,13 @@ def _snapshot_transformers(snapshot):
     # manual transformers since we are passing SQS attributes through lambdas and back again
     snapshot.add_transformer(snapshot.transform.key_value("sequenceNumber"))
     snapshot.add_transformer(snapshot.transform.resource_name())
+    snapshot.add_transformer(
+        KeyValueBasedTransformer(
+            lambda k, v: str(v) if k == "approximateArrivalTimestamp" else None,
+            "<approximate-arrival-timestamp>",
+            replace_reference=False,
+        )
+    )
     snapshot.add_transformer(
         KeyValueBasedTransformer(
             lambda k, v: str(v) if k == "executionStart" else None,
@@ -443,17 +450,16 @@ class TestKinesisSource:
         )
 
     @markers.snapshot.skip_snapshot_verify(
-        condition=is_v2_esm,
         paths=[
-            "$..Messages..MessageId",
+            "$..Messages..Body.KinesisBatchInfo.shardId",
+            "$..Messages..Body.KinesisBatchInfo.streamArn",
         ],
     )
     @markers.snapshot.skip_snapshot_verify(
+        condition=is_old_esm,
         paths=[
             "$..Messages..Body.KinesisBatchInfo.approximateArrivalOfFirstRecord",
             "$..Messages..Body.KinesisBatchInfo.approximateArrivalOfLastRecord",
-            "$..Messages..Body.KinesisBatchInfo.shardId",
-            "$..Messages..Body.KinesisBatchInfo.streamArn",
             "$..Messages..Body.requestContext.approximateInvokeCount",
             "$..Messages..Body.responseContext.statusCode",
         ],
@@ -474,6 +480,7 @@ class TestKinesisSource:
         snapshot.add_transformer(snapshot.transform.key_value("MD5OfBody"))
         snapshot.add_transformer(snapshot.transform.key_value("ReceiptHandle"))
         snapshot.add_transformer(snapshot.transform.key_value("startSequenceNumber"))
+
         function_name = f"lambda_func-{short_uid()}"
         role = f"test-lambda-role-{short_uid()}"
         policy_name = f"test-lambda-policy-{short_uid()}"
@@ -549,12 +556,8 @@ class TestKinesisEventFiltering:
     )
     @markers.snapshot.skip_snapshot_verify(
         paths=[
-            "$..Messages..Body.KinesisBatchInfo.approximateArrivalOfFirstRecord",
-            "$..Messages..Body.KinesisBatchInfo.approximateArrivalOfLastRecord",
             "$..Messages..Body.KinesisBatchInfo.shardId",
             "$..Messages..Body.KinesisBatchInfo.streamArn",
-            "$..Messages..Body.requestContext.approximateInvokeCount",
-            "$..Messages..Body.responseContext.statusCode",
         ],
     )
     @markers.aws.validated

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -445,12 +445,6 @@ class TestKinesisSource:
     @markers.snapshot.skip_snapshot_verify(
         condition=is_v2_esm,
         paths=[
-            # Pipe uses "context" (extra)
-            "$..context",
-            # ESM uses "requestContext" and "responseContext" (not implemented yet)
-            "$..requestContext",
-            "$..responseContext",
-            # uuid ordering issue because the missing requestContext contains a uuid
             "$..Messages..MessageId",
         ],
     )

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping": {
-    "recorded-date": "31-07-2024, 13:52:24",
+    "recorded-date": "03-09-2024, 15:27:35",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 100,
@@ -11,7 +11,7 @@
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 0,
         "MaximumRecordAgeInSeconds": -1,
@@ -31,14 +31,14 @@
         "Records": [
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:1>",
+            "eventID": "shardId-111111111111:<sequence-number:1>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
             "eventVersion": "1.0",
             "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
             "kinesis": {
-              "approximateArrivalTimestamp": "timestamp",
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
               "data": "aGVsbG8=",
               "kinesisSchemaVersion": "1.0",
               "partitionKey": "test_0",
@@ -47,14 +47,14 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:2>",
+            "eventID": "shardId-111111111111:<sequence-number:2>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
             "eventVersion": "1.0",
             "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
             "kinesis": {
-              "approximateArrivalTimestamp": "timestamp",
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
               "data": "aGVsbG8=",
               "kinesisSchemaVersion": "1.0",
               "partitionKey": "test_1",
@@ -63,14 +63,14 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:3>",
+            "eventID": "shardId-111111111111:<sequence-number:3>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
             "eventVersion": "1.0",
             "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
             "kinesis": {
-              "approximateArrivalTimestamp": "timestamp",
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
               "data": "aGVsbG8=",
               "kinesisSchemaVersion": "1.0",
               "partitionKey": "test_2",
@@ -79,14 +79,14 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:4>",
+            "eventID": "shardId-111111111111:<sequence-number:4>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
             "eventVersion": "1.0",
             "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
             "kinesis": {
-              "approximateArrivalTimestamp": "timestamp",
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
               "data": "aGVsbG8=",
               "kinesisSchemaVersion": "1.0",
               "partitionKey": "test_3",
@@ -95,14 +95,14 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:5>",
+            "eventID": "shardId-111111111111:<sequence-number:5>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
             "eventVersion": "1.0",
             "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
             "kinesis": {
-              "approximateArrivalTimestamp": "timestamp",
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
               "data": "aGVsbG8=",
               "kinesisSchemaVersion": "1.0",
               "partitionKey": "test_4",
@@ -111,14 +111,14 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:6>",
+            "eventID": "shardId-111111111111:<sequence-number:6>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
             "eventVersion": "1.0",
             "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
             "kinesis": {
-              "approximateArrivalTimestamp": "timestamp",
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
               "data": "aGVsbG8=",
               "kinesisSchemaVersion": "1.0",
               "partitionKey": "test_5",
@@ -127,14 +127,14 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:7>",
+            "eventID": "shardId-111111111111:<sequence-number:7>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
             "eventVersion": "1.0",
             "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
             "kinesis": {
-              "approximateArrivalTimestamp": "timestamp",
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
               "data": "aGVsbG8=",
               "kinesisSchemaVersion": "1.0",
               "partitionKey": "test_6",
@@ -143,14 +143,14 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:8>",
+            "eventID": "shardId-111111111111:<sequence-number:8>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
             "eventVersion": "1.0",
             "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
             "kinesis": {
-              "approximateArrivalTimestamp": "timestamp",
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
               "data": "aGVsbG8=",
               "kinesisSchemaVersion": "1.0",
               "partitionKey": "test_7",
@@ -159,14 +159,14 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:9>",
+            "eventID": "shardId-111111111111:<sequence-number:9>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
             "eventVersion": "1.0",
             "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
             "kinesis": {
-              "approximateArrivalTimestamp": "timestamp",
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
               "data": "aGVsbG8=",
               "kinesisSchemaVersion": "1.0",
               "partitionKey": "test_8",
@@ -175,14 +175,14 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:10>",
+            "eventID": "shardId-111111111111:<sequence-number:10>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
             "eventVersion": "1.0",
             "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
             "kinesis": {
-              "approximateArrivalTimestamp": "timestamp",
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
               "data": "aGVsbG8=",
               "kinesisSchemaVersion": "1.0",
               "partitionKey": "test_9",
@@ -560,7 +560,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_trim_horizon": {
-    "recorded-date": "27-02-2023, 16:56:17",
+    "recorded-date": "03-09-2024, 15:28:22",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -571,7 +571,7 @@
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 0,
         "MaximumRecordAgeInSeconds": -1,
@@ -593,164 +593,164 @@
           "event": {
             "Records": [
               {
+                "eventID": "shardId-111111111111:<sequence-number:1>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "eventSource": "aws:kinesis",
+                "eventVersion": "1.0",
+                "eventName": "aws:kinesis:record",
+                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
+                "awsRegion": "<region>",
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAwfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_0",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:2>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:1>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:2>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAxfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_0",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:3>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:2>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:3>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAyfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_0",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:4>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:3>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:4>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAzfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_0",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:5>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:4>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:5>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA0fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_0",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:6>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:5>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:6>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA1fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_0",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:7>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:6>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:7>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA2fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_0",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:8>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:7>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:8>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA3fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_0",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:9>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:8>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:9>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA4fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
-                "eventSource": "aws:kinesis",
-                "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:9>",
-                "eventName": "aws:kinesis:record",
-                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
-                "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
-                "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
                   "partitionKey": "test_0",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:10>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "eventSource": "aws:kinesis",
+                "eventVersion": "1.0",
+                "eventName": "aws:kinesis:record",
+                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
+                "awsRegion": "<region>",
+                "kinesis": {
                   "sequenceNumber": "<sequence-number:10>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
-                "eventSource": "aws:kinesis",
-                "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:10>",
-                "eventName": "aws:kinesis:record",
-                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
-                "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+                  "partitionKey": "test_0",
+                  "kinesisSchemaVersion": "1.0"
+                }
               }
             ]
           }
@@ -760,164 +760,164 @@
           "event": {
             "Records": [
               {
+                "eventID": "shardId-111111111111:<sequence-number:11>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "eventSource": "aws:kinesis",
+                "eventVersion": "1.0",
+                "eventName": "aws:kinesis:record",
+                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
+                "awsRegion": "<region>",
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:11>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAwfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_1",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:12>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:11>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:12>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAxfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_1",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:13>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:12>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:13>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAyfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_1",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:14>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:13>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:14>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAzfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_1",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:15>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:14>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:15>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA0fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_1",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:16>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:15>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:16>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA1fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_1",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:17>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:16>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:17>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA2fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_1",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:18>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:17>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:18>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA3fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_1",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:19>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:18>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:19>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA4fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
-                "eventSource": "aws:kinesis",
-                "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:19>",
-                "eventName": "aws:kinesis:record",
-                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
-                "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+                  "partitionKey": "test_1",
+                  "kinesisSchemaVersion": "1.0"
+                }
               },
               {
-                "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_1",
-                  "sequenceNumber": "<sequence-number:20>",
-                  "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                "eventID": "shardId-111111111111:<sequence-number:20>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:20>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+                "kinesis": {
+                  "sequenceNumber": "<sequence-number:20>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
+                  "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
+                  "partitionKey": "test_1",
+                  "kinesisSchemaVersion": "1.0"
+                }
               }
             ]
           }
@@ -927,164 +927,164 @@
           "event": {
             "Records": [
               {
+                "eventID": "shardId-111111111111:<sequence-number:21>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "eventSource": "aws:kinesis",
+                "eventVersion": "1.0",
+                "eventName": "aws:kinesis:record",
+                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
+                "awsRegion": "<region>",
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:21>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAwfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_3",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:22>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:21>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:22>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAxfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_3",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:23>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:22>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:23>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAyfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_3",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:24>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:23>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:24>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAzfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_3",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:25>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:24>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:25>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA0fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_3",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:26>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:25>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:26>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA1fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_3",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:27>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:26>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:27>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA2fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_3",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:28>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:27>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:28>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA3fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                  "partitionKey": "test_3",
+                  "kinesisSchemaVersion": "1.0"
+                }
+              },
+              {
+                "eventID": "shardId-111111111111:<sequence-number:29>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:28>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-              },
-              {
                 "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:29>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA4fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
-                "eventSource": "aws:kinesis",
-                "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:29>",
-                "eventName": "aws:kinesis:record",
-                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
-                "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+                  "partitionKey": "test_3",
+                  "kinesisSchemaVersion": "1.0"
+                }
               },
               {
-                "kinesis": {
-                  "kinesisSchemaVersion": "1.0",
-                  "partitionKey": "test_3",
-                  "sequenceNumber": "<sequence-number:30>",
-                  "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
-                },
+                "eventID": "shardId-111111111111:<sequence-number:30>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
-                "eventID": "shardId-000000000000:<sequence-number:30>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+                "kinesis": {
+                  "sequenceNumber": "<sequence-number:30>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
+                  "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
+                  "partitionKey": "test_3",
+                  "kinesisSchemaVersion": "1.0"
+                }
               }
             ]
           }
@@ -1093,7 +1093,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_disable_kinesis_event_source_mapping": {
-    "recorded-date": "27-02-2023, 16:59:49",
+    "recorded-date": "03-09-2024, 15:28:51",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1104,7 +1104,7 @@
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 0,
         "MaximumRecordAgeInSeconds": -1,
@@ -1124,164 +1124,164 @@
         {
           "Records": [
             {
+              "eventID": "shardId-111111111111:<sequence-number:1>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+              "eventSource": "aws:kinesis",
+              "eventVersion": "1.0",
+              "eventName": "aws:kinesis:record",
+              "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
+              "awsRegion": "<region>",
               "kinesis": {
-                "kinesisSchemaVersion": "1.0",
-                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:1>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiAwfQ==",
-                "approximateArrivalTimestamp": "timestamp"
-              },
+                "partitionKey": "test",
+                "kinesisSchemaVersion": "1.0"
+              }
+            },
+            {
+              "eventID": "shardId-111111111111:<sequence-number:2>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
-              "eventID": "shardId-000000000000:<sequence-number:1>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-            },
-            {
               "kinesis": {
-                "kinesisSchemaVersion": "1.0",
-                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:2>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiAxfQ==",
-                "approximateArrivalTimestamp": "timestamp"
-              },
+                "partitionKey": "test",
+                "kinesisSchemaVersion": "1.0"
+              }
+            },
+            {
+              "eventID": "shardId-111111111111:<sequence-number:3>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
-              "eventID": "shardId-000000000000:<sequence-number:2>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-            },
-            {
               "kinesis": {
-                "kinesisSchemaVersion": "1.0",
-                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:3>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiAyfQ==",
-                "approximateArrivalTimestamp": "timestamp"
-              },
+                "partitionKey": "test",
+                "kinesisSchemaVersion": "1.0"
+              }
+            },
+            {
+              "eventID": "shardId-111111111111:<sequence-number:4>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
-              "eventID": "shardId-000000000000:<sequence-number:3>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-            },
-            {
               "kinesis": {
-                "kinesisSchemaVersion": "1.0",
-                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:4>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiAzfQ==",
-                "approximateArrivalTimestamp": "timestamp"
-              },
+                "partitionKey": "test",
+                "kinesisSchemaVersion": "1.0"
+              }
+            },
+            {
+              "eventID": "shardId-111111111111:<sequence-number:5>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
-              "eventID": "shardId-000000000000:<sequence-number:4>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-            },
-            {
               "kinesis": {
-                "kinesisSchemaVersion": "1.0",
-                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:5>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiA0fQ==",
-                "approximateArrivalTimestamp": "timestamp"
-              },
+                "partitionKey": "test",
+                "kinesisSchemaVersion": "1.0"
+              }
+            },
+            {
+              "eventID": "shardId-111111111111:<sequence-number:6>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
-              "eventID": "shardId-000000000000:<sequence-number:5>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-            },
-            {
               "kinesis": {
-                "kinesisSchemaVersion": "1.0",
-                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:6>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiA1fQ==",
-                "approximateArrivalTimestamp": "timestamp"
-              },
+                "partitionKey": "test",
+                "kinesisSchemaVersion": "1.0"
+              }
+            },
+            {
+              "eventID": "shardId-111111111111:<sequence-number:7>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
-              "eventID": "shardId-000000000000:<sequence-number:6>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-            },
-            {
               "kinesis": {
-                "kinesisSchemaVersion": "1.0",
-                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:7>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiA2fQ==",
-                "approximateArrivalTimestamp": "timestamp"
-              },
+                "partitionKey": "test",
+                "kinesisSchemaVersion": "1.0"
+              }
+            },
+            {
+              "eventID": "shardId-111111111111:<sequence-number:8>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
-              "eventID": "shardId-000000000000:<sequence-number:7>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-            },
-            {
               "kinesis": {
-                "kinesisSchemaVersion": "1.0",
-                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:8>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiA3fQ==",
-                "approximateArrivalTimestamp": "timestamp"
-              },
+                "partitionKey": "test",
+                "kinesisSchemaVersion": "1.0"
+              }
+            },
+            {
+              "eventID": "shardId-111111111111:<sequence-number:9>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
-              "eventID": "shardId-000000000000:<sequence-number:8>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
-            },
-            {
               "kinesis": {
-                "kinesisSchemaVersion": "1.0",
-                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:9>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiA4fQ==",
-                "approximateArrivalTimestamp": "timestamp"
-              },
-              "eventSource": "aws:kinesis",
-              "eventVersion": "1.0",
-              "eventID": "shardId-000000000000:<sequence-number:9>",
-              "eventName": "aws:kinesis:record",
-              "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
-              "awsRegion": "<region>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+                "partitionKey": "test",
+                "kinesisSchemaVersion": "1.0"
+              }
             },
             {
-              "kinesis": {
-                "kinesisSchemaVersion": "1.0",
-                "partitionKey": "test",
-                "sequenceNumber": "<sequence-number:10>",
-                "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
-                "approximateArrivalTimestamp": "timestamp"
-              },
+              "eventID": "shardId-111111111111:<sequence-number:10>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
-              "eventID": "shardId-000000000000:<sequence-number:10>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              "kinesis": {
+                "sequenceNumber": "<sequence-number:10>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
+                "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
+                "partitionKey": "test",
+                "kinesisSchemaVersion": "1.0"
+              }
             }
           ]
         }
@@ -1289,7 +1289,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_on_failure_destination_config": {
-    "recorded-date": "27-02-2023, 17:01:08",
+    "recorded-date": "03-09-2024, 15:41:42",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -1302,7 +1302,7 @@
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -1334,13 +1334,13 @@
                 "functionError": "Unhandled"
               },
               "version": "1.0",
-              "timestamp": "date",
+              "timestamp": "<timestamp:2022-07-13T13:48:01.000Z>",
               "KinesisBatchInfo": {
                 "shardId": "shardId-000000000000",
                 "startSequenceNumber": "<start-sequence-number:1>",
                 "endSequenceNumber": "<start-sequence-number:1>",
-                "approximateArrivalOfFirstRecord": "date",
-                "approximateArrivalOfLastRecord": "date",
+                "approximateArrivalOfFirstRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
+                "approximateArrivalOfLastRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
                 "batchSize": 1,
                 "streamArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
               }
@@ -1358,7 +1358,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisEventFiltering::test_kinesis_event_filtering_json_pattern": {
-    "recorded-date": "14-08-2024, 17:21:57",
+    "recorded-date": "03-09-2024, 15:29:09",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -1382,7 +1382,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -1420,7 +1420,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -1440,7 +1440,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_duplicate_event_source_mappings": {
-    "recorded-date": "04-01-2024, 17:16:56",
+    "recorded-date": "03-09-2024, 15:27:56",
     "recorded-content": {
       "create": {
         "BatchSize": 100,
@@ -1451,7 +1451,7 @@
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 0,
         "MaximumRecordAgeInSeconds": -1,
@@ -1482,7 +1482,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping_multiple_lambdas_single_kinesis_event_stream": {
-    "recorded-date": "02-02-2024, 10:58:38",
+    "recorded-date": "03-09-2024, 15:27:54",
     "recorded-content": {
       "create_event_source_mapping_response-a": {
         "BatchSize": 100,
@@ -1493,7 +1493,7 @@
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 0,
         "MaximumRecordAgeInSeconds": -1,
@@ -1518,7 +1518,7 @@
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 0,
         "MaximumRecordAgeInSeconds": -1,
@@ -1538,14 +1538,14 @@
         "Records": [
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:1>",
+            "eventID": "shardId-111111111111:<sequence-number:1>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
             "eventVersion": "1.0",
             "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:4>",
             "kinesis": {
-              "approximateArrivalTimestamp": "timestamp",
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
               "data": "aGVsbG8=",
               "kinesisSchemaVersion": "1.0",
               "partitionKey": "test_1",
@@ -1558,14 +1558,14 @@
         "Records": [
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:1>",
+            "eventID": "shardId-111111111111:<sequence-number:1>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
             "eventVersion": "1.0",
             "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:4>",
             "kinesis": {
-              "approximateArrivalTimestamp": "timestamp",
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
               "data": "aGVsbG8=",
               "kinesisSchemaVersion": "1.0",
               "partitionKey": "test_1",

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -3,7 +3,7 @@
     "last_validated_date": "2023-02-27T16:01:08+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisEventFiltering::test_kinesis_event_filtering_json_pattern": {
-    "last_validated_date": "2024-08-14T17:21:54+00:00"
+    "last_validated_date": "2024-09-03T13:36:58+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping": {
     "last_validated_date": "2024-07-31T13:52:23+00:00"
@@ -21,7 +21,7 @@
     "last_validated_date": "2023-02-27T15:55:08+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_on_failure_destination_config": {
-    "last_validated_date": "2024-08-29T12:25:02+00:00"
+    "last_validated_date": "2024-09-03T15:41:37+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_trim_horizon": {
     "last_validated_date": "2023-02-27T15:56:17+00:00"

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -20,6 +20,9 @@
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_async_invocation": {
     "last_validated_date": "2023-02-27T15:55:08+00:00"
   },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_on_failure_destination_config": {
+    "last_validated_date": "2024-08-29T12:25:02+00:00"
+  },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_trim_horizon": {
     "last_validated_date": "2023-02-27T15:56:17+00:00"
   }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_failing_lambda_retries_after_visibility_timeout": {
-    "recorded-date": "27-02-2023, 17:02:53",
+    "recorded-date": "06-09-2024, 13:40:40",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -14,7 +14,7 @@
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Enabled",
         "StateTransitionReason": "USER_INITIATED",
@@ -37,9 +37,9 @@
                     "body": "{\"destination\": \"<queue-url:1>\", \"fail_attempts\": 1}",
                     "attributes": {
                       "ApproximateReceiveCount": "1",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SenderId": "sender-id",
-                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
                     },
                     "messageAttributes": {},
                     "md5OfBody": "<md5-of-body:1>",
@@ -73,9 +73,9 @@
                     "body": "{\"destination\": \"<queue-url:1>\", \"fail_attempts\": 1}",
                     "attributes": {
                       "ApproximateReceiveCount": "2",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SenderId": "sender-id",
-                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
                     },
                     "messageAttributes": {},
                     "md5OfBody": "<md5-of-body:1>",
@@ -99,7 +99,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_redrive_policy_with_failing_lambda": {
-    "recorded-date": "27-02-2023, 17:03:26",
+    "recorded-date": "06-09-2024, 13:41:24",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -121,9 +121,9 @@
                     "body": "{\"destination\": \"<queue-url:1>\", \"fail_attempts\": 2}",
                     "attributes": {
                       "ApproximateReceiveCount": "1",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SenderId": "sender-id",
-                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
                     },
                     "messageAttributes": {},
                     "md5OfBody": "<m-d5-of-body:3>",
@@ -157,9 +157,9 @@
                     "body": "{\"destination\": \"<queue-url:1>\", \"fail_attempts\": 2}",
                     "attributes": {
                       "ApproximateReceiveCount": "2",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SenderId": "sender-id",
-                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
                     },
                     "messageAttributes": {},
                     "md5OfBody": "<m-d5-of-body:3>",
@@ -200,7 +200,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_sqs_queue_as_lambda_dead_letter_queue": {
-    "recorded-date": "09-08-2023, 15:06:36",
+    "recorded-date": "06-09-2024, 13:41:38",
     "recorded-content": {
       "lambda-response-dlq-config": {
         "TargetArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>"
@@ -239,7 +239,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures": {
-    "recorded-date": "07-12-2023, 12:55:26",
+    "recorded-date": "06-09-2024, 13:42:09",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -287,7 +287,7 @@
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
         ],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -305,12 +305,12 @@
                 "Records": [
                   {
                     "attributes": {
-                      "ApproximateFirstReceiveTimestamp": "timestamp",
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>",
                       "ApproximateReceiveCount": "1",
                       "MessageDeduplicationId": "dedup-1",
                       "MessageGroupId": "1",
                       "SenderId": "sender-id",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SequenceNumber": "<sequence-number:1>"
                     },
                     "awsRegion": "<region>",
@@ -327,12 +327,12 @@
                   },
                   {
                     "attributes": {
-                      "ApproximateFirstReceiveTimestamp": "timestamp",
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>",
                       "ApproximateReceiveCount": "1",
                       "MessageDeduplicationId": "dedup-2",
                       "MessageGroupId": "1",
                       "SenderId": "sender-id",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SequenceNumber": "<sequence-number:2>"
                     },
                     "awsRegion": "<region>",
@@ -349,12 +349,12 @@
                   },
                   {
                     "attributes": {
-                      "ApproximateFirstReceiveTimestamp": "timestamp",
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>",
                       "ApproximateReceiveCount": "1",
                       "MessageDeduplicationId": "dedup-3",
                       "MessageGroupId": "1",
                       "SenderId": "sender-id",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SequenceNumber": "<sequence-number:3>"
                     },
                     "awsRegion": "<region>",
@@ -371,12 +371,12 @@
                   },
                   {
                     "attributes": {
-                      "ApproximateFirstReceiveTimestamp": "timestamp",
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>",
                       "ApproximateReceiveCount": "1",
                       "MessageDeduplicationId": "dedup-4",
                       "MessageGroupId": "1",
                       "SenderId": "sender-id",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SequenceNumber": "<sequence-number:4>"
                     },
                     "awsRegion": "<region>",
@@ -425,12 +425,12 @@
                 "Records": [
                   {
                     "attributes": {
-                      "ApproximateFirstReceiveTimestamp": "timestamp",
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>",
                       "ApproximateReceiveCount": "2",
                       "MessageDeduplicationId": "dedup-2",
                       "MessageGroupId": "1",
                       "SenderId": "sender-id",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SequenceNumber": "<sequence-number:2>"
                     },
                     "awsRegion": "<region>",
@@ -447,12 +447,12 @@
                   },
                   {
                     "attributes": {
-                      "ApproximateFirstReceiveTimestamp": "timestamp",
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>",
                       "ApproximateReceiveCount": "2",
                       "MessageDeduplicationId": "dedup-3",
                       "MessageGroupId": "1",
                       "SenderId": "sender-id",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SequenceNumber": "<sequence-number:3>"
                     },
                     "awsRegion": "<region>",
@@ -469,12 +469,12 @@
                   },
                   {
                     "attributes": {
-                      "ApproximateFirstReceiveTimestamp": "timestamp",
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>",
                       "ApproximateReceiveCount": "2",
                       "MessageDeduplicationId": "dedup-4",
                       "MessageGroupId": "1",
                       "SenderId": "sender-id",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SequenceNumber": "<sequence-number:4>"
                     },
                     "awsRegion": "<region>",
@@ -529,7 +529,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_on_lambda_error": {
-    "recorded-date": "27-02-2023, 17:08:09",
+    "recorded-date": "06-09-2024, 13:42:29",
     "recorded-content": {
       "dlq_messages": [
         {
@@ -551,7 +551,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_invalid_result_json_batch_fails": {
-    "recorded-date": "27-02-2023, 17:08:39",
+    "recorded-date": "06-09-2024, 13:42:52",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -572,9 +572,9 @@
                     "body": "{\"message\": 1, \"fail_attempts\": 0}",
                     "attributes": {
                       "ApproximateReceiveCount": "1",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SenderId": "sender-id",
-                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
                     },
                     "messageAttributes": {},
                     "md5OfBody": "<m-d5-of-body:3>",
@@ -614,9 +614,9 @@
                     "body": "{\"message\": 1, \"fail_attempts\": 0}",
                     "attributes": {
                       "ApproximateReceiveCount": "2",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SenderId": "sender-id",
-                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
                     },
                     "messageAttributes": {},
                     "md5OfBody": "<m-d5-of-body:3>",
@@ -664,7 +664,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_empty_json_batch_succeeds": {
-    "recorded-date": "27-02-2023, 17:09:08",
+    "recorded-date": "06-09-2024, 13:43:29",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -685,9 +685,9 @@
                     "body": "{\"message\": 1, \"fail_attempts\": 0}",
                     "attributes": {
                       "ApproximateReceiveCount": "1",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SenderId": "sender-id",
-                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
                     },
                     "messageAttributes": {},
                     "md5OfBody": "<md5-of-body:1>",
@@ -712,14 +712,14 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_event_source_mapping_default_batch_size": {
-    "recorded-date": "27-02-2023, 17:09:20",
+    "recorded-date": "06-09-2024, 13:45:16",
     "recorded-content": {
       "create-event-source-mapping": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -756,14 +756,14 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping": {
-    "recorded-date": "27-02-2023, 17:10:13",
+    "recorded-date": "06-09-2024, 13:46:02",
     "recorded-content": {
       "create-event-source-mapping-response": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 1,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -784,9 +784,9 @@
               },
               "attributes": {
                 "ApproximateReceiveCount": "1",
-                "SentTimestamp": "timestamp",
+                "SentTimestamp": "sent-timestamp",
                 "SenderId": "sender-id",
-                "ApproximateFirstReceiveTimestamp": "timestamp"
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
               },
               "messageAttributes": {},
               "md5OfMessageAttributes": null,
@@ -801,7 +801,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter0-item_matching0-item_not_matching0]": {
-    "recorded-date": "27-02-2023, 17:10:46",
+    "recorded-date": "06-09-2024, 13:46:44",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -821,7 +821,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 1,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -842,13 +842,13 @@
               },
               "attributes": {
                 "ApproximateReceiveCount": "1",
-                "SentTimestamp": "timestamp",
+                "SentTimestamp": "sent-timestamp",
                 "SenderId": "sender-id",
-                "ApproximateFirstReceiveTimestamp": "timestamp"
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
               },
               "messageAttributes": {},
-              "md5OfBody": "<md5-of-body:1>",
               "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
               "eventSource": "aws:sqs",
               "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
               "awsRegion": "<region>"
@@ -859,7 +859,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter1-item_matching1-item_not_matching1]": {
-    "recorded-date": "27-02-2023, 17:11:32",
+    "recorded-date": "06-09-2024, 13:47:18",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -880,7 +880,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 1,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -901,13 +901,13 @@
               },
               "attributes": {
                 "ApproximateReceiveCount": "1",
-                "SentTimestamp": "timestamp",
+                "SentTimestamp": "sent-timestamp",
                 "SenderId": "sender-id",
-                "ApproximateFirstReceiveTimestamp": "timestamp"
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
               },
               "messageAttributes": {},
-              "md5OfMessageAttributes": null,
               "md5OfBody": "<md5-of-body:1>",
+              "md5OfMessageAttributes": null,
               "eventSource": "aws:sqs",
               "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
               "awsRegion": "<region>"
@@ -918,7 +918,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter2-item_matching2-item_not_matching2]": {
-    "recorded-date": "27-02-2023, 17:12:15",
+    "recorded-date": "06-09-2024, 13:48:07",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -942,7 +942,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 1,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -964,9 +964,9 @@
               },
               "attributes": {
                 "ApproximateReceiveCount": "1",
-                "SentTimestamp": "timestamp",
+                "SentTimestamp": "sent-timestamp",
                 "SenderId": "sender-id",
-                "ApproximateFirstReceiveTimestamp": "timestamp"
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
               },
               "messageAttributes": {},
               "md5OfMessageAttributes": null,
@@ -981,7 +981,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter3-item_matching3-item_not_matching3]": {
-    "recorded-date": "27-02-2023, 17:12:57",
+    "recorded-date": "06-09-2024, 13:48:45",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1003,7 +1003,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 1,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -1024,9 +1024,9 @@
               },
               "attributes": {
                 "ApproximateReceiveCount": "1",
-                "SentTimestamp": "timestamp",
+                "SentTimestamp": "sent-timestamp",
                 "SenderId": "sender-id",
-                "ApproximateFirstReceiveTimestamp": "timestamp"
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
               },
               "messageAttributes": {},
               "md5OfMessageAttributes": null,
@@ -1041,7 +1041,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter4-item_matching4-this is a test string]": {
-    "recorded-date": "27-02-2023, 17:13:42",
+    "recorded-date": "06-09-2024, 13:49:17",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1066,7 +1066,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 1,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -1087,9 +1087,9 @@
               },
               "attributes": {
                 "ApproximateReceiveCount": "1",
-                "SentTimestamp": "timestamp",
+                "SentTimestamp": "sent-timestamp",
                 "SenderId": "sender-id",
-                "ApproximateFirstReceiveTimestamp": "timestamp"
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
               },
               "messageAttributes": {},
               "md5OfMessageAttributes": null,
@@ -1104,7 +1104,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter5-item_matching5-item_not_matching5]": {
-    "recorded-date": "27-02-2023, 17:14:29",
+    "recorded-date": "06-09-2024, 13:49:57",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1129,7 +1129,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 1,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -1150,13 +1150,13 @@
               },
               "attributes": {
                 "ApproximateReceiveCount": "1",
-                "SentTimestamp": "timestamp",
+                "SentTimestamp": "sent-timestamp",
                 "SenderId": "sender-id",
-                "ApproximateFirstReceiveTimestamp": "timestamp"
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
               },
               "messageAttributes": {},
-              "md5OfBody": "<md5-of-body:1>",
               "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
               "eventSource": "aws:sqs",
               "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
               "awsRegion": "<region>"
@@ -1167,7 +1167,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter6-item_matching6-item_not_matching6]": {
-    "recorded-date": "27-02-2023, 17:15:15",
+    "recorded-date": "06-09-2024, 13:50:34",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1194,7 +1194,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 1,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -1215,9 +1215,9 @@
               },
               "attributes": {
                 "ApproximateReceiveCount": "1",
-                "SentTimestamp": "timestamp",
+                "SentTimestamp": "sent-timestamp",
                 "SenderId": "sender-id",
-                "ApproximateFirstReceiveTimestamp": "timestamp"
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
               },
               "messageAttributes": {},
               "md5OfMessageAttributes": null,
@@ -1232,7 +1232,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter7-item_matching7-item_not_matching7]": {
-    "recorded-date": "27-02-2023, 17:16:04",
+    "recorded-date": "06-09-2024, 13:51:23",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1254,7 +1254,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 1,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -1275,9 +1275,9 @@
               },
               "attributes": {
                 "ApproximateReceiveCount": "1",
-                "SentTimestamp": "timestamp",
+                "SentTimestamp": "sent-timestamp",
                 "SenderId": "sender-id",
-                "ApproximateFirstReceiveTimestamp": "timestamp"
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
               },
               "messageAttributes": {},
               "md5OfMessageAttributes": null,
@@ -1292,7 +1292,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[None]": {
-    "recorded-date": "27-02-2023, 17:16:07",
+    "recorded-date": "06-09-2024, 13:51:28",
     "recorded-content": {
       "create_event_source_mapping_exception": {
         "Error": {
@@ -1309,7 +1309,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[simple string]": {
-    "recorded-date": "27-02-2023, 17:16:11",
+    "recorded-date": "06-09-2024, 13:51:33",
     "recorded-content": {
       "create_event_source_mapping_exception": {
         "Error": {
@@ -1326,7 +1326,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[invalid_filter2]": {
-    "recorded-date": "27-02-2023, 17:16:15",
+    "recorded-date": "06-09-2024, 13:51:39",
     "recorded-content": {
       "create_event_source_mapping_exception": {
         "Error": {
@@ -1343,7 +1343,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[invalid_filter3]": {
-    "recorded-date": "27-02-2023, 17:16:18",
+    "recorded-date": "06-09-2024, 13:51:44",
     "recorded-content": {
       "create_event_source_mapping_exception": {
         "Error": {
@@ -1360,7 +1360,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_message_body_and_attributes_passed_correctly": {
-    "recorded-date": "17-03-2023, 17:04:06",
+    "recorded-date": "06-09-2024, 13:40:58",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -1382,9 +1382,9 @@
                     "body": "{\"destination\": \"<queue-url:1>\", \"fail_attempts\": 0}",
                     "attributes": {
                       "ApproximateReceiveCount": "1",
-                      "SentTimestamp": "timestamp",
+                      "SentTimestamp": "sent-timestamp",
                       "SenderId": "sender-id",
-                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                      "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
                     },
                     "messageAttributes": {
                       "WeeksOn": {
@@ -1406,8 +1406,8 @@
                         "dataType": "String"
                       }
                     },
-                    "md5OfMessageAttributes": "d25a6aea97eb8f585bfa92d314504a92",
                     "md5OfBody": "<md5-of-body:1>",
+                    "md5OfMessageAttributes": "d25a6aea97eb8f585bfa92d314504a92",
                     "eventSource": "aws:sqs",
                     "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
                     "awsRegion": "<region>"
@@ -1428,14 +1428,14 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_update": {
-    "recorded-date": "31-10-2023, 15:18:45",
+    "recorded-date": "06-09-2024, 13:53:43",
     "recorded-content": {
       "create-event-source-mapping-response": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 1,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -1459,9 +1459,9 @@
                 },
                 "attributes": {
                   "ApproximateReceiveCount": "1",
-                  "SentTimestamp": "timestamp",
+                  "SentTimestamp": "sent-timestamp",
                   "SenderId": "sender-id",
-                  "ApproximateFirstReceiveTimestamp": "timestamp"
+                  "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
                 },
                 "messageAttributes": {},
                 "md5OfMessageAttributes": null,
@@ -1479,7 +1479,7 @@
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 1,
         "State": "Updating",
         "StateTransitionReason": "USER_INITIATED",
@@ -1487,6 +1487,21 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 202
+        }
+      },
+      "updated_event_source_mapping": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Enabled",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "events_postupdate": [
@@ -1503,9 +1518,9 @@
                 },
                 "attributes": {
                   "ApproximateReceiveCount": "1",
-                  "SentTimestamp": "timestamp",
+                  "SentTimestamp": "sent-timestamp",
                   "SenderId": "sender-id",
-                  "ApproximateFirstReceiveTimestamp": "timestamp"
+                  "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
                 },
                 "messageAttributes": {},
                 "md5OfMessageAttributes": null,
@@ -1530,9 +1545,9 @@
                 },
                 "attributes": {
                   "ApproximateReceiveCount": "1",
-                  "SentTimestamp": "timestamp",
+                  "SentTimestamp": "sent-timestamp",
                   "SenderId": "sender-id",
-                  "ApproximateFirstReceiveTimestamp": "timestamp"
+                  "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
                 },
                 "messageAttributes": {},
                 "md5OfMessageAttributes": null,
@@ -1548,14 +1563,14 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_duplicate_event_source_mappings": {
-    "recorded-date": "04-01-2024, 17:10:43",
+    "recorded-date": "06-09-2024, 13:53:54",
     "recorded-content": {
       "create": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
@@ -1580,14 +1595,14 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_fifo_message_group_parallelism": {
-    "recorded-date": "02-08-2024, 14:48:56",
+    "recorded-date": "06-09-2024, 13:44:51",
     "recorded-content": {
       "create_esm_disabled": {
         "BatchSize": 1,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Disabled",
         "StateTransitionReason": "USER_INITIATED",
@@ -1602,7 +1617,7 @@
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Enabling",
         "StateTransitionReason": "USER_INITIATED",
@@ -1617,7 +1632,7 @@
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Enabled",
         "StateTransitionReason": "USER_INITIATED",

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.validation.json
@@ -1,77 +1,77 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_duplicate_event_source_mappings": {
-    "last_validated_date": "2024-01-04T23:36:38+00:00"
+    "last_validated_date": "2024-09-06T13:53:49+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_event_source_mapping_default_batch_size": {
-    "last_validated_date": "2023-02-27T16:09:20+00:00"
+    "last_validated_date": "2024-09-06T13:45:13+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter0-item_matching0-item_not_matching0]": {
-    "last_validated_date": "2023-02-27T16:10:46+00:00"
+    "last_validated_date": "2024-09-06T13:46:42+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter1-item_matching1-item_not_matching1]": {
-    "last_validated_date": "2023-02-27T16:11:32+00:00"
+    "last_validated_date": "2024-09-06T13:47:16+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter2-item_matching2-item_not_matching2]": {
-    "last_validated_date": "2023-02-27T16:12:15+00:00"
+    "last_validated_date": "2024-09-06T13:48:05+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter3-item_matching3-item_not_matching3]": {
-    "last_validated_date": "2023-02-27T16:12:57+00:00"
+    "last_validated_date": "2024-09-06T13:48:43+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter4-item_matching4-this is a test string]": {
-    "last_validated_date": "2023-02-27T16:13:42+00:00"
+    "last_validated_date": "2024-09-06T13:49:16+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter5-item_matching5-item_not_matching5]": {
-    "last_validated_date": "2023-02-27T16:14:29+00:00"
+    "last_validated_date": "2024-09-06T13:49:56+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter6-item_matching6-item_not_matching6]": {
-    "last_validated_date": "2023-02-27T16:15:15+00:00"
+    "last_validated_date": "2024-09-06T13:50:32+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter7-item_matching7-item_not_matching7]": {
-    "last_validated_date": "2023-02-27T16:16:04+00:00"
+    "last_validated_date": "2024-09-06T13:51:21+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping": {
-    "last_validated_date": "2023-02-27T16:10:13+00:00"
+    "last_validated_date": "2024-09-06T13:46:01+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_update": {
-    "last_validated_date": "2023-10-31T14:18:45+00:00"
+    "last_validated_date": "2024-09-06T13:53:41+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[None]": {
-    "last_validated_date": "2023-02-27T16:16:07+00:00"
+    "last_validated_date": "2024-09-06T13:51:27+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[invalid_filter2]": {
-    "last_validated_date": "2023-02-27T16:16:15+00:00"
+    "last_validated_date": "2024-09-06T13:51:36+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[invalid_filter3]": {
-    "last_validated_date": "2023-02-27T16:16:18+00:00"
+    "last_validated_date": "2024-09-06T13:51:42+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[simple string]": {
-    "last_validated_date": "2023-02-27T16:16:11+00:00"
+    "last_validated_date": "2024-09-06T13:51:31+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_failing_lambda_retries_after_visibility_timeout": {
-    "last_validated_date": "2023-02-27T16:02:53+00:00"
+    "last_validated_date": "2024-09-06T13:40:37+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_fifo_message_group_parallelism": {
-    "last_validated_date": "2024-08-02T14:48:55+00:00"
+    "last_validated_date": "2024-09-06T13:44:50+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_message_body_and_attributes_passed_correctly": {
-    "last_validated_date": "2023-03-17T16:04:06+00:00"
+    "last_validated_date": "2024-09-06T13:40:55+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_redrive_policy_with_failing_lambda": {
-    "last_validated_date": "2023-02-27T16:03:26+00:00"
+    "last_validated_date": "2024-09-06T13:41:21+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures": {
-    "last_validated_date": "2024-08-27T14:55:51+00:00"
+    "last_validated_date": "2024-09-06T13:42:06+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_empty_json_batch_succeeds": {
-    "last_validated_date": "2023-02-27T16:09:08+00:00"
+    "last_validated_date": "2024-09-06T13:43:26+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_invalid_result_json_batch_fails": {
-    "last_validated_date": "2023-02-27T16:08:39+00:00"
+    "last_validated_date": "2024-09-06T13:42:49+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_on_lambda_error": {
-    "last_validated_date": "2023-02-27T16:08:09+00:00"
+    "last_validated_date": "2024-09-06T13:42:27+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_sqs_queue_as_lambda_dead_letter_queue": {
-    "last_validated_date": "2023-08-09T13:06:36+00:00"
+    "last_validated_date": "2024-09-06T13:41:36+00:00"
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.validation.json
@@ -60,7 +60,7 @@
     "last_validated_date": "2023-02-27T16:03:26+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures": {
-    "last_validated_date": "2023-11-10T18:17:37+00:00"
+    "last_validated_date": "2024-08-27T14:55:51+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_empty_json_batch_succeeds": {
     "last_validated_date": "2023-02-27T16:09:08+00:00"

--- a/tests/aws/services/lambda_/event_source_mapping/utils.py
+++ b/tests/aws/services/lambda_/event_source_mapping/utils.py
@@ -1,11 +1,10 @@
-import os
-
+from localstack.config import LAMBDA_EVENT_SOURCE_MAPPING
 from localstack.testing.aws.util import is_aws_cloud
 
 
 def is_v2_esm():
-    return os.environ.get("LAMBDA_EVENT_SOURCE_MAPPING") == "v2" and not is_aws_cloud()
+    return LAMBDA_EVENT_SOURCE_MAPPING == "v2" and not is_aws_cloud()
 
 
 def is_old_esm():
-    return os.environ.get("LAMBDA_EVENT_SOURCE_MAPPING") == "v1" and not is_aws_cloud()
+    return LAMBDA_EVENT_SOURCE_MAPPING == "v1" and not is_aws_cloud()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Different failure context payloads in ESM and pipes require that we accommodate for both scenarios. This PR makes the context generation an abstract method that classes implementing the `EventsProcessor` interface will have to define.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

### `EventsProcessor` and context generation changes
- Add abstract `generate_event_failure_context` to `EventsProcessor` interface.
- Define `generate_event_failure_context` for ESM, returning a `requestContext` and `responseContext` on failure.

### Exceptions and error handling
- Add error context field to `BatchFailureError` exception.
- Pass and use error contexts for `requestContext` and `responseContext` generation via `SenderError`, `PartialFailureSenderError`, and `BatchFailureError`.

### Other
- Correct timestamp formatting for DynamoDB (without milliseconds) and Kinesis (with miliseconds).
- Added several inline `TODOs` for future refactoring/implementation improvements.
- Removed some snapshot verification skipping for ESM v2.
- Regenerated all ESM snapshots and added `conftest.py` to allow better timestamp transforming in the `event_source_mapping` subdir.

## Testing
The below tests have been validated following these changes. In addition, `requestContext` and `responseContext` are no longer skipped from snapshot matching.
- Kinesis: `TestKinesisSource::test_kinesis_event_source_mapping_with_on_failure_destination_config`
- DynamoDB: `TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_on_failure_destination_config`

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
