### PR TITLE
fix S3 VersionId EventBridge and fix DeleteMarker notification

### DIFF
--- a/tests/aws/services/s3/conftest.py
+++ b/tests/aws/services/s3/conftest.py
@@ -1,3 +1,9 @@
 import os
 
+from localstack.config import LEGACY_V2_S3_PROVIDER
+
 TEST_S3_IMAGE = os.path.exists("/usr/lib/localstack/.s3-version")
+
+
+def is_v2_provider():
+    return LEGACY_V2_S3_PROVIDER

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -71,7 +71,7 @@ from localstack.utils.strings import (
 from localstack.utils.sync import retry
 from localstack.utils.testutil import check_expected_lambda_log_events_length
 from localstack.utils.urls import localstack_host as get_localstack_host
-from tests.aws.services.s3.conftest import TEST_S3_IMAGE
+from tests.aws.services.s3.conftest import TEST_S3_IMAGE, is_v2_provider
 
 if TYPE_CHECKING:
     from mypy_boto3_s3 import S3Client
@@ -116,14 +116,6 @@ S3_POLICY = {
         }
     ],
 }
-
-
-def is_v3_provider():
-    return not LEGACY_V2_S3_PROVIDER
-
-
-def is_v2_provider():
-    return LEGACY_V2_S3_PROVIDER
 
 
 @pytest.fixture

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -11,20 +11,14 @@ from localstack import config
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.strings import long_uid, short_uid
-from tests.aws.services.s3.conftest import TEST_S3_IMAGE
+from tests.aws.services.s3.conftest import TEST_S3_IMAGE, is_v2_provider
 
 
-def is_legacy_v2_provider():
-    return config.LEGACY_V2_S3_PROVIDER
-
-
-@markers.snapshot.skip_snapshot_verify(
-    condition=is_legacy_v2_provider, paths=["$..ServerSideEncryption"]
-)
+@markers.snapshot.skip_snapshot_verify(condition=is_v2_provider, paths=["$..ServerSideEncryption"])
 class TestS3BucketCRUD:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        condition=is_legacy_v2_provider, paths=["$.delete-with-obj.Error.BucketName"]
