### PR TITLE
Feature/SNS/Eventstudio: pass context to patched function required in eventstudio

### DIFF
--- a/localstack-core/localstack/services/sns/provider.py
+++ b/localstack-core/localstack/services/sns/provider.py
@@ -252,7 +252,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             request_headers=context.request.headers,
             topic_attributes=vars(moto_topic),
         )
-        self._publisher.publish_batch_to_topic(publish_ctx, topic_arn)
+        self._publisher.publish_batch_to_topic(publish_ctx, topic_arn, context)
 
         return response
 
@@ -613,7 +613,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             # 2 quick call to this method in succession might not be executed in order in the executor?
             # TODO: test how this behaves in a FIFO context with a lot of threads.
             publish_ctx.topic_attributes |= vars(topic_model)
-            self._publisher.publish_to_topic(publish_ctx, topic_or_target_arn)
+            self._publisher.publish_to_topic(publish_ctx, topic_or_target_arn, context)
 
         if is_fifo:
             return PublishResponse(

--- a/localstack-core/localstack/services/sns/publisher.py
+++ b/localstack-core/localstack/services/sns/publisher.py
@@ -16,7 +16,6 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 
 from localstack import config
-from localstack.aws.api import RequestContext
 from localstack.aws.api.lambda_ import InvocationType
 from localstack.aws.api.sns import MessageAttributeMap
 from localstack.aws.connect import connect_to
@@ -46,6 +45,7 @@ from localstack.utils.cloudwatch.cloudwatch_util import store_cloudwatch_logs
 from localstack.utils.objects import not_none_or
 from localstack.utils.strings import long_uid, md5, to_bytes, to_str
 from localstack.utils.time import timestamp_millis
+from localstack.utils.tracing import TraceContext
 
 LOG = logging.getLogger(__name__)
 
@@ -1170,7 +1170,7 @@ class PublishDispatcher:
                 )
 
     def publish_to_topic(
-        self, ctx: SnsPublishContext, topic_arn: str, context: RequestContext
+        self, ctx: SnsPublishContext, topic_arn: str, trace_context: TraceContext
     ) -> None:  # context required by eventstudio
         subscriptions = ctx.store.get_topic_subscriptions(topic_arn)
         for subscriber in subscriptions:
@@ -1187,7 +1187,7 @@ class PublishDispatcher:
                 self.executor.submit(notifier.publish, context=ctx, subscriber=subscriber)
 
     def publish_batch_to_topic(
-        self, ctx: SnsBatchPublishContext, topic_arn: str, context: RequestContext
+        self, ctx: SnsBatchPublishContext, topic_arn: str, trace_context: TraceContext
     ) -> None:  # context required by eventstudio
         subscriptions = ctx.store.get_topic_subscriptions(topic_arn)
         for subscriber in subscriptions:

--- a/localstack-core/localstack/services/sns/publisher.py
+++ b/localstack-core/localstack/services/sns/publisher.py
@@ -1170,7 +1170,7 @@ class PublishDispatcher:
                 )
 
     def publish_to_topic(
-        self, ctx: SnsPublishContext, topic_arn: str, trace_context: TraceContext
+        self, ctx: SnsPublishContext, topic_arn: str, trace_context: TraceContext | None = None
     ) -> None:  # context required by eventstudio
         subscriptions = ctx.store.get_topic_subscriptions(topic_arn)
         for subscriber in subscriptions:
@@ -1187,7 +1187,7 @@ class PublishDispatcher:
                 self.executor.submit(notifier.publish, context=ctx, subscriber=subscriber)
 
     def publish_batch_to_topic(
-        self, ctx: SnsBatchPublishContext, topic_arn: str, trace_context: TraceContext
+        self, ctx: SnsBatchPublishContext, topic_arn: str, trace_context: TraceContext | None = None
     ) -> None:  # context required by eventstudio
         subscriptions = ctx.store.get_topic_subscriptions(topic_arn)
         for subscriber in subscriptions:

--- a/localstack-core/localstack/services/sns/publisher.py
+++ b/localstack-core/localstack/services/sns/publisher.py
@@ -16,6 +16,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 
 from localstack import config
+from localstack.aws.api import RequestContext
 from localstack.aws.api.lambda_ import InvocationType
 from localstack.aws.api.sns import MessageAttributeMap
 from localstack.aws.connect import connect_to
@@ -1168,7 +1169,9 @@ class PublishDispatcher:
                     message_body=message_ctx.message_content(subscriber["Protocol"]),
                 )
 
-    def publish_to_topic(self, ctx: SnsPublishContext, topic_arn: str) -> None:
+    def publish_to_topic(
+        self, ctx: SnsPublishContext, topic_arn: str, context: RequestContext
+    ) -> None:  # context required by eventstudio
         subscriptions = ctx.store.get_topic_subscriptions(topic_arn)
         for subscriber in subscriptions:
             if self._should_publish(ctx.store.subscription_filter_policy, ctx.message, subscriber):
@@ -1183,7 +1186,9 @@ class PublishDispatcher:
                 )
                 self.executor.submit(notifier.publish, context=ctx, subscriber=subscriber)
 
-    def publish_batch_to_topic(self, ctx: SnsBatchPublishContext, topic_arn: str) -> None:
+    def publish_batch_to_topic(
+        self, ctx: SnsBatchPublishContext, topic_arn: str, context: RequestContext
+    ) -> None:  # context required by eventstudio
         subscriptions = ctx.store.get_topic_subscriptions(topic_arn)
         for subscriber in subscriptions:
             protocol = subscriber["Protocol"]

--- a/localstack-core/localstack/utils/tracing.py
+++ b/localstack-core/localstack/utils/tracing.py
@@ -1,0 +1,20 @@
+from typing import TypedDict
+
+from localstack.aws.api import RequestContext
+
+
+class TraceContext(TypedDict):
+    trace_id: str
+    parent_id: str
+
+
+def get_trace_context(context: RequestContext) -> TraceContext | None:
+    """Generate a data transfer object with only the relevant subset of the context.
+    Required for tracing propagation and to keep performance overhead low."""
+    trace_id = context.get("trace_id")
+    parent_id = context.get("parent_id")
+
+    if trace_id is not None or parent_id is not None:
+        return TraceContext(trace_id=trace_id, parent_id=parent_id)
+
+    return None


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Eventstudio patches the boot client to propagate tracing data (parent_id and trace_id) in the header and automatically adds it to the context.
If an event is stored in the extension via the patched localstack function, the following is treated as a new span and the parent_id is updated.
To be able to update the parent_id the function that is patched (to record the event) needs to have the context, therefore we need to pass the context along.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add context to publisher `publish_to_topic` and `publish_batch_to_topic` 

## Testing
see EventStudio PR: https://github.com/localstack/localstack-extension-event-studio/pull/70