### PR TITLE
introduce plugins to load openapi specs

### DIFF
--- a/localstack-core/localstack/aws/handlers/validation.py
+++ b/localstack-core/localstack/aws/handlers/validation.py
@@ -69,21 +69,21 @@ class OpenAPIRequestValidator(OpenAPIValidator):
         path = context.request.path
 
         if path.startswith(f"{INTERNAL_RESOURCE_PATH}/") or path.startswith("/_aws/"):
-            try:
-                for openapi in self.open_apis:
+            for openapi in self.open_apis:
+                try:
                     openapi.validate_request(WerkzeugOpenAPIRequest(context.request))
-            except RequestValidationError as e:
-                # Note: in this handler we only check validation errors, e.g., wrong body, missing required in the body.
-                response.status_code = 400
-                response.set_json({"error": "Bad Request", "message": str(e)})
-                chain.stop()
-            except OpenAPIError:
-                # Other errors can be raised when validating a request against the OpenAPI specification.
-                #   The most common are: ServerNotFound, OperationNotFound, or PathNotFound.
-                #   We explicitly do not check any other error but RequestValidationError ones.
-                #   We shallow the exception to avoid excessive logging (e.g., a lot of ServerNotFound), as the only
-                #   purpose of this handler is to check for request validation errors.
-                pass
+                except RequestValidationError as e:
+                    # Note: in this handler we only check validation errors, e.g., wrong body, missing required.
+                    response.status_code = 400
+                    response.set_json({"error": "Bad Request", "message": str(e)})
+                    chain.stop()
+                except OpenAPIError:
+                    # Other errors can be raised when validating a request against the OpenAPI specification.
+                    #   The most common are: ServerNotFound, OperationNotFound, or PathNotFound.
+                    #   We explicitly do not check any other error but RequestValidationError ones.
+                    #   We shallow the exception to avoid excessive logging (e.g., a lot of ServerNotFound), as the only
+                    #   purpose of this handler is to check for request validation errors.
+                    pass
 
 
 class OpenAPIResponseValidator(OpenAPIValidator):
@@ -96,14 +96,14 @@ class OpenAPIResponseValidator(OpenAPIValidator):
         path = context.request.path
 
         if path.startswith(f"{INTERNAL_RESOURCE_PATH}/") or path.startswith("/_aws/"):
-            try:
-                for openapi in self.open_apis:
+            for openapi in self.open_apis:
+                try:
                     openapi.validate_response(
                         WerkzeugOpenAPIRequest(context.request),
                         WerkzeugOpenAPIResponse(response),
                     )
-            except ResponseValidationError as exc:
-                LOG.error("Response validation failed for %s: $s", path, exc)
-                response.status_code = 500
-                response.set_json({"error": exc.__class__.__name__, "message": str(exc)})
-                chain.stop()
+                except ResponseValidationError as exc:
+                    LOG.error("Response validation failed for %s: $s", path, exc)
+                    response.status_code = 500
+                    response.set_json({"error": exc.__class__.__name__, "message": str(exc)})
+                    chain.stop()

--- a/localstack-core/localstack/plugins.py
+++ b/localstack-core/localstack/plugins.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from localstack import config
 from localstack.aws.handlers.validation import OASPlugin
@@ -26,8 +25,4 @@ def delete_cached_certificate():
 
 
 class CoreOASPlugin(OASPlugin):
-    name = "localstack.core"
-
-    def __init__(self):
-        path = os.path.join(os.path.dirname(__file__), "openapi.yaml")
-        super().__init__(path)
+    name = "localstack"

--- a/localstack-core/localstack/plugins.py
+++ b/localstack-core/localstack/plugins.py
@@ -1,11 +1,8 @@
 import logging
 import os
-from pathlib import Path
-
-import yaml
-from plux import Plugin
 
 from localstack import config
+from localstack.aws.handlers.validation import OASPlugin
 from localstack.runtime import hooks
 from localstack.utils.files import rm_rf
 from localstack.utils.ssl import get_cert_pem_file_path
@@ -28,15 +25,9 @@ def delete_cached_certificate():
     rm_rf(target_file)
 
 
-class OASPlugin(Plugin):
-    namespace = "localstack.openapi.spec"
+class CoreOASPlugin(OASPlugin):
+    name = "localstack.core"
 
-    def __init__(self, spec_path: os.PathLike | str) -> None:
-        if isinstance(spec_path, str):
-            spec_path = Path(spec_path)
-        self.spec_path = spec_path
-        self.spec = {}
-
-    def load(self):
-        with self.spec_path.open("r") as f:
-            self.spec = yaml.safe_load(f)
+    def __init__(self):
+        path = os.path.join(os.path.dirname(__file__), "openapi.yaml")
+        super().__init__(path)

--- a/localstack-core/localstack/plugins.py
+++ b/localstack-core/localstack/plugins.py
@@ -1,4 +1,9 @@
 import logging
+import os
+from pathlib import Path
+
+import yaml
+from plux import Plugin
 
 from localstack import config
 from localstack.runtime import hooks
@@ -21,3 +26,17 @@ def delete_cached_certificate():
     LOG.debug("Removing the cached local SSL certificate")
     target_file = get_cert_pem_file_path()
     rm_rf(target_file)
+
+
+class OASPlugin(Plugin):
+    namespace = "localstack.openapi.spec"
+
+    def __init__(self, spec_path: os.PathLike | str) -> None:
+        if isinstance(spec_path, str):
+            spec_path = Path(spec_path)
+        self.spec_path = spec_path
+        self.spec = {}
+
+    def load(self):
+        with self.spec_path.open("r") as f:
+            self.spec = yaml.safe_load(f)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR is a small improvement over https://github.com/localstack/localstack/pull/11452.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added a plux plugin which is responsible for loading a spec given a certain path;
- The validator can work now on multiple specs. For instance, pro would have its spec and plugin and the validation will be performed against all the specs the plugin manager can find.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
