### PR TITLE
make OPENAPI_VALIDATE_REQUEST opt-in

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -751,7 +751,7 @@ ARN_PARTITION_REWRITING = is_env_true("ARN_PARTITION_REWRITING")
 # Feature flag to enable validation of internal endpoint responses in the handler chain. For test use only.
 OPENAPI_VALIDATE_RESPONSE = is_env_true("OPENAPI_VALIDATE_RESPONSE")
 # Flag to enable the validation of the requests made to the LocalStack internal endpoints. Active by default.
-OPENAPI_VALIDATE_REQUEST = is_env_not_false("OPENAPI_VALIDATE_REQUEST")
+OPENAPI_VALIDATE_REQUEST = is_env_true("OPENAPI_VALIDATE_REQUEST")
 
 # Fallback partition to use if not possible to determine from ARN region.
 # Applicable only when ARN partition rewriting is enabled.


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We have seen the OpenAPI validation create issues with snapshot persistence.
With this PR we make the request for validation opt-in (was by default) upon further investigation.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- `OPENAPI_VALIDATE_REQUEST` is now switched off by default.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
