### PR TITLE
Feature/Eventstudio/Events: use thread local for trace_context propagation

### DIFF
--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -1130,7 +1130,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
 
                 target_sender = self._target_sender_store[target["Arn"]]
                 try:
-                    target_sender.process_event(event)
+                    target_sender.process_event(event.copy())
                 except Exception as e:
                     LOG.info(
                         "Unable to send event notification %s to target %s: %s",
@@ -1363,7 +1363,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                         else:
                             target_sender = self._target_sender_store[target_arn]
                             try:
-                                target_sender.process_event(event_formatted)
+                                target_sender.process_event(event_formatted.copy())
                                 processed_entries.append({"EventId": event_formatted["id"]})
                             except Exception as error:
                                 processed_entries.append(

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -545,7 +545,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
 
         if rule_service.schedule_cron:
             schedule_job_function = self._get_scheduled_rule_job_function(
-                account_id, region, rule_service.rule, context
+                account_id, region, rule_service.rule
             )
             rule_service.create_schedule_job(schedule_job_function)
         response = PutTargetsResponse(
@@ -1109,9 +1109,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             rule_name = resource_arn.split("/")[-1]
             self.get_rule(rule_name, event_bus)
 
-    def _get_scheduled_rule_job_function(
-        self, account_id, region, rule: Rule, context: RequestContext
-    ) -> Callable:
+    def _get_scheduled_rule_job_function(self, account_id, region, rule: Rule) -> Callable:
         def func(*args, **kwargs):
             """Create custom scheduled event and send it to all targets specified by associated rule using respective TargetSender"""
             for target in rule.targets.values():
@@ -1132,7 +1130,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
 
                 target_sender = self._target_sender_store[target["Arn"]]
                 try:
-                    target_sender.process_event(event, context)
+                    target_sender.process_event(event)
                 except Exception as e:
                     LOG.info(
                         "Unable to send event notification %s to target %s: %s",
@@ -1365,7 +1363,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                         else:
                             target_sender = self._target_sender_store[target_arn]
                             try:
-                                target_sender.process_event(event_formatted, context)
+                                target_sender.process_event(event_formatted)
                                 processed_entries.append({"EventId": event_formatted["id"]})
                             except Exception as error:
                                 processed_entries.append(

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -8,7 +8,6 @@ from typing import Any, Set
 
 from botocore.client import BaseClient
 
-from localstack.aws.api import RequestContext
 from localstack.aws.api.events import Arn, InputTransformer, RuleName, Target, TargetInputPath
 from localstack.aws.connect import connect_to
 from localstack.services.events.models import FormattedEvent, TransformedEvent, ValidationException
@@ -139,24 +138,17 @@ class TargetSender(ABC):
     def send_event(self, event: FormattedEvent | TransformedEvent):
         pass
 
-    def proxy_send_event(
-        self, event: FormattedEvent | TransformedEvent, context: RequestContext
-    ):  # context required by eventstudio
-        """Proxy method to process the event and send it to the target,
-        in addition it removes the field event-bus-name from the event,
-        required for EventStudio extension"""
-        self.send_event(event)
-
-    def process_event(self, event: FormattedEvent, context: RequestContext):
+    def process_event(self, event: FormattedEvent):
         # context required by eventstudio
         """Processes the event and send it to the target."""
+        event = event.copy()
         if isinstance(event, dict):
             event.pop("event-bus-name", None)
         if input_path := self.target.get("InputPath"):
             event = transform_event_with_target_input_path(input_path, event)
         if input_transformer := self.target.get("InputTransformer"):
             event = self.transform_event_with_target_input_transformer(input_transformer, event)
-        self.proxy_send_event(event, context)
+        self.send_event(event)
 
     def transform_event_with_target_input_transformer(
         self, input_transformer: InputTransformer, event: FormattedEvent

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -139,9 +139,7 @@ class TargetSender(ABC):
         pass
 
     def process_event(self, event: FormattedEvent):
-        # context required by eventstudio
         """Processes the event and send it to the target."""
-        event = event.copy()
         if isinstance(event, dict):
             event.pop("event-bus-name", None)
         if input_path := self.target.get("InputPath"):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
For EventStudio we introduced thread.local based propagation of trace_context, thus the context is not needed in the patched functions anymore.
Furthermore, a copy of a event is sent to target_sender since the same base event can be sent to multiple targets and modification further down the chain can happen. 
Also we handle capturing of transformation steps also inside the extension now, so the proxy_send_event is also no longer needed.

## Changes
- remove context input to patched methods
- decompose process_events
- add function to process single event from input events
- add proxy to capture event if no rule is attached
- add function to process individual rule

