### PR TITLE
Add CLI version command prefix

### DIFF
--- a/localstack-core/localstack/cli/localstack.py
+++ b/localstack-core/localstack/cli/localstack.py
@@ -155,7 +155,13 @@ _click_format_option = click.option(
         "show_default": True,
     },
 )
-@click.version_option(VERSION, "--version", "-v", message="%(version)s")
+@click.version_option(
+    VERSION,
+    "--version",
+    "-v",
+    message="LocalStack CLI %(version)s",
+    help="Show the version of the LocalStack CLI and exit",
+)
 @click.option("-d", "--debug", is_flag=True, help="Enable CLI debugging mode")
 @click.option("-p", "--profile", type=str, help="Set the configuration profile")
 def localstack(debug, profile) -> None:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Besides LocalStack releases, CLI is also released with semantic versioning.

This can be confusing to users, see relevant discussions[[1](https://localstack-cloud.slack.com/archives/C060ZRAULEL/p1725464854452179?thread_ts=1725445367.911869&cid=C060ZRAULEL)][[2](https://localstack-cloud.slack.com/archives/C02N36URU1G/p1725467328964489)][[3](https://localstack-cloud.slack.com/archives/C02N36URU1G/p1725556984925929)][...]. 
Cc @SimonWallner @HarshCasper @dfangl @inothnagel @whummer 

The CLI _version_ command outputs a semantic number, but does not specify if this is referring to LocalStack or CLI.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

This will add LocalStack CLI as a prefix before the version number and style the message to be more subtle and different from the rest of the output, so that the version command is more explicit and can be used later on in every command invocation for reference.

| BEFORE | AFTER |
|--------|--------|
| <img width="652" alt="Frame 48096558" src="https://github.com/user-attachments/assets/d10e7065-338c-4a5d-a9c1-c1336ecf136e"> | <img width="652" alt="Frame 48096557" src="https://github.com/user-attachments/assets/29ab7e15-00a7-45cf-b63e-83a1272c8bd7"> |
| <img width="652" alt="Frame 48096556" src="https://github.com/user-attachments/assets/00de73ce-bd79-4665-8723-e261cded49f9"> | <img width="652" alt="Frame 48096555" src="https://github.com/user-attachments/assets/21fe3350-f254-4611-b516-b69dac64e294"> |

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
