### PR TITLE
fix S3 region for DNS resolving

### DIFF
--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -4309,13 +4309,13 @@ class TestS3:
         response = requests.get(bucket_url)
         assert response.status_code == 404
 
-        bucket_vhost_url = _bucket_url_vhost(bucket_name, region="us-west-2")
-        assert "us-west-2" in bucket_vhost_url
+        bucket_vhost_url = _bucket_url_vhost(bucket_name, region="eu-central-1")
+        assert "eu-central-1" in bucket_vhost_url
         response = requests.get(bucket_vhost_url)
         assert response.status_code == 404
 
-        bucket_url = _bucket_url(bucket_name, region="us-west-2")
-        assert "us-west-2" in bucket_url
+        bucket_url = _bucket_url(bucket_name, region="eu-central-1")
+        assert "eu-central-1" in bucket_url
         response = requests.get(bucket_url)
         assert response.status_code == 404
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Seems like we've had an issue with resolving the `us-west-2` subdomain. Switched it to `eu-central-1` to fix the pipeline for now, and we'll keep looking into the issue. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- switch the region in `test_bucket_does_not_exist`
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
