### PR TITLE
APIGW: patch UpdateRoute spec

### DIFF
--- a/localstack-core/localstack/aws/spec-patches.json
+++ b/localstack-core/localstack/aws/spec-patches.json
@@ -1309,6 +1309,11 @@
       "op": "add",
       "path": "/operations/UpdateApi/http/responseCode",
       "value": 201
+    },
+    {
+      "op": "add",
+      "path": "/operations/UpdateRoute/http/responseCode",
+      "value": 201
     }
   ]
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While working on the apigw v2 provider, another update route was discovered that returns `201` instead of `200` as per the specs.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Updating spec for apigatewayv2 `UpdatedRoute` operation
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
