### PR TITLE
fix deletion of failed nested stack in CFn

### DIFF
--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -455,6 +455,7 @@ class ResourceProviderExecutor:
 
             match event.status:
                 case OperationStatus.FAILED:
+                    resource["Properties"] = event.resource_model
                     return event
                 case OperationStatus.SUCCESS:
                     if not hasattr(resource_provider, "SCHEMA"):

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -455,7 +455,6 @@ class ResourceProviderExecutor:
 
             match event.status:
                 case OperationStatus.FAILED:
-                    resource["Properties"] = event.resource_model
                     return event
                 case OperationStatus.SUCCESS:
                     if not hasattr(resource_provider, "SCHEMA"):
@@ -478,6 +477,7 @@ class ResourceProviderExecutor:
                     context = {**payload["callbackContext"], **event.custom_context}
                     payload["callbackContext"] = context
                     payload["requestData"]["resourceProperties"] = event.resource_model
+                    resource["Properties"] = event.resource_model
 
                     if current_iteration == 0:
                         time.sleep(0)

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.snapshot.json
@@ -63,5 +63,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_nested_stacks.py::test_deletion_of_failed_nested_stack": {
+    "recorded-date": "17-09-2024, 20:09:36",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Stack with id <nested-stack-name> does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.validation.json
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/api/test_nested_stacks.py::test_deletion_of_failed_nested_stack": {
-    "last_validated_date": "2024-09-09T20:46:34+00:00"
+    "last_validated_date": "2024-09-10T14:56:37+00:00"
   },
   "tests/aws/services/cloudformation/api/test_nested_stacks.py::test_nested_output_in_params": {
     "last_validated_date": "2023-02-07T09:57:47+00:00"

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.validation.json
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/cloudformation/api/test_nested_stacks.py::test_deletion_of_failed_nested_stack": {
+    "last_validated_date": "2024-09-09T20:46:34+00:00"
+  },
   "tests/aws/services/cloudformation/api/test_nested_stacks.py::test_nested_output_in_params": {
     "last_validated_date": "2023-02-07T09:57:47+00:00"
   }

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.validation.json
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/api/test_nested_stacks.py::test_deletion_of_failed_nested_stack": {
-    "last_validated_date": "2024-09-10T14:56:37+00:00"
+    "last_validated_date": "2024-09-11T15:02:20+00:00"
   },
   "tests/aws/services/cloudformation/api/test_nested_stacks.py::test_nested_output_in_params": {
     "last_validated_date": "2023-02-07T09:57:47+00:00"

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.validation.json
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/api/test_nested_stacks.py::test_deletion_of_failed_nested_stack": {
-    "last_validated_date": "2024-09-11T15:02:20+00:00"
+    "last_validated_date": "2024-09-17T20:09:36+00:00"
   },
   "tests/aws/services/cloudformation/api/test_nested_stacks.py::test_nested_output_in_params": {
     "last_validated_date": "2023-02-07T09:57:47+00:00"

--- a/tests/aws/templates/cfn_failed_nested_stack_child.yml
+++ b/tests/aws/templates/cfn_failed_nested_stack_child.yml
@@ -1,0 +1,9 @@
+Parameters:
+  BucketName:
+    Type: string
+
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketName

--- a/tests/aws/templates/cfn_failed_nested_stack_child.yml
+++ b/tests/aws/templates/cfn_failed_nested_stack_child.yml
@@ -1,9 +1,34 @@
-Parameters:
-  BucketName:
-    Type: string
-
 Resources:
-  Bucket:
-    Type: AWS::S3::Bucket
+  MyLambdaFunction:
+    Type: AWS::Lambda::Function
     Properties:
-      BucketName: !Ref BucketName
+      FunctionName: testFunction
+      Handler: index.handler
+      Runtime: python3.8
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code:
+        S3Bucket: non-existent-bucket-name  # Invalid S3 bucket that does not exist
+        S3Key: non-existent-key.zip
+
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: LambdaExecutionRole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaBasicExecution
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:*

--- a/tests/aws/templates/cfn_failed_nested_stack_parent.yml
+++ b/tests/aws/templates/cfn_failed_nested_stack_parent.yml
@@ -1,14 +1,14 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
-  BucketName:
-    Type: String
-    Default: test-bucket-test!@#$!
   TemplateUri:
     Type: String
+
 Resources:
-  Bucket:
+  ChildStack:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Ref TemplateUri
-      Parameters:
-        BucketName: !Ref BucketName
+
+Outputs:
+  BucketStackId:
+    Value: !Ref ChildStack

--- a/tests/aws/templates/cfn_failed_nested_stack_parent.yml
+++ b/tests/aws/templates/cfn_failed_nested_stack_parent.yml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  BucketName:
+    Type: String
+    Default: test-bucket-test!@#$!
+  TemplateUri:
+    Type: String
+Resources:
+  Bucket:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Ref TemplateUri
+      Parameters:
+        BucketName: !Ref BucketName


### PR DESCRIPTION
## Motivation
Addresses #10826. The resource_provider class only stores the new model properties if the create operation is successful. This can cause issues where a nested stack reaches a failed status after being in a pending state. The Id property is never stored, and if the delete method is called, the property required for deletion cannot be found.

## Changes
- Now the resource_provider stores the model properties 

## Testing
- New aws validated test based on issue triaged.