### PR TITLE
Feature/SQS/Eventstudio: Add context to queue.put

### DIFF
--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -251,14 +251,14 @@ class MessageMoveTask:
         source_arn: str,
         destination_arn: str,
         max_number_of_messages_per_second: int = None,
-        context: RequestContext = None,
+        trace_context: TraceContext | None = None,
     ):
         self.task_id = long_uid()
         self.source_arn = source_arn
         self.destination_arn = destination_arn
         self.max_number_of_messages_per_second = max_number_of_messages_per_second
         self.cancel_event = threading.Event()
-        self.submitted_request_context = context
+        self.submitted_request_trace_context = trace_context
 
     def mark_started(self):
         self.started_timestamp = datetime.utcnow()

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -507,6 +507,7 @@ class SqsQueue:
     def put(
         self,
         message: Message,
+        context: RequestContext,
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,
@@ -738,11 +739,12 @@ class StandardQueue(SqsQueue):
     def put(
         self,
         message: Message,
+        context: RequestContext,
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,
         delay_seconds: int = None,
-    ):
+    ):  # context required by eventstudio
         if message_deduplication_id:
             raise InvalidParameterValueException(
                 f"Value {message_deduplication_id} for parameter MessageDeduplicationId is invalid. Reason: The "
@@ -994,11 +996,12 @@ class FifoQueue(SqsQueue):
     def put(
         self,
         message: Message,
+        context: RequestContext,
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,
         delay_seconds: int = None,
-    ):
+    ):  # context required by eventstudio
         if delay_seconds:
             # in fifo queues, delay is only applied on queue level. However, explicitly setting delay_seconds=0 is valid
             raise InvalidParameterValueException(

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -739,12 +739,12 @@ class StandardQueue(SqsQueue):
     def put(
         self,
         message: Message,
-        context: RequestContext,
+        context: RequestContext,  # context required by eventstudio
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,
         delay_seconds: int = None,
-    ):  # context required by eventstudio
+    ):
         if message_deduplication_id:
             raise InvalidParameterValueException(
                 f"Value {message_deduplication_id} for parameter MessageDeduplicationId is invalid. Reason: The "
@@ -996,12 +996,12 @@ class FifoQueue(SqsQueue):
     def put(
         self,
         message: Message,
-        context: RequestContext,
+        context: RequestContext,  # context required by eventstudio
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,
         delay_seconds: int = None,
-    ):  # context required by eventstudio
+    ):
         if delay_seconds:
             # in fifo queues, delay is only applied on queue level. However, explicitly setting delay_seconds=0 is valid
             raise InvalidParameterValueException(

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -514,7 +514,7 @@ class SqsQueue:
     def put(
         self,
         message: Message,
-        context: RequestContext,
+        context: RequestContext = None,  # context required by eventstudio, not enforced due to lambda FakeSqsClient
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,
@@ -746,7 +746,7 @@ class StandardQueue(SqsQueue):
     def put(
         self,
         message: Message,
-        context: RequestContext,  # context required by eventstudio
+        context: RequestContext = None,  # context required by eventstudio, not enforced due to lambda FakeSqsClient
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,
@@ -1003,7 +1003,7 @@ class FifoQueue(SqsQueue):
     def put(
         self,
         message: Message,
-        context: RequestContext,  # context required by eventstudio
+        context: RequestContext = None,  # context required by eventstudio, not enforced due to lambda FakeSqsClient
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -40,6 +40,7 @@ from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttr
 from localstack.utils.aws.arns import get_partition
 from localstack.utils.strings import long_uid
 from localstack.utils.time import now
+from localstack.utils.tracing import TraceContext
 from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
@@ -514,7 +515,7 @@ class SqsQueue:
     def put(
         self,
         message: Message,
-        context: RequestContext = None,  # context required by eventstudio, not enforced due to lambda FakeSqsClient
+        trace_context: TraceContext = None,  # context data required by eventstudio, not enforced due to lambda FakeSqsClient
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,
@@ -746,7 +747,7 @@ class StandardQueue(SqsQueue):
     def put(
         self,
         message: Message,
-        context: RequestContext = None,  # context required by eventstudio, not enforced due to lambda FakeSqsClient
+        trace_context: TraceContext = None,  # context data required by eventstudio, not enforced due to lambda FakeSqsClient
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,
@@ -1003,7 +1004,7 @@ class FifoQueue(SqsQueue):
     def put(
         self,
         message: Message,
-        context: RequestContext = None,  # context required by eventstudio, not enforced due to lambda FakeSqsClient
+        trace_context: TraceContext = None,  # context data required by eventstudio, not enforced due to lambda FakeSqsClient
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -232,6 +232,8 @@ class MessageMoveTask:
     destination_arn: str | None = None
     """If the DestinationArn is not specified, the original source arn will be used as target."""
     max_number_of_messages_per_second: int | None = None
+    """An optional RequestContext we can pass from the StartMessageMoveTask request"""
+    submitted_request_context: Optional[RequestContext]
 
     # dynamic fields
     task_id: str
@@ -244,13 +246,18 @@ class MessageMoveTask:
     cancel_event: threading.Event
 
     def __init__(
-        self, source_arn: str, destination_arn: str, max_number_of_messages_per_second: int = None
+        self,
+        source_arn: str,
+        destination_arn: str,
+        max_number_of_messages_per_second: int = None,
+        context: RequestContext = None,
     ):
         self.task_id = long_uid()
         self.source_arn = source_arn
         self.destination_arn = destination_arn
         self.max_number_of_messages_per_second = max_number_of_messages_per_second
         self.cancel_event = threading.Event()
+        self.submitted_request_context = context
 
     def mark_started(self):
         self.started_timestamp = datetime.utcnow()

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -508,7 +508,7 @@ class MessageMoveTaskManager:
 
                 target_queue.put(
                     message=message.message,
-                    context=move_task.submitted_request_context,
+                    trace_context=move_task.submitted_request_trace_context,
                     message_group_id=message.message_group_id,
                     message_deduplication_id=message.message_deduplication_id,
                 )
@@ -1513,11 +1513,12 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                     "arn at a given time."
                 )
 
+            trace_context = get_trace_context(context)
             task = MessageMoveTask(
                 source_arn,
                 destination_arn,
                 max_number_of_messages_per_second,
-                context=context,
+                trace_context=trace_context,
             )
             store.move_tasks[task.task_id] = task
 

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -507,7 +507,7 @@ class MessageMoveTaskManager:
 
                 target_queue.put(
                     message=message.message,
-                    context=None,  # TODO how to add context here?
+                    context=move_task.submitted_request_context,
                     message_group_id=message.message_group_id,
                     message_deduplication_id=message.message_deduplication_id,
                 )
@@ -1513,6 +1513,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                 source_arn,
                 destination_arn,
                 max_number_of_messages_per_second,
+                context=context,
             )
             store.move_tasks[task.task_id] = task
 

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -507,6 +507,7 @@ class MessageMoveTaskManager:
 
                 target_queue.put(
                     message=message.message,
+                    context=None,  # TODO how to add context here?
                     message_group_id=message.message_group_id,
                     message_deduplication_id=message.message_deduplication_id,
                 )
@@ -1174,6 +1175,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
         return queue.put(
             message=message,
+            context=context,
             message_deduplication_id=message_deduplication_id,
             message_group_id=message_group_id,
             delay_seconds=int(delay_seconds) if delay_seconds is not None else None,
@@ -1229,6 +1231,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                 )
                 dl_queue.put(
                     message=message,
+                    context=context,
                     message_deduplication_id=standard_message.message_deduplication_id,
                     message_group_id=standard_message.message_group_id,
                 )

--- a/localstack-core/localstack/utils/tracing.py
+++ b/localstack-core/localstack/utils/tracing.py
@@ -1,0 +1,20 @@
+from typing import TypedDict
+
+from localstack.aws.api import RequestContext
+
+
+class TraceContext(TypedDict):
+    trace_id: str
+    parent_id: str
+
+
+def get_trace_context(context: RequestContext) -> TraceContext | None:
+    """Generate a data transfer object with only the relevant subset of the context.
+    Required for tracing propagation and to keep performance overhead low."""
+    trace_id = context.get("trace_id")
+    parent_id = context.get("parent_id")
+
+    if trace_id is not None or parent_id is not None:
+        return TraceContext(trace_id=trace_id, parent_id=parent_id)
+
+    return None


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Eventstudio patches the boot client to propagate tracing data (parent_id and trace_id) in the header and automatically adds it to the context.
If an event is stored in the extension via the patched localstack function, the following is treated as a new span and the parent_id is updated.
To be able to update the parent_id the function that is patched (to record the event) needs to have the context, therefore we need to pass the context along.
Lambda uses a "fake" sqs client and no context is available for calling the models.put method, therefore the context is optional.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add context to put message for standard queue and fifo queue  in models `StandardQueue.put` and `FifoQueue.put` 

## Testing
see EventStudio PR: https://github.com/localstack/localstack-extension-event-studio/pull/70
