### PR TITLE
Add more context about disabling DNS server

### DIFF
--- a/docs/development-environment-setup/README.md
+++ b/docs/development-environment-setup/README.md
@@ -55,8 +55,7 @@ Refer to our official [Dockerfile](https://github.com/localstack/localstack/blob
 
 #### Root Permissions
 
-* Set `DNS_ADDRESS=0` to disable the LocalStack [DNS server](https://docs.localstack.cloud/user-guide/tools/dns-server/) if you are getting the error "cannot run command as root" because the DNS server tries to bind port 53.
-  * LocalStack runs its own [DNS server](https://docs.localstack.cloud/user-guide/tools/dns-server/) which listens for requests on port 53. This requires root permission. When LocalStack starts in host mode it runs the DNS server as sudo, so a prompt is triggered asking for the sudo password. This is annoying during local development, so to disable this functionality, use `DNS_ADDRESS=0`.
+LocalStack runs its own [DNS server](https://docs.localstack.cloud/user-guide/tools/dns-server/) which listens for requests on port 53. This requires root permission. When LocalStack starts in host mode it runs the DNS server as sudo, so a prompt is triggered asking for the sudo password. This is annoying during local development, so to disable this functionality, use `DNS_ADDRESS=0`.
 
 > [!NOTE]
 > We don't recommend disabling the DNS server in general (e.g. in Docker) because the [DNS server](https://docs.localstack.cloud/user-guide/tools/dns-server/) enables seamless connectivity to LocalStack from different environments via the domain name `localhost.localstack.cloud`.

--- a/docs/development-environment-setup/README.md
+++ b/docs/development-environment-setup/README.md
@@ -55,8 +55,12 @@ Refer to our official [Dockerfile](https://github.com/localstack/localstack/blob
 
 #### Root Permissions
 
-* Set `DNS_ADDRESS=0` to disable the LocalStack [DNS server](https://docs.localstack.cloud/user-guide/tools/dns-server/)
-  if you are getting the error "cannot run command as root" because the DNS server tries to bind port 53.
+* Set `DNS_ADDRESS=0` to disable the LocalStack [DNS server](https://docs.localstack.cloud/user-guide/tools/dns-server/) if you are getting the error "cannot run command as root" because the DNS server tries to bind port 53.
+  * LocalStack runs its own [DNS server](https://docs.localstack.cloud/user-guide/tools/dns-server/) which listens for requests on port 53. This requires root permission. When LocalStack starts in host mode it runs the DNS server as sudo, so a prompt is triggered asking for the sudo password. This is annoying during local development, so to disable this functionality, use `DNS_ADDRESS=0`.
+
+> [!NOTE]
+> We don't recommend disabling the DNS server in general, and when running in a Docker container the sudo password is not required.
+
 
 #### Python Dependencies
 

--- a/docs/development-environment-setup/README.md
+++ b/docs/development-environment-setup/README.md
@@ -59,7 +59,7 @@ Refer to our official [Dockerfile](https://github.com/localstack/localstack/blob
   * LocalStack runs its own [DNS server](https://docs.localstack.cloud/user-guide/tools/dns-server/) which listens for requests on port 53. This requires root permission. When LocalStack starts in host mode it runs the DNS server as sudo, so a prompt is triggered asking for the sudo password. This is annoying during local development, so to disable this functionality, use `DNS_ADDRESS=0`.
 
 > [!NOTE]
-> We don't recommend disabling the DNS server in general, and when running in a Docker container the sudo password is not required.
+> We don't recommend disabling the DNS server in general (e.g. in Docker) because the [DNS server](https://docs.localstack.cloud/user-guide/tools/dns-server/) enables seamless connectivity to LocalStack from different environments via the domain name `localhost.localstack.cloud`.
 
 
 #### Python Dependencies


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

PR https://github.com/localstack/localstack/pull/11502 added helpful advice for when developers are asked for their sudo password during startup. This suggests to disable the DNS server with `DNS_ADDRESS=0`. We don't recommend disabling the DNS server where possible, so more context to this statement is required.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Add sub-item for the advice explaining the context to the advice
* Add a callout indicating that it should not be the standard configuration

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
