### PR TITLE
ESM-v2: Filter irrelevant fields before logging with PipesLogger

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pipe_loggers/pipe_logger.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pipe_loggers/pipe_logger.py
@@ -72,34 +72,38 @@ class PipeLogger(ABC):
         ```
         """
         # https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-logs.html#eb-pipes-logs-execution-data
-        execution_data_fields = [
+        execution_data_fields = {
             "payload",
             "awsRequest",
             "awsResponse",
-        ]
-        fields_to_include = [
+        }
+        fields_to_include = {
             "resourceArn",
             "timestamp",
             "executionId",
             "messageType",
             "logLevel",
-        ]
-        error_fields_to_include = [
+        }
+        error_fields_to_include = {
             "message",
             "httpStatusCode",
             "awsService",
             "requestId",
             "exceptionType",
             "resourceArn",
-        ]
+        }
 
         if self.include_execution_data == [IncludeExecutionDataOption.ALL]:
-            fields_to_include.extend(execution_data_fields)
+            fields_to_include.update(execution_data_fields)
 
-        filtered_message = {key: message[key] for key in fields_to_include if key in message}
+        filtered_message = {
+            key: value for key, value in message.items() if key in fields_to_include
+        }
 
         if error := message.get("error"):
-            filtered_error = {key: error[key] for key in error_fields_to_include if key in error}
+            filtered_error = {
+                key: value for key, value in error.items() if key in error_fields_to_include
+            }
             filtered_message["error"] = filtered_error
 
         return filtered_message

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pipe_loggers/pipe_logger.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pipe_loggers/pipe_logger.py
@@ -55,14 +55,31 @@ class PipeLogger(ABC):
             "awsRequest",
             "awsResponse",
         ]
-        fields_to_remove = (
-            []
-            if self.include_execution_data == [IncludeExecutionDataOption.ALL]
-            else execution_data_fields
-        )
-        filtered_message = {
-            key: value for key, value in message.items() if key not in fields_to_remove
-        }
+        fields_to_include = [
+            "resourceArn",
+            "timestamp",
+            "executionId",
+            "messageType",
+            "logLevel",
+        ]
+        error_fields_to_include = [
+            "message",
+            "httpStatusCode",
+            "awsService",
+            "requestId",
+            "exceptionType",
+            "resourceArn",
+        ]
+
+        if self.include_execution_data == [IncludeExecutionDataOption.ALL]:
+            fields_to_include.extend(execution_data_fields)
+
+        filtered_message = {key: message[key] for key in fields_to_include if key in message}
+
+        if error := message.get("error"):
+            filtered_error = {key: error[key] for key in error_fields_to_include if key in error}
+            filtered_message["error"] = filtered_error
+
         return filtered_message
 
 

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pipe_loggers/pipe_logger.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pipe_loggers/pipe_logger.py
@@ -49,6 +49,28 @@ class PipeLogger(ABC):
         return self.log_configuration["Level"]
 
     def filter_message(self, message: dict) -> dict:
+        """
+        Filters a message payload to ensure it is formatted correcly for EventBridge Pipes Logging (see [AWS docs example](https://aws.amazon.com/blogs/compute/introducing-logging-support-for-amazon-eventbridge-pipes/)):
+        ```python
+        {
+            "resourceArn": str,
+            "timestamp": str,
+            "executionId": str,
+            "messageType": str,
+            "logLevel": str,
+            "error": {
+                "message": str,
+                "httpStatusCode": int,
+                "awsService": str,
+                "requestId": str,
+                "exceptionType": str,
+                "resourceArn": str
+            }, # Optional
+            "awsRequest": str, # Optional
+            "awsResponse": str # Optional
+        }
+        ```
+        """
         # https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-logs.html#eb-pipes-logs-execution-data
         execution_data_fields = [
             "payload",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Small rework of `PipesLogger's` message filtering to strip invalid fields from logs. This means we don't have to implement any pipes/esm specific checks when generating and passing around error payloads.

Fields derived from downstream snapshots and [this article](https://aws.amazon.com/blogs/compute/introducing-logging-support-for-amazon-eventbridge-pipes/).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Uses hardcoded log-fields to filter out irrelevant data from being logged. 

## Testing
- Backwards compatible changes so shoudn't break anything. Nevertheless, this was tested against pipes suite in pro on my local.
