### PR TITLE
env var to delete the cached cert at startup

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -722,6 +722,9 @@ SKIP_SSL_CERT_DOWNLOAD = is_env_true("SKIP_SSL_CERT_DOWNLOAD")
 # Absolute path to a custom certificate (pem file)
 CUSTOM_SSL_CERT_PATH = os.environ.get("CUSTOM_SSL_CERT_PATH", "").strip()
 
+# Whether delete the cached signed SSL certificate at startup
+REMOVE_SSL_CERT = is_env_true("REMOVE_SSL_CERT")
+
 # Allow non-standard AWS regions
 ALLOW_NONSTANDARD_REGIONS = is_env_true("ALLOW_NONSTANDARD_REGIONS")
 if ALLOW_NONSTANDARD_REGIONS:
@@ -1258,6 +1261,7 @@ CONFIG_ENV_VARS = [
     "PERSISTENCE",
     "PORTS_CHECK_DOCKER_IMAGE",
     "REQUESTS_CA_BUNDLE",
+    "REMOVE_SSL_CERT",
     "S3_SKIP_SIGNATURE_VALIDATION",
     "S3_SKIP_KMS_KEY_VALIDATION",
     "SERVICES",

--- a/localstack-core/localstack/plugins.py
+++ b/localstack-core/localstack/plugins.py
@@ -2,6 +2,8 @@ import logging
 
 from localstack import config
 from localstack.runtime import hooks
+from localstack.utils.files import rm_rf
+from localstack.utils.ssl import get_cert_pem_file_path
 
 LOG = logging.getLogger(__name__)
 
@@ -24,3 +26,10 @@ def deprecation_warnings() -> None:
     from localstack.deprecations import log_deprecation_warnings
 
     log_deprecation_warnings()
+
+
+@hooks.on_infra_start(should_load=lambda: config.REMOVE_SSL_CERT)
+def delete_cached_certificate():
+    LOG.debug("Removing the cached local SSL certificate")
+    target_file = get_cert_pem_file_path()
+    rm_rf(target_file)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Manually deleting the cached certificate could be a cumbersome operation for customers.
We should have a way to make this easier.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Introduce a `REMOVE_SSL_CERT` env var.
- Added a hook that removes the cached certificate at startup.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