+        condition=is_v2_provider, paths=["$.delete-with-obj.Error.BucketName"]
     )
     def test_delete_bucket_with_objects(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
@@ -44,7 +38,7 @@ class TestS3BucketCRUD:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        condition=is_legacy_v2_provider,
+        condition=is_v2_provider,
         paths=[
             "$..Error.BucketName",
             "$..Error.Message",
@@ -86,9 +80,7 @@ class TestS3BucketCRUD:
         snapshot.match("success-delete-bucket", delete_bucket)
 
 
-@markers.snapshot.skip_snapshot_verify(
-    condition=is_legacy_v2_provider, paths=["$..ServerSideEncryption"]
-)
+@markers.snapshot.skip_snapshot_verify(condition=is_v2_provider, paths=["$..ServerSideEncryption"])
 class TestS3ObjectCRUD:
     @markers.aws.validated
     @pytest.mark.skipif(
@@ -449,7 +441,7 @@ class TestS3ObjectCRUD:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        condition=is_legacy_v2_provider,
+        condition=is_v2_provider,
         paths=[
             "$..Delimiter",
             "$..EncodingType",
@@ -540,9 +532,7 @@ class TestS3ObjectCRUD:
         snapshot.match("get-100-200", e.value.response)
 
 
-@markers.snapshot.skip_snapshot_verify(
-    condition=is_legacy_v2_provider, paths=["$..ServerSideEncryption"]
-)
+@markers.snapshot.skip_snapshot_verify(condition=is_v2_provider, paths=["$..ServerSideEncryption"])
 class TestS3Multipart:
     # TODO: write a validated test for UploadPartCopy preconditions
 
@@ -872,9 +862,7 @@ class TestS3BucketEncryption:
     @markers.aws.validated
     # there is currently no server side encryption is place in LS, ETag will be different
     @markers.snapshot.skip_snapshot_verify(paths=["$..ETag"])
-    @markers.snapshot.skip_snapshot_verify(
-        condition=is_legacy_v2_provider, paths=["$..BucketKeyEnabled"]
-    )
+    @markers.snapshot.skip_snapshot_verify(condition=is_v2_provider, paths=["$..BucketKeyEnabled"])
     def test_s3_bucket_encryption_sse_kms(self, s3_bucket, kms_key, aws_client, snapshot):
         put_bucket_enc = aws_client.s3.put_bucket_encryption(
             Bucket=s3_bucket,
@@ -981,13 +969,11 @@ class TestS3BucketEncryption:
         snapshot.match("get-object-encrypted", get_object_encrypted)
 
 
-@markers.snapshot.skip_snapshot_verify(
-    condition=is_legacy_v2_provider, paths=["$..ServerSideEncryption"]
-)
+@markers.snapshot.skip_snapshot_verify(condition=is_v2_provider, paths=["$..ServerSideEncryption"])
 class TestS3BucketObjectTagging:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        condition=is_legacy_v2_provider, paths=["$.get-bucket-tags.TagSet[1].Value"]
+        condition=is_v2_provider, paths=["$.get-bucket-tags.TagSet[1].Value"]
     )
     def test_bucket_tagging_crud(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
@@ -1453,7 +1439,7 @@ class TestS3ObjectLock:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        condition=is_legacy_v2_provider,
+        condition=is_v2_provider,
         paths=["$.get-lock-config.ObjectLockConfiguration.Rule.DefaultRetention.Years"],
     )
     def test_get_put_object_lock_configuration(self, s3_create_bucket, aws_client, snapshot):
@@ -1565,9 +1551,7 @@ class TestS3ObjectLock:
         snapshot.match("put-lock-config-both-days-years", e.value.response)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        condition=is_legacy_v2_provider, paths=["$..Error.BucketName"]
-    )
+    @markers.snapshot.skip_snapshot_verify(condition=is_v2_provider, paths=["$..Error.BucketName"])
     def test_get_object_lock_configuration_exc(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
         with pytest.raises(ClientError) as e:
@@ -1825,7 +1809,7 @@ class TestS3BucketAccelerateConfiguration:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        condition=is_legacy_v2_provider,
+        condition=is_v2_provider,
         paths=[
             "$.put-bucket-accelerate-config-dot-bucket.Error.Code",
             "$.put-bucket-accelerate-config-dot-bucket.Error.Message",

--- a/tests/aws/services/s3/test_s3_list_operations.py
+++ b/tests/aws/services/s3/test_s3_list_operations.py
@@ -17,10 +17,7 @@ from localstack.config import LEGACY_V2_S3_PROVIDER, S3_VIRTUAL_HOSTNAME
 from localstack.constants import AWS_REGION_US_EAST_1, LOCALHOST_HOSTNAME
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
-
-
-def is_v2_provider():
-    return LEGACY_V2_S3_PROVIDER
+from tests.aws.services.s3.conftest import is_v2_provider
 
 
 def _bucket_url(bucket_name: str, region: str = "", localstack_host: str = None) -> str:

--- a/tests/aws/services/s3/test_s3_notifications_eventbridge.py
+++ b/tests/aws/services/s3/test_s3_notifications_eventbridge.py
@@ -6,7 +6,7 @@ from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
-from tests.aws.services.s3.conftest import TEST_S3_IMAGE
+from tests.aws.services.s3.conftest import TEST_S3_IMAGE, is_v2_provider
 
 
 @pytest.fixture
@@ -238,6 +238,7 @@ class TestS3NotificationsToEventBridge:
         aws_client_factory,
         aws_client,
         secondary_region_name,
+        region_name,
     ):
         snapshot.add_transformer(snapshot.transform.key_value("region"), priority=-1)
         # create the bucket and the queue URL in the default region
@@ -262,4 +263,85 @@ class TestS3NotificationsToEventBridge:
         retries = 10 if is_aws_cloud() else 5
         retry(_receive_messages, retries=retries)
         snapshot.match("object-created-different-regions", {"messages": messages})
-        assert messages[0]["region"] == messages[1]["region"] == aws_client.s3.meta.region_name
+        assert messages[0]["region"] == messages[1]["region"] == region_name
+
+    @markers.aws.validated
+    @pytest.mark.skipif(
+        condition=is_v2_provider(),
+        reason="Not implemented in Legacy provider",
+    )
+    def test_object_created_put_versioned(
+        self, basic_event_bridge_rule_to_sqs_queue, snapshot, aws_client
+    ):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("version-id"),
+                snapshot.transform.key_value("VersionId"),
+            ]
+        )
+        bucket_name, queue_url = basic_event_bridge_rule_to_sqs_queue
+        aws_client.s3.put_bucket_versioning(
+            Bucket=bucket_name, VersioningConfiguration={"Status": "Enabled"}
+        )
+
+        test_key = "test-key"
+        # We snapshot all objects to snapshot their VersionId, to be sure the events correspond well to what we think
+        # create first version
+        obj_ver1 = aws_client.s3.put_object(Bucket=bucket_name, Key=test_key, Body=b"data")
+        snapshot.match("obj-ver1", obj_ver1)
+        # create second version
+        obj_ver2 = aws_client.s3.put_object(Bucket=bucket_name, Key=test_key, Body=b"data-version2")
+        snapshot.match("obj-ver2", obj_ver2)
+        # delete the top most version, creating a DeleteMarker
+        delete_marker = aws_client.s3.delete_object(Bucket=bucket_name, Key=test_key)
+        snapshot.match("delete-marker", delete_marker)
+        # delete a specific version (Version1)
+        delete_version = aws_client.s3.delete_object(
+            Bucket=bucket_name, Key=test_key, VersionId=obj_ver1["VersionId"]
+        )
+        snapshot.match("delete-version", delete_version)
+
+        messages = []
+
+        def _receive_messages(expected: int):
+            received = aws_client.sqs.receive_message(QueueUrl=queue_url).get("Messages", [])
+            for msg in received:
+                event_message = json.loads(msg["Body"])
+                messages.append(event_message)
+                aws_client.sqs.delete_message(
+                    QueueUrl=queue_url, ReceiptHandle=msg["ReceiptHandle"]
+                )
+
+            assert len(messages) == expected
+            # make the list always be sorted the same way, as it can be inconsistent in AWS
+            messages.sort(
+                key=lambda x: (
+                    x["detail"].get("deletion-type", ""),
+                    x["detail-type"],
+                    x["detail"]["object"].get("etag", ""),
+                )
+            )
+            return messages
+
+        retries = 10 if is_aws_cloud() else 5
+        retry(_receive_messages, retries=retries, expected=4)
+        snapshot.match("message-versioning-active", messages)
+        messages.clear()
+
+        # suspend the versioning
+        aws_client.s3.put_bucket_versioning(
+            Bucket=bucket_name, VersioningConfiguration={"Status": "Suspended"}
+        )
+        # add a new object, which will have versionId = null
+        add_null_version = aws_client.s3.put_object(
+            Bucket=bucket_name, Key=test_key, Body=b"data-version3"
+        )
+        snapshot.match("add-null-version", add_null_version)
+        # delete the DeleteMarker
+        del_delete_marker = aws_client.s3.delete_object(
+            Bucket=bucket_name, Key=test_key, VersionId=delete_marker["VersionId"]
+        )
+        snapshot.match("del-delete-marker", del_delete_marker)
+
+        retry(_receive_messages, retries=retries, expected=2)
+        snapshot.match("message-versioning-suspended", messages)

--- a/tests/aws/services/s3/test_s3_notifications_eventbridge.snapshot.json
+++ b/tests/aws/services/s3/test_s3_notifications_eventbridge.snapshot.json
@@ -298,5 +298,175 @@
         ]
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_notifications_eventbridge.py::TestS3NotificationsToEventBridge::test_object_created_put_versioned": {
+    "recorded-date": "03-09-2024, 14:18:13",
+    "recorded-content": {
+      "obj-ver1": {
+        "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "obj-ver2": {
+        "ETag": "\"6869c34ca384e0ed836d49214f881e87\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-marker": {
+        "DeleteMarker": true,
+        "VersionId": "<version-id:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "delete-version": {
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "message-versioning-active": [
+        {
+          "version": "0",
+          "id": "<uuid:1>",
+          "detail-type": "Object Created",
+          "source": "aws.s3",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [
+            "arn:<partition>:s3:::<bucket-name:1>"
+          ],
+          "detail": {
+            "version": "0",
+            "bucket": {
+              "name": "<bucket-name:1>"
+            },
+            "object": {
+              "key": "<key-name:1>",
+              "size": 13,
+              "etag": "2fb1d4988881168bbcd6432d7593be5a",
+              "sequencer": "object-sequencer"
+            },
+            "request-id": "request-id",
+            "requester": "<requester>",
+            "source-ip-address": "<ip-address:1>",
+            "reason": "PutObject"
+          }
+        },
+        {
+          "version": "0",
+          "id": "<uuid:2>",
+          "detail-type": "Object Deleted",
+          "source": "aws.s3",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [
+            "arn:<partition>:s3:::<bucket-name:1>"
+          ],
+          "detail": {
+            "version": "0",
+            "bucket": {
+              "name": "<bucket-name:1>"
+            },
+            "object": {
+              "key": "<key-name:1>",
+              "version-id": "<version-id:3>",
+              "sequencer": "object-sequencer"
+            },
+            "request-id": "request-id",
+            "requester": "<requester>",
+            "source-ip-address": "<ip-address:1>",
+            "reason": "DeleteObject",
+            "deletion-type": "Permanently Deleted"
+          }
+        }
+      ],
+      "add-null-version": {
+        "ETag": "\"2fb1d4988881168bbcd6432d7593be5a\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "del-delete-marker": {
+        "DeleteMarker": true,
+        "VersionId": "<version-id:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "message-versioning-suspended": [
+        {
+          "version": "0",
+          "id": "<uuid:1>",
+          "detail-type": "Object Created",
+          "source": "aws.s3",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [
+            "arn:<partition>:s3:::<bucket-name:1>"
+          ],
+          "detail": {
+            "version": "0",
+            "bucket": {
+              "name": "<bucket-name:1>"
+            },
+            "object": {
+              "key": "<key-name:1>",
+              "size": 13,
+              "etag": "2fb1d4988881168bbcd6432d7593be5a",
+              "sequencer": "object-sequencer"
+            },
+            "request-id": "request-id",
+            "requester": "<requester>",
+            "source-ip-address": "<ip-address:1>",
+            "reason": "PutObject"
+          }
+        },
+        {
+          "version": "0",
+          "id": "<uuid:2>",
+          "detail-type": "Object Deleted",
+          "source": "aws.s3",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [
+            "arn:<partition>:s3:::<bucket-name:1>"
+          ],
+          "detail": {
+            "version": "0",
+            "bucket": {
+              "name": "<bucket-name:1>"
+            },
+            "object": {
+              "key": "<key-name:1>",
+              "version-id": "<version-id:3>",
+              "sequencer": "object-sequencer"
+            },
+            "request-id": "request-id",
+            "requester": "<requester>",
+            "source-ip-address": "<ip-address:1>",
+            "reason": "DeleteObject",
+            "deletion-type": "Permanently Deleted"
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_notifications_eventbridge.validation.json
+++ b/tests/aws/services/s3/test_s3_notifications_eventbridge.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/s3/test_s3_notifications_eventbridge.py::TestS3NotificationsToEventBridge::test_object_created_put_in_different_region": {
     "last_validated_date": "2023-10-17T23:26:55+00:00"
   },
+  "tests/aws/services/s3/test_s3_notifications_eventbridge.py::TestS3NotificationsToEventBridge::test_object_created_put_versioned": {
+    "last_validated_date": "2024-09-03T14:18:10+00:00"
+  },
   "tests/aws/services/s3/test_s3_notifications_eventbridge.py::TestS3NotificationsToEventBridge::test_object_put_acl": {
     "last_validated_date": "2023-08-04T23:08:43+00:00"
   },

--- a/tests/aws/services/s3/test_s3_notifications_sqs.snapshot.json
+++ b/tests/aws/services/s3/test_s3_notifications_sqs.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_put": {
-    "recorded-date": "05-08-2023, 00:55:23",
+    "recorded-date": "03-09-2024, 14:22:07",
     "recorded-content": {
       "receive_messages": {
         "messages": [
@@ -30,8 +30,7 @@
                 "eTag": "437b930db84b8079c2dd804a71936b5f",
                 "key": "my_key_0",
                 "sequencer": "sequencer",
-                "size": 9,
-                "versionId": "version-id"
+                "size": 9
               },
               "s3SchemaVersion": "1.0"
             },
@@ -65,8 +64,7 @@
                 "eTag": "6c7ba9c5a141421e1c03cb9807c97c74",
                 "key": "my_key_1",
                 "sequencer": "sequencer",
-                "size": 14,
-                "versionId": "version-id"
+                "size": 14
               },
               "s3SchemaVersion": "1.0"
             },
@@ -1111,6 +1109,268 @@
           }
         ]
       }
+    }
+  },
+  "tests/aws/services/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_put_versioned": {
+    "recorded-date": "03-09-2024, 14:30:59",
+    "recorded-content": {
+      "obj-ver1": {
+        "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "obj-ver2": {
+        "ETag": "\"6869c34ca384e0ed836d49214f881e87\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-marker": {
+        "DeleteMarker": true,
+        "VersionId": "<version-id:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "delete-version": {
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "message-versioning-active": [
+        {
+          "eventVersion": "2.1",
+          "eventSource": "aws:s3",
+          "awsRegion": "<region>",
+          "eventTime": "date",
+          "eventName": "ObjectCreated:Put",
+          "userIdentity": {
+            "principalId": "<principal-id:2>"
+          },
+          "requestParameters": {
+            "sourceIPAddress": "<ip-address:1>"
+          },
+          "responseElements": {
+            "x-amz-request-id": "amz-request-id",
+            "x-amz-id-2": "amz-id"
+          },
+          "s3": {
+            "s3SchemaVersion": "1.0",
+            "configurationId": "<config-id:1>",
+            "bucket": {
+              "name": "<resource:1>",
+              "ownerIdentity": {
+                "principalId": "<principal-id:1>"
+              },
+              "arn": "arn:<partition>:s3:::<resource:1>"
+            },
+            "object": {
+              "key": "test-key",
+              "size": 13,
+              "eTag": "6869c34ca384e0ed836d49214f881e87",
+              "versionId": "version-id",
+              "sequencer": "sequencer"
+            }
+          }
+        },
+        {
+          "eventVersion": "2.1",
+          "eventSource": "aws:s3",
+          "awsRegion": "<region>",
+          "eventTime": "date",
+          "eventName": "ObjectCreated:Put",
+          "userIdentity": {
+            "principalId": "<principal-id:2>"
+          },
+          "requestParameters": {
+            "sourceIPAddress": "<ip-address:1>"
+          },
+          "responseElements": {
+            "x-amz-request-id": "amz-request-id",
+            "x-amz-id-2": "amz-id"
+          },
+          "s3": {
+            "s3SchemaVersion": "1.0",
+            "configurationId": "<config-id:1>",
+            "bucket": {
+              "name": "<resource:1>",
+              "ownerIdentity": {
+                "principalId": "<principal-id:1>"
+              },
+              "arn": "arn:<partition>:s3:::<resource:1>"
+            },
+            "object": {
+              "key": "test-key",
+              "size": 4,
+              "eTag": "8d777f385d3dfec8815d20f7496026dc",
+              "versionId": "version-id",
+              "sequencer": "sequencer"
+            }
+          }
+        },
+        {
+          "eventVersion": "2.1",
+          "eventSource": "aws:s3",
+          "awsRegion": "<region>",
+          "eventTime": "date",
+          "eventName": "ObjectRemoved:Delete",
+          "userIdentity": {
+            "principalId": "<principal-id:2>"
+          },
+          "requestParameters": {
+            "sourceIPAddress": "<ip-address:1>"
+          },
+          "responseElements": {
+            "x-amz-request-id": "amz-request-id",
+            "x-amz-id-2": "amz-id"
+          },
+          "s3": {
+            "s3SchemaVersion": "1.0",
+            "configurationId": "<config-id:1>",
+            "bucket": {
+              "name": "<resource:1>",
+              "ownerIdentity": {
+                "principalId": "<principal-id:1>"
+              },
+              "arn": "arn:<partition>:s3:::<resource:1>"
+            },
+            "object": {
+              "key": "test-key",
+              "versionId": "version-id",
+              "sequencer": "sequencer"
+            }
+          }
+        },
+        {
+          "eventVersion": "2.1",
+          "eventSource": "aws:s3",
+          "awsRegion": "<region>",
+          "eventTime": "date",
+          "eventName": "ObjectRemoved:DeleteMarkerCreated",
+          "userIdentity": {
+            "principalId": "<principal-id:2>"
+          },
+          "requestParameters": {
+            "sourceIPAddress": "<ip-address:1>"
+          },
+          "responseElements": {
+            "x-amz-request-id": "amz-request-id",
+            "x-amz-id-2": "amz-id"
+          },
+          "s3": {
+            "s3SchemaVersion": "1.0",
+            "configurationId": "<config-id:1>",
+            "bucket": {
+              "name": "<resource:1>",
+              "ownerIdentity": {
+                "principalId": "<principal-id:1>"
+              },
+              "arn": "arn:<partition>:s3:::<resource:1>"
+            },
+            "object": {
+              "key": "test-key",
+              "eTag": "d41d8cd98f00b204e9800998ecf8427e",
+              "versionId": "version-id",
+              "sequencer": "sequencer"
+            }
+          }
+        }
+      ],
+      "add-null-version": {
+        "ETag": "\"2fb1d4988881168bbcd6432d7593be5a\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "del-delete-marker": {
+        "DeleteMarker": true,
+        "VersionId": "<version-id:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "message-versioning-suspended": [
+        {
+          "eventVersion": "2.1",
+          "eventSource": "aws:s3",
+          "awsRegion": "<region>",
+          "eventTime": "date",
+          "eventName": "ObjectCreated:Put",
+          "userIdentity": {
+            "principalId": "<principal-id:2>"
+          },
+          "requestParameters": {
+            "sourceIPAddress": "<ip-address:1>"
+          },
+          "responseElements": {
+            "x-amz-request-id": "amz-request-id",
+            "x-amz-id-2": "amz-id"
+          },
+          "s3": {
+            "s3SchemaVersion": "1.0",
+            "configurationId": "<config-id:1>",
+            "bucket": {
+              "name": "<resource:1>",
+              "ownerIdentity": {
+                "principalId": "<principal-id:1>"
+              },
+              "arn": "arn:<partition>:s3:::<resource:1>"
+            },
+            "object": {
+              "key": "test-key",
+              "size": 13,
+              "eTag": "2fb1d4988881168bbcd6432d7593be5a",
+              "sequencer": "sequencer"
+            }
+          }
+        },
+        {
+          "eventVersion": "2.1",
+          "eventSource": "aws:s3",
+          "awsRegion": "<region>",
+          "eventTime": "date",
+          "eventName": "ObjectRemoved:Delete",
+          "userIdentity": {
+            "principalId": "<principal-id:2>"
+          },
+          "requestParameters": {
+            "sourceIPAddress": "<ip-address:1>"
+          },
+          "responseElements": {
+            "x-amz-request-id": "amz-request-id",
+            "x-amz-id-2": "amz-id"
+          },
+          "s3": {
+            "s3SchemaVersion": "1.0",
+            "configurationId": "<config-id:1>",
+            "bucket": {
+              "name": "<resource:1>",
+              "ownerIdentity": {
+                "principalId": "<principal-id:1>"
+              },
+              "arn": "arn:<partition>:s3:::<resource:1>"
+            },
+            "object": {
+              "key": "test-key",
+              "versionId": "version-id",
+              "sequencer": "sequencer"
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/tests/aws/services/s3/test_s3_notifications_sqs.validation.json
+++ b/tests/aws/services/s3/test_s3_notifications_sqs.validation.json
@@ -30,7 +30,10 @@
     "last_validated_date": "2023-08-04T22:55:27+00:00"
   },
   "tests/aws/services/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_put": {
-    "last_validated_date": "2023-08-04T22:55:23+00:00"
+    "last_validated_date": "2024-09-03T14:22:07+00:00"
+  },
+  "tests/aws/services/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_put_versioned": {
+    "last_validated_date": "2024-09-03T14:30:59+00:00"
   },
   "tests/aws/services/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_put_with_presigned_url_upload": {
     "last_validated_date": "2024-08-29T14:05:28+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #11448, we did not add the `version-id` field in EventBridge S3 notifications, even though we did for other services.
This PR fixes that, and as the request was about bucket versioning, I made sure that we handled correctly `DeleteMarker`. 
(Quick primer on how versioning works in S3 and Delete Markers: https://docs.aws.amazon.com/AmazonS3/latest/userguide/versioning-workflows.html) 

It adds a test for EventBridge and SQS, with a flow adding 2 objects on the same key, then deleting the "top most" key to create a delete marker, then deleting a specific object version.
It then suspend versioning, delete a delete marker to verify behavior, and add a new object on top with a `null` version to check. 

Improved parity along the way for a few fields. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement logic around `DeleteMarker` creation
- fix the missing `version-id` field for EventBridge target
- also updated an existing test that was testing versioned bucket, to test regular behavior vs versioned in a specific test 

_fixes #11448_
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
