### PR TITLE
feat: pass context to functions patched in eventstudio

### DIFF
--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -545,7 +545,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
 
         if rule_service.schedule_cron:
             schedule_job_function = self._get_scheduled_rule_job_function(
-                account_id, region, rule_service.rule
+                account_id, region, rule_service.rule, context
             )
             rule_service.create_schedule_job(schedule_job_function)
         response = PutTargetsResponse(
@@ -1109,7 +1109,9 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             rule_name = resource_arn.split("/")[-1]
             self.get_rule(rule_name, event_bus)
 
-    def _get_scheduled_rule_job_function(self, account_id, region, rule: Rule) -> Callable:
+    def _get_scheduled_rule_job_function(
+        self, account_id, region, rule: Rule, context: RequestContext
+    ) -> Callable:
         def func(*args, **kwargs):
             """Create custom scheduled event and send it to all targets specified by associated rule using respective TargetSender"""
             for target in rule.targets.values():
@@ -1130,7 +1132,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
 
                 target_sender = self._target_sender_store[target["Arn"]]
                 try:
-                    target_sender.process_event(event)
+                    target_sender.process_event(event, context)
                 except Exception as e:
                     LOG.info(
                         "Unable to send event notification %s to target %s: %s",
@@ -1363,7 +1365,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                         else:
                             target_sender = self._target_sender_store[target_arn]
                             try:
-                                target_sender.process_event(event_formatted)
+                                target_sender.process_event(event_formatted, context)
                                 processed_entries.append({"EventId": event_formatted["id"]})
                             except Exception as error:
                                 processed_entries.append(

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -8,6 +8,7 @@ from typing import Any, Set
 
 from botocore.client import BaseClient
 
+from localstack.aws.api import RequestContext
 from localstack.aws.api.events import Arn, InputTransformer, RuleName, Target, TargetInputPath
 from localstack.aws.connect import connect_to
 from localstack.services.events.models import FormattedEvent, TransformedEvent, ValidationException
@@ -138,13 +139,13 @@ class TargetSender(ABC):
     def send_event(self, event: FormattedEvent | TransformedEvent):
         pass
 
-    def proxy_send_event(self, event: FormattedEvent | TransformedEvent):
+    def proxy_send_event(self, event: FormattedEvent | TransformedEvent, context: RequestContext):
         """Proxy method to process the event and send it to the target,
         in addition it removes the field event-bus-name from the event,
         required for EventStudio extension"""
         self.send_event(event)
 
-    def process_event(self, event: FormattedEvent):
+    def process_event(self, event: FormattedEvent, context: RequestContext):
         """Processes the event and send it to the target."""
         if isinstance(event, dict):
             event.pop("event-bus-name", None)
@@ -152,7 +153,7 @@ class TargetSender(ABC):
             event = transform_event_with_target_input_path(input_path, event)
         if input_transformer := self.target.get("InputTransformer"):
             event = self.transform_event_with_target_input_transformer(input_transformer, event)
-        self.proxy_send_event(event)
+        self.proxy_send_event(event, context)
 
     def transform_event_with_target_input_transformer(
         self, input_transformer: InputTransformer, event: FormattedEvent


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Eventstudio patches the boot client to propagate tracing data (parent_id and trace_id) in the header and automatically add it to the context.
If a event is stored in the extension via the patched localstack function, the following is treated as a new span and the parent_id is updated.
To be able to update the parent_id the function that is patched (to record the event) needs to have the context, therefore we need to pass the context along.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add context to target process_evente and 

## Testing
see eventstudio PR: https://github.com/localstack/localstack-extension-event-studio/pull/70