### PR TITLE
fix error message if logs-stream doesn't exist

### DIFF
--- a/localstack-core/localstack/services/logs/provider.py
+++ b/localstack-core/localstack/services/logs/provider.py
@@ -455,3 +455,12 @@ def moto_to_describe_dict(target, self):
     if self.kms_key_id:
         log_group["kmsKeyId"] = self.kms_key_id
     return log_group
+
+
+@patch(MotoLogGroup.get_log_events)
+def moto_get_log_events(
+    target, self, log_stream_name, start_time, end_time, limit, next_token, start_from_head
+):
+    if log_stream_name not in self.streams:
+        raise ResourceNotFoundException("The specified log stream does not exist.")
+    return target(self, log_stream_name, start_time, end_time, limit, next_token, start_from_head)

--- a/tests/aws/services/logs/test_logs.snapshot.json
+++ b/tests/aws/services/logs/test_logs.snapshot.json
@@ -216,5 +216,30 @@
         }
       ]
     }
+  },
+  "tests/aws/services/logs/test_logs.py::TestCloudWatchLogs::test_resource_does_not_exist": {
+    "recorded-date": "05-09-2024, 16:43:20",
+    "recorded-content": {
+      "error-log-group-does-not-exist": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "The specified log group does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-log-stream-does-not-exist": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "The specified log stream does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/logs/test_logs.validation.json
+++ b/tests/aws/services/logs/test_logs.validation.json
@@ -19,5 +19,8 @@
   },
   "tests/aws/services/logs/test_logs.py::TestCloudWatchLogs::test_put_subscription_filter_lambda": {
     "last_validated_date": "2023-03-17T12:55:00+00:00"
+  },
+  "tests/aws/services/logs/test_logs.py::TestCloudWatchLogs::test_resource_does_not_exist": {
+    "last_validated_date": "2024-09-05T16:43:20+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Fixes https://github.com/localstack/localstack/issues/9226, which returned the wrong error message.
The issue originates in moto, that doesn't provide the correct error message. To avoid another iteration of moto-upgrade, adding a small patch in LocalStack to return the correct exception message.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* added patch for moto
* added test to validate the error message is the same as on AWS

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
