### PR TITLE
Feature/Events/Eventstudio: Only propagate trace_context

### DIFF
--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -8,7 +8,6 @@ from typing import Any, Set
 
 from botocore.client import BaseClient
 
-from localstack.aws.api import RequestContext
 from localstack.aws.api.events import Arn, InputTransformer, RuleName, Target, TargetInputPath
 from localstack.aws.connect import connect_to
 from localstack.services.events.models import FormattedEvent, TransformedEvent, ValidationException
@@ -29,6 +28,7 @@ from localstack.utils.aws.client_types import ServicePrincipal
 from localstack.utils.json import extract_jsonpath
 from localstack.utils.strings import to_bytes
 from localstack.utils.time import now_utc
+from localstack.utils.tracing import TraceContext
 
 LOG = logging.getLogger(__name__)
 
@@ -140,15 +140,15 @@ class TargetSender(ABC):
         pass
 
     def proxy_send_event(
-        self, event: FormattedEvent | TransformedEvent, context: RequestContext
-    ):  # context required by eventstudio
+        self, event: FormattedEvent | TransformedEvent, trace_context: TraceContext | None = None
+    ):  # context data required by eventstudio
         """Proxy method to process the event and send it to the target,
         in addition it removes the field event-bus-name from the event,
         required for EventStudio extension"""
         self.send_event(event)
 
-    def process_event(self, event: FormattedEvent, context: RequestContext):
-        # context required by eventstudio
+    def process_event(self, event: FormattedEvent, trace_context: TraceContext | None = None):
+        # context data required by eventstudio
         """Processes the event and send it to the target."""
         if isinstance(event, dict):
             event.pop("event-bus-name", None)
@@ -156,7 +156,7 @@ class TargetSender(ABC):
             event = transform_event_with_target_input_path(input_path, event)
         if input_transformer := self.target.get("InputTransformer"):
             event = self.transform_event_with_target_input_transformer(input_transformer, event)
-        self.proxy_send_event(event, context)
+        self.proxy_send_event(event, trace_context)
 
     def transform_event_with_target_input_transformer(
         self, input_transformer: InputTransformer, event: FormattedEvent

--- a/localstack-core/localstack/utils/tracing.py
+++ b/localstack-core/localstack/utils/tracing.py
@@ -2,19 +2,24 @@ from typing import TypedDict
 
 from localstack.aws.api import RequestContext
 
+INTERNAL_CONTEXT_EVENTSTUDIO_TRACING_PARAMETER = "_eventstudio_tracing_parameter"
+
 
 class TraceContext(TypedDict):
-    trace_id: str
-    parent_id: str
+    trace_id: str | None
+    parent_id: str | None
 
 
 def get_trace_context(context: RequestContext) -> TraceContext | None:
     """Generate a data transfer object with only the relevant subset of the context.
     Required for tracing propagation and to keep performance overhead low."""
-    trace_id = context.get("trace_id")
-    parent_id = context.get("parent_id")
+    eventstudio_tracing_parameter = context.get(INTERNAL_CONTEXT_EVENTSTUDIO_TRACING_PARAMETER)
 
-    if trace_id is not None or parent_id is not None:
-        return TraceContext(trace_id=trace_id, parent_id=parent_id)
+    if eventstudio_tracing_parameter is not None:
+        trace_id = context.get("trace_id")
+        parent_id = context.get("parent_id")
+
+        if trace_id is not None or parent_id is not None:
+            return TraceContext(trace_id=trace_id, parent_id=parent_id)
 
     return None

--- a/localstack-core/localstack/utils/tracing.py
+++ b/localstack-core/localstack/utils/tracing.py
@@ -1,0 +1,20 @@
+from typing import TypedDict
+
+from localstack.aws.api import RequestContext
+
+
+class TraceContext(TypedDict):
+    trace_id: str
+    parent_id: str
+
+
+def get_trace_context(context: RequestContext) -> TraceContext | None:
+    """Generate a data transfer object with only the relevant subset of the context.
+    Required for tracing propagation and to keep performance overhead low."""
+    trace_id = context.get("trace_id")
+    parent_id = context.get("parent_id")
+
+    if trace_id is not None or parent_id is not None:
+        return TraceContext(trace_id=trace_id, parent_id=parent_id)
+
+    return None


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
To keep the overhead minimal, especially important for SQS and SNS we want to only propagate the minimal required information, therefore we use a DTO trace_context that links to only the necessary data of the context and not propagate the complete context.
