### PR TITLE
fix SNS Publish and PublishBatch message size calculation and restriction

### DIFF
--- a/localstack-core/localstack/services/sns/provider.py
+++ b/localstack-core/localstack/services/sns/provider.py
@@ -1053,7 +1053,7 @@ def _get_byte_size(payload: str | bytes) -> int:
 def get_total_publish_size(
     message_body: str, message_attributes: MessageAttributeMap | None
 ) -> int:
-    size = len(to_bytes(message_body))
+    size = _get_byte_size(message_body)
     if message_attributes:
         # https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
         # All parts of the message attribute, including name, type, and value, are included in the message size

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -512,6 +512,70 @@ class TestSNSPublishCrud:
         assert publish["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     @markers.aws.validated
+    def test_publish_batch_too_long_message(self, sns_create_topic, snapshot, aws_client):
+        topic_arn = sns_create_topic()["TopicArn"]
+        # simulate payload over 256kb
+        max_size = 262144
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish_batch(
+                TopicArn=topic_arn,
+                PublishBatchRequestEntries=[
+                    {
+                        "Id": "1",
+                        "Message": "a" * (max_size // 2),
+                    },
+                    {
+                        "Id": "2",
+                        "Message": "b" * (1 + max_size // 2),
+                    },
+                ],
+            )
+
+        snapshot.match("error-no-attrs", e.value.response)
+
+        # craft a message body that is under the limit, but goes over with the message attributes
+        message_attrs = {"attr1": {"DataType": "Number", "StringValue": "1"}}
+        counted_values = [*message_attrs.keys(), *message_attrs["attr1"].values()]
+        message_attrs_len = sum(len(to_bytes(value)) for value in counted_values)
+        message_with_attrs = (262144 - message_attrs_len) * "a"
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish_batch(
+                TopicArn=topic_arn,
+                PublishBatchRequestEntries=[
+                    {
+                        "Id": "1",
+                        "Message": message_with_attrs,
+                        "MessageAttributes": message_attrs,
+                    },
+                    {
+                        "Id": "2",
+                        "Message": "b",
+                    },
+                ],
+            )
+
+        snapshot.match("error-with-attrs", e.value.response)
+
+        # assert that it goes through with the right size, remove the last char
+        publish_batch = aws_client.sns.publish_batch(
+            TopicArn=topic_arn,
+            PublishBatchRequestEntries=[
+                {
+                    "Id": "1",
+                    "Message": message_with_attrs[:-1],
+                    "MessageAttributes": message_attrs,
+                },
+                {
+                    "Id": "2",
+                    "Message": "b",
+                },
+            ],
+        )
+        assert publish_batch["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    @markers.aws.validated
     def test_message_structure_json_exc(self, sns_create_topic, snapshot, aws_client):
         topic_arn = sns_create_topic()["TopicArn"]
         # TODO: add batch

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -565,9 +565,20 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_too_long_message": {
-    "recorded-date": "24-08-2023, 22:31:49",
+    "recorded-date": "04-09-2024, 00:38:07",
     "recorded-content": {
       "error": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Message too long",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-with-attrs": {
         "Error": {
           "Code": "InvalidParameter",
           "Message": "Invalid parameter: Message too long",

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4154,5 +4154,32 @@
         }
       }
     }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_batch_too_long_message": {
+    "recorded-date": "04-09-2024, 00:48:01",
+    "recorded-content": {
+      "error-no-attrs": {
+        "Error": {
+          "Code": "BatchRequestTooLong",
+          "Message": "The length of all the messages put together is more than the limit.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-with-attrs": {
+        "Error": {
+          "Code": "BatchRequestTooLong",
+          "Message": "The length of all the messages put together is more than the limit.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -18,7 +18,7 @@
     "last_validated_date": "2023-08-24T20:31:46+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_too_long_message": {
-    "last_validated_date": "2023-08-24T20:31:49+00:00"
+    "last_validated_date": "2024-09-04T00:38:06+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_verify_signature": {
     "last_validated_date": "2024-01-04T17:22:57+00:00"

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_message_structure_json_exc": {
     "last_validated_date": "2023-08-24T20:31:50+00:00"
   },
+  "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_batch_too_long_message": {
+    "last_validated_date": "2024-09-04T00:48:01+00:00"
+  },
   "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_by_path_parameters": {
     "last_validated_date": "2023-08-24T20:31:40+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #11115, we did not take into account the `MessageAttributes` while calculating the max message size. This was a shortcut taken at the time, but we can now properly fix it. The implementation is inspired by SQS as reported in the GitHub issue.

The documentation specifies: https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
> All parts of the message attribute, including name, type, and value, are included in the message size restriction, which is 256 KB.

I've taken the opportunity to also validate the max message size for `PublishBatch` as well, as it was easy to do so. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- take into account `MessageAttributes` when calculating the message size following the documentation, and validated the assumption
- add message size validation for `PublishBatch`
- improve the exiting validated test, and added one for `PublishBatch`

_fixes #11115_

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
