### PR TITLE
ESM-v2: Add persistence to Lambda event source mapping

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
@@ -86,6 +86,7 @@ class EsmWorker:
             with self._state_lock:
                 self.current_state = EsmState.DISABLED
                 self.state_transition_reason = self.user_state_reason
+            self.update_esm_state_in_store(EsmState.DISABLED)
 
     def start(self):
         with self._state_lock:

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -326,9 +326,39 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                                 exc_info=True,
                             )
 
-                # Restore event source listeners
                 for esm in state.event_source_mappings.values():
-                    EventSourceListener.start_listeners_for_asf(esm, self.lambda_service)
+                    if config.LAMBDA_EVENT_SOURCE_MAPPING == "v2":
+                        # Restores event source workers
+                        function_arn = esm.get("FunctionArn")
+
+                        # TODO: How do we know the event source is up?
+                        # A basic poll to see if the mapped Lambda function is active/failed
+                        if not poll_condition(
+                            lambda: get_function_version_from_arn(function_arn).config.state.state
+                            in [State.Active, State.Failed],
+                            timeout=10,
+                        ):
+                            LOG.warning(
+                                "Creating ESM for Lambda that is not in running state: %s",
+                                function_arn,
+                            )
+
+                        function_version = get_function_version_from_arn(function_arn)
+                        function_role = function_version.config.role
+
+                        is_esm_enabled = esm.get("State", EsmState.DISABLED) not in (
+                            EsmState.DISABLED,
+                            EsmState.DISABLING,
+                        )
+                        esm_worker = EsmWorkerFactory(
+                            esm, function_role, is_esm_enabled
+                        ).get_esm_worker()
+
+                        # Note: a worker is created in the DISABLED state if not enabled
+                        esm_worker.create()
+                    else:
+                        # Restore event source listeners
+                        EventSourceListener.start_listeners_for_asf(esm, self.lambda_service)
 
     def on_after_init(self):
         self.router.register_routes()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR aims to add persistence support to Event Source Mapping V2. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Add to the Lambda provider's `on_after_state_load` method.
- Poll whether the mapped Lambda is in a ready state (`Active/Failed`). Log a warning if not ready and proceed.
- If ESM is in a disabled/disabling state on re-load, then set the `enabled` flag of the ESM worker to false. Otherwise, create the ESM as normal.
- Left a TODO about polling for a ready event source.

## Testing
- Downstream persistence tests for Lambda should pass.

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
