### PR TITLE
fix: apigateway S3 integration method

### DIFF
--- a/localstack-core/localstack/services/apigateway/integration.py
+++ b/localstack-core/localstack/services/apigateway/integration.py
@@ -718,7 +718,8 @@ class S3Integration(BackendIntegration):
 
         action = None
         invoke_args = {"Bucket": bucket, "Key": object_key}
-        match invocation_context.method:
+        integration_method = integration.get("httpMethod") or invocation_context.method
+        match integration_method:
             case HTTPMethod.GET:
                 action = s3.get_object
             case HTTPMethod.PUT:


### PR DESCRIPTION
- Retreive S3 action according to integration method defined and not http method
- fallback to http method if integration method not defined

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using S3 integration with ApiGateway, use correct S3 action depending on integration httpMethod

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Retreive S3 action according to integration method defined and not http method
- fallback to http method if integration method not defined
- 
<!-- Optional section: How to test these changes? -->
<!--
## Testing

### Create S3 bucket

awslocal s3api create-bucket --bucket my-bucket


### Create APIGateway and resources
awslocal apigateway create-rest-api --name api-local --tags '{"_custom_id_":"api-local"}'
rootResourceId=$(awslocal apigateway get-resources --rest-api api-local --query 'items[0].id' --output text)

awslocal apigateway create-resource --rest-api api-local --path-part s3 --parent-id $rootResourceId

subResourceId=$(awslocal apigateway get-resources --rest-api api-local --query 'items[1].id' --output text)

awslocal apigateway put-method --rest-api api-local --resource-id $subResourceId --http-method POST --authorization-type "NONE" --no-api-key-required

awslocal apigateway put-integration --rest-api api-local --resource-id $subResourceId --http-method POST --type AWS --integration-http-method PUT --uri 'arn:aws:apigateway:us-east-1:s3:path/my-bucket/{time}_{uuid}.json' --passthrough-behavior WHEN_NO_MATCH  --credentials arn:aws:iam::000000000000:role/fake-role --request-parameters '{ "integration.request.path.time": "context.requestTimeEpoch", "integration.request.path.uuid": "context.requestId"}'

awslocal apigateway put-integration-response --rest-api api-local --resource-id $subResourceId --http-method POST --status-code 200 --response-parameters '{"method.response.header.Content-Type": "integration.response.header.Content-Type"}'

awslocal apigateway create-deployment --rest-api api-local --stage-name local

-->