### PR TITLE
Support quiet downloads

### DIFF
--- a/localstack-core/localstack/utils/http.py
+++ b/localstack-core/localstack/utils/http.py
@@ -180,8 +180,12 @@ def download(
     verify_ssl: bool = True,
     timeout: float = None,
     request_headers: Optional[dict] = None,
-):
-    """Downloads file at url to the given path. Raises TimeoutError if the optional timeout (in secs) is reached."""
+    quiet: bool = False,
+) -> None:
+    """Downloads file at url to the given path. Raises TimeoutError if the optional timeout (in secs) is reached.
+
+    If `quiet` is passed, do not log any status messages. Error messages are still logged.
+    """
 
     # make sure we're creating a new session here to enable parallel file downloads
     s = requests.Session()
@@ -207,7 +211,8 @@ def download(
         total_downloaded = 0
         if not os.path.exists(os.path.dirname(path)):
             os.makedirs(os.path.dirname(path))
-        LOG.debug("Starting download from %s to %s", url, path)
+        if not quiet:
+            LOG.debug("Starting download from %s to %s", url, path)
         with open(path, "wb") as f:
             iter_length = 0
             percentage_limit = next_percentage_record = 10  # print a log line for every 10%
@@ -222,7 +227,7 @@ def download(
                 total_downloaded = new_total_downloaded
                 if chunk:  # filter out keep-alive new chunks
                     f.write(chunk)
-                else:
+                elif not quiet:
                     LOG.debug(
                         "Empty chunk %s (total %dK of %dK) from %s",
                         chunk,
@@ -241,22 +246,24 @@ def download(
                         math.floor(current_percent / percentage_limit) * percentage_limit
                         + percentage_limit
                     )
-                    LOG.debug(
-                        "Downloaded %d%% (total %dK of %dK) to %s",
-                        current_percent,
-                        total_downloaded / 1024,
-                        total_size / 1024,
-                        path,
-                    )
+                    if not quiet:
+                        LOG.debug(
+                            "Downloaded %d%% (total %dK of %dK) to %s",
+                            current_percent,
+                            total_downloaded / 1024,
+                            total_size / 1024,
+                            path,
+                        )
                     iter_length = 0
                 elif total_size <= 0 and iter_length >= iter_limit:
-                    # print log message every x K if the total size is not known
-                    LOG.debug(
-                        "Downloaded %dK (total %dK) to %s",
-                        iter_length / 1024,
-                        total_downloaded / 1024,
-                        path,
-                    )
+                    if not quiet:
+                        # print log message every x K if the total size is not known
+                        LOG.debug(
+                            "Downloaded %dK (total %dK) to %s",
+                            iter_length / 1024,
+                            total_downloaded / 1024,
+                            path,
+                        )
                     iter_length = 0
             f.flush()
             os.fsync(f)
@@ -264,12 +271,13 @@ def download(
             LOG.warning("Zero bytes downloaded from %s, retrying", url)
             download(url, path, verify_ssl)
             return
-        LOG.debug(
-            "Done downloading %s, response code %s, total %dK",
-            url,
-            r.status_code,
-            total_downloaded / 1024,
-        )
+        if not quiet:
+            LOG.debug(
+                "Done downloading %s, response code %s, total %dK",
+                url,
+                r.status_code,
+                total_downloaded / 1024,
+            )
     except requests.exceptions.ReadTimeout as e:
         raise TimeoutError(f"Timeout ({timeout}) reached on download: {url} - {e}")
     finally:

--- a/localstack-core/localstack/utils/ssl.py
+++ b/localstack-core/localstack/utils/ssl.py
@@ -28,7 +28,7 @@ def install_predefined_cert_if_available():
         pass
 
 
-def setup_ssl_cert():
+def setup_ssl_cert() -> None:
     target_file = get_cert_pem_file_path()
 
     # cache file for 6 hours (non-enterprise) or forever (enterprise)
@@ -45,11 +45,13 @@ def setup_ssl_cert():
     # apply timeout (and fall back to using self-signed certs)
     timeout = 5  # slightly higher timeout for our proxy
     try:
-        return download(SSL_CERT_URL, target_file, timeout=timeout)
+        download(SSL_CERT_URL, target_file, timeout=timeout, quiet=True)
+        LOG.debug("SSL certificate downloaded successfully")
     except Exception:
         # try fallback URL, directly from our API proxy
         try:
-            return download(SSL_CERT_URL_FALLBACK, target_file, timeout=timeout)
+            download(SSL_CERT_URL_FALLBACK, target_file, timeout=timeout, quiet=True)
+            LOG.debug("SSL certificate downloaded successfully")
         except Exception as e:
             LOG.info(
                 "Unable to download local test SSL certificate from %s to %s (using self-signed cert as fallback): %s",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Sometimes the download process is very noisy. In particular it logs every megabyte which could be a lot of log spam for large files.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->


## Changes

* Add flag to the `download` function to disable logging debug messages

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
