### PR TITLE
Feature/lambda: Add recursion get-put API functions

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
+++ b/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
@@ -31,6 +31,7 @@ from localstack.aws.api.lambda_ import (
     LoggingConfig,
     PackageType,
     ProvisionedConcurrencyStatusEnum,
+    RecursiveLoop,
     Runtime,
     RuntimeVersionConfig,
     SnapStartResponse,
@@ -590,6 +591,7 @@ class Function:
         default_factory=dict
     )  # key is $LATEST(?), version or alias
     reserved_concurrent_executions: Optional[int] = None
+    recursive_loop: RecursiveLoop = RecursiveLoop.Terminate
     provisioned_concurrency_configs: dict[str, ProvisionedConcurrencyConfiguration] = (
         dataclasses.field(default_factory=dict)
     )

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -378,87 +378,6 @@ class TestLambdaFunction:
         snapshot.match("delete_postdelete", e.value.response)
 
     @markers.aws.validated
-    def test_put_function_recursion_config_allow(
-        self, create_lambda_function, account_id, snapshot, aws_client
-    ):
-        """Tests Lambda recursion configuration with allowance."""
-        # Arrange: Create a Lambda function
-        function_name = f"recursion-test-{short_uid()}"
-        snapshot.add_transformer(snapshot.transform.regex(function_name, "<fn-name>"))
-
-        create_lambda_function(
-            handler_file=TEST_LAMBDA_PYTHON_ECHO,
-            func_name=function_name,
-            runtime=Runtime.python3_12,
-            Description="Lambda with recursion test",
-        )
-
-        # Act: Put recursion configuration to Allow
-        put_response = aws_client.lambda_.put_function_recursion_config(
-            FunctionName=function_name, RecursiveLoop="Allow"
-        )
-
-        # Assert: Validate the recursion config is set to Allow
-        snapshot.match("put_recursion_config_response", put_response)
-
-        get_response = aws_client.lambda_.get_function_recursion_config(
-            FunctionName=function_name,
-        )
-        snapshot.match("get_recursion_config_response", get_response)
-        assert get_response["RecursiveLoop"] == "Allow"
-
-    @markers.aws.validated
-    def test_put_function_recursion_config_default_terminate(
-        self, create_lambda_function, account_id, snapshot, aws_client
-    ):
-        """Tests Lambda recursion config with default termination behavior."""
-        # Arrange: Create a Lambda function
-        function_name = f"recursion-test-{short_uid()}"
-        snapshot.add_transformer(snapshot.transform.regex(function_name, "<fn-name>"))
-
-        create_lambda_function(
-            handler_file=TEST_LAMBDA_PYTHON_ECHO,
-            func_name=function_name,
-            runtime=Runtime.python3_12,
-            Description="Lambda with recursion test",
-        )
-
-        # Act: Get recursion configuration without setting it (default behavior)
-        get_response = aws_client.lambda_.get_function_recursion_config(
-            FunctionName=function_name,
-        )
-
-        # Assert: Default should be "Terminate"
-        snapshot.match("get_recursion_default_terminate_response", get_response)
-        assert get_response["RecursiveLoop"] == "Terminate"
-
-    @markers.aws.validated
-    def test_put_function_recursion_config_invalid_value(
-        self, create_lambda_function, account_id, snapshot, aws_client
-    ):
-        """Tests Lambda recursion configuration with invalid value."""
-        # Arrange: Create a Lambda function
-        function_name = f"recursion-test-{short_uid()}"
-        snapshot.add_transformer(snapshot.transform.regex(function_name, "<fn-name>"))
-
-        create_lambda_function(
-            handler_file=TEST_LAMBDA_PYTHON_ECHO,
-            func_name=function_name,
-            runtime=Runtime.python3_12,
-            Description="Lambda with recursion test",
-        )
-
-        # Act and Assert: Set an invalid RecursiveLoop value and expect ClientError
-        invalid_value = "InvalidValue"
-        with pytest.raises(ClientError) as e:
-            aws_client.lambda_.put_function_recursion_config(
-                FunctionName=function_name, RecursiveLoop=invalid_value
-            )
-
-        # Match the error response for the invalid value
-        snapshot.match("put_recursion_invalid_value_error", e.value.response)
-
-    @markers.aws.validated
     def test_redundant_updates(self, create_lambda_function, snapshot, aws_client):
         """validates that redundant updates work (basically testing idempotency)"""
         function_name = f"fn-{short_uid()}"
