### PR TITLE
Add DNS server host mode advice

### DIFF
--- a/docs/development-environment-setup/README.md
+++ b/docs/development-environment-setup/README.md
@@ -53,6 +53,11 @@ In host mode, additional dependencies (e.g., Java) are required for developing c
 The required dependencies vary depending on the service, [Configuration](https://docs.localstack.cloud/references/configuration/), operating system, and system architecture (i.e., x86 vs ARM).
 Refer to our official [Dockerfile](https://github.com/localstack/localstack/blob/master/Dockerfile) and our [package installer LPM](Concepts/index.md#packages-and-installers) for more details.
 
+#### Root Permissions
+
+* Set `DNS_ADDRESS=0` to disable the LocalStack [DNS server](https://docs.localstack.cloud/user-guide/tools/dns-server/)
+  if you are getting the error "cannot run command as root" because the DNS server tries to bind port 53.
+
 #### Python Dependencies
 
 * [JPype1](https://pypi.org/project/JPype1/) might require `g++` to fix a compile error on ARM Linux `gcc: fatal error: cannot execute ‘cc1plus’`

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -24,15 +24,15 @@ from tests.aws.services.kinesis.helper_functions import get_shard_iterator
 from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON_ECHO
 
 # TODO:
-# - Add tests for the following services:
-#   - API Gateway
-#   - AppSync
-#   - Batch
-#   - Container
-#   - Logs
-#   - Redshift
-#   - Sagemaker
-#   - StepFunctions
+#  Add tests for the following services:
+#   - API Gateway (community)
+#   - CloudWatch Logs (community)
+#  These tests should go into LocalStack Pro:
+#   - AppSync (pro)
+#   - Batch (pro)
+#   - Container (pro)
+#   - Redshift (pro)
+#   - Sagemaker (pro)
 
 
 class TestEventsTargetEvents:


### PR DESCRIPTION
## Motivation

We are missing instructions on disabling the DNS server in host mode leading to undocumented errors for new contributors.

## Changes

* Add instructions on how to disable the DNS server in host mode
* Update and clarify outdated TODO comments about missing EventBridge target tests