### PR TITLE
cloudwatch: move TaggingService to the store

### DIFF
--- a/localstack-core/localstack/services/cloudwatch/models.py
+++ b/localstack-core/localstack/services/cloudwatch/models.py
@@ -9,6 +9,7 @@ from localstack.services.stores import (
     LocalAttribute,
 )
 from localstack.utils.aws import arns
+from localstack.utils.tagging import TaggingService
 
 
 class LocalStackMetricAlarm:
@@ -81,7 +82,7 @@ LocalStackAlarm = LocalStackMetricAlarm | LocalStackCompositeAlarm
 
 class CloudWatchStore(BaseStore):
     # maps resource ARN to tags
-    TAGS: Dict[str, Dict[str, str]] = CrossRegionAttribute(default=dict)
+    TAGS: TaggingService = CrossRegionAttribute(default=TaggingService)
 
     # maps resource ARN to alarms
     alarms: Dict[str, LocalStackAlarm] = LocalAttribute(default=dict)

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -658,7 +658,10 @@ class TestCloudwatch:
         snapshot.match("describe_alarms", describe_alarms)
         alarm = describe_alarms["MetricAlarms"][0]
         alarm_arn = alarm["AlarmArn"]
+        list_tags_for_resource = aws_client.cloudwatch.list_tags_for_resource(ResourceARN=alarm_arn)
+        snapshot.match("list_tags_for_resource_empty ", list_tags_for_resource)
 
+        # add tags
         tags = [{"Key": "tag1", "Value": "foo"}, {"Key": "tag2", "Value": "bar"}]
         response = aws_client.cloudwatch.tag_resource(ResourceARN=alarm_arn, Tags=tags)
         assert 200 == response["ResponseMetadata"]["HTTPStatusCode"]

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -648,7 +648,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_store_tags": {
-    "recorded-date": "12-09-2023, 11:54:46",
+    "recorded-date": "02-09-2024, 14:03:31",
     "recorded-content": {
       "put_metric_alarm": {
         "ResponseMetadata": {
@@ -681,6 +681,13 @@
             "Threshold": 30.0
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_resource_empty ": {
+        "Tags": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -60,6 +60,6 @@
     "last_validated_date": "2024-01-19T15:30:05+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_store_tags": {
-    "last_validated_date": "2023-09-12T09:54:46+00:00"
+    "last_validated_date": "2024-09-02T14:03:31+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, persistence for tags in cloudwatch is not working properly, because we use the `TaggingService` directly in the provider. 
With this PR we move the `TaggingService` to the cloudwatch-store (for the v2 implementation).
We are not adapting the v1 implementation as we would encourage customers to use the new default provider.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* moved `TaggingService` to the cloudwatch store
* updated related snapshot test (and enhanced with check for empty tag)

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