@@ -1453,6 +1372,89 @@ class TestLambdaFunction:
         # release hold on updates
         update_finish_event.set()
         aws_client.lambda_.get_waiter("function_updated_v2").wait(FunctionName=function_name)
+
+
+class TestLambdaRecursion:
+    @markers.aws.validated
+    def test_put_function_recursion_config_allow(
+        self, create_lambda_function, account_id, snapshot, aws_client
+    ):
+        """Tests Lambda recursion configuration with allowance."""
+        # Arrange: Create a Lambda function
+        function_name = f"recursion-test-{short_uid()}"
+        snapshot.add_transformer(snapshot.transform.regex(function_name, "<fn-name>"))
+
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name,
+            runtime=Runtime.python3_12,
+            Description="Lambda with recursion test",
+        )
+
+        # Act: Put recursion configuration to Allow
+        put_response = aws_client.lambda_.put_function_recursion_config(
+            FunctionName=function_name, RecursiveLoop="Allow"
+        )
+
+        # Assert: Validate the recursion config is set to Allow
+        snapshot.match("put_recursion_config_response", put_response)
+
+        get_response = aws_client.lambda_.get_function_recursion_config(
+            FunctionName=function_name,
+        )
+        snapshot.match("get_recursion_config_response", get_response)
+        assert get_response["RecursiveLoop"] == "Allow"
+
+    @markers.aws.validated
+    def test_put_function_recursion_config_default_terminate(
+        self, create_lambda_function, account_id, snapshot, aws_client
+    ):
+        """Tests Lambda recursion config with default termination behavior."""
+        # Arrange: Create a Lambda function
+        function_name = f"recursion-test-{short_uid()}"
+        snapshot.add_transformer(snapshot.transform.regex(function_name, "<fn-name>"))
+
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name,
+            runtime=Runtime.python3_12,
+            Description="Lambda with recursion test",
+        )
+
+        # Act: Get recursion configuration without setting it (default behavior)
+        get_response = aws_client.lambda_.get_function_recursion_config(
+            FunctionName=function_name,
+        )
+
+        # Assert: Default should be "Terminate"
+        snapshot.match("get_recursion_default_terminate_response", get_response)
+        assert get_response["RecursiveLoop"] == "Terminate"
+
+    @markers.aws.validated
+    def test_put_function_recursion_config_invalid_value(
+        self, create_lambda_function, account_id, snapshot, aws_client
+    ):
+        """Tests Lambda recursion configuration with invalid value."""
+        # Arrange: Create a Lambda function
+        function_name = f"recursion-test-{short_uid()}"
+        snapshot.add_transformer(snapshot.transform.regex(function_name, "<fn-name>"))
+
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name,
+            runtime=Runtime.python3_12,
+            Description="Lambda with recursion test",
+        )
+
+        # Act and Assert: Set an invalid RecursiveLoop value and expect ClientError
+        invalid_value = "InvalidValue"
+        with pytest.raises(ClientError) as e:
+            aws_client.lambda_.put_function_recursion_config(
+                FunctionName=function_name, RecursiveLoop=invalid_value
+            )
+
+        # Match the error response for the invalid value
+        snapshot.match("put_recursion_invalid_value_error", e.value.response)
 
 
 class TestLambdaImages:

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_lifecycle": {
-    "recorded-date": "10-04-2024, 08:59:22",
+    "recorded-date": "12-09-2024, 11:29:18",
     "recorded-content": {
       "create_response": {
         "CreateEventSourceMappingResponse": null,
@@ -327,7 +327,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_redundant_updates": {
-    "recorded-date": "10-04-2024, 08:59:29",
+    "recorded-date": "12-09-2024, 11:29:23",
     "recorded-content": {
       "create_response": {
         "CreateEventSourceMappingResponse": null,
@@ -622,7 +622,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[delete_function]": {
-    "recorded-date": "10-04-2024, 08:59:30",
+    "recorded-date": "12-09-2024, 11:29:23",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -651,7 +651,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function]": {
-    "recorded-date": "10-04-2024, 08:59:30",
+    "recorded-date": "12-09-2024, 11:29:23",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -680,7 +680,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function_configuration]": {
-    "recorded-date": "10-04-2024, 08:59:30",
+    "recorded-date": "12-09-2024, 11:29:24",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -709,7 +709,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function]": {
-    "recorded-date": "10-04-2024, 08:59:33",
+    "recorded-date": "12-09-2024, 11:29:26",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -726,7 +726,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function_configuration]": {
-    "recorded-date": "10-04-2024, 08:59:36",
+    "recorded-date": "12-09-2024, 11:29:28",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -743,7 +743,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function_event_invoke_config]": {
-    "recorded-date": "10-04-2024, 08:59:39",
+    "recorded-date": "12-09-2024, 11:29:30",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -760,7 +760,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_delete_on_nonexisting_version": {
-    "recorded-date": "10-04-2024, 08:59:42",
+    "recorded-date": "12-09-2024, 11:29:32",
     "recorded-content": {
       "delete_function_response_non_existent": {
         "Error": {
@@ -789,7 +789,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[delete_function]": {
-    "recorded-date": "10-04-2024, 08:59:43",
+    "recorded-date": "12-09-2024, 11:29:32",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -806,7 +806,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function]": {
-    "recorded-date": "10-04-2024, 08:59:43",
+    "recorded-date": "12-09-2024, 11:29:32",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -823,7 +823,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_configuration]": {
-    "recorded-date": "10-04-2024, 08:59:43",
+    "recorded-date": "12-09-2024, 11:29:33",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -840,7 +840,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_url_config]": {
-    "recorded-date": "10-04-2024, 08:59:44",
+    "recorded-date": "12-09-2024, 11:29:33",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -857,7 +857,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_code_signing_config]": {
-    "recorded-date": "10-04-2024, 08:59:44",
+    "recorded-date": "12-09-2024, 11:29:33",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -874,7 +874,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_event_invoke_config]": {
-    "recorded-date": "10-04-2024, 08:59:44",
+    "recorded-date": "12-09-2024, 11:29:33",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -891,7 +891,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_concurrency]": {
-    "recorded-date": "10-04-2024, 08:59:44",
+    "recorded-date": "12-09-2024, 11:29:33",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -908,7 +908,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function]": {
-    "recorded-date": "10-04-2024, 08:59:48",
+    "recorded-date": "12-09-2024, 11:29:35",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -925,7 +925,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_configuration]": {
-    "recorded-date": "10-04-2024, 08:59:51",
+    "recorded-date": "12-09-2024, 11:29:37",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -942,7 +942,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_url_config]": {
-    "recorded-date": "10-04-2024, 08:59:54",
+    "recorded-date": "12-09-2024, 11:29:39",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -959,7 +959,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_code_signing_config]": {
-    "recorded-date": "10-04-2024, 08:59:57",
+    "recorded-date": "12-09-2024, 11:29:41",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -976,7 +976,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_event_invoke_config]": {
-    "recorded-date": "10-04-2024, 09:00:00",
+    "recorded-date": "12-09-2024, 11:29:43",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -993,7 +993,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_concurrency]": {
-    "recorded-date": "10-04-2024, 09:00:03",
+    "recorded-date": "12-09-2024, 11:29:46",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -1010,7 +1010,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[delete_function]": {
-    "recorded-date": "10-04-2024, 09:00:06",
+    "recorded-date": "12-09-2024, 11:29:48",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -1027,7 +1027,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[invoke]": {
-    "recorded-date": "10-04-2024, 09:00:09",
+    "recorded-date": "12-09-2024, 11:29:50",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -1044,7 +1044,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_zipfile": {
-    "recorded-date": "10-04-2024, 09:00:13",
+    "recorded-date": "12-09-2024, 11:29:52",
     "recorded-content": {
       "create-response-zip-file": {
         "Architectures": [
@@ -1234,7 +1234,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_s3": {
-    "recorded-date": "10-04-2024, 09:00:19",
+    "recorded-date": "12-09-2024, 11:29:57",
     "recorded-content": {
       "create_response_s3": {
         "Architectures": [
@@ -7821,7 +7821,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "recorded-date": "10-04-2024, 09:00:26",
+    "recorded-date": "12-09-2024, 11:30:07",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7893,7 +7893,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "recorded-date": "10-04-2024, 09:00:29",
+    "recorded-date": "12-09-2024, 11:30:09",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7932,7 +7932,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_list_functions": {
-    "recorded-date": "10-04-2024, 09:00:42",
+    "recorded-date": "12-09-2024, 11:30:20",
     "recorded-content": {
       "create_response_1": {
         "CreateEventSourceMappingResponse": null,
@@ -13350,7 +13350,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_vpc_config": {
-    "recorded-date": "10-04-2024, 09:09:00",
+    "recorded-date": "12-09-2024, 11:34:43",
     "recorded-content": {
       "create_response": {
         "CreateEventSourceMappingResponse": null,
@@ -14049,7 +14049,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_arns": {
-    "recorded-date": "22-08-2024, 15:53:32",
+    "recorded-date": "12-09-2024, 11:30:01",
     "recorded-content": {
       "create-function-arn-response": {
         "CreateEventSourceMappingResponse": null,
@@ -14448,7 +14448,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_invalid_invoke": {
-    "recorded-date": "10-04-2024, 09:09:00",
+    "recorded-date": "12-09-2024, 11:34:43",
     "recorded-content": {
       "invoke_function_name_pattern_exc": {
         "Error": {
@@ -14564,7 +14564,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_code_updates": {
-    "recorded-date": "10-04-2024, 09:09:04",
+    "recorded-date": "12-09-2024, 11:34:47",
     "recorded-content": {
       "create-function-response": {
         "Architectures": [
@@ -14624,7 +14624,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_config_updates": {
-    "recorded-date": "10-04-2024, 09:09:09",
+    "recorded-date": "12-09-2024, 11:34:50",
     "recorded-content": {
       "create-function-response": {
         "CreateEventSourceMappingResponse": null,
@@ -16421,7 +16421,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:25",
+    "recorded-date": "12-09-2024, 11:30:01",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -16433,7 +16433,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:26",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -16445,7 +16445,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:26",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -16457,7 +16457,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:26",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -16469,7 +16469,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:24",
+    "recorded-date": "12-09-2024, 11:30:01",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -16481,7 +16481,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:24",
+    "recorded-date": "12-09-2024, 11:30:01",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -16493,7 +16493,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:25",
+    "recorded-date": "12-09-2024, 11:30:01",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -16505,7 +16505,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:25",
+    "recorded-date": "12-09-2024, 11:30:01",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -16517,7 +16517,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:27",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -16529,7 +16529,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:27",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -16541,7 +16541,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:27",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -16553,7 +16553,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:27",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -16613,7 +16613,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:29",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -16625,7 +16625,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:29",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -16637,7 +16637,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:29",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -16649,7 +16649,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:30",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -16661,7 +16661,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:30",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -16673,7 +16673,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:30",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -16685,7 +16685,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:31",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -16697,7 +16697,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:31",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -16709,7 +16709,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:31",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -16721,7 +16721,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:31",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -16733,7 +16733,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:32",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -16745,7 +16745,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:32",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -16757,7 +16757,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:32",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ResourceNotFoundException",
@@ -16766,7 +16766,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:33",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ResourceNotFoundException",
@@ -16775,7 +16775,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:33",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ResourceNotFoundException",
@@ -16784,7 +16784,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:33",
+    "recorded-date": "12-09-2024, 11:30:03",
     "recorded-content": {
       "create_function_exception": {
         "Code": "InvalidParameterValueException",
@@ -16796,7 +16796,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:34",
+    "recorded-date": "12-09-2024, 11:30:04",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -16809,7 +16809,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:34",
+    "recorded-date": "12-09-2024, 11:30:04",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -16822,7 +16822,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:34",
+    "recorded-date": "12-09-2024, 11:30:04",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -16835,7 +16835,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:35",
+    "recorded-date": "12-09-2024, 11:30:04",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -16848,7 +16848,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:35",
+    "recorded-date": "12-09-2024, 11:30:04",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -16862,7 +16862,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:35",
+    "recorded-date": "12-09-2024, 11:30:04",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -16876,7 +16876,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:36",
+    "recorded-date": "12-09-2024, 11:30:04",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -16890,7 +16890,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:36",
+    "recorded-date": "12-09-2024, 11:30:04",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -16934,7 +16934,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:36",
+    "recorded-date": "12-09-2024, 11:30:04",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -16946,7 +16946,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:36",
+    "recorded-date": "12-09-2024, 11:30:04",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -16958,7 +16958,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:37",
+    "recorded-date": "12-09-2024, 11:30:04",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -16970,7 +16970,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:37",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -16982,7 +16982,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:37",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ResourceNotFoundException",
@@ -16991,7 +16991,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:38",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ResourceNotFoundException",
@@ -17000,7 +17000,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:38",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ResourceNotFoundException",
@@ -17009,11 +17009,11 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:38",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:38",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -17025,7 +17025,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:39",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -17037,7 +17037,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:39",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -17049,7 +17049,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:39",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -17061,7 +17061,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:39",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "get_function_exception": {
         "Code": "InvalidParameterValueException",
@@ -17070,7 +17070,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:40",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "InvalidParameterValueException",
@@ -17079,7 +17079,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:40",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "invoke_exception": {
         "Code": "InvalidParameterValueException",
@@ -17088,7 +17088,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:40",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -17100,7 +17100,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:41",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ResourceNotFoundException",
@@ -17109,11 +17109,11 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:41",
+    "recorded-date": "12-09-2024, 11:30:05",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:41",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ResourceNotFoundException",
@@ -17122,7 +17122,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:41",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -17134,7 +17134,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:42",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -17146,7 +17146,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:42",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -17158,7 +17158,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:42",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -17170,7 +17170,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:43",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -17182,7 +17182,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:43",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -17194,7 +17194,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:43",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -17206,7 +17206,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:44",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -17218,7 +17218,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:44",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -17230,7 +17230,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:44",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -17242,7 +17242,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:44",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -17254,7 +17254,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:45",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -17266,7 +17266,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:45",
+    "recorded-date": "12-09-2024, 11:30:06",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -17278,7 +17278,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-get_function]": {
-    "recorded-date": "22-08-2024, 15:20:28",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "get_function_exception": {
         "Code": "ValidationException",
@@ -17290,7 +17290,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-delete_function]": {
-    "recorded-date": "22-08-2024, 15:20:28",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "delete_function_exception": {
         "Code": "ValidationException",
@@ -17302,7 +17302,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-invoke]": {
-    "recorded-date": "22-08-2024, 15:20:28",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "invoke_exception": {
         "Code": "ValidationException",
@@ -17314,7 +17314,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-create_function]": {
-    "recorded-date": "22-08-2024, 15:20:29",
+    "recorded-date": "12-09-2024, 11:30:02",
     "recorded-content": {
       "create_function_exception": {
         "Code": "ValidationException",
@@ -17463,8 +17463,8 @@
       }
     }
   },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_put_function_recursion_config_allow": {
-    "recorded-date": "11-09-2024, 18:37:59",
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaRecursion::test_put_function_recursion_config_allow": {
+    "recorded-date": "12-09-2024, 11:35:20",
     "recorded-content": {
       "put_recursion_config_response": {
         "RecursiveLoop": "Allow",
@@ -17482,8 +17482,8 @@
       }
     }
   },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_put_function_recursion_config_default_terminate": {
-    "recorded-date": "11-09-2024, 18:38:02",
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaRecursion::test_put_function_recursion_config_default_terminate": {
+    "recorded-date": "12-09-2024, 11:35:22",
     "recorded-content": {
       "get_recursion_default_terminate_response": {
         "RecursiveLoop": "Terminate",
@@ -17494,8 +17494,8 @@
       }
     }
   },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_put_function_recursion_config_invalid_value": {
-    "recorded-date": "11-09-2024, 18:38:04",
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaRecursion::test_put_function_recursion_config_invalid_value": {
+    "recorded-date": "12-09-2024, 11:35:24",
     "recorded-content": {
       "put_recursion_invalid_value_error": {
         "Error": {

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -17462,5 +17462,51 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_put_function_recursion_config_allow": {
+    "recorded-date": "11-09-2024, 18:37:59",
+    "recorded-content": {
+      "put_recursion_config_response": {
+        "RecursiveLoop": "Allow",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_recursion_config_response": {
+        "RecursiveLoop": "Allow",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_put_function_recursion_config_default_terminate": {
+    "recorded-date": "11-09-2024, 18:38:02",
+    "recorded-content": {
+      "get_recursion_default_terminate_response": {
+        "RecursiveLoop": "Terminate",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_put_function_recursion_config_invalid_value": {
+    "recorded-date": "11-09-2024, 18:38:04",
+    "recorded-content": {
+      "put_recursion_invalid_value_error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'InvalidValue' at 'recursiveLoop' failed to satisfy constraint: Member must satisfy enum value set: [Terminate, Allow]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -398,6 +398,15 @@
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function_configuration]": {
     "last_validated_date": "2024-04-10T08:59:30+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_put_function_recursion_config_allow": {
+    "last_validated_date": "2024-09-11T18:37:59+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_put_function_recursion_config_default_terminate": {
+    "last_validated_date": "2024-09-11T18:38:01+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_put_function_recursion_config_invalid_value": {
+    "last_validated_date": "2024-09-11T18:38:03+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_redundant_updates": {
     "last_validated_date": "2024-04-10T08:59:28+00:00"
   },

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -48,10 +48,10 @@
     "last_validated_date": "2024-04-10T08:58:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "last_validated_date": "2024-04-10T09:00:26+00:00"
+    "last_validated_date": "2024-09-12T11:30:07+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_delete_on_nonexisting_version": {
-    "last_validated_date": "2024-04-10T08:59:42+00:00"
+    "last_validated_date": "2024-09-12T11:29:32+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_advanced_configuration": {
     "last_validated_date": "2024-03-28T09:54:41+00:00"
@@ -60,34 +60,34 @@
     "last_validated_date": "2024-04-10T08:59:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_arns": {
-    "last_validated_date": "2024-08-22T15:53:29+00:00"
+    "last_validated_date": "2024-09-12T11:30:00+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_lifecycle": {
-    "last_validated_date": "2024-04-10T08:59:22+00:00"
+    "last_validated_date": "2024-09-12T11:29:18+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:36+00:00"
+    "last_validated_date": "2024-09-12T11:30:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:35+00:00"
+    "last_validated_date": "2024-09-12T11:30:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:35+00:00"
+    "last_validated_date": "2024-09-12T11:30:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_and_qualifier_too_long_and_invalid_region-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:36+00:00"
+    "last_validated_date": "2024-09-12T11:30:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:37+00:00"
+    "last_validated_date": "2024-09-12T11:30:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:36+00:00"
+    "last_validated_date": "2024-09-12T11:30:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:36+00:00"
+    "last_validated_date": "2024-09-12T11:30:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[full_arn_with_multiple_qualifiers-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:37+00:00"
+    "last_validated_date": "2024-09-12T11:30:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_and_qualifier_too_long-delete_function]": {
     "last_validated_date": "2024-08-22T15:10:43+00:00"
@@ -99,190 +99,190 @@
     "last_validated_date": "2024-08-22T15:10:44+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:26+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:26+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:25+00:00"
+    "last_validated_date": "2024-09-12T11:30:01+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_is_single_invalid-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:26+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:33+00:00"
+    "last_validated_date": "2024-09-12T11:30:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:33+00:00"
+    "last_validated_date": "2024-09-12T11:30:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:32+00:00"
+    "last_validated_date": "2024-09-12T11:30:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long-invoke]": {
     "last_validated_date": "2024-08-22T15:20:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:35+00:00"
+    "last_validated_date": "2024-09-12T11:30:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:34+00:00"
+    "last_validated_date": "2024-09-12T11:30:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:34+00:00"
+    "last_validated_date": "2024-09-12T11:30:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[function_name_too_long_and_invalid_region-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:34+00:00"
+    "last_validated_date": "2024-09-12T11:30:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:38+00:00"
+    "last_validated_date": "2024-09-12T11:30:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:37+00:00"
+    "last_validated_date": "2024-09-12T11:30:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[incomplete_arn-invoke]": {
     "last_validated_date": "2024-08-22T15:20:38+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:30+00:00"
+    "last_validated_date": "2024-09-12T11:30:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:29+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:29+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_account_id_in_partial_arn-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:29+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:25+00:00"
+    "last_validated_date": "2024-09-12T11:30:01+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:24+00:00"
+    "last_validated_date": "2024-09-12T11:30:01+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:24+00:00"
+    "last_validated_date": "2024-09-12T11:30:01+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_function_name-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:25+00:00"
+    "last_validated_date": "2024-09-12T11:30:01+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:27+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:27+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:27+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_characters_in_qualifier-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:27+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:31+00:00"
+    "last_validated_date": "2024-09-12T11:30:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:30+00:00"
+    "last_validated_date": "2024-09-12T11:30:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:30+00:00"
+    "last_validated_date": "2024-09-12T11:30:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[invalid_region_in_arn-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:31+00:00"
+    "last_validated_date": "2024-09-12T11:30:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:40+00:00"
+    "last_validated_date": "2024-09-12T11:30:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:40+00:00"
+    "last_validated_date": "2024-09-12T11:30:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:39+00:00"
+    "last_validated_date": "2024-09-12T11:30:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[latest_version_with_additional_qualifier-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:40+00:00"
+    "last_validated_date": "2024-09-12T11:30:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:41+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:41+00:00"
+    "last_validated_date": "2024-09-12T11:30:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[lowercase_latest_qualifier-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:41+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:44+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:43+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:43+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_account_id_in_arn-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:44+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:43+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:42+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:42+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[missing_region_in_arn-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:42+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:45+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:44+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:44+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[misspelled_latest_in_arn-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:45+00:00"
+    "last_validated_date": "2024-09-12T11:30:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:32+00:00"
+    "last_validated_date": "2024-09-12T11:30:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:31+00:00"
+    "last_validated_date": "2024-09-12T11:30:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:31+00:00"
+    "last_validated_date": "2024-09-12T11:30:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[non_lambda_arn-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:32+00:00"
+    "last_validated_date": "2024-09-12T11:30:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:39+00:00"
+    "last_validated_date": "2024-09-12T11:30:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:38+00:00"
+    "last_validated_date": "2024-09-12T11:30:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:38+00:00"
+    "last_validated_date": "2024-09-12T11:30:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[partial_arn_with_extra_qualifier-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:39+00:00"
+    "last_validated_date": "2024-09-12T11:30:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-create_function]": {
-    "last_validated_date": "2024-08-22T15:20:29+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-delete_function]": {
-    "last_validated_date": "2024-08-22T15:20:28+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-get_function]": {
-    "last_validated_date": "2024-08-22T15:20:28+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long-invoke]": {
-    "last_validated_date": "2024-08-22T15:20:28+00:00"
+    "last_validated_date": "2024-09-12T11:30:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_name_and_qualifier_validation[qualifier_too_long0-create_function]": {
     "last_validated_date": "2024-08-22T15:07:10+00:00"
@@ -318,103 +318,94 @@
     "last_validated_date": "2024-04-10T08:59:09+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[delete_function]": {
-    "last_validated_date": "2024-04-10T09:00:05+00:00"
+    "last_validated_date": "2024-09-12T11:29:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function]": {
-    "last_validated_date": "2024-04-10T08:59:46+00:00"
+    "last_validated_date": "2024-09-12T11:29:35+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_code_signing_config]": {
-    "last_validated_date": "2024-04-10T08:59:56+00:00"
+    "last_validated_date": "2024-09-12T11:29:41+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_concurrency]": {
-    "last_validated_date": "2024-04-10T09:00:02+00:00"
+    "last_validated_date": "2024-09-12T11:29:45+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_configuration]": {
-    "last_validated_date": "2024-04-10T08:59:50+00:00"
+    "last_validated_date": "2024-09-12T11:29:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_event_invoke_config]": {
-    "last_validated_date": "2024-04-10T08:59:59+00:00"
+    "last_validated_date": "2024-09-12T11:29:43+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_url_config]": {
-    "last_validated_date": "2024-04-10T08:59:53+00:00"
+    "last_validated_date": "2024-09-12T11:29:39+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[invoke]": {
-    "last_validated_date": "2024-04-10T09:00:08+00:00"
+    "last_validated_date": "2024-09-12T11:29:49+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_invalid_invoke": {
-    "last_validated_date": "2024-04-10T09:09:00+00:00"
+    "last_validated_date": "2024-09-12T11:34:43+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_s3": {
-    "last_validated_date": "2024-04-10T09:00:17+00:00"
+    "last_validated_date": "2024-09-12T11:29:56+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_zipfile": {
-    "last_validated_date": "2024-04-10T09:00:12+00:00"
+    "last_validated_date": "2024-09-12T11:29:52+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_code_updates": {
-    "last_validated_date": "2024-04-10T09:09:04+00:00"
+    "last_validated_date": "2024-09-12T11:34:46+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_config_updates": {
-    "last_validated_date": "2024-04-10T09:09:08+00:00"
+    "last_validated_date": "2024-09-12T11:34:50+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_list_functions": {
-    "last_validated_date": "2024-04-10T09:00:40+00:00"
+    "last_validated_date": "2024-09-12T11:30:19+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[delete_function]": {
-    "last_validated_date": "2024-04-10T08:59:43+00:00"
+    "last_validated_date": "2024-09-12T11:29:32+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function]": {
-    "last_validated_date": "2024-04-10T08:59:43+00:00"
+    "last_validated_date": "2024-09-12T11:29:32+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_code_signing_config]": {
-    "last_validated_date": "2024-04-10T08:59:44+00:00"
+    "last_validated_date": "2024-09-12T11:29:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_concurrency]": {
-    "last_validated_date": "2024-04-10T08:59:44+00:00"
+    "last_validated_date": "2024-09-12T11:29:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_configuration]": {
-    "last_validated_date": "2024-04-10T08:59:43+00:00"
+    "last_validated_date": "2024-09-12T11:29:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_event_invoke_config]": {
-    "last_validated_date": "2024-04-10T08:59:44+00:00"
+    "last_validated_date": "2024-09-12T11:29:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_url_config]": {
-    "last_validated_date": "2024-04-10T08:59:44+00:00"
+    "last_validated_date": "2024-09-12T11:29:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function]": {
-    "last_validated_date": "2024-04-10T08:59:32+00:00"
+    "last_validated_date": "2024-09-12T11:29:25+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function_configuration]": {
-    "last_validated_date": "2024-04-10T08:59:35+00:00"
+    "last_validated_date": "2024-09-12T11:29:27+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function_event_invoke_config]": {
-    "last_validated_date": "2024-04-10T08:59:38+00:00"
+    "last_validated_date": "2024-09-12T11:29:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[delete_function]": {
-    "last_validated_date": "2024-04-10T08:59:30+00:00"
+    "last_validated_date": "2024-09-12T11:29:23+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function]": {
-    "last_validated_date": "2024-04-10T08:59:30+00:00"
+    "last_validated_date": "2024-09-12T11:29:23+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function_configuration]": {
-    "last_validated_date": "2024-04-10T08:59:30+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_put_function_recursion_config_allow": {
-    "last_validated_date": "2024-09-11T18:37:59+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_put_function_recursion_config_default_terminate": {
-    "last_validated_date": "2024-09-11T18:38:01+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_put_function_recursion_config_invalid_value": {
-    "last_validated_date": "2024-09-11T18:38:03+00:00"
+    "last_validated_date": "2024-09-12T11:29:24+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_redundant_updates": {
-    "last_validated_date": "2024-04-10T08:59:28+00:00"
+    "last_validated_date": "2024-09-12T11:29:23+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "last_validated_date": "2024-04-10T09:00:29+00:00"
+    "last_validated_date": "2024-09-12T11:30:09+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_vpc_config": {
-    "last_validated_date": "2024-04-10T09:08:55+00:00"
+    "last_validated_date": "2024-09-12T11:34:40+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaImages::test_lambda_image_and_image_config_crud": {
     "last_validated_date": "2024-04-10T09:11:13+00:00"
@@ -481,6 +472,15 @@
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaProvisionedConcurrency::test_provisioned_concurrency_limits": {
     "last_validated_date": "2024-04-10T09:13:59+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaRecursion::test_put_function_recursion_config_allow": {
+    "last_validated_date": "2024-09-12T11:35:19+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaRecursion::test_put_function_recursion_config_default_terminate": {
+    "last_validated_date": "2024-09-12T11:35:21+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaRecursion::test_put_function_recursion_config_invalid_value": {
+    "last_validated_date": "2024-09-12T11:35:23+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaReservedConcurrency::test_function_concurrency": {
     "last_validated_date": "2024-04-10T09:13:50+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This feature introduces AWS Lambda Recursive Loop Detection APIs into LocalStack, The purpose of this PR is to implement the CRUD layer, specifically the API to configure the feature, without addressing the actual behavior of the loop detection.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Added support for two key API functions: GetFunctionRecursionConfig and PutFunctionRecursionConfig.
* Updated the Function data model to include the RecursiveLoop attribute.

## Testing
Parity tests were written to verify the behavior of the newly implemented APIs (GetFunctionRecursionConfig and PutFunctionRecursionConfig).


## TODO

What's left to do:

- [ Implement the actual behavior of Lambda Recursive Loop Detection in a future update. The current PR only covers the CRUD operations. ] 
