### PR TITLE
lambda fix create self managed event source

### DIFF
--- a/localstack-core/localstack/services/lambda_/api_utils.py
+++ b/localstack-core/localstack/services/lambda_/api_utils.py
@@ -631,7 +631,7 @@ def map_alias_out(alias: "VersionAlias", function: "Function") -> AliasConfigura
     )
 
 
-def validate_and_set_batch_size(event_source_arn: str, batch_size: Optional[int] = None) -> int:
+def validate_and_set_batch_size(service: str, batch_size: Optional[int] = None) -> int:
     min_batch_size = 1
 
     BATCH_SIZE_RANGES = {
@@ -642,10 +642,7 @@ def validate_and_set_batch_size(event_source_arn: str, batch_size: Optional[int]
         "sqs": (10, 10_000),
         "mq": (100, 10_000),
     }
-    svc = event_source_arn.split(":")[2]  # arn:<parition>:<svc>:<region>:...
-    if svc == "sqs" and "fifo" in event_source_arn:
-        svc = "sqs-fifo"
-    svc_range = BATCH_SIZE_RANGES.get(svc)
+    svc_range = BATCH_SIZE_RANGES.get(service)
 
     if svc_range:
         default_batch_size, max_batch_size = svc_range

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1817,6 +1817,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         params["FunctionResponseTypes"] = request.get("FunctionResponseTypes", [])
         params["State"] = "Enabled"
         if "sqs" in service_type:
+            # can be "sqs" or "sqs-fifo"
             params["StateTransitionReason"] = "USER_INITIATED"
             if batch_size > 10 and request.get("MaximumBatchingWindowInSeconds", 0) == 0:
                 raise InvalidParameterValueException(

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -2145,7 +2145,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         # TODO: update and test State and StateTransitionReason for ESM v2
 
         if event_source_arn:  # TODO: validate pattern
-            esms = [e for e in esms if e["EventSourceArn"] == event_source_arn]
+            esms = [e for e in esms if e.get("EventSourceArn") == event_source_arn]
 
         if function_name:
             esms = [e for e in esms if function_name in e["FunctionArn"]]

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -17355,5 +17355,112 @@
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_and_qualifier_too_long-create_function]": {
     "recorded-date": "22-08-2024, 15:10:45",
     "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_self_managed": {
+    "recorded-date": "03-09-2024, 20:58:29",
+    "recorded-content": {
+      "missing-source-access-configuration": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Required 'sourceAccessConfigurations' parameter is missing."
+        },
+        "Type": "User",
+        "message": "Required 'sourceAccessConfigurations' parameter is missing.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "event-source-mapping-default": {
+        "BatchSize": 100,
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:1>",
+        "LastModified": "datetime",
+        "LastProcessingResult": "No records processed",
+        "SelfManagedEventSource": {
+          "Endpoints": {
+            "KAFKA_BOOTSTRAP_SERVERS": [
+              "kafka:1000"
+            ]
+          }
+        },
+        "SelfManagedKafkaEventSourceConfig": {
+          "ConsumerGroupId": "<uuid:1>"
+        },
+        "SourceAccessConfigurations": [
+          {
+            "Type": "BASIC_AUTH",
+            "URI": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<resource:2>"
+          }
+        ],
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "Topics": [
+          "topic"
+        ],
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "duplicate-source": {
+        "Error": {
+          "Code": "ResourceConflictException",
+          "Message": "An event source mapping with event source (\"kafka:1000\"), function (\"arn:<partition>:lambda:<region>:111111111111:function:<resource:1>\"), topics (\"topic\") already exists. Please update or delete the existing mapping with UUID <uuid:1>"
+        },
+        "Type": "User",
+        "message": "An event source mapping with event source (\"kafka:1000\"), function (\"arn:<partition>:lambda:<region>:111111111111:function:<resource:1>\"), topics (\"topic\") already exists. Please update or delete the existing mapping with UUID <uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "event-source-mapping-values": {
+        "BatchSize": 1,
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:1>",
+        "LastModified": "datetime",
+        "LastProcessingResult": "No records processed",
+        "SelfManagedEventSource": {
+          "Endpoints": {
+            "KAFKA_BOOTSTRAP_SERVERS": [
+              "kafka:1000"
+            ]
+          }
+        },
+        "SelfManagedKafkaEventSourceConfig": {
+          "ConsumerGroupId": "random_id"
+        },
+        "SourceAccessConfigurations": [
+          {
+            "Type": "BASIC_AUTH",
+            "URI": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<resource:2>"
+          }
+        ],
+        "StartingPosition": "LATEST",
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "Topics": [
+          "topic_2"
+        ],
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "multiple-duplicate-source": {
+        "Error": {
+          "Code": "ResourceConflictException",
+          "Message": "An event source mapping with event source (\"kafka:1000,kafka:2000\"), function (\"arn:<partition>:lambda:<region>:111111111111:function:<resource:1>\"), topics (\"topic\") already exists. Please update or delete the existing mapping with UUID <uuid:1>"
+        },
+        "Type": "User",
+        "message": "An event source mapping with event source (\"kafka:1000,kafka:2000\"), function (\"arn:<partition>:lambda:<region>:111111111111:function:<resource:1>\"), topics (\"topic\") already exists. Please update or delete the existing mapping with UUID <uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -29,6 +29,9 @@
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventInvokeConfig::test_lambda_eventinvokeconfig_lifecycle": {
     "last_validated_date": "2024-04-10T09:13:20+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_self_managed": {
+    "last_validated_date": "2024-09-03T20:58:27+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_validation": {
     "last_validated_date": "2024-04-10T09:21:59+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR aims to fix support for self managed kafka event sources.

Lambda function event source mapping usually has a `EventSourceArn` as a AWS resource arn, but Kafka sources can be [self managed](https://docs.aws.amazon.com/lambda/latest/dg/with-kafka.html) in which case this value is not present in the request. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Prevent `KeyError` by removing direct access to the key where necessary
- Added CRUD support for Kafka event source
- Added tests

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
