### PR TITLE
Simplify ACM patch

### DIFF
--- a/localstack-core/localstack/services/acm/provider.py
+++ b/localstack-core/localstack/services/acm/provider.py
@@ -73,9 +73,6 @@ def describe(describe_orig, self):
     if cert.get("KeyAlgorithm") in ["RSA_1024", "RSA_2048"]:
         cert["KeyAlgorithm"] = cert["KeyAlgorithm"].replace("RSA_", "RSA-")
 
-    if "InUse" not in cert:
-        cert["InUse"] = False
-
     # add subject alternative names
     if cert["DomainName"] not in sans:
         sans.append(cert["DomainName"])


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR simplifies (a little) the moto patch we have in the ACM provider concerning the `DescribeCertificate` operation.
Internally, `moto` [uses](https://github.com/getmoto/moto/blob/fb51925d2be3a14d96abc12349be3ad332d18dc1/moto/acm/responses.py#L129-L136) the patched method to implement `ListCerficates`. This response for this operation contains an `InUse` key that `moto` was not returning. 
Therefore, to have the key in LocalStack we were patching the `describe` method to have it landed in `ListCertificates`.

We fixed this in the upstream PR: https://github.com/getmoto/moto/pull/8054

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Simplify `moto` patch.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
