### PR TITLE
ESM-v2: Remove reference to unbound variable

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/senders/lambda_sender.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/senders/lambda_sender.py
@@ -49,8 +49,7 @@ class LambdaSender(Sender):
             **optional_qualifier,
         )
         payload = json.load(invoke_result["Payload"])
-        if "FunctionError" in invoke_result:
-            function_error = invoke_result["FunctionError"]
+        if function_error := invoke_result.get("FunctionError"):
             LOG.debug(
                 "Pipe target function %s failed with FunctionError %s. Payload: %s",
                 self.target_arn,
@@ -85,8 +84,6 @@ class LambdaSender(Sender):
                 "requestId": invoke_result["ResponseMetadata"]["RequestId"],
                 "exceptionType": "BadRequest",
                 "resourceArn": self.target_arn,
-                "functionError": function_error,
-                "executedVersion": invoke_result.get("ExecutedVersion", "$LATEST"),
             }
             raise PartialFailureSenderError(error=error, partial_failure_payload=payload)
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
- The PR to support failure destination contexts introduced a small bug where we incorrectly reference an unbound variable. https://github.com/localstack/localstack/pull/11433

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Remove incorrect + unbound reference to `function_error` in batch error payload
- Remove `executedVersion` from batch error payload

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
