### PR TITLE
Feature/Eventstudio: Add context to invoke lambda

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack-core/localstack/services/lambda_/invocation/lambda_service.py
@@ -14,6 +14,7 @@ from threading import RLock
 from typing import TYPE_CHECKING, Optional
 
 from localstack import config
+from localstack.aws.api import RequestContext
 from localstack.aws.api.lambda_ import (
     InvalidParameterValueException,
     InvalidRequestContentException,
@@ -220,6 +221,7 @@ class LambdaService:
         qualifier: str,
         region: str,
         account_id: str,
+        context: RequestContext,  # context required by eventstudio
         invocation_type: InvocationType | None,
         client_context: Optional[str],
         request_id: str,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Eventstudio patches the boot client to propagate tracing data (parent_id and trace_id) in the header and automatically adds it to the context.
If an event is stored in the extension via the patched localstack function, the following is treated as a new span and the parent_id is updated.
To be able to update the parent_id the function that is patched (to record the event) needs to have the context, therefore we need to pass the context along.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add context to invoke lambda function

## Testing
see EventStudio PR: https://github.com/localstack/localstack-extension-event-studio/pull/70

## TODO
- [ ] Direct invoke
- [ ]  Event invoke
- [ ]  Event source mapping