### PR TITLE
fix parsing issue for cloudwatch alarm names

### DIFF
--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import re
 import threading
 import uuid
 from typing import List
@@ -555,6 +556,13 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         dashboard_body: DashboardBody,
         **kwargs,
     ) -> PutDashboardOutput:
+        pattern = r"^[a-zA-Z0-9_-]+$"
+        if not re.match(pattern, dashboard_name):
+            raise InvalidParameterValueException(
+                "The value for field DashboardName contains invalid characters. "
+                "It can only contain alphanumerics, dash (-) and underscore (_).\n"
+            )
+
         store = self.get_store(context.account_id, context.region)
         store.dashboards[dashboard_name] = LocalStackDashboard(
             context.account_id, context.region, dashboard_name, dashboard_body

--- a/localstack-core/localstack/utils/aws/arns.py
+++ b/localstack-core/localstack/utils/aws/arns.py
@@ -195,9 +195,10 @@ def dynamodb_stream_arn(
 
 
 def cloudwatch_alarm_arn(alarm_name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:%s:cloudwatch:%s:%s:alarm:%s"
     # format pattern directly as alarm_name can include ":" and this is not supported by the helper _resource_arn
-    return pattern % (get_partition(region_name), region_name, account_id, alarm_name)
+    return (
+        f"arn:{get_partition(region_name)}:cloudwatch:{region_name}:{account_id}:alarm:{alarm_name}"
+    )
 
 
 def cloudwatch_dashboard_arn(dashboard_name: str, account_id: str, region_name: str) -> str:

--- a/localstack-core/localstack/utils/aws/arns.py
+++ b/localstack-core/localstack/utils/aws/arns.py
@@ -196,12 +196,13 @@ def dynamodb_stream_arn(
 
 def cloudwatch_alarm_arn(alarm_name: str, account_id: str, region_name: str) -> str:
     pattern = "arn:%s:cloudwatch:%s:%s:alarm:%s"
-    return _resource_arn(alarm_name, pattern, account_id=account_id, region_name=region_name)
+    # format pattern directly as alarm_name can include ":" and this is not supported by the helper _resource_arn
+    return pattern % (get_partition(region_name), region_name, account_id, alarm_name)
 
 
-def cloudwatch_dashboard_arn(alarm_name: str, account_id: str, region_name: str) -> str:
+def cloudwatch_dashboard_arn(dashboard_name: str, account_id: str, region_name: str) -> str:
     pattern = "arn:%s:cloudwatch::%s:dashboard/%s"
-    return _resource_arn(alarm_name, pattern, account_id=account_id, region_name=region_name)
+    return _resource_arn(dashboard_name, pattern, account_id=account_id, region_name=region_name)
 
 
 #

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1394,9 +1394,7 @@ class TestCloudwatch:
         snapshot.match("get_metric_data_2", response)
 
     @markers.aws.validated
-    @pytest.mark.skipif(
-        condition=not is_aws_cloud(), reason="Old provider is not raising exception"
-    )
+    @pytest.mark.skipif(condition=is_old_provider(), reason="Old provider is not raising exception")
     def test_invalid_dashboard_name(self, aws_client, region_name, snapshot):
         dashboard_name = f"test-{short_uid()}:invalid"
         dashboard_body = {

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     from mypy_boto3_logs import CloudWatchLogsClient
 PUBLICATION_RETRIES = 5
 
-
 LOG = logging.getLogger(__name__)
 
 
@@ -580,7 +579,7 @@ class TestCloudwatch:
 
     @markers.aws.validated
     def test_describe_alarms_converts_date_format_correctly(self, aws_client, cleanups):
-        alarm_name = f"a-{short_uid()}"
+        alarm_name = f"a-{short_uid()}:test"
         metric_name = f"test-metric-{short_uid()}"
         namespace = f"test-ns-{short_uid()}"
         aws_client.cloudwatch.put_metric_alarm(
@@ -1074,7 +1073,8 @@ class TestCloudwatch:
             AlarmActions=[topic_arn_alarm],
             EvaluationPeriods=1,
             ComparisonOperator="GreaterThanThreshold",
-            TreatMissingData="ignore",  # notBreaching had some downsides, as depending on the alarm evaluation interval it would first go into OK
+            TreatMissingData="ignore",
+            # notBreaching had some downsides, as depending on the alarm evaluation interval it would first go into OK
         )
         cleanups.append(lambda: aws_client.cloudwatch.delete_alarms(AlarmNames=[alarm_name]))
         response = aws_client.cloudwatch.describe_alarms(AlarmNames=[alarm_name])
@@ -1392,6 +1392,37 @@ class TestCloudwatch:
         )
 
         snapshot.match("get_metric_data_2", response)
+
+    @markers.aws.validated
+    @pytest.mark.skipif(
+        condition=not is_aws_cloud(), reason="Old provider is not raising exception"
+    )
+    def test_invalid_dashboard_name(self, aws_client, region_name, snapshot):
+        dashboard_name = f"test-{short_uid()}:invalid"
+        dashboard_body = {
+            "widgets": [
+                {
+                    "type": "metric",
+                    "x": 0,
+                    "y": 0,
+                    "width": 6,
+                    "height": 6,
+                    "properties": {
+                        "metrics": [["AWS/EC2", "CPUUtilization", "InstanceId", "i-12345678"]],
+                        "region": region_name,
+                        "view": "timeSeries",
+                        "stacked": False,
+                    },
+                }
+            ]
+        }
+
+        with pytest.raises(Exception) as ex:
+            aws_client.cloudwatch.put_dashboard(
+                DashboardName=dashboard_name, DashboardBody=json.dumps(dashboard_body)
+            )
+
+        snapshot.match("error-invalid-dashboardname", ex.value.response)
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
@@ -2199,6 +2230,7 @@ class TestCloudwatch:
                 {"MetricName": "metric1", "Value": val, "Unit": "Seconds"} for val in values
             ],
         )
+
         # get_metric_data
 
         def _get_metric_data():
@@ -2442,7 +2474,7 @@ class TestCloudwatch:
                                 "MetricStat": {
                                     "Metric": {
                                         "Namespace": namespace,
-                                        "MetricName": f"metric-{runner-1}-1",
+                                        "MetricName": f"metric-{runner - 1}-1",
                                     },
                                     "Period": 60,
                                     "Stat": "Sum",
@@ -2453,7 +2485,7 @@ class TestCloudwatch:
                                 "MetricStat": {
                                     "Metric": {
                                         "Namespace": namespace,
-                                        "MetricName": f"metric-{runner-1}-2",
+                                        "MetricName": f"metric-{runner - 1}-2",
                                     },
                                     "Period": 60,
                                     "Stat": "Sum",

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -2087,5 +2087,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_invalid_dashboard_name": {
+    "recorded-date": "04-09-2024, 16:28:05",
+    "recorded-content": {
+      "error-invalid-dashboardname": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "The value for field DashboardName contains invalid characters. It can only contain alphanumerics, dash (-) and underscore (_).\n",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -20,6 +20,9 @@
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_delete_alarm": {
     "last_validated_date": "2024-01-12T14:06:42+00:00"
   },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_describe_alarms_converts_date_format_correctly": {
+    "last_validated_date": "2024-09-04T15:59:17+00:00"
+  },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_enable_disable_alarm_actions": {
     "last_validated_date": "2023-09-12T10:00:45+00:00"
   },
@@ -46,6 +49,9 @@
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_invalid_amount_of_datapoints": {
     "last_validated_date": "2024-08-23T14:16:44+00:00"
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_invalid_dashboard_name": {
+    "last_validated_date": "2024-09-04T16:28:05+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_multiple_dimensions_statistics": {
     "last_validated_date": "2024-07-29T07:56:05+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Fixes https://github.com/localstack/localstack/issues/11391
The parsing of alarm-names does not work correctly when the alarm-name contains a colon `:` which is apparently a valid name for alarms.

Also checked the same for dashboard-names where this pattern is not allowed. (Only adding the fix for the default provider v2.)

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* fixed creation of `AlarmArn` which was the root cause (it would not parse the pattern and instead just return the alarm-name as it contains a colon)
* adapted one testcase to use alarm-name with a colon to make sure this is valid on AWS and passes on LocalStack
* added validation for Dashboard name and added test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
