### PR TITLE
feat: make packaged terraform version user-configurable

### DIFF
--- a/localstack-core/localstack/packages/terraform.py
+++ b/localstack-core/localstack/packages/terraform.py
@@ -7,7 +7,7 @@ from localstack.packages.core import ArchiveDownloadAndExtractInstaller
 from localstack.utils.files import chmod_r
 from localstack.utils.platform import get_arch
 
-TERRAFORM_VERSION = "1.1.3"
+TERRAFORM_VERSION = os.getenv("LS_TERRAFORM_VERSION", "1.5.7")
 TERRAFORM_URL_TEMPLATE = (
     "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{os}_{arch}.zip"
 )
@@ -15,10 +15,10 @@ TERRAFORM_URL_TEMPLATE = (
 
 class TerraformPackage(Package):
     def __init__(self):
-        super().__init__("Terraform", "1.1.3")
+        super().__init__("Terraform", TERRAFORM_VERSION)
 
     def get_versions(self) -> List[str]:
-        return ["1.1.3"]
+        return [TERRAFORM_VERSION]
 
     def _get_installer(self, version: str) -> PackageInstaller:
         return TerraformPackageInstaller("terraform", version)

--- a/localstack-core/localstack/packages/terraform.py
+++ b/localstack-core/localstack/packages/terraform.py
@@ -7,7 +7,7 @@ from localstack.packages.core import ArchiveDownloadAndExtractInstaller
 from localstack.utils.files import chmod_r
 from localstack.utils.platform import get_arch
 
-TERRAFORM_VERSION = os.getenv("LS_TERRAFORM_VERSION", "1.5.7")
+TERRAFORM_VERSION = os.getenv("TERRAFORM_VERSION", "1.5.7")
 TERRAFORM_URL_TEMPLATE = (
     "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{os}_{arch}.zip"
 )


### PR DESCRIPTION
## Motivation

PR addresses #11473, specifically:

1) The pinned version in the terraform package is [>2 years old](https://github.com/hashicorp/terraform/releases/tag/v1.1.3)
2) Allowing users to specify the version of terraform they need installed simplifies IaC and helps eliminate skew on the user side of things (i.e. users wouldn't be forced to maintain two sets of terraform files because localstack is locked to `v1.1.3`)


## Changes
1) Updates the pinned version to the latest non-BSL version of terraform
  - note: the current pinned version of terraform (`v1.1.3`) uses the same license as the newly pinned version (`v1.5.7`)
    - ref:
      - [v1.1.3](https://github.com/hashicorp/terraform/blob/v1.1.3/LICENSE)
      - [v1.5.7](https://github.com/hashicorp/terraform/blob/v1.5.7/LICENSE)
      - [v1.6.0](https://github.com/hashicorp/terraform/blob/v1.6.0/LICENSE)

2) Consolidate the places where the terraform version is used or defined from 3 to one (i.e. single source of truth)
3) Allow users to specify their desired version of terraform via the `LS_TERRAFORM_VERSION` environment variable, falling back to `1.5.7` is the environment variable is not set
