### PR TITLE
add G ruleset to Ruff (logging-format)

### DIFF
--- a/localstack-core/localstack/aws/handlers/service_plugin.py
+++ b/localstack-core/localstack/aws/handlers/service_plugin.py
@@ -64,8 +64,9 @@ class ServiceLoader(Handler):
                 request_router.add_skeleton(service_plugin.skeleton)
             else:
                 LOG.warning(
-                    f"found plugin for '{service_name}', "
-                    f"but cannot attach service plugin of type '{type(service_plugin)}'",
+                    "found plugin for '%s', but cannot attach service plugin of type '%s'",
+                    service_name,
+                    type(service_plugin),
                 )
 
 

--- a/localstack-core/localstack/dns/server.py
+++ b/localstack-core/localstack/dns/server.py
@@ -217,7 +217,9 @@ class RecordConverter:
 
         # no best solution found
         LOG.warning(
-            f"could not determine subnet-matched IP address for {self.request.q.qname}, falling back to {LOCALHOST_IP}"
+            "could not determine subnet-matched IP address for %s, falling back to %s",
+            self.request.q.qname,
+            LOCALHOST_IP,
         )
         return LOCALHOST_IP
 
@@ -874,7 +876,7 @@ def start_server(upstream_dns: str, host: str, port: int = config.DNS_PORT):
         LOG.debug("DNS servers are already started. Avoid starting again.")
         return
 
-    LOG.debug("Starting DNS servers (tcp/udp port %s on %s)..." % (port, host))
+    LOG.debug("Starting DNS servers (tcp/udp port %s on %s)...", port, host)
     dns_server = DnsServer(port, protocols=["tcp", "udp"], host=host, upstream_dns=upstream_dns)
 
     for name in NAME_PATTERNS_POINTING_TO_LOCALSTACK:

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -786,11 +786,11 @@ def get_resource_for_path(
 
     # if there are no matches, it's not worth to proceed, bail here!
     if not matches:
-        LOG.debug(f"No match found for path: '{path}' and method: '{method}'")
+        LOG.debug("No match found for path: '%s' and method: '%s'", path, method)
         return None, None
 
     if len(matches) == 1:
-        LOG.debug(f"Match found for path: '{path}' and method: '{method}'")
+        LOG.debug("Match found for path: '%s' and method: '%s'", path, method)
         return matches[0]
 
     # so we have more than one match
@@ -816,7 +816,7 @@ def get_resource_for_path(
     if param_matches:
         # count the amount of parameters, return the one with the least which is the most precise
         sorted_matches = sorted(param_matches, key=lambda x: x[0].count("{"))
-        LOG.debug(f"Match found for path: '{path}' and method: '{method}'")
+        LOG.debug("Match found for path: '%s' and method: '%s'", path, method)
         return sorted_matches[0]
 
     if proxy_matches:
@@ -824,11 +824,11 @@ def get_resource_for_path(
         # /{proxy+} or /api/{proxy+}, so we pick the best match by sorting by length, only if they have a method
         # that could match
         sorted_matches = sorted(proxy_matches, key=lambda x: len(x[0]), reverse=True)
-        LOG.debug(f"Match found for path: '{path}' and method: '{method}'")
+        LOG.debug("Match found for path: '%s' and method: '%s'", path, method)
         return sorted_matches[0]
 
     # if there are no matches with a method that would match, return
-    LOG.debug(f"No match found for method: '{method}' for matched path: {path}")
+    LOG.debug("No match found for method: '%s' for matched path: %s", method, path)
     return None, None
 
 

--- a/localstack-core/localstack/services/apigateway/integration.py
+++ b/localstack-core/localstack/services/apigateway/integration.py
@@ -519,7 +519,9 @@ class KinesisIntegration(BackendIntegration):
             target = "Kinesis_20131202.ListStreams"
         else:
             LOG.info(
-                f"Unexpected API Gateway integration URI '{uri}' for integration type {integration_type}",
+                "Unexpected API Gateway integration URI '%s' for integration type %s",
+                uri,
+                integration_type,
             )
             target = ""
 

--- a/localstack-core/localstack/services/apigateway/templates.py
+++ b/localstack-core/localstack/services/apigateway/templates.py
@@ -267,7 +267,7 @@ class RequestTemplates(Templates):
             variables.get("context", {}).get("requestOverride", {}).get("header", {})
         )
 
-        LOG.debug(f"Endpoint request body after transformations:\n{result}")
+        LOG.debug("Endpoint request body after transformations:\n%s", result)
         return result
 
 

--- a/localstack-core/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack-core/localstack/services/cloudformation/deployment_utils.py
@@ -275,8 +275,10 @@ def convert_data_types(type_conversions: dict[str, Callable], params: dict) -> d
 
 def log_not_available_message(resource_type: str, message: str):
     LOG.warning(
-        f"{message}. To find out if {resource_type} is supported in LocalStack Pro, "
-        "please check out our docs at https://docs.localstack.cloud/user-guide/aws/cloudformation/#resources-pro--enterprise-edition"
+        "%s. To find out if %s is supported in LocalStack Pro, "
+        "please check out our docs at https://docs.localstack.cloud/user-guide/aws/cloudformation/#resources-pro--enterprise-edition",
+        message,
+        resource_type,
     )
 
 

--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -87,7 +87,10 @@ def get_attr_from_model_instance(
     valid_atts = VALID_GETATT_PROPERTIES.get(resource_type)
     if valid_atts is not None and attribute_name not in valid_atts:
         LOG.warning(
-            f"Invalid attribute in Fn::GetAtt for {resource_type}:  | {resource_id}.{attribute_name}"
+            "Invalid attribute in Fn::GetAtt for %s:  | %s.%s",
+            resource_type,
+            resource_id,
+            attribute_name,
         )
         raise Exception(
             f"Resource type {resource_type} does not support attribute {{{attribute_name}}}"
@@ -285,7 +288,9 @@ def resolve_refs_recursively(
                 else:
                     return secret_value
             else:
-                LOG.warning(f"Unsupported service for dynamic parameter: {service_name=}")
+                LOG.warning(
+                    "Unsupported service for dynamic parameter: service_name=%s", service_name
+                )
 
     return result
 
@@ -1358,7 +1363,7 @@ class TemplateDeployer:
                 return self.stack.resource_status(r_id).get("ResourceStatus") == "DELETE_COMPLETE"
             except Exception:
                 if config.CFN_VERBOSE_ERRORS:
-                    LOG.exception(f"failed to lookup if resource {r_id} is deleted")
+                    LOG.exception("failed to lookup if resource %s is deleted", r_id)
                 return True  # just an assumption
 
         ordered_resource_ids = list(
@@ -1499,7 +1504,7 @@ class TemplateDeployer:
                     status_reason=str(e),
                 )
                 if config.CFN_VERBOSE_ERRORS:
-                    LOG.exception(f"Failed to deploy resource {resource_id}, stack deploy failed")
+                    LOG.exception("Failed to deploy resource %s, stack deploy failed", resource_id)
                 raise
 
         # clean up references to deleted resources in stack

--- a/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
@@ -107,12 +107,14 @@ class AlarmScheduler:
         for param in required_parameters:
             if param not in alarm_details.keys():
                 LOG.debug(
-                    f"Currently only simple MetricAlarm are supported. Alarm is missing '{param}'. ExtendedStatistic is not yet supported."
+                    "Currently only simple MetricAlarm are supported. Alarm is missing '%s'. ExtendedStatistic is not yet supported.",
+                    param,
                 )
                 return False
         if alarm_details["ComparisonOperator"] not in COMPARISON_OPS.keys():
             LOG.debug(
-                f"ComparisonOperator '{alarm_details['ComparisonOperator']}' not yet supported."
+                "ComparisonOperator '%s' not yet supported.",
+                alarm_details["ComparisonOperator"],
             )
             return False
         return True

--- a/localstack-core/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack-core/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -40,7 +40,7 @@ class CloudwatchDatabase:
     def __init__(self):
         self.DATABASE_LOCK = threading.RLock()
         if os.path.exists(self.METRICS_DB):
-            LOG.debug(f"database for metrics already exists ({self.METRICS_DB})")
+            LOG.debug("database for metrics already exists (%s)", self.METRICS_DB)
             return
 
         mkdir(self.CLOUDWATCH_DATA_ROOT)

--- a/localstack-core/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack-core/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -164,7 +164,8 @@ def delete_streams(account_id: str, region_name: str, table_arn: str) -> None:
                 kinesis_client.get_waiter("stream_not_exists").wait(StreamName=stream_name)
             except Exception:
                 LOG.warning(
-                    f"Failed to delete underlying kinesis stream for dynamodb table {table_arn=}",
+                    "Failed to delete underlying kinesis stream for dynamodb table table_arn=%s",
+                    table_arn,
                     exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
 

--- a/localstack-core/localstack/services/events/archive.py
+++ b/localstack-core/localstack/services/events/archive.py
@@ -109,11 +109,11 @@ class ArchiveService:
                 Rule=self.rule_name, EventBusName=self.event_bus_name, Ids=[self.target_id]
             )
         except Exception as e:
-            LOG.debug(f"Target {self.target_id} could not be removed, {e}")
+            LOG.debug("Target %s could not be removed, %s", self.target_id, e)
         try:
             self.client.delete_rule(Name=self.rule_name, EventBusName=self.event_bus_name)
         except Exception as e:
-            LOG.debug(f"Rule {self.rule_name} could not be deleted, {e}")
+            LOG.debug("Rule %s could not be deleted, %s", self.rule_name, e)
 
     def put_events(self, events: FormattedEventList) -> None:
         for event in events:

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -1077,7 +1077,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                 try:
                     del self._target_sender_store[target_arn]
                 except KeyError:
-                    LOG.error(f"Error deleting target service {target_arn}.")
+                    LOG.error("Error deleting target service %s.", target_arn)
 
     def _get_limited_dict_and_next_token(
         self, input_dict: dict, next_token: NextToken | None, limit: LimitMax100 | None

--- a/localstack-core/localstack/services/events/v1/provider.py
+++ b/localstack-core/localstack/services/events/v1/provider.py
@@ -311,7 +311,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         rule_scheduled_jobs = self.get_store(context).rule_scheduled_jobs
         job_id = rule_scheduled_jobs.get(name)
         if job_id:
-            LOG.debug("Removing scheduled Events: {} | job_id: {}".format(name, job_id))
+            LOG.debug("Removing scheduled Events: %s | job_id: %s", name, job_id)
             JobScheduler.instance().cancel_job(job_id=job_id)
         call_moto(context)
 
@@ -325,7 +325,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         rule_scheduled_jobs = self.get_store(context).rule_scheduled_jobs
         job_id = rule_scheduled_jobs.get(name)
         if job_id:
-            LOG.debug("Disabling Rule: {} | job_id: {}".format(name, job_id))
+            LOG.debug("Disabling Rule: %s | job_id: %s", name, job_id)
             JobScheduler.instance().disable_job(job_id=job_id)
         call_moto(context)
 
@@ -488,7 +488,12 @@ def process_events(event: Dict, targets: list[Dict]):
                 source_arn=target.get("RuleArn"),
             )
         except Exception as e:
-            LOG.info(f"Unable to send event notification {truncate(event)} to target {target}: {e}")
+            LOG.info(
+                "Unable to send event notification %s to target %s: %s",
+                truncate(event),
+                target,
+                e,
+            )
 
 
 def get_event_bus_name(event_bus_name_or_arn: Optional[EventBusNameOrArn] = None) -> str:

--- a/localstack-core/localstack/services/firehose/provider.py
+++ b/localstack-core/localstack/services/firehose/provider.py
@@ -691,7 +691,7 @@ class FirehoseProvider(FirehoseApi):
                 try:
                     requests.post(url, json=record_to_send, headers=headers)
                 except Exception as e:
-                    LOG.exception(f"Unable to put Firehose records to HTTP endpoint {url}.")
+                    LOG.exception("Unable to put Firehose records to HTTP endpoint %s.", url)
                     raise e
             if "RedshiftDestinationDescription" in destination:
                 s3_dest_desc = destination["RedshiftDestinationDescription"][
@@ -755,18 +755,19 @@ class FirehoseProvider(FirehoseApi):
             try:
                 body = json.loads(data)
             except Exception as e:
-                LOG.warning(f"{db_flavor} only allows json input data!")
+                LOG.warning("%s only allows json input data!", db_flavor)
                 raise e
 
-            LOG.debug(
-                "Publishing to {} destination. Data: {}".format(
-                    db_flavor, truncate(data, max_length=300)
+            if LOG.isEnabledFor(logging.DEBUG):
+                LOG.debug(
+                    "Publishing to %s destination. Data: %s",
+                    db_flavor,
+                    truncate(data, max_length=300),
                 )
-            )
             try:
                 db_connection.create(index=search_db_index, id=obj_id, body=body)
             except Exception as e:
-                LOG.exception(f"Unable to put record to stream {delivery_stream_name}.")
+                LOG.exception("Unable to put record to stream %s.", delivery_stream_name)
                 raise e
 
     def _add_missing_record_attributes(self, records: List[Dict]) -> None:
@@ -844,7 +845,10 @@ class FirehoseProvider(FirehoseApi):
             LOG.debug("Publishing to S3 destination: %s. Data: %s", bucket, batched_data)
             s3.put_object(Bucket=bucket, Key=obj_path, Body=batched_data)
         except Exception as e:
-            LOG.exception(f"Unable to put records {records} to s3 bucket.")
+            LOG.exception(
+                "Unable to put records %s to s3 bucket.",
+                records,
+            )
             raise e
 
     def _get_s3_object_path(self, stream_name, prefix, file_extension):
@@ -898,7 +902,10 @@ class FirehoseProvider(FirehoseApi):
                 )
                 redshift_data.execute_statement(Parameters=row_to_insert, **execute_statement)
             except Exception as e:
-                LOG.exception(f"Unable to put records {row_to_insert} to redshift cluster.")
+                LOG.exception(
+                    "Unable to put records %s to redshift cluster.",
+                    row_to_insert,
+                )
                 raise e
 
     def _get_cluster_id_from_jdbc_url(self, jdbc_url: str) -> str:

--- a/localstack-core/localstack/services/lambda_/event_source_listeners/kinesis_event_source_listener.py
+++ b/localstack-core/localstack/services/lambda_/event_source_listeners/kinesis_event_source_listener.py
@@ -88,7 +88,8 @@ class KinesisEventSourceListener(StreamEventSourceListener):
                 parsed_records.append(parsed_record)
             except json.JSONDecodeError:
                 LOG.warning(
-                    f"Unable to convert record '{raw_data}' to json... Record will be dropped.",
+                    "Unable to convert record '%s' to json... Record will be dropped.",
+                    raw_data,
                     exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
 

--- a/localstack-core/localstack/services/lambda_/event_source_listeners/sqs_event_source_listener.py
+++ b/localstack-core/localstack/services/lambda_/event_source_listeners/sqs_event_source_listener.py
@@ -200,7 +200,9 @@ class SQSEventSourceListener(EventSourceListener):
             except Exception as e:
                 LOG.info(
                     "Unable to delete Lambda events from SQS queue "
-                    + "(please check SQS visibility timeout settings): %s - %s" % (entries, e)
+                    "(please check SQS visibility timeout settings): %s - %s",
+                    entries,
+                    e,
                 )
 
         for msg in messages:
@@ -230,7 +232,8 @@ class SQSEventSourceListener(EventSourceListener):
                     record["body"] = json.loads(record["body"])
                 except json.JSONDecodeError:
                     LOG.warning(
-                        f"Unable to convert record '{record['body']}' to json... Record might be dropped."
+                        "Unable to convert record '%s' to json... Record might be dropped.",
+                        record["body"],
                     )
             records = filter_stream_records(records, event_filter_criterias)
             # convert them back

--- a/localstack-core/localstack/services/lambda_/event_source_listeners/stream_event_source_listener.py
+++ b/localstack-core/localstack/services/lambda_/event_source_listeners/stream_event_source_listener.py
@@ -128,7 +128,7 @@ class StreamEventSourceListener(EventSourceListener):
         if self._COORDINATOR_THREAD is not None:
             return
 
-        LOG.debug(f"Starting {self.source_type()} event source listener coordinator thread")
+        LOG.debug("Starting %s event source listener coordinator thread", self.source_type())
         self._invoke_adapter = invoke_adapter
         if self._invoke_adapter is None:
             LOG.error("Invoke adapter needs to be set for new Lambda provider. Aborting.")

--- a/localstack-core/localstack/services/lambda_/event_source_listeners/utils.py
+++ b/localstack-core/localstack/services/lambda_/event_source_listeners/utils.py
@@ -67,7 +67,7 @@ def does_match_event(event_pattern: dict[str, any], event: dict[str, any]) -> bo
                     if isinstance(value[0], dict):
                         does_pattern_match = verify_dict_filter(event_value, value[0])
                 else:
-                    LOG.warning(f"Empty lambda filter: {key}")
+                    LOG.warning("Empty lambda filter: %s", key)
             elif isinstance(value, dict):
                 does_pattern_match = does_match_event(value, event_value)
         else:
@@ -113,7 +113,7 @@ def verify_dict_filter(record_value: any, dict_filter: dict[str, any]) -> bool:
             )  # exists means that the key exists in the event record
         elif key == "prefix":
             if not isinstance(record_value, str):
-                LOG.warning(f"Record Value {record_value} does not seem to be a valid string.")
+                LOG.warning("Record Value %s does not seem to be a valid string.", record_value)
             does_match_filter = isinstance(record_value, str) and record_value.startswith(
                 str(filter_value)
             )

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/noops_event_processor.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/noops_event_processor.py
@@ -8,4 +8,4 @@ LOG = logging.getLogger(__name__)
 class NoOpsEventProcessor(EventProcessor):
     def process_events_batch(self, input_events: list[dict]) -> None:
         """Intentionally do nothing"""
-        LOG.debug(f"Process input events {input_events} using NoOpsEventProcessor")
+        LOG.debug("Process input events %s using NoOpsEventProcessor", input_events)

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/kinesis_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/kinesis_poller.py
@@ -161,7 +161,8 @@ class KinesisPoller(StreamPoller):
                     parsed_events.append(parsed_event)
                 except json.JSONDecodeError:
                     LOG.warning(
-                        f"Unable to convert event data '{raw_data}' to json... Record will be dropped.",
+                        "Unable to convert event data '%s' to json... Record will be dropped.",
+                        raw_data,
                         exc_info=LOG.isEnabledFor(logging.DEBUG),
                     )
             return parsed_events

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py
@@ -102,7 +102,8 @@ class SqsPoller(Poller):
                 event["body"] = json.loads(event["body"])
             except json.JSONDecodeError:
                 LOG.debug(
-                    f"Unable to convert event body '{event['body']}' to json... Event might be dropped."
+                    "Unable to convert event body '%s' to json... Event might be dropped.",
+                    event["body"],
                 )
         matching_events = self.filter_events(polled_events)
         # convert them back (HACK for fixing parity with v1 and getting regression tests passing)

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -193,7 +193,10 @@ class StreamPoller(Poller):
 
                 # let entire batch fail (ideally raise BatchFailureError)
                 LOG.debug(
-                    f"Attempt {attempts} failed while processing {self.partner_resource_arn} with events: {events}"
+                    "Attempt %s failed while processing %s with events: %s",
+                    attempts,
+                    self.partner_resource_arn,
+                    events,
                 )
                 attempts += 1
                 # Retry polling until the record expires at the source
@@ -202,7 +205,10 @@ class StreamPoller(Poller):
                     return
             except Exception:
                 LOG.warning(
-                    f"Attempt {attempts} failed unexpectedly while processing {self.partner_resource_arn} with events: {events}"
+                    "Attempt %s failed unexpectedly while processing %s with events: %s",
+                    attempts,
+                    self.partner_resource_arn,
+                    events,
                 )
                 attempts += 1
                 # Retry polling until the record expires at the source

--- a/localstack-core/localstack/services/lambda_/invocation/docker_runtime_executor.py
+++ b/localstack-core/localstack/services/lambda_/invocation/docker_runtime_executor.py
@@ -179,7 +179,8 @@ class RuntimeImageResolver:
 
         except Exception:
             LOG.error(
-                f"Failed to load config from LAMBDA_RUNTIME_IMAGE_MAPPING={custom_image_mapping}"
+                "Failed to load config from LAMBDA_RUNTIME_IMAGE_MAPPING=%s",
+                custom_image_mapping,
             )
             raise  # TODO: validate config at start and prevent startup
 

--- a/localstack-core/localstack/services/lambda_/invocation/event_manager.py
+++ b/localstack-core/localstack/services/lambda_/invocation/event_manager.py
@@ -451,8 +451,10 @@ class LambdaEventManager:
             sqs_client.send_message(QueueUrl=self.event_queue_url, MessageBody=message_body)
         except Exception:
             LOG.error(
-                f"Failed to enqueue Lambda event into queue {self.event_queue_url}."
-                f" Invocation: request_id={invocation.request_id}, invoked_arn={invocation.invoked_arn}",
+                "Failed to enqueue Lambda event into queue %s. Invocation: request_id=%s, invoked_arn=%s",
+                self.event_queue_url,
+                invocation.request_id,
+                invocation.invoked_arn,
             )
             raise
 

--- a/localstack-core/localstack/services/lambda_/invocation/execution_environment.py
+++ b/localstack-core/localstack/services/lambda_/invocation/execution_environment.py
@@ -293,7 +293,9 @@ class ExecutionEnvironment:
         )
         if LOG.isEnabledFor(logging.DEBUG):
             LOG.debug(
-                f"Logs from the execution environment {self.id} after startup timeout:\n{self.get_prefixed_logs()}"
+                "Logs from the execution environment %s after startup timeout:\n%s",
+                self.id,
+                self.get_prefixed_logs(),
             )
         with self.status_lock:
             if self.status != RuntimeStatus.STARTING:
@@ -317,7 +319,9 @@ class ExecutionEnvironment:
         )
         if LOG.isEnabledFor(logging.DEBUG):
             LOG.debug(
-                f"Logs from the execution environment {self.id} after startup error:\n{self.get_prefixed_logs()}"
+                "Logs from the execution environment %s after startup error:\n%s",
+                self.id,
+                self.get_prefixed_logs(),
             )
         with self.status_lock:
             if self.status != RuntimeStatus.STARTING:

--- a/localstack-core/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack-core/localstack/services/lambda_/invocation/version_manager.py
@@ -92,7 +92,9 @@ class LambdaVersionManager:
             # https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunctionConfiguration.html#SSS-GetFunctionConfiguration-response-LastUpdateStatusReasonCode
             new_state = VersionState(state=State.Active)
             LOG.debug(
-                f"Changing Lambda {self.function_arn} (id {self.function_version.config.internal_revision}) to active"
+                "Changing Lambda %s (id %s) to active",
+                self.function_arn,
+                self.function_version.config.internal_revision,
             )
         except Exception as e:
             new_state = VersionState(
@@ -101,8 +103,9 @@ class LambdaVersionManager:
                 reason=f"Error while creating lambda: {e}",
             )
             LOG.debug(
-                f"Changing Lambda {self.function_arn} (id {self.function_version.config.internal_revision}) to "
-                f"failed. Reason: %s",
+                "Changing Lambda %s (id %s) to " "failed. Reason: %s",
+                self.function_arn,
+                self.function_version.config.internal_revision,
                 e,
                 exc_info=True,
             )

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -778,9 +778,11 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
 
         if runtime in DEPRECATED_RUNTIMES:
             LOG.warning(
-                f"The Lambda runtime {runtime} is deprecated. "
-                f"Please upgrade the runtime for the function {function_name}: "
-                f"https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+                "The Lambda runtime %s} is deprecated. "
+                "Please upgrade the runtime for the function %s: "
+                "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html",
+                runtime,
+                function_name,
             )
         if snap_start := request.get("SnapStart"):
             self._validate_snapstart(snap_start, runtime)
@@ -1045,9 +1047,11 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 )
             if runtime in DEPRECATED_RUNTIMES:
                 LOG.warning(
-                    f"The Lambda runtime {runtime} is deprecated. "
-                    f"Please upgrade the runtime for the function {function_name}: "
-                    f"https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+                    "The Lambda runtime %s is deprecated. "
+                    "Please upgrade the runtime for the function %s: "
+                    "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html",
+                    runtime,
+                    function_name,
                 )
             replace_kwargs["runtime"] = request["Runtime"]
 
@@ -1695,7 +1699,9 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         if version_alias and name in function.function_url_configs:
             url_config = function.function_url_configs.pop(name)
             LOG.debug(
-                f"Stopping aliased Lambda Function URL {url_config.url} for {url_config.function_arn}"
+                "Stopping aliased Lambda Function URL %s for %s",
+                url_config.url,
+                url_config.function_name,
             )
 
     def get_alias(
@@ -2202,7 +2208,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 # strict parity with AWS over the localstack-only custom_id
                 LOG.warning(
                     "Invalid custom ID tag value for lambda URL (%s=%s). "
-                    + "Replaced with default (random id)",
+                    "Replaced with default (random id)",
                     TAG_KEY_CUSTOM_URL,
                     custom_id_tag_value,
                 )

--- a/localstack-core/localstack/services/opensearch/cluster.py
+++ b/localstack-core/localstack/services/opensearch/cluster.py
@@ -243,7 +243,7 @@ def register_cluster(
     strategy = config.OPENSEARCH_ENDPOINT_STRATEGY
     # custom endpoints override any endpoint strategy
     if custom_endpoint and custom_endpoint.enabled:
-        LOG.debug(f"Registering route from {host}{path} to {endpoint.proxy.forward_base_url}")
+        LOG.debug("Registering route from %s%s to %s", host, path, endpoint.proxy.forward_base_url)
         assert not (
             host == localstack_host().host and (not path or path == "/")
         ), "trying to register an illegal catch all route"
@@ -262,7 +262,7 @@ def register_cluster(
             )
         )
     elif strategy == "domain":
-        LOG.debug(f"Registering route from {host} to {endpoint.proxy.forward_base_url}")
+        LOG.debug("Registering route from %s to %s", host, endpoint.proxy.forward_base_url)
         assert not host == localstack_host().host, "trying to register an illegal catch all route"
         rules.append(
             ROUTER.add(
@@ -279,13 +279,13 @@ def register_cluster(
             )
         )
     elif strategy == "path":
-        LOG.debug(f"Registering route from {path} to {endpoint.proxy.forward_base_url}")
+        LOG.debug("Registering route from %s to %s", path, endpoint.proxy.forward_base_url)
         assert path and not path == "/", "trying to register an illegal catch all route"
         rules.append(ROUTER.add(path, endpoint=endpoint))
         rules.append(ROUTER.add(f"{path}/<path:path>", endpoint=endpoint))
 
     elif strategy != "port":
-        LOG.warning(f"Attempted to register route for cluster with invalid strategy '{strategy}'")
+        LOG.warning("Attempted to register route for cluster with invalid strategy '%s'", strategy)
 
     return rules
 

--- a/localstack-core/localstack/services/opensearch/cluster_manager.py
+++ b/localstack-core/localstack/services/opensearch/cluster_manager.py
@@ -111,7 +111,8 @@ def build_cluster_endpoint(
                 assigned_port = external_service_ports.reserve_port(preferred_port)
             except PortNotAvailableException:
                 LOG.warning(
-                    f"Preferred port {preferred_port} is not available, trying to reserve another port."
+                    "Preferred port %s is not available, trying to reserve another port.",
+                    preferred_port,
                 )
                 assigned_port = external_service_ports.reserve_port()
         else:

--- a/localstack-core/localstack/services/opensearch/provider.py
+++ b/localstack-core/localstack/services/opensearch/provider.py
@@ -435,7 +435,7 @@ class OpensearchProvider(OpensearchApi, ServiceLifecycleHook):
                     # cluster already restored in previous call to on_after_state_load
                     continue
 
-                LOG.info(f"Restoring domain {domain_name} in region {region}.")
+                LOG.info("Restoring domain %s in region %s.", domain_name, region)
                 try:
                     preferred_port = None
                     if config.OPENSEARCH_ENDPOINT_STRATEGY == "port":
@@ -457,7 +457,11 @@ class OpensearchProvider(OpensearchApi, ServiceLifecycleHook):
                         preferred_port=preferred_port,
                     )
                 except Exception:
-                    LOG.exception(f"Could not restore domain {domain_name} in region {region}.")
+                    LOG.exception(
+                        "Could not restore domain %s in region %s.",
+                        domain_name,
+                        region,
+                    )
 
     def on_before_state_reset(self):
         self._stop_clusters()

--- a/localstack-core/localstack/services/s3/legacy/virtual_host.py
+++ b/localstack-core/localstack/services/s3/legacy/virtual_host.py
@@ -37,7 +37,11 @@ class S3VirtualHostProxyHandler:
         # TODO region pattern currently not working -> removing it from url
         rewritten_url = self._rewrite_url(request=request, **kwargs)
 
-        LOG.debug(f"Rewritten original host url: {request.url} to path-style url: {rewritten_url}")
+        LOG.debug(
+            "Rewritten original host url: %s to path-style url: %s",
+            request.url,
+            rewritten_url,
+        )
 
         forward_to_url = urlsplit(rewritten_url)
         copied_headers = copy.copy(request.headers)

--- a/localstack-core/localstack/services/sns/publisher.py
+++ b/localstack-core/localstack/services/sns/publisher.py
@@ -876,7 +876,9 @@ def send_message_to_gcm(
     )
     if response.status_code != 200:
         LOG.warning(
-            f"Platform GCM returned response {response.status_code} with content {response.content}"
+            "Platform GCM returned response %s with content %s",
+            response.status_code,
+            response.content,
         )
 
 

--- a/localstack-core/localstack/services/stepfunctions/asl/component/eval_component.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/eval_component.py
@@ -23,7 +23,13 @@ class EvalComponent(Component, abc.ABC):
         return self.__heap_key
 
     def _log_evaluation_step(self, subject: str = "Generic") -> None:
-        LOG.debug(f"[ASL] [{subject.lower()[:4]}] [{self.__class__.__name__}]: '{repr(self)}'")
+        if LOG.isEnabledFor(logging.DEBUG):
+            LOG.debug(
+                "[ASL] [%s] [%s]: '%s'",
+                subject.lower()[:4],
+                self.__class__.__name__,
+                repr(self),
+            )
 
     def _log_failure_event_exception(self, failure_event_exception: FailureEventException) -> None:
         error_log_parts = ["Exception=FailureEventException"]
@@ -38,7 +44,7 @@ class EvalComponent(Component, abc.ABC):
 
         error_log = ", ".join(error_log_parts)
         component_repr = repr(self)
-        LOG.error(f"{error_log} at '{component_repr}'")
+        LOG.error("%s at '%s'", error_log, component_repr)
 
     def _log_exception(self, exception: Exception) -> None:
         exception_name = exception.__class__.__name__
@@ -53,7 +59,7 @@ class EvalComponent(Component, abc.ABC):
 
         error_log = ", ".join(error_log_parts)
         component_repr = repr(self)
-        LOG.error(f"{error_log} at '{component_repr}'")
+        LOG.error("%s at '%s'", error_log, component_repr)
 
     def eval(self, env: Environment) -> None:
         if env.is_running():

--- a/localstack-core/localstack/services/stepfunctions/asl/component/program/program.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/program/program.py
@@ -99,7 +99,7 @@ class Program(EvalComponent):
             env.set_error(error=ex.get_execution_failed_event_details())
         except Exception as ex:
             cause = f"{type(ex).__name__}({str(ex)})"
-            LOG.error(f"Stepfunctions computation ended with exception '{cause}'.")
+            LOG.error("Stepfunctions computation ended with exception '%s'.", cause)
             env.set_error(
                 ExecutionFailedEventDetails(
                     error=StatesErrorName(typ=StatesErrorNameType.StatesRuntime).error_name,

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state.py
@@ -96,7 +96,7 @@ class CommonStateField(EvalComponent, ABC):
         elif isinstance(self.continue_with, ContinueWithEnd):  # This includes ContinueWithSuccess
             env.set_ended()
         else:
-            LOG.error(f"Could not handle ContinueWith type of '{type(self.continue_with)}'.")
+            LOG.error("Could not handle ContinueWith type of '%s'.", type(self.continue_with))
 
     def _get_state_entered_event_details(self, env: Environment) -> StateEnteredEventDetails:
         return StateEnteredEventDetails(

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/operator/implementations/is_operator.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/operator/implementations/is_operator.py
@@ -102,7 +102,9 @@ class IsTimestamp(Operator):
     def eval(env: Environment, value: Any) -> None:
         variable = env.stack.pop()
         LOG.warning(
-            f"State Choice's 'IsTimestamp' operator is not fully supported for input '{variable}' and target '{value}'."
+            "State Choice's 'IsTimestamp' operator is not fully supported for input '%s' and target '%s'.",
+            variable,
+            value,
         )
         res = IsTimestamp.is_timestamp(variable) is value
         env.stack.append(res)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/itemprocessor/distributed_item_processor_worker.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/itemprocessor/distributed_item_processor_worker.py
@@ -98,19 +98,25 @@ class DistributedItemProcessorWorker(InlineItemProcessorWorker):
 
         except EvalTimeoutError as timeout_error:
             LOG.debug(
-                f"MapRun worker Timeout Error '{timeout_error}' for input '{to_json_str(job.job_input)}'."
+                "MapRun worker Timeout Error '%s' for input '%s'.",
+                timeout_error,
+                to_json_str(job.job_input),
             )
             self._map_run_record.item_counter.timed_out.count()
 
         except FailureEventException as failure_event_ex:
             LOG.debug(
-                f"MapRun worker Event Exception '{to_json_str(failure_event_ex.failure_event)}' for input '{to_json_str(job.job_input)}'."
+                "MapRun worker Event Exception '%s' for input '%s'.",
+                to_json_str(failure_event_ex.failure_event),
+                to_json_str(job.job_input),
             )
             self._map_run_record.item_counter.failed.count()
 
         except Exception as exception:
             LOG.debug(
-                f"MapRun worker Error '{exception}' for input '{to_json_str(job.job_input)}'."
+                "MapRun worker Error '%s' for input '%s'.",
+                exception,
+                to_json_str(job.job_input),
             )
             self._map_run_record.item_counter.failed.count()
 

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/iteration_worker.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/iteration_worker.py
@@ -150,7 +150,8 @@ class IterationWorker(abc.ABC):
         except Exception as ex:
             # Error case.
             LOG.warning(
-                f"Unhandled termination error in item processor worker for job '{job.job_index}'."
+                "Unhandled termination error in item processor worker for job '%s'.",
+                job.job_index,
             )
 
             # Pass the exception upstream leading to evaluation halt.

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/job.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/job.py
@@ -82,7 +82,9 @@ class JobPool:
 
             if job in self._closed_jobs:
                 LOG.warning(
-                    f"Duplicate execution of Job with index '{job.job_index}' and input '{to_json_str(job.job_input)}'"
+                    "Duplicate execution of Job with index '%s' and input '%s'",
+                    job.job_index,
+                    to_json_str(job.job_input),
                 )
 
             if isinstance(job.job_output, Exception):

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_parallel/branch_worker.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_parallel/branch_worker.py
@@ -28,9 +28,9 @@ class BranchWorker:
         self._worker_thread = None
 
     def _thread_routine(self) -> None:
-        LOG.info(f"[BranchWorker] [launched] [id: {self._worker_thread.native_id}]")
+        LOG.info("[BranchWorker] [launched] [id: %s]", self._worker_thread.native_id)
         self._program.eval(self.env)
-        LOG.info(f"[BranchWorker] [terminated] [id: {self._worker_thread.native_id}]")
+        LOG.info("[BranchWorker] [terminated] [id: %s]", self._worker_thread.native_id)
         self._branch_worker_comm.on_terminated(env=self.env)
 
     def start(self):

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_api_gateway.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_api_gateway.py
@@ -201,7 +201,11 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
         given_api_endpoint = parameters["ApiEndpoint"]
         api_endpoint = StateTaskServiceApiGateway._path_based_url_of(given_api_endpoint)
         if given_api_endpoint != api_endpoint:
-            LOG.warning(f"ApiEndpoint '{given_api_endpoint}' ignored in favour of {api_endpoint}")
+            LOG.warning(
+                "ApiEndpoint '%s' ignored in favour of %s",
+                given_api_endpoint,
+                api_endpoint,
+            )
 
         url_base = api_endpoint + "/"
         # http://localhost:4566/restapis/<api-id>/<stage>/_user_request_/<path>(?<query-parameters>)?

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
@@ -63,12 +63,14 @@ class StateTaskServiceAwsSdk(StateTaskServiceCallback):
                 return sfn_normalised_service_name
         except UnknownServiceError:
             LOG.warning(
-                f"No service for name '{service_name}' when building aws-sdk service error name."
+                "No service for name '%s' when building aws-sdk service error name.",
+                service_name,
             )
 
         # Revert to returning the resource's service name and log the missing binding.
         LOG.error(
-            f"No normalised service error name for aws-sdk integration was found for service: '{service_name}'"
+            "No normalised service error name for aws-sdk integration was found for service: '%s'",
+            service_name,
         )
         return service_name
 

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_unsupported.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_unsupported.py
@@ -28,9 +28,10 @@ class StateTaskServiceUnsupported(StateTaskServiceCallback):
         service_name = self._get_boto_service_name()
         resource_arn = self.resource.resource_arn
         LOG.warning(
-            f"Unsupported Optimised service integration for service_name '{service_name}' "
-            f"in resource: '{resource_arn}'."
-            "Attempting to forward request to service."
+            "Unsupported Optimised service integration for service_name '%s' in resource: '%s'. "
+            "Attempting to forward request to service.",
+            service_name,
+            resource_arn,
         )
 
     def _eval_service_task(

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/wait_function.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/wait_function.py
@@ -24,13 +24,16 @@ class WaitFunction(EvalComponent, abc.ABC):
         elif env.is_running():
             # Unrelated interrupt: continue waiting.
             LOG.warning(
-                f"Wait function '{self}' successfully reentered waiting for "
-                f"another '{wait_seconds_delta}' seconds."
+                "Wait function '%s' successfully reentered waiting for another '%s' seconds.",
+                self,
+                wait_seconds_delta,
             )
             return self._wait_interval(env=env, wait_seconds=wait_seconds_delta)
         else:
             LOG.info(
-                f"Wait function '{self}' successfully interrupted after '{round_sec_waited}' seconds."
+                "Wait function '%s' successfully interrupted after '%s' seconds.",
+                self,
+                round_sec_waited,
             )
 
     def _eval_body(self, env: Environment) -> None:

--- a/localstack-core/localstack/services/stepfunctions/asl/component/test_state/program/test_state_program.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/test_state/program/test_state_program.py
@@ -52,7 +52,7 @@ class TestStateProgram(EvalComponent):
             env.set_error(error=ex.get_execution_failed_event_details())
         except Exception as ex:
             cause = f"{type(ex).__name__}({str(ex)})"
-            LOG.error(f"Stepfunctions computation ended with exception '{cause}'.")
+            LOG.error("Stepfunctions computation ended with exception '%s'.", cause)
             env.set_error(
                 ExecutionFailedEventDetails(
                     error=StatesErrorName(typ=StatesErrorNameType.StatesRuntime).error_name,

--- a/localstack-core/localstack/services/stepfunctions/asl/eval/event/event_manager.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/eval/event/event_manager.py
@@ -166,7 +166,10 @@ class EventManager:
         )
         if event_details:
             if len(event_details) > 1:
-                LOG.warning(f"Event details with multiple bindings: {to_json_str(event_details)}")
+                LOG.warning(
+                    "Event details with multiple bindings: %s",
+                    to_json_str(event_details),
+                )
             details_body = next(iter(event_details.values()))
             if not include_execution_data:
                 # clone the object before modifying it as the change is limited to the history log value.

--- a/localstack-core/localstack/services/stepfunctions/asl/eval/event/logging.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/eval/event/logging.py
@@ -77,7 +77,7 @@ def is_logging_enabled_for(log_level: LogLevel, history_event_type: HistoryEvent
     elif log_level == LogLevel.FATAL:
         return history_event_type in _FATAL_LOG_EVENT_TYPES
     else:
-        LOG.error(f"Unknown LogLevel '{log_level}'")
+        LOG.error("Unknown LogLevel '%s'", log_level)
 
 
 class CloudWatchLoggingConfiguration:
@@ -229,7 +229,9 @@ class CloudWatchLoggingSession:
         message = to_json_str(history_log)
         log_events = [InputLogEvent(timestamp=timestamp_value, message=message)]
         LOG.debug(
-            f"New CloudWatch Log for execution '{self.execution_arn}' with message: '{message}'"
+            "New CloudWatch Log for execution '%s' with message: '%s'",
+            self.execution_arn,
+            message,
         )
         self._publish_history_log_or_setup(log_events=log_events)
 
@@ -244,7 +246,8 @@ class CloudWatchLoggingSession:
         if not is_setup:
             LOG.debug(
                 "CloudWatch Log was not published due to setup errors encountered "
-                f"while creating the LogStream for execution '{self.execution_arn}'."
+                "while creating the LogStream for execution '%s'.",
+                self.execution_arn,
             )
             return
 
@@ -265,7 +268,8 @@ class CloudWatchLoggingSession:
                 return False
         except Exception as ignored:
             LOG.warning(
-                f"State Machine execution log event could not be published due to an error: '{ignored}'"
+                "State Machine execution log event could not be published due to an error: '%s'",
+                ignored,
             )
         return True
 
@@ -282,7 +286,9 @@ class CloudWatchLoggingSession:
             error_code = error.response["Error"]["Code"]
             if error_code != "ResourceAlreadyExistsException":
                 LOG.error(
-                    f"Could not create execution log stream for execution '{self.execution_arn}' due to {error}"
+                    "Could not create execution log stream for execution '%s' due to %s",
+                    self.execution_arn,
+                    error,
                 )
                 return False
         return True

--- a/localstack-core/localstack/services/stepfunctions/backend/execution.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/execution.py
@@ -328,7 +328,9 @@ class Execution:
             self._get_events_client().put_events(Entries=[entry])
         except Exception:
             LOG.exception(
-                f"Unable to send notification of Entry='{entry}' for Step Function execution with Arn='{self.exec_arn}' to EventBridge."
+                "Unable to send notification of Entry='%s' for Step Function execution with Arn='%s' to EventBridge.",
+                entry,
+                self.exec_arn,
             )
 
 

--- a/localstack-core/localstack/services/stepfunctions/backend/test_state/execution.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/test_state/execution.py
@@ -120,7 +120,8 @@ class TestStateExecution(Execution):
         else:
             # TODO: handle other statuses
             LOG.warning(
-                f"Unsupported StateMachine exit type for TestState '{type(exit_program_state)}'"
+                "Unsupported StateMachine exit type for TestState '%s'",
+                type(exit_program_state),
             )
             output_str = to_json_str(self.output)
             test_state_output = TestStateOutput(

--- a/localstack-core/localstack/services/transcribe/provider.py
+++ b/localstack-core/localstack/services/transcribe/provider.py
@@ -282,7 +282,7 @@ class TranscribeProvider(TranscribeApi):
                 )
             )
             format = ffprobe_output["format"]["format_name"]
-            LOG.debug(f"Media format detected as: {format}")
+            LOG.debug("Media format detected as: %s", format)
             job["MediaFormat"] = SUPPORTED_FORMAT_NAMES[format]
 
             # Determine the sample rate of input audio if possible

--- a/localstack-core/localstack/testing/pytest/container.py
+++ b/localstack-core/localstack/testing/pytest/container.py
@@ -93,7 +93,8 @@ class ContainerFactory:
         if failures:
             for container, ex in failures:
                 LOG.error(
-                    f"Failed to remove container {container.running_container.id}",
+                    "Failed to remove container %s",
+                    container.running_container.id,
                     exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
 

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -237,7 +237,7 @@ def s3_create_bucket_with_client(s3_empty_bucket, aws_client):
             s3_empty_bucket(bucket)
             aws_client.s3.delete_bucket(Bucket=bucket)
         except Exception as e:
-            LOG.debug(f"error cleaning up bucket {bucket}: {e}")
+            LOG.debug("error cleaning up bucket %s: %s", bucket, e)
 
 
 @pytest.fixture
@@ -456,7 +456,7 @@ def sns_subscription(aws_client):
         try:
             aws_client.sns.unsubscribe(SubscriptionArn=sub_arn)
         except Exception as e:
-            LOG.debug(f"error cleaning up subscription {sub_arn}: {e}")
+            LOG.debug("error cleaning up subscription %s: %s", sub_arn, e)
 
 
 @pytest.fixture
@@ -600,7 +600,7 @@ def route53_hosted_zone(aws_client):
         try:
             aws_client.route53.delete_hosted_zone(Id=zone)
         except Exception as e:
-            LOG.debug(f"error cleaning up route53 HostedZone {zone}: {e}")
+            LOG.debug("error cleaning up route53 HostedZone %s: %s", zone, e)
 
 
 @pytest.fixture
@@ -914,7 +914,7 @@ def cleanup_stacks(aws_client):
                 aws_client.cloudformation.delete_stack(StackName=stack)
                 aws_client.cloudformation.get_waiter("stack_delete_complete").wait(StackName=stack)
             except Exception:
-                LOG.debug(f"Failed to cleanup stack '{stack}'")
+                LOG.debug("Failed to cleanup stack '%s'", stack)
 
     return _cleanup_stacks
 
@@ -927,7 +927,7 @@ def cleanup_changesets(aws_client):
             try:
                 aws_client.cloudformation.delete_change_set(ChangeSetName=cs)
             except Exception:
-                LOG.debug(f"Failed to cleanup changeset '{cs}'")
+                LOG.debug("Failed to cleanup changeset '%s'", cs)
 
     return _cleanup_changesets
 
@@ -1089,7 +1089,7 @@ def deploy_cfn_template(
         try:
             teardown()
         except Exception as e:
-            LOG.debug(f"Failed cleaning up stack {stack_id=}: {e}")
+            LOG.debug("Failed cleaning up stack stack_id=%s: %s", stack_id, e)
 
 
 @pytest.fixture
@@ -1186,7 +1186,7 @@ def wait_until_lambda_ready(aws_client):
                     client.get_function(FunctionName=function_name)["Configuration"]["State"]
                     != "Pending"
                 )
-                LOG.debug(f"lambda state result: {result=}")
+                LOG.debug("lambda state result: result=%s", result)
                 return result
             except Exception as e:
                 LOG.error(e)
@@ -1267,7 +1267,7 @@ def create_lambda_function_aws(aws_client):
         try:
             aws_client.lambda_.delete_function(FunctionName=arn)
         except Exception:
-            LOG.debug(f"Unable to delete function {arn=} in cleanup")
+            LOG.debug("Unable to delete function arn=%s in cleanup", arn)
 
 
 @pytest.fixture
@@ -1307,13 +1307,13 @@ def create_lambda_function(aws_client, wait_until_lambda_ready, lambda_su_role):
         try:
             client.delete_function(FunctionName=arn)
         except Exception:
-            LOG.debug(f"Unable to delete function {arn=} in cleanup")
+            LOG.debug("Unable to delete function arn=%s in cleanup", arn)
 
     for log_group_name in log_groups:
         try:
             logs_client.delete_log_group(logGroupName=log_group_name)
         except Exception:
-            LOG.debug(f"Unable to delete log group {log_group_name} in cleanup")
+            LOG.debug("Unable to delete log group %s in cleanup", log_group_name)
 
 
 @pytest.fixture
@@ -1408,7 +1408,7 @@ def create_event_source_mapping(aws_client):
         try:
             aws_client.lambda_.delete_event_source_mapping(UUID=uuid)
         except Exception:
-            LOG.debug(f"Unable to delete event source mapping {uuid} in cleanup")
+            LOG.debug("Unable to delete event source mapping %s in cleanup", uuid)
 
 
 @pytest.fixture
@@ -2051,7 +2051,7 @@ def appsync_create_api(aws_client):
         try:
             aws_client.appsync.delete_graphql_api(apiId=api)
         except Exception as e:
-            LOG.debug(f"Error cleaning up AppSync API: {api}, {e}")
+            LOG.debug("Error cleaning up AppSync API: %s, %s", api, e)
 
 
 @pytest.fixture

--- a/localstack-core/localstack/testing/pytest/stepfunctions/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/stepfunctions/fixtures.py
@@ -276,7 +276,7 @@ def create_state_machine(aws_client):
                     aws_client.stepfunctions.stop_execution(executionArn=execution["executionArn"])
             aws_client.stepfunctions.delete_state_machine(stateMachineArn=state_machine_arn)
         except Exception:
-            LOG.debug(f"Unable to delete state machine '{state_machine_arn}' during cleanup.")
+            LOG.debug("Unable to delete state machine '%s' during cleanup.", state_machine_arn)
 
 
 @pytest.fixture
@@ -295,7 +295,7 @@ def create_activity(aws_client):
         try:
             aws_client.stepfunctions.delete_activity(activityArn=activity_arn)
         except Exception:
-            LOG.debug(f"Unable to delete Activity '{activity_arn}' during cleanup.")
+            LOG.debug("Unable to delete Activity '%s' during cleanup.", activity_arn)
 
 
 @pytest.fixture
@@ -705,7 +705,7 @@ def sfn_glue_create_job(aws_client, create_role, create_policy, wait_and_assume_
             aws_client.glue.delete_job(JobName=job_name)
         except Exception as ex:
             # TODO: the glue provider should not fail on deletion of deleted job, however this is currently the case.
-            LOG.warning(f"Could not delete job '{job_name}': {ex}")
+            LOG.warning("Could not delete job '%s': %s", job_name, ex)
 
 
 @pytest.fixture
@@ -726,4 +726,4 @@ def sfn_create_log_group(aws_client, snapshot):
         try:
             aws_client.logs.delete_log_group(logGroupName=log_group_name)
         except Exception:
-            LOG.debug(f"Cannot delete log group {log_group_name}")
+            LOG.debug("Cannot delete log group %s", log_group_name)

--- a/localstack-core/localstack/testing/pytest/stepfunctions/utils.py
+++ b/localstack-core/localstack/testing/pytest/stepfunctions/utils.py
@@ -89,7 +89,7 @@ def await_state_machine_not_listed(stepfunctions_client, state_machine_arn: str)
         interval=1,
     )
     if not success:
-        LOG.warning(f"Timed out whilst awaiting for listing to exclude '{state_machine_arn}'.")
+        LOG.warning("Timed out whilst awaiting for listing to exclude '%s'.", state_machine_arn)
 
 
 def await_state_machine_listed(stepfunctions_client, state_machine_arn: str):
@@ -99,7 +99,7 @@ def await_state_machine_listed(stepfunctions_client, state_machine_arn: str):
         interval=1,
     )
     if not success:
-        LOG.warning(f"Timed out whilst awaiting for listing to include '{state_machine_arn}'.")
+        LOG.warning("Timed out whilst awaiting for listing to include '%s'.", state_machine_arn)
 
 
 def await_state_machine_version_not_listed(
@@ -114,7 +114,9 @@ def await_state_machine_version_not_listed(
     )
     if not success:
         LOG.warning(
-            f"Timed out whilst awaiting for version of {state_machine_arn} to exclude '{state_machine_version_arn}'."
+            "Timed out whilst awaiting for version of %s to exclude '%s'.",
+            state_machine_arn,
+            state_machine_version_arn,
         )
 
 
@@ -130,7 +132,9 @@ def await_state_machine_version_listed(
     )
     if not success:
         LOG.warning(
-            f"Timed out whilst awaiting for version of {state_machine_arn} to include '{state_machine_version_arn}'."
+            "Timed out whilst awaiting for version of %s to include '%s'.",
+            state_machine_arn,
+            state_machine_version_arn,
         )
 
 
@@ -186,7 +190,9 @@ def await_list_execution_status(
     success = poll_condition(condition=_run_check, timeout=120, interval=1)
     if not success:
         LOG.warning(
-            f"Timed out whilst awaiting for execution status {status} to satisfy condition for execution '{execution_arn}'."
+            "Timed out whilst awaiting for execution status %s to satisfy condition for execution '%s'.",
+            status,
+            execution_arn,
         )
 
 
@@ -225,7 +231,8 @@ def await_execution_lists_terminated(
     success = poll_condition(condition=_check_last_is_terminal, timeout=120, interval=1)
     if not success:
         LOG.warning(
-            f"Timed out whilst awaiting for execution events to satisfy condition for execution '{execution_arn}'."
+            "Timed out whilst awaiting for execution events to satisfy condition for execution '%s'.",
+            execution_arn,
         )
 
 
@@ -250,7 +257,7 @@ def await_execution_aborted(stepfunctions_client, execution_arn: str):
 
     success = poll_condition(condition=_run_check, timeout=120, interval=1)
     if not success:
-        LOG.warning(f"Timed out whilst awaiting for execution '{execution_arn}' to abort.")
+        LOG.warning("Timed out whilst awaiting for execution '%s' to abort.", execution_arn)
 
 
 def get_expected_execution_logs(
@@ -710,7 +717,10 @@ class SfnNoneRecursiveParallelTransformer:
         for i, event in enumerate(events):
             event_type = event.get("type")
             if event_type is None:
-                LOG.debug(f"No 'type' in event item '{event}'.")
+                LOG.debug(
+                    "No 'type' in event item '%s'.",
+                    event,
+                )
                 in_sublist = False
 
             elif event_type in {
@@ -735,7 +745,7 @@ class SfnNoneRecursiveParallelTransformer:
         pattern = parse("$..events")
         events = pattern.find(input_data)
         if not events:
-            LOG.debug(f"No Stepfunctions 'events' for jsonpath '{self.events_jsonpath}'.")
+            LOG.debug("No Stepfunctions 'events' for jsonpath '%s'.", self.events_jsonpath)
             return input_data
 
         for events_data in events:

--- a/localstack-core/localstack/testing/scenario/provisioning.py
+++ b/localstack-core/localstack/testing/scenario/provisioning.py
@@ -34,19 +34,20 @@ CFN_MAX_TEMPLATE_SIZE = 51_200
 
 # TODO: move/unify with utils
 def cleanup_s3_bucket(s3_client: "S3Client", bucket_name: str, delete_bucket: bool = False):
-    LOG.debug(f"Cleaning provisioned S3 Bucket {bucket_name=}")
+    LOG.debug("Cleaning provisioned S3 Bucket %s", bucket_name)
     try:
         objs = s3_client.list_objects_v2(Bucket=bucket_name)
         objs_num = objs["KeyCount"]
         if objs_num > 0:
-            LOG.debug(f"Deleting {objs_num} objects from {bucket_name=}")
+            LOG.debug("Deleting %s objects from bucket_name=%s", objs_num, bucket_name)
             obj_keys = [{"Key": o["Key"]} for o in objs["Contents"]]
             s3_client.delete_objects(Bucket=bucket_name, Delete={"Objects": obj_keys})
         if delete_bucket:
             s3_client.delete_bucket(Bucket=bucket_name)
     except Exception:
         LOG.warning(
-            f"Failed to clean provisioned S3 Bucket {bucket_name=}",
+            "Failed to clean provisioned S3 Bucket bucket_name=%s",
+            bucket_name,
             exc_info=LOG.isEnabledFor(logging.DEBUG),
         )
 

--- a/localstack-core/localstack/utils/aws/arns.py
+++ b/localstack-core/localstack/utils/aws/arns.py
@@ -284,7 +284,7 @@ def lambda_function_or_layer_arn(
 
         except Exception as e:
             msg = f"Alias {alias} of {entity_name} not found"
-            LOG.info(f"{msg}: {e}")
+            LOG.info("%s: %s", msg, e)
             raise Exception(msg)
 
     result = (

--- a/localstack-core/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack-core/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -88,7 +88,7 @@ def publish_sqs_metric_batch(
         try:
             cw_client.put_metric_data(Namespace="AWS/SQS", MetricData=metric_data)
         except Exception as e:
-            LOG.info(f"Unable to put metric data for metrics to CloudWatch: {e}")
+            LOG.info("Unable to put metric data for metrics to CloudWatch: %s", e)
 
         # Update for the next batch
         metric_data.clear()
@@ -130,7 +130,7 @@ def publish_sqs_metric(
             ],
         )
     except Exception as e:
-        LOG.info(f'Unable to put metric data for metric "{metric}" to CloudWatch: {e}')
+        LOG.info('Unable to put metric data for metric "%s" to CloudWatch: %s', metric, e)
 
 
 def publish_lambda_duration(time_before, kwargs):

--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -1331,7 +1331,7 @@ class Util:
                 hard_limit = int(hard) if hard else int(soft)
                 new_ulimit = Ulimit(name=name, soft_limit=int(soft), hard_limit=hard_limit)
                 if ulimits_dict.get(name):
-                    LOG.warning(f"Overwriting Docker ulimit {new_ulimit}")
+                    LOG.warning("Overwriting Docker ulimit %s", new_ulimit)
                 ulimits_dict[name] = new_ulimit
             ulimits = list(ulimits_dict.values())
 

--- a/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
@@ -228,7 +228,7 @@ class SdkDockerClient(ContainerClient):
                         }
                     )
                 except Exception as e:
-                    LOG.error(f"Error checking container {container}: {e}")
+                    LOG.error("Error checking container %s: %s", container, e)
             return result
         except APIError as e:
             raise ContainerException() from e
@@ -574,7 +574,8 @@ class SdkDockerClient(ContainerClient):
                     stdout, stderr = self._read_from_sock(sock, False)
                 except socket.timeout:
                     LOG.debug(
-                        f"Socket timeout when talking to the I/O streams of Docker container '{container_name_or_id}'"
+                        "Socket timeout when talking to the I/O streams of Docker container '%s'",
+                        container_name_or_id,
                     )
                 finally:
                     sock.close()

--- a/localstack-core/localstack/utils/http.py
+++ b/localstack-core/localstack/utils/http.py
@@ -2,7 +2,6 @@ import logging
 import math
 import os
 import re
-import traceback
 from typing import Dict, Optional, Union
 from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlunparse
 
@@ -291,9 +290,11 @@ def download_github_artifact(url: str, target_file: str, timeout: int = None):
             return True
         except Exception as e:
             if print_error:
-                LOG.info(
-                    "Unable to download Github artifact from %s to %s: %s %s"
-                    % (url, target_file, e, traceback.format_exc())
+                LOG.exception(
+                    "Unable to download Github artifact from %s to %s: %s %s",
+                    url,
+                    target_file,
+                    e,
                 )
 
     # if a GitHub API token is set, use it to avoid rate limiting issues

--- a/localstack-core/localstack/utils/lambda_debug_mode/lambda_debug_mode_config.py
+++ b/localstack-core/localstack/utils/lambda_debug_mode/lambda_debug_mode_config.py
@@ -100,7 +100,8 @@ def from_yaml_string(yaml_string: str) -> Optional[LambdaDebugModeConfig]:
         data = yaml.load(yaml_string, _SafeLoaderWithDuplicateCheck)
     except yaml.YAMLError as yaml_error:
         LOG.error(
-            f"Could not parse yaml lambda debug mode configuration file due to: {str(yaml_error)}"
+            "Could not parse yaml lambda debug mode configuration file due to: %s",
+            yaml_error,
         )
         data = None
     if not data:
@@ -194,7 +195,8 @@ def load_lambda_debug_mode_config(yaml_string: str) -> Optional[LambdaDebugModeC
         yaml_data = yaml.load(yaml_string, _SafeLoaderWithDuplicateCheck)
     except yaml.YAMLError as yaml_error:
         LOG.error(
-            f"Could not parse yaml lambda debug mode configuration file due to: {str(yaml_error)}"
+            "Could not parse yaml lambda debug mode configuration file due to: %s",
+            yaml_error,
         )
         yaml_data = None
     if not yaml_data:
@@ -210,7 +212,8 @@ def load_lambda_debug_mode_config(yaml_string: str) -> Optional[LambdaDebugModeC
             for err in validation_errors
         ]
         LOG.error(
-            f"Unable to parse lambda debug mode configuration file due to errors: {error_messages}"
+            "Unable to parse lambda debug mode configuration file due to errors: %s",
+            error_messages,
         )
         return None
 
@@ -218,7 +221,10 @@ def load_lambda_debug_mode_config(yaml_string: str) -> Optional[LambdaDebugModeC
     try:
         post_process_lambda_debug_mode_config(config)
     except LambdaDebugModeConfigException as lambda_debug_mode_error:
-        LOG.error(f"Invalid lambda debug mode configuration due to: {lambda_debug_mode_error}")
+        LOG.error(
+            "Invalid lambda debug mode configuration due to: %s",
+            lambda_debug_mode_error,
+        )
         config = None
 
     return config

--- a/localstack-core/localstack/utils/lambda_debug_mode/lambda_debug_mode_session.py
+++ b/localstack-core/localstack/utils/lambda_debug_mode/lambda_debug_mode_session.py
@@ -39,21 +39,24 @@ class LambdaDebugModeSession:
             with open(file_path, "r") as df:
                 yaml_configuration_string = df.read()
         except FileNotFoundError:
-            LOG.error(f"Error: The file lambda debug config " f"file '{file_path}' was not found.")
+            LOG.error("Error: The file lambda debug config " "file '%s' was not found.", file_path)
         except IsADirectoryError:
             LOG.error(
-                f"Error: Expected a lambda debug config file "
-                f"but found a directory at '{file_path}'."
+                "Error: Expected a lambda debug config file " "but found a directory at '%s'.",
+                file_path,
             )
         except PermissionError:
             LOG.error(
-                f"Error: Permission denied while trying to read "
-                f"the lambda debug config file '{file_path}'."
+                "Error: Permission denied while trying to read "
+                "the lambda debug config file '%s'.",
+                file_path,
             )
         except Exception as ex:
             LOG.error(
-                f"Error: An unexpected error occurred while reading "
-                f"lambda debug config '{file_path}': '{ex}'"
+                "Error: An unexpected error occurred while reading "
+                "lambda debug config '%s': '%s'",
+                file_path,
+                ex,
             )
         if not yaml_configuration_string:
             return None

--- a/localstack-core/localstack/utils/net.py
+++ b/localstack-core/localstack/utils/net.py
@@ -186,7 +186,7 @@ def port_can_be_bound(port: IntOrPort, address: str = "") -> bool:
         # either the port is used or we don't have permission to bind it
         return False
     except Exception:
-        LOG.error(f"cannot bind port {port}", exc_info=LOG.isEnabledFor(logging.DEBUG))
+        LOG.error("cannot bind port %s", port, exc_info=LOG.isEnabledFor(logging.DEBUG))
         return False
 
 

--- a/localstack-core/localstack/utils/no_exit_argument_parser.py
+++ b/localstack-core/localstack/utils/no_exit_argument_parser.py
@@ -13,7 +13,7 @@ class NoExitArgumentParser(argparse.ArgumentParser):
     """
 
     def exit(self, status: int = ..., message: Optional[str] = ...) -> NoReturn:
-        LOG.warning(f"Error in argument parser but preventing exit: {message}")
+        LOG.warning("Error in argument parser but preventing exit: %s", message)
 
     def error(self, message: str) -> NoReturn:
         raise NotImplementedError(f"Unsupported flag by this Docker client: {message}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,7 +207,7 @@ ignore = [
     "T201", # TODO `print` found
     "T203", # TODO `pprint` found
 ]
-select = ["B", "C", "E", "F", "I", "W", "T", "B9"]
+select = ["B", "C", "E", "F", "I", "W", "T", "B9", "G"]
 
 [tool.coverage.run]
 relative_files = true

--- a/tests/aws/scenario/kinesis_firehose/conftest.py
+++ b/tests/aws/scenario/kinesis_firehose/conftest.py
@@ -34,7 +34,7 @@ def get_all_expected_messages_from_s3(
         for input_string in bucket_data.values():
             json_array_string = "[" + input_string.replace("}{", "},{") + "]"
             message = json.loads(json_array_string)
-            LOG.debug(f"Received messages: {message}")
+            LOG.debug("Received messages: %s", message)
             messages.extend(message)
         if expected_message_count is not None and len(messages) != expected_message_count:
             raise Exception(f"Failed to receive all sent messages: {messages}")

--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -239,7 +239,7 @@ def apigateway_placeholder_authorizer_lambda_invocation_arn(
             try:
                 aws_client.lambda_.delete_function(FunctionName=arn)
             except Exception:
-                LOG.debug(f"Unable to delete function {arn=} in cleanup")
+                LOG.debug("Unable to delete function %s in cleanup", arn)
 
 
 @pytest.fixture

--- a/tests/aws/services/cloudcontrol/test_cloudcontrol_api.py
+++ b/tests/aws/services/cloudcontrol/test_cloudcontrol_api.py
@@ -64,7 +64,7 @@ def create_resource(aws_client):
                 RequestToken=delete_request["ProgressEvent"]["RequestToken"]
             )
         except Exception:
-            LOG.warning(f"Failed to delete resource with request token {rr}")
+            LOG.warning("Failed to delete resource with request token %s", rr)
 
 
 @pytest.mark.skip("Not Implemented yet")

--- a/tests/aws/services/cloudformation/resources/test_cloudformation.py
+++ b/tests/aws/services/cloudformation/resources/test_cloudformation.py
@@ -36,7 +36,7 @@ class SignalSuccess(Thread):
                 LOG.debug("fetching parameter")
                 res = self.client.get_parameter(Name=PARAMETER_NAME)
                 url = res["Parameter"]["Value"]
-                LOG.info(f"signalling url {url}")
+                LOG.info("signalling url %s", url)
 
                 payload = {
                     "Status": "SUCCESS",
@@ -45,7 +45,7 @@ class SignalSuccess(Thread):
                     "Data": "Application has completed configuration.",
                 }
                 r = self.session.put(url, json=payload)
-                LOG.debug(f"status from signalling: {r.status_code}")
+                LOG.debug("status from signalling: %s", r.status_code)
                 r.raise_for_status()
                 LOG.debug("status signalled")
                 break

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -2464,7 +2464,7 @@ class TestCloudwatch:
                         EndTime=end_time,
                     )
             except Exception as e:
-                LOG.exception(f"runner {runner} failed: {e}")
+                LOG.exception("runner %s failed: %s", runner, e)
                 exception_caught = True
 
         thread_list = []

--- a/tests/aws/services/cloudwatch/test_cloudwatch_performance.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_performance.py
@@ -80,7 +80,7 @@ class TestCloudWatchPerformance:
                 else:
                     cw_client.list_metrics()
             except Exception as e:
-                LOG.exception(f"runner {runner} failed: {e}")
+                LOG.exception("runner %s failed: %s", runner, e)
                 error_counter.increment()
 
         start_time = datetime.utcnow()
@@ -95,7 +95,7 @@ class TestCloudWatchPerformance:
 
         end_time = datetime.utcnow()
         diff = end_time - start_time
-        LOG.info(f"N={num_threads} took {diff.total_seconds()} seconds")
+        LOG.info("N=%s took %s seconds", num_threads, diff.total_seconds())
 
         assert error_counter.get_value() == 0
         metrics = []
@@ -181,7 +181,7 @@ class TestCloudWatchPerformance:
                     ],
                 )
             except Exception as e:
-                LOG.exception(f"runner {runner} failed: {e}")
+                LOG.exception("runner %s failed: %s", runner, e)
                 error_counter.increment()
 
         start_time = datetime.utcnow()
@@ -196,7 +196,7 @@ class TestCloudWatchPerformance:
 
         end_time = datetime.utcnow()
         diff = end_time - start_time
-        LOG.info(f"N={num_threads} took {diff.total_seconds()} seconds")
+        LOG.info("N=%s took %s seconds", num_threads, diff.total_seconds())
 
         assert error_counter.get_value() == 0
         metrics = []

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -48,7 +48,11 @@ def events_create_event_bus(aws_client, region_name, account_id):
 
                     aws_client.events.delete_rule(Name=rule, EventBusName=event_bus_name)
                 except Exception as e:
-                    LOG.warning(f"Failed to delete rule {rule}: {e}")
+                    LOG.warning(
+                        "Failed to delete rule %s: %s",
+                        rule,
+                        e,
+                    )
 
             # Delete archives for event bus
             event_source_arn = (
@@ -60,11 +64,19 @@ def events_create_event_bus(aws_client, region_name, account_id):
                 try:
                     aws_client.events.delete_archive(ArchiveName=archive)
                 except Exception as e:
-                    LOG.warning(f"Failed to delete archive {archive}: {e}")
+                    LOG.warning(
+                        "Failed to delete archive %s: %s",
+                        archive,
+                        e,
+                    )
 
             aws_client.events.delete_event_bus(Name=event_bus_name)
         except Exception as e:
-            LOG.warning(f"Failed to delete event bus {event_bus_name}: {e}")
+            LOG.warning(
+                "Failed to delete event bus %s: %s",
+                event_bus_name,
+                e,
+            )
 
 
 @pytest.fixture
@@ -148,7 +160,11 @@ def events_put_rule(aws_client):
 
             aws_client.events.delete_rule(Name=rule, EventBusName=event_bus_name)
         except Exception as e:
-            LOG.warning(f"Failed to delete rule {rule}: {e}")
+            LOG.warning(
+                "Failed to delete rule %s: %s",
+                rule,
+                e,
+            )
 
 
 @pytest.fixture
@@ -174,7 +190,11 @@ def events_create_archive(aws_client, region_name, account_id):
         try:
             aws_client.events.delete_archive(ArchiveName=archive)
         except Exception as e:
-            LOG.warning(f"Failed to delete archive {archive}: {e}")
+            LOG.warning(
+                "Failed to delete archive %s: %s",
+                archive,
+                e,
+            )
 
 
 @pytest.fixture

--- a/tests/aws/services/lambda_/functions/lambda_logging.py
+++ b/tests/aws/services/lambda_/functions/lambda_logging.py
@@ -6,5 +6,5 @@ logger.setLevel(logging.DEBUG)
 
 def handler(event, ctx):
     verification_token = event["verification_token"]
-    logging.info(f"{verification_token=}")
+    logging.info("verification_token=%s", verification_token)
     return {"verification_token": verification_token}

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -2926,7 +2926,7 @@ class TestLambdaVersions:
                 assert payload["function_variant"] == "variant-2"
                 assert payload["function_version"] == "$LATEST"
             except Exception:
-                LOG.exception(f"Updating lambda function {function_name} failed.")
+                LOG.exception("Updating lambda function %s failed.", function_name)
                 errored = True
 
         # Start thread with upcoming function update (slightly delayed)

--- a/tests/aws/services/lambda_/test_lambda_performance.py
+++ b/tests/aws/services/lambda_/test_lambda_performance.py
@@ -320,7 +320,7 @@ def test_lambda_event_invoke(create_lambda_function, s3_bucket, aws_client, aws_
             with lock:
                 request_ids.append(request_id)
         except Exception as e:
-            LOG.error(f"runner-{runner} failed: {e}")
+            LOG.error("runner-%s failed: %s", runner, e)
             error_counter.increment()
 
     start_time = datetime.utcnow()
@@ -335,12 +335,12 @@ def test_lambda_event_invoke(create_lambda_function, s3_bucket, aws_client, aws_
         thread.join()
     end_time = datetime.utcnow()
     diff = end_time - start_time
-    LOG.info(f"N={num_invocations} took {diff.total_seconds()} seconds")
+    LOG.info("N=%s took %s seconds", num_invocations, diff.total_seconds())
     assert error_counter.counter == 0
 
     # Sleeping here is a bit hacky, but we want to avoid polling for now because polling affects the results.
     sleep_seconds = 2000
-    LOG.info(f"Sleeping for {sleep_seconds} ...")
+    LOG.info("Sleeping for %s ...", sleep_seconds)
     time.sleep(sleep_seconds)
 
     # Validate CloudWatch invocation metric
@@ -458,7 +458,7 @@ def test_lambda_event_source_mapping_sqs(
             with lock:
                 request_ids.append(request_id)
         except Exception as e:
-            LOG.error(f"runner-{runner} failed: {e}")
+            LOG.error("runner-%s failed: %s", runner, e)
             error_counter.increment()
 
     start_time = datetime.utcnow()
@@ -473,12 +473,12 @@ def test_lambda_event_source_mapping_sqs(
         thread.join()
     end_time = datetime.utcnow()
     diff = end_time - start_time
-    LOG.info(f"N={num_invocations} took {diff.total_seconds()} seconds")
+    LOG.info("N=%s took %s seconds", num_invocations, diff.total_seconds())
     assert error_counter.counter == 0
 
     # Sleeping here is a bit hacky, but we want to avoid polling for now because polling affects the results.
     sleep_seconds = 400
-    LOG.info(f"Sleeping for {sleep_seconds} ...")
+    LOG.info("Sleeping for %s ...", sleep_seconds)
     time.sleep(sleep_seconds)
 
     # Validate CloudWatch invocation metric
@@ -609,7 +609,7 @@ def test_sns_subscription_lambda(
             with lock:
                 request_ids.append(request_id)
         except Exception as e:
-            LOG.error(f"runner-{runner} failed: {e}")
+            LOG.error("runner-%s failed: %s", runner, e)
             error_counter.increment()
 
     start_time = datetime.utcnow()
@@ -624,11 +624,11 @@ def test_sns_subscription_lambda(
         thread.join()
     end_time = datetime.utcnow()
     diff = end_time - start_time
-    LOG.info(f"N={num_invocations} took {diff.total_seconds()} seconds")
+    LOG.info("N=%s took %s seconds", num_invocations, diff.total_seconds())
     assert error_counter.counter == 0
 
     sleep_seconds = 600
-    LOG.info(f"Sleeping for {sleep_seconds} ...")
+    LOG.info("Sleeping for %s ...", sleep_seconds)
     time.sleep(sleep_seconds)
 
     # Validate CloudWatch invocation metric

--- a/tests/aws/services/route53resolver/test_route53resolver.py
+++ b/tests/aws/services/route53resolver/test_route53resolver.py
@@ -115,7 +115,10 @@ class TestRoute53Resolver:
 
         if not poll_condition(condition=_list_resolver_rule_associations, timeout=180, interval=2):
             LOG.warning(
-                f"Timed out while awaiting for resolver rule to {action} with with VPCId:'{vpc_id}' and ResolverRuleId: '{resolver_rule_id}'."
+                "Timed out while awaiting for resolver rule to '%s' with with VPCId:'%s' and ResolverRuleId: '%s'.",
+                action,
+                vpc_id,
+                resolver_rule_id,
             )
         else:
             return True
@@ -134,7 +137,8 @@ class TestRoute53Resolver:
 
         if not poll_condition(condition=_is_req_id_in_list, timeout=120, interval=2):
             LOG.warning(
-                f"Timed out while awaiting for resolver query log config with with id:'{id}' to become listable."
+                "Timed out while awaiting for resolver query log config with with id:'%s' to become listable.",
+                id,
             )
         else:
             return True
@@ -156,7 +160,8 @@ class TestRoute53Resolver:
 
         if not poll_condition(condition=_is_req_id_in_list, timeout=180, interval=2):
             LOG.warning(
-                f"Timed out while awaiting for resolver endpoint with with request id:'{req_id}' to become listable."
+                "Timed out while awaiting for resolver endpoint with with request id:'%s' to become listable.",
+                req_id,
             )
         else:
             return True

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -257,7 +257,7 @@ def create_tmp_folder_lambda():
         try:
             shutil.rmtree(folder)
         except Exception:
-            LOG.warning(f"could not delete folder {folder}")
+            LOG.warning("could not delete folder %s", folder)
 
 
 @pytest.fixture

--- a/tests/aws/services/secretsmanager/functions/lambda_rotate_secret.py
+++ b/tests/aws/services/secretsmanager/functions/lambda_rotate_secret.py
@@ -66,18 +66,20 @@ def handler(event, context):
     metadata = service_client.describe_secret(SecretId=arn)
 
     if not metadata["RotationEnabled"]:
-        logger.error(f"Secret {arn} is not enabled for rotation")
+        logger.error("Secret %s is not enabled for rotation", arn)
         raise ValueError(f"Secret {arn} is not enabled for rotation")
     #
     versions = metadata["VersionIdsToStages"]
     if token not in versions:
-        logger.error(f"Secret version {token} has no stage for rotation of secret {arn}.")
+        logger.error("Secret version %s has no stage for rotation of secret %s.", token, arn)
         raise ValueError(f"Secret version {token} has no stage for rotation of secret {arn}.")
     if "AWSCURRENT" in versions[token]:
-        logger.info(f"Secret version {token} already set as AWSCURRENT for secret {arn}.")
+        logger.info("Secret version %s already set as AWSCURRENT for secret %s.", token, arn)
         return
     elif "AWSPENDING" not in versions[token]:
-        logger.error(f"Secret version {token} not set as AWSPENDING for rotation of secret {arn}.")
+        logger.error(
+            "Secret version %s not set as AWSPENDING for rotation of secret %s.", token, arn
+        )
         raise ValueError(
             f"Secret version {token} not set as AWSPENDING for rotation of secret {arn}."
         )
@@ -121,7 +123,7 @@ def create_secret(service_client, arn, token):
     # Now try to get the secret version, if that fails, put a new secret
     try:
         service_client.get_secret_value(SecretId=arn, VersionId=token, VersionStage="AWSPENDING")
-        logger.info(f"createSecret: Successfully retrieved secret for {arn}.")
+        logger.info("createSecret: Successfully retrieved secret for %s.", arn)
     except service_client.exceptions.ResourceNotFoundException:
         # Signal the correct exception was triggered during create_secret stage.
         sig_exception = secret_signal_resource_not_found_exception_on_create(token)
@@ -138,7 +140,10 @@ def create_secret(service_client, arn, token):
             VersionStages=["AWSPENDING"],
         )
         logger.info(
-            f"createSecret: Successfully put secret for ARN {arn} and version {token} with passwd {passwd}."
+            "createSecret: Successfully put secret for ARN %s and version %s with passwd %s.",
+            arn,
+            token,
+            passwd,
         )
 
 
@@ -201,7 +206,7 @@ def finish_secret(service_client, arn, token):
             if version == token:
                 # The correct version is already marked as current, return
                 logger.info(
-                    f"finishSecret: Version {version} already marked as AWSCURRENT for {arn}"
+                    "finishSecret: Version %s already marked as AWSCURRENT for %s", version, arn
                 )
                 return
             current_version = version
@@ -215,5 +220,7 @@ def finish_secret(service_client, arn, token):
         RemoveFromVersionId=current_version,
     )
     logger.info(
-        f"finishSecret: Successfully set AWSCURRENT stage to version {token} for secret {arn}."
+        "finishSecret: Successfully set AWSCURRENT stage to version %s for secret %s.",
+        token,
+        arn,
     )

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -97,7 +97,8 @@ class TestSecretsManager:
         success = poll_condition(condition=_is_secret_deleted, timeout=120, interval=30)
         if not success:
             LOG.warning(
-                f"Timed out whilst awaiting for force deletion of secret '{secret_id}' to complete."
+                "Timed out whilst awaiting for force deletion of secret '%s' to complete.",
+                secret_id,
             )
 
     @staticmethod
@@ -114,7 +115,8 @@ class TestSecretsManager:
         success = poll_condition(condition=_is_secret_rotated, timeout=120, interval=5)
         if not success:
             LOG.warning(
-                f"Timed out whilst awaiting for secret '{secret_id}' to be rotated to new version."
+                "Timed out whilst awaiting for secret '%s' to be rotated to new version.",
+                secret_id,
             )
 
     @pytest.mark.parametrize(

--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -121,7 +121,8 @@ class TestTranscribe:
 
         if not poll_condition(condition=is_transcription_done, timeout=60, interval=2):
             LOG.warning(
-                f"Timed out while awaiting for transcription of job with transcription job name:'{transcribe_job_name}'."
+                "Timed out while awaiting for transcription of job with transcription job name:'%s'.",
+                transcribe_job_name,
             )
             return False
         else:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
I've seen f-strings in newly created PR,  but f-string are eagerly executed even if the logging level would not have that statement printed out, and the default way of using the Python logger will defer execution/interpolation only if needed.

https://docs.python.org/3/howto/logging.html#optimization
https://docs.astral.sh/ruff/rules/#flake8-logging-log

Adding these new rules would prevent f-string to be used inside logging statements, something we often comment on during PR reviews. Using the linter to prevent it should alleviate and make review easier. 

We had a lot of those in tests, which shouldn't matter really as we're not aiming for that kind of performance, but it should still be best practice to do so. 

There's the downside that sometimes the readability suffers a bit, but `extra` could be used in those case. 
See https://docs.astral.sh/ruff/rules/logging-f-string/

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add new `G` ruleset in Ruff to catch string interpolation in logging statements
- fix existing issues

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
