### PR TITLE
fixup and validate test_serverless.py

### DIFF
--- a/tests/aws/serverless/package.json
+++ b/tests/aws/serverless/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "deploy": "serverless deploy --stage local",
     "undeploy": "serverless remove --stage local",
+    "deploy-aws": "serverless deploy --stage dev",
+    "undeploy-aws": "serverless remove --stage dev",
     "version": "serverless --version"
   },
   "devDependencies": {

--- a/tests/aws/serverless/serverless.yml
+++ b/tests/aws/serverless/serverless.yml
@@ -49,7 +49,7 @@ resources:
   Resources:
     TestTable:
       Type: AWS::DynamoDB::Table
-      DeletionPolicy: Retain
+      DeletionPolicy: Delete
       Properties:
         TableName: 'Test'
         AttributeDefinitions:
@@ -66,11 +66,13 @@ resources:
 
     KinesisStream:
       Type: AWS::Kinesis::Stream
+      DeletionPolicy: Delete
       Properties:
         Name: KinesisTestStream
         ShardCount: 1
     KinesisStreamConsumer:
       Type: AWS::Kinesis::StreamConsumer
+      DeletionPolicy: Delete
       Properties:
         ConsumerName: stream-consumer1
         StreamARN: !GetAtt 'KinesisStream.Arn'
@@ -78,6 +80,7 @@ resources:
     # DynamoDB configuration
     loginsTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Delete
       Properties:
         TableName: "jizo.${opt:stage}.loginsTable"
         AttributeDefinitions:
@@ -91,6 +94,7 @@ resources:
           WriteCapacityUnits: 1
     authAuditTrailTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Delete
       Properties:
         TableName: "jizo.${opt:stage}.authAuditTrailTable"
         AttributeDefinitions:
@@ -106,6 +110,7 @@ resources:
     # incoming SQS configuration
     CreateQueue:
       Type: AWS::SQS::Queue
+      DeletionPolicy: Delete
       Properties:
         QueueName: "${self:service}-${opt:stage}-CreateQueue"
         VisibilityTimeout: 1080
@@ -123,8 +128,10 @@ resources:
 
     TestBucket:
       Type: AWS::S3::Bucket
+      DeletionPolicy: Delete
       Properties:
-        BucketName: 'testing-bucket'
+        BucketName:
+          !Sub "testing-bucket-${AWS::StackName}-${AWS::Region}"
 
 functions:
   tests:

--- a/tests/aws/test_serverless.py
+++ b/tests/aws/test_serverless.py
@@ -72,10 +72,8 @@ class TestServerless:
                     Delete={"Objects": objects},
                 )
             # TODO the cleanup still fails due to inability to find ECR service in community
-            if is_aws_cloud():
-                run(["npm", "run", "undeploy-aws", "--", f"--region={region_name}"], cwd=base_dir)
-            else:
-                run(["npm", "run", "undeploy", "--", f"--region={region_name}"], cwd=base_dir)
+            command = "undeploy-aws" if is_aws_cloud() else "undeploy"
+            run(["npm", "run", command, "--", f"--region={region_name}"], cwd=base_dir)
         except Exception:
             LOG.error("Unable to clean up serverless stack")
 

--- a/tests/aws/test_serverless.validation.json
+++ b/tests/aws/test_serverless.validation.json
@@ -1,0 +1,20 @@
+{
+  "tests/aws/test_serverless.py::TestServerless::test_dynamodb_stream_handler_deployed": {
+    "last_validated_date": "2024-09-09T15:38:17+00:00"
+  },
+  "tests/aws/test_serverless.py::TestServerless::test_event_rules_deployed": {
+    "last_validated_date": "2024-09-09T15:38:07+00:00"
+  },
+  "tests/aws/test_serverless.py::TestServerless::test_kinesis_stream_handler_deployed": {
+    "last_validated_date": "2024-09-09T14:19:10+00:00"
+  },
+  "tests/aws/test_serverless.py::TestServerless::test_lambda_with_configs_deployed": {
+    "last_validated_date": "2024-09-09T15:42:59+00:00"
+  },
+  "tests/aws/test_serverless.py::TestServerless::test_queue_handler_deployed": {
+    "last_validated_date": "2024-09-09T15:59:19+00:00"
+  },
+  "tests/aws/test_serverless.py::TestServerless::test_s3_bucket_deployed": {
+    "last_validated_date": "2024-09-09T15:44:53+00:00"
+  }
+}

--- a/tests/aws/test_serverless.validation.json
+++ b/tests/aws/test_serverless.validation.json
@@ -1,20 +1,20 @@
 {
   "tests/aws/test_serverless.py::TestServerless::test_dynamodb_stream_handler_deployed": {
-    "last_validated_date": "2024-09-09T15:38:17+00:00"
+    "last_validated_date": "2024-09-10T07:58:51+00:00"
   },
   "tests/aws/test_serverless.py::TestServerless::test_event_rules_deployed": {
-    "last_validated_date": "2024-09-09T15:38:07+00:00"
+    "last_validated_date": "2024-09-10T07:58:50+00:00"
   },
   "tests/aws/test_serverless.py::TestServerless::test_kinesis_stream_handler_deployed": {
     "last_validated_date": "2024-09-09T14:19:10+00:00"
   },
   "tests/aws/test_serverless.py::TestServerless::test_lambda_with_configs_deployed": {
-    "last_validated_date": "2024-09-09T15:42:59+00:00"
+    "last_validated_date": "2024-09-10T07:58:53+00:00"
   },
   "tests/aws/test_serverless.py::TestServerless::test_queue_handler_deployed": {
-    "last_validated_date": "2024-09-09T15:59:19+00:00"
+    "last_validated_date": "2024-09-10T07:58:52+00:00"
   },
   "tests/aws/test_serverless.py::TestServerless::test_s3_bucket_deployed": {
-    "last_validated_date": "2024-09-09T15:44:53+00:00"
+    "last_validated_date": "2024-09-10T07:58:54+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This is part of the initiative of removing the `markers.aws.unknown` from the tests.
The `test_serverless.py` is running a few tests using the `serverless` plugin. 

In the future, we should move these tests to the [serverless repo](https://github.com/localstack/serverless-localstack), but we still need to setup a suitable framework, ideally also allowing running snapshot tests (this is out of scope of this PR).

There is one test left that needs fixing `test_apigateway_deployed` where the assertion doesn't hold for AWS. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* added scripts to the `package.json` to run deployment against AWS
* fixed some definitions in the `serverless.yml`
  * bucket-name
  * added deletion-policy to make sure the stack is properly cleaned-up
* adapted the test cases to use the proper function/queue/bucket names
* cleanup s3 bucket before attempting deleting it

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
