### PR TITLE
fix S3 VersionId format

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -6,7 +6,6 @@ import logging
 from collections import defaultdict
 from io import BytesIO
 from operator import itemgetter
-from secrets import token_urlsafe
 from typing import IO, Optional, Union
 from urllib import parse as urlparse
 
@@ -252,6 +251,7 @@ from localstack.services.s3.utils import (
     create_s3_kms_managed_key_for_region,
     etag_to_base_64_content_md5,
     extract_bucket_key_version_id_from_copy_source,
+    generate_safe_version_id,
     get_canned_acl,
     get_class_attrs_from_spec_class,
     get_failed_precondition_copy_source,
@@ -4103,8 +4103,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 def generate_version_id(bucket_versioning_status: str) -> str | None:
     if not bucket_versioning_status:
         return None
-    # TODO: check VersionID format, could it be base64 urlsafe encoded?
-    return token_urlsafe(16) if bucket_versioning_status.lower() == "enabled" else "null"
+    elif bucket_versioning_status.lower() == "enabled":
+        return generate_safe_version_id()
+    else:
+        return "null"
 
 
 def add_encryption_to_response(response: dict, s3_object: S3Object):

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -3625,5 +3625,19 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3BucketVersioning::test_object_version_id_format": {
+    "recorded-date": "03-09-2024, 13:17:03",
+    "recorded-content": {
+      "put-object": {
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -65,6 +65,9 @@
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketVersioning::test_bucket_versioning_crud": {
     "last_validated_date": "2024-01-15T03:12:29+00:00"
   },
+  "tests/aws/services/s3/test_s3_api.py::TestS3BucketVersioning::test_object_version_id_format": {
+    "last_validated_date": "2024-09-03T13:17:03+00:00"
+  },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_no_copy_source_range": {
     "last_validated_date": "2023-11-14T19:50:28+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #11450, the format of our `VersionId` did not closely follow AWS, most importantly we sent an invalid XML character, leading to issue in `DeleteObject`. 

Looking at AWS documentation, AWS is pretty vague about the format, probably to have some leeway in doing changes in the future (I have a vague memory the length changing over time).

> Version IDs are Unicode, UTF-8 encoded, URL-ready, opaque strings that are no more than 1,024 bytes long. The following is an example:
>
> 3sL4kqtJlcpXroDTDmJ+rmSpXd3dIbrHY+MTRCxf3vjVBH40Nr8X8gdRQBpUMLUo

However, the documentation format isn't really right, as it contains the `+` character which actual `VersionId` cannot contain.

I've generated a list of 100 VersionId in AWS to validate my assumptions, see the detail under. 

<details><summary>Generated VersionIds</summary>
<p>

```python
version_ids = [
    "36jjeSq7OlGnNPRQK4VxLvy_TZ1iJddq",
    "kGg.8H_73_cdxO2Ey4bwYmT8.DupPK4x",
    "DpevK3OKFnlYQl_QPB3Md_qP4Ju90bS4",
    "aoHgIUMCT9b2hbsOPqabc.WPgxTM22nx",
    "ripI30YxQFSW3h.VVQo2oO2SsLUm9xiy",
    "dhglviHNJv.TJkIbDoYjUIVEqWo14urn",
    "kP0fmA85JEEpiZ.mqw.foqNwLskY.KmJ",
    "nZ5v1pGcH1GuEplYTQ3oMDvyhD52PGI6",
    "m_RkMuFgbnUJhyhIjfq_ioZQIYiVK.e5",
    "cFOGKTQf5CHI7CBpSG1noNvk2DVm_7QH",
    "8LKew79zLAd5D4VAnaHhXBS_mJBB99Vi",
    "sDJWlTMOSmzoe2.k86ozH_u2DMYri_Tu",
    "DSLWVCjZ8vmrtIP2uWMjfKSaIiEbZs5D",
    "xW5KN8KNYSYO.ZAl4U_lkJyOwNQKoQNp",
    "QwOqzkkay7unUOfxw7wWakemMXlo6ND_",
    "hyoLTarKwcfkoX3o1VtOD_jsTd8JDWMV",
    "TX5NXTqjqRxOgbCAyuPdlo_AYMTMSfEl",
    "9FGnhozVR2ZM17tEwC3QcLkc2cbIxfe5",
    "i5FoB9W0RQHxZ.fUaSeCptH9v.KPLGF9",
    "gRYH1N.jnHsw2fUccahfOqIdozTCPmC_",
    "rt5AvvWO7vleZaN0LuUlGPWbpcTHJp4X",
    "WRN37UVwaXgoXCEIpilK9kU6akUuwyII",
    "N8XNyEr.6KkKFer__iE.f8DB6ZpsiGnC",
    "q.aupfI0PSsBpM6R47ZA2DMjvh_6Op3G",
    "97WoN8qJ0azfj_N1dagKJuhBvke5sG6v",
    "efsu3eRh3fmcdjxJjQ0gc66G7yMA78_x",
    "BIK2gs.cAMMK3kxi1r6wsWD2ayA.rXDj",
    "iOY6Mq3.swCXMc7x_N1SA2TKGW3HErHH",
    "pVPjucoTax1O9laDoqtzD1ghOgGnRiZ6",
    "l7Ap.nnLKyt1F_wnkvPSILVnOjiYVFJO",
    "vaco26JMExPHh8Vb65Sz_k1UgUGWP3qh",
    "EEq6ms9B9gcvogZ36uQ43u.hFfxpz92c",
    "sO0nOg7Gb0r25F.pg3IBA6XWQ6Cwy9y0",
    "jU41YgtprbWk7.J6xHiheOFUAwvVM8uI",
    "Pk1.PHkauFuXHdqWJL14svRxyI1EaB5N",
    "Wb0T8S5htoLL1SmJtjK4n32CKzsbGQN8",
    "RknP3Yw3DcCySEApcAsqXsLMOpvDBWOM",
    "MPVaTjsqShb42Odb2MGXWeuMRnim7D8O",
    "LMHZKxAa1QR9fg9GlbqKtOxkKuTGIUs1",
    "Rc7xV8npvI94A53oGGm81bBaCJ0boDB8",
    "7TsJPid4H7velMxmKamh3I.6o2I4BZo0",
    "nguIMkBv1aiAJb3Bu2ISYV94B6K0UxPW",
    "Sq3fOKCVEfZqQokcC7DSMILi.qSpzPc2",
    "MUlcAxnDd9fj4tgWkuRVX1rAZbUcsMQ4",
    "SloA6Dmy1B7M8KkiEO67jyLeNofT358s",
    "LUcyOvXS7QOmp5SOqMWaskmKVkYukM5o",
    "4bU7qVkjVIZLR1ch.f0zRDdCUZKkpN18",
    "hVXtLY4RxMx6M.dNmHn4tOM4blPNY1nU",
    "EqkJJIcWedzYTG71Kmo4lJ1tkyDxtute",
    "aKRW7IZb3WYQaAm1m1r47jtIJBHGxzZ2",
    "ZC6k8N9XXi1RQy.oyemnPjE7vyv7Ce90",
    "odnjAo_.lSP1nPN3YKJeUELDha7N89Oh",
    "R4Nh83GWcgOsmPRKeu9doeyqdJbp25G3",
    "bWx6o1Xs7ZVqhBqYnRduUSMbyRU9rcfZ",
    "TrTJF6JrxfF1iPOEPNhXK2y_1ZEAIrCu",
    "vT8OMJAQ3fEygtVmgdBFpm52WoSD2w3O",
    "itNXw05x7xlQrBOGq4k6H9WUZdkExrkr",
    ".itcPOvvEsxoOWVnMnufU.J9e99wKaiq",
    "kidwnhgefAFK.gCk0tFmXHVxeQ_.f7Yq",
    "AC7Wz10hVp60yogUve.tHg5INU8X_Pt_",
    "NP0aabgp7HRNXvsvZZY1PygrkkcxUfk1",
    "O8kuITgNBVlTJ5mATiJnhBzR_uTRFQfW",
    "Mb2WhL47vS3yM3wc7B_7vK_QBLdtfrQ_",
    "Mibsoz6HPh.9KC15R369sAs.5qB7OKAE",
    "Ef0GJLlqNgD9Wd2dN491YTM4p87YN3Nn",
    "E2lmuGBA0TSOHefBMuAh7ffgws1.tWlt",
    "Y_6vDG7c45kr8dfEvpSCiVtylGzy5jrP",
    "T.DwxXvxLr51LFKSX3j.Ztd4zbClqJFb",
    "POjq5ZcG058q_S6ZwJgicFNucpdcs9tL",
    "vACCKoSrgYoIMH2SNc9KcMGaolSIASib",
    "zFmq2FUVWPc8wrMxfm3sqbNDKMp4sb_S",
    "684ZegyblN2lEq_mCuwgy22BoDipE5nD",
    "Fo5VC3nxzxGSy8rAOUf2ATDFKPX9OGB4",
    "VJXy3ETSN7F.iAJKLEA5_wLn9sAB6o4K",
    "SlpaVIoGrWlIPJdl.Fix..DQ.t001vgU",
    "85036rUfXbv4Ia9cq07NYsVRsdr09BHH",
    "AM.h8_wjP401PcNz2rJroAkhFq.8xurI",
    "4amEAZTK3xchucT.ieLDaKA9YLVr2HYt",
    ".mq_WsxXxmDtoPDrHxQozCMBFkBbMfBR",
    "t7WwHm1SsYb4J93C_DBbvU.8pgNUOYKY",
    "M3MM8XY6YpMA6Mdb6XCPAlEAgdijfSKr",
    "WHdg2zRp_U.k4SqCJ2anlt4FfaFVZxc9",
    "NjS2O6Khg0bFDHSAIXRkrAm_kUvGjKwZ",
    "dVmiMspMG65XDPRs4JoVQ9N2FxdGM7bb",
    "GdrdCuAO9nrYkruIC4XYxzT.wziN1Ojc",
    "qSjwAOx6meGSl1xdnI8GaaoPFlPOcw_8",
    "XqiQUA3BtwMtpBDk1FbDJKgPgm4Q0.88",
    "2RqUTyI2fU7Rq9pFCdRbzSHNmtd8rJ_R",
    "s2fQ_Tf.i1awhuHYc2kw_KwBlZYEc6LK",
    "nA3WzXTTml89ilAhIWPpoDtqqDvoz3pL",
    "DbHj6tKzbBNYf_4.QQhvon9ltuEGRFpE",
    "y8LhqcfSpJK4pdDqCrk71_Loib22rh1p",
    "_HLM9GNKkHEqwrHcw8HnAAOdNFVzrnz8",
    "3zpSDuvXHMvhOf3oKc2nG2eLH3YGl20x",
    "63FnocLilTKgqBK0F49Z07fxuYmd0duM",
    "9U9ZsF04lk2oVFNZD_2BXDtwdyRrldAF",
    "eto68cXV3jUgWRZ8lA5ohbuYBB0xKLmT",
    "k_r.GKS18RfqRIiSyjEFUPxxy4qGYe60",
    "RhY0S_hJAQ56tjhmJL5_ScRXy7Naapav",
    "5FQkcw_xqq101Ru13K3dSvhB8E6DS3XX"
]
```

</p>
</details> 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- We're now generating the `VersionId` using a technique inspired by `secrets.token_urlsafe`, generating secrets bytes and b64 encoding them. `base64` has a url safe method, using a different alphabet. Using the same inspiration, we're replacing the bytes with different characters adapted for S3. 

_fixes #11450_

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
