### PR TITLE
Replace auto-install of setuptools_scm with error in helper scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,10 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
+          name: Install global python dependencies
+          command: |
+            pip install --upgrade setuptools setuptools_scm
+      - run:
           name: Build community docker image
           command: ./bin/docker-helper.sh build
       - run:
@@ -770,6 +774,10 @@ jobs:
       - prepare-acceptance-tests
       - attach_workspace:
           at: /tmp/workspace
+      - run:
+          name: Install global python dependencies
+          command: |
+            pip install --upgrade setuptools setuptools_scm
       - run:
           name: Load docker image - amd64
           working_directory: target

--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install release helper dependencies
+        run: pip install --upgrade setuptools setuptools_scm
+
       - name: Cache LocalStack community dependencies (venv)
         uses: actions/cache@v4
         with:

--- a/.github/workflows/tests-bin.yml
+++ b/.github/workflows/tests-bin.yml
@@ -31,6 +31,14 @@ jobs:
           cd "$HOME"/bats-core
           sudo ./install.sh /usr/local
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install helper script dependencies
+        run: pip install --upgrade setuptools setuptools_scm
+
       - name: Run bats tests
         run: |
           bats --report-formatter junit -r tests/bin/ --output .

--- a/.github/workflows/tests-s3-image.yml
+++ b/.github/workflows/tests-s3-image.yml
@@ -113,6 +113,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install docker build dependencies
+        run: pip install --upgrade setuptools setuptools_scm
+
       - name: Build S3 Docker Image
         env:
           DOCKERFILE: "./Dockerfile.s3"
@@ -199,6 +207,14 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install docker build dependencies
+        run: pip install --upgrade setuptools setuptools_scm
 
       - name: Download AMD64 image
         uses: actions/download-artifact@v4

--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -49,9 +49,9 @@ function _fail {
 }
 
 function _get_current_version() {
-    # setuptools_scm will be installed transparently if not available, Python3 is expected to be present
-    if ! python3 -m pip -qqq list | grep -F "setuptools_scm"; then
-      python3 -m pip install -qqq setuptools_scm > /dev/null 2>&1
+    # check if setuptools_scm is installed, if not prompt to install. python3 is expected to be present
+    if ! python3 -m pip -qqq show setuptools_scm > /dev/null ; then
+      echo "ERROR: setuptools_scm is not installed. Run 'pip install --upgrade setuptools setuptools_scm'" && exit 1
     fi
     python3 -m setuptools_scm
 }

--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -51,7 +51,8 @@ function _fail {
 function _get_current_version() {
     # check if setuptools_scm is installed, if not prompt to install. python3 is expected to be present
     if ! python3 -m pip -qqq show setuptools_scm > /dev/null ; then
-      echo "ERROR: setuptools_scm is not installed. Run 'pip install --upgrade setuptools setuptools_scm'" && exit 1
+      echo "ERROR: setuptools_scm is not installed. Run 'pip install --upgrade setuptools setuptools_scm'" >&2
+      exit 1
     fi
     python3 -m setuptools_scm
 }

--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -44,7 +44,7 @@ function usage() {
 function get_current_version() {
     # check if setuptools_scm is installed, if not prompt to install. python3 is expected to be present
     if ! python3 -m pip -qqq show setuptools_scm > /dev/null ; then
-      echo "ERROR: setuptools_scm is not installed. Run 'pip install --upgrade setuptools setuptools_scm'"
+      echo "ERROR: setuptools_scm is not installed. Run 'pip install --upgrade setuptools setuptools_scm'" >&2
       exit 1
     fi
     python3 -m setuptools_scm

--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -44,7 +44,8 @@ function usage() {
 function get_current_version() {
     # check if setuptools_scm is installed, if not prompt to install. python3 is expected to be present
     if ! python3 -m pip -qqq show setuptools_scm > /dev/null ; then
-      echo "ERROR: setuptools_scm is not installed. Run 'pip install --upgrade setuptools setuptools_scm'" && exit 1
+      echo "ERROR: setuptools_scm is not installed. Run 'pip install --upgrade setuptools setuptools_scm'"
+      exit 1
     fi
     python3 -m setuptools_scm
 }

--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -42,9 +42,9 @@ function usage() {
 }
 
 function get_current_version() {
-    # setuptools_scm will be installed transparently if not available, Python3 is expected to be present
-    if ! python3 -m pip -qqq list | grep -F "setuptools_scm"; then
-      python3 -m pip install -qqq setuptools_scm > /dev/null 2>&1
+    # check if setuptools_scm is installed, if not prompt to install. python3 is expected to be present
+    if ! python3 -m pip -qqq show setuptools_scm > /dev/null ; then
+      echo "ERROR: setuptools_scm is not installed. Run 'pip install --upgrade setuptools setuptools_scm'" && exit 1
     fi
     python3 -m setuptools_scm
 }

--- a/tests/bin/test.release-helper.bats
+++ b/tests/bin/test.release-helper.bats
@@ -14,6 +14,13 @@ setup_file() {
       # setuptools_scm returns out test version
       echo "$TEST_SPECIFIC_VERSION"
       ;;
+    "pip")
+      # pip exits with $TEST_PIP_EXIT_CODE
+      echo "python3 $@"
+      if [ -n "${TEST_PIP_FAIL-}" ]; then
+        exit 1
+      fi
+      ;;
     *)
       # everything else just prints the command
       echo "python3 $@"
@@ -98,4 +105,13 @@ _setup_tmp_dependency_file() {
 
   [ "$status" -eq 0 ]
   [[ "$output" =~ "git commit --allow-empty -m prepare next development iteration" ]]
+}
+
+@test "get-ver throws error when setuptools-scm is not installed" {
+  export TEST_PIP_FAIL=1
+
+  run bin/release-helper.sh get-ver
+  echo "output = ${output}"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "ERROR: setuptools_scm is not installed. Run 'pip install --upgrade setuptools setuptools_scm'" ]]
 }

--- a/tests/bin/test.release-helper.bats
+++ b/tests/bin/test.release-helper.bats
@@ -18,7 +18,7 @@ setup_file() {
       # pip exits with $TEST_PIP_EXIT_CODE
       echo "python3 $@"
       if [ -n "${TEST_PIP_FAIL-}" ]; then
-        exit 1
+        return 1
       fi
       ;;
     *)
@@ -111,7 +111,6 @@ _setup_tmp_dependency_file() {
   export TEST_PIP_FAIL=1
 
   run bin/release-helper.sh get-ver
-  echo "output = ${output}"
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "ERROR: setuptools_scm is not installed. Run 'pip install --upgrade setuptools setuptools_scm'" ]]
+  [[ "$output" =~ "ERROR" ]]
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

With the introduction of `setuptools_scm` our helper scripts started to depend on it. First, we added an automatic install of this dependency. However, unknowing users of those scripts might then install those dependencies into their global python environment which they might not want.
Decoupling the installation from the script execution will solve this.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Change check for installation of setuptools_scm to use `pip show`,  so that both `setuptools-scm` and `setuptools_scm` can be detected (at some version, they switched the naming)
- Display an ERROR when the package is missing instead of quietly installing it in the active environment
- Change the workflows that use the helper script to install the newest versions of `setuptools` and `setuptools-scm` to avoid version incompatibilities.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
