### PR TITLE
allow reference unsupported cfn resources

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -63,6 +63,9 @@ LOG = logging.getLogger(__name__)
 # list of static attribute references to be replaced in {'Fn::Sub': '...'} strings
 STATIC_REFS = ["AWS::Region", "AWS::Partition", "AWS::StackName", "AWS::AccountId"]
 
+# Mock value for unsupported type references
+MOCK_REFERENCE = "unknown"
+
 
 class NoStackUpdates(Exception):
     """Exception indicating that no actions are to be performed in a stack update (which is not allowed)"""
@@ -324,7 +327,7 @@ def _resolve_refs_recursively(
                     resource_type
                 )
                 if resource_provider is None:
-                    return ""
+                    return MOCK_REFERENCE
 
                 raise DependencyNotYetSatisfied(resource_ids=value["Ref"], message=msg)
 
@@ -360,7 +363,7 @@ def _resolve_refs_recursively(
             )
             resource = resources.get(resource_logical_id)
 
-            resource_type = (get_resource_type(resource),)
+            resource_type = get_resource_type(resource)
             resolved_getatt = get_attr_from_model_instance(
                 resource,
                 attribute_name,
@@ -375,7 +378,7 @@ def _resolve_refs_recursively(
                     resource_type
                 )
                 if resource_provider is None:
-                    return ""
+                    return MOCK_REFERENCE
 
                 raise DependencyNotYetSatisfied(
                     resource_ids=resource_logical_id,

--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -1286,7 +1286,6 @@ class TemplateDeployer:
             )
         else:
             resource["PhysicalResourceId"] = MOCK_REFERENCE
-            resource["Ref"] = MOCK_REFERENCE
             progress_event = ProgressEvent(OperationStatus.SUCCESS, resource_model={})
 
         # TODO: clean up the surrounding loop (do_apply_changes_in_loop) so that the responsibilities are clearer

--- a/tests/aws/services/cloudformation/api/test_reference_resolving.py
+++ b/tests/aws/services/cloudformation/api/test_reference_resolving.py
@@ -83,3 +83,20 @@ def test_sub_resolving(deploy_cfn_template, aws_client, snapshot):
     # Verify resource was created
     topic_arns = [t["TopicArn"] for t in aws_client.sns.list_topics()["Topics"]]
     assert topic_arn in topic_arns
+
+
+@markers.aws.only_localstack
+def test_reference_unsupported_resource(deploy_cfn_template, aws_client):
+    """
+    This test verifies that templates can be deployed even when unsupported resources are references
+    Make sure to update the template as coverage of resources increases.
+    """
+
+    deployment = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/cfn_ref_unsupported.yml"
+        ),
+    )
+
+    ref_of_unsupported = deployment.outputs["reference"]
+    assert ref_of_unsupported is None

--- a/tests/aws/services/cloudformation/api/test_reference_resolving.py
+++ b/tests/aws/services/cloudformation/api/test_reference_resolving.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from localstack.services.cloudformation.engine.template_deployer import MOCK_REFERENCE
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 
@@ -99,4 +100,4 @@ def test_reference_unsupported_resource(deploy_cfn_template, aws_client):
     )
 
     ref_of_unsupported = deployment.outputs["reference"]
-    assert ref_of_unsupported is None
+    assert ref_of_unsupported == MOCK_REFERENCE

--- a/tests/aws/services/cloudformation/api/test_reference_resolving.py
+++ b/tests/aws/services/cloudformation/api/test_reference_resolving.py
@@ -100,4 +100,6 @@ def test_reference_unsupported_resource(deploy_cfn_template, aws_client):
     )
 
     ref_of_unsupported = deployment.outputs["reference"]
+    value_of_unsupported = deployment.outputs["parameter"]
     assert ref_of_unsupported == MOCK_REFERENCE
+    assert value_of_unsupported == f"The value of the attribute is: {MOCK_REFERENCE}"

--- a/tests/aws/templates/cfn_ref_unsupported.yml
+++ b/tests/aws/templates/cfn_ref_unsupported.yml
@@ -6,5 +6,5 @@ Resources:
 
 Outputs:
   reference:
-    Value: !Ref Application
+    Value: !Ref CodeDeployApplication
 

--- a/tests/aws/templates/cfn_ref_unsupported.yml
+++ b/tests/aws/templates/cfn_ref_unsupported.yml
@@ -1,10 +1,21 @@
 Resources:
-  CodeDeployApplication:
-    Type: AWS::CodeDeploy::Application
+  UnknownResource:
+    Type: AWS::LocalStack::Unknown
     Properties:
       ComputePlatform: Lambda
 
+  Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value:
+        Fn::Sub:
+         -  "The value of the attribute is: ${value}"
+         - value: !GetAtt UnknownResource.NotReal
+
 Outputs:
   reference:
-    Value: !Ref CodeDeployApplication
+    Value: !Ref UnknownResource
 
+  parameter:
+    Value: !GetAtt Parameter.Value

--- a/tests/aws/templates/cfn_ref_unsupported.yml
+++ b/tests/aws/templates/cfn_ref_unsupported.yml
@@ -1,0 +1,10 @@
+Resources:
+  CodeDeployApplication:
+    Type: AWS::CodeDeploy::Application
+    Properties:
+      ComputePlatform: Lambda
+
+Outputs:
+  reference:
+    Value: !Ref Application
+


### PR DESCRIPTION
## Motivation
Addresses #11362. LocalStack already allows the deployment of templates with unsupported resource types. (Check `CFN_IGNORE_UNSUPPORTED_RESOURCE_TYPES` in [docs](https://docs.localstack.cloud/references/configuration/)). With these changes any reference to these types returns a mock value.

## Changes
- Before raising DependencyNotYetSatisfied the template deployer check if the resource type is supported

## Testing
- New `only_localstack` test.