### PR TITLE
Fix: Make secret value decoded for specific usecases

### DIFF
--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import re
 import time
-from typing import Final, Optional, Union
+from typing import Any, Dict, Final, Optional, Union
 
 import moto.secretsmanager.exceptions as moto_exception
 from botocore.utils import InvalidArnException
@@ -246,6 +247,8 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         self._raise_if_default_kms_key(secret_id, context, backend)
         try:
             response = backend.get_secret_value(secret_id, version_id, version_stage)
+            if should_decode_secret_binary(context):
+                response = decode_secret_binary_from_response(response)
         except moto_exception.SecretNotFoundException:
             raise ResourceNotFoundException(
                 f"Secrets Manager can't find the specified secret value for staging label: {version_stage}"
@@ -861,6 +864,19 @@ def get_resource_policy_model(self, secret_id):
 def get_resource_policy_response(self):
     secret_id = self._get_param("SecretId")
     return self.backend.get_resource_policy(secret_id=secret_id)
+
+
+def should_decode_secret_binary(context: RequestContext):
+    headers = context.request.headers
+    user_agents = headers.get("User-Agent", "").split(" ")
+    return not any(ua_val.startswith(("boto3", "botocore", "aws-cli")) for ua_val in user_agents)
+
+
+def decode_secret_binary_from_response(response: Dict[str, Any]):
+    if "SecretBinary" in response:
+        response["SecretBinary"] = base64.b64decode(response["SecretBinary"])
+
+    return response
 
 
 def delete_resource_policy_model(self, secret_id):

--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -247,8 +247,7 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         self._raise_if_default_kms_key(secret_id, context, backend)
         try:
             response = backend.get_secret_value(secret_id, version_id, version_stage)
-            if should_decode_secret_binary(context):
-                response = decode_secret_binary_from_response(response)
+            response = decode_secret_binary_from_response(response)
         except moto_exception.SecretNotFoundException:
             raise ResourceNotFoundException(
                 f"Secrets Manager can't find the specified secret value for staging label: {version_stage}"
@@ -864,12 +863,6 @@ def get_resource_policy_model(self, secret_id):
 def get_resource_policy_response(self):
     secret_id = self._get_param("SecretId")
     return self.backend.get_resource_policy(secret_id=secret_id)
-
-
-def should_decode_secret_binary(context: RequestContext):
-    headers = context.request.headers
-    user_agents = headers.get("User-Agent", "").split(" ")
-    return not any(ua_val.startswith(("boto3", "botocore", "aws-cli")) for ua_val in user_agents)
 
 
 def decode_secret_binary_from_response(response: Dict[str, Any]):

--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -5,7 +5,7 @@ import json
 import logging
 import re
 import time
-from typing import Any, Dict, Final, Optional, Union
+from typing import Any, Final, Optional, Union
 
 import moto.secretsmanager.exceptions as moto_exception
 from botocore.utils import InvalidArnException
@@ -865,7 +865,7 @@ def get_resource_policy_response(self):
     return self.backend.get_resource_policy(secret_id=secret_id)
 
 
-def decode_secret_binary_from_response(response: Dict[str, Any]):
+def decode_secret_binary_from_response(response: dict[str, Any]):
     if "SecretBinary" in response:
         response["SecretBinary"] = base64.b64decode(response["SecretBinary"])
 

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -2397,7 +2397,7 @@ class TestSecretsManager:
         sm_snapshot.match("mismatch_version_id_and_stage", exc.value.response)
 
     @markers.aws.validated
-    def test_get_secret_value_to_fix_11319(
+    def test_get_secret_value(
         self, aws_client, aws_http_client_factory, region_name, create_secret, sm_snapshot
     ):
         """

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -2396,7 +2396,7 @@ class TestSecretsManager:
             )
         sm_snapshot.match("mismatch_version_id_and_stage", exc.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_get_secret_value(self, aws_client, create_secret, sm_snapshot):
         secret_name = short_uid()
         secret_string = b"footest"
@@ -2412,9 +2412,11 @@ class TestSecretsManager:
 
         secret_arn = response["ARN"]
 
-        value_response = aws_client.secretsmanager.get_secret_value(SecretId=secret_arn)
+        secret_value_response = aws_client.secretsmanager.get_secret_value(SecretId=secret_arn)
 
-        assert value_response["SecretBinary"] == secret_string_b64_encoded
+        sm_snapshot.match("secret_value_response", secret_value_response)
+
+        assert secret_value_response["SecretBinary"] == secret_string_b64_encoded
 
 
 class TestSecretsManagerMultiAccounts:

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4510,8 +4510,8 @@
       "get_secret_value_stage_not_found_ex": "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret value for staging label: AWSPENDING"
     }
   },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
-    "recorded-date": "20-09-2024, 15:27:04",
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_to_fix_11319": {
+    "recorded-date": "20-09-2024, 15:38:39",
     "recorded-content": {
       "secret_value_response": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4510,8 +4510,8 @@
       "get_secret_value_stage_not_found_ex": "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret value for staging label: AWSPENDING"
     }
   },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_to_fix_11319": {
-    "recorded-date": "20-09-2024, 15:38:39",
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
+    "recorded-date": "24-09-2024, 11:18:11",
     "recorded-content": {
       "secret_value_response": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4509,5 +4509,24 @@
       "get_secret_value_version_not_found_ex": "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret value for VersionId: <version-id>",
       "get_secret_value_stage_not_found_ex": "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret value for staging label: AWSPENDING"
     }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
+    "recorded-date": "19-09-2024, 09:35:21",
+    "recorded-content": {
+      "secret_value_response": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "CreatedDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "SecretBinary": "b'Zm9vdGVzdA=='",
+        "VersionId": "<version_uuid:1>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4511,7 +4511,7 @@
     }
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
-    "recorded-date": "19-09-2024, 20:19:26",
+    "recorded-date": "20-09-2024, 15:27:04",
     "recorded-content": {
       "secret_value_response": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
@@ -4529,7 +4529,7 @@
       },
       "secret_value_http_response": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
-        "CreatedDate": 1726777166.068,
+        "CreatedDate": "datetime",
         "Name": "<SecretId-0idx>",
         "SecretBinary": "Zm9vdGVzdA==",
         "VersionId": "<version_uuid:1>",

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4511,13 +4511,13 @@
     }
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
-    "recorded-date": "19-09-2024, 09:35:21",
+    "recorded-date": "19-09-2024, 20:19:26",
     "recorded-content": {
       "secret_value_response": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "CreatedDate": "datetime",
         "Name": "<SecretId-0idx>",
-        "SecretBinary": "b'Zm9vdGVzdA=='",
+        "SecretBinary": "b'footest'",
         "VersionId": "<version_uuid:1>",
         "VersionStages": [
           "AWSCURRENT"
@@ -4526,6 +4526,16 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "secret_value_http_response": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "CreatedDate": 1726777166.068,
+        "Name": "<SecretId-0idx>",
+        "SecretBinary": "Zm9vdGVzdA==",
+        "VersionId": "<version_uuid:1>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ]
       }
     }
   }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -44,11 +44,11 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_random_exclude_characters_and_symbols": {
     "last_validated_date": "2024-03-15T08:12:01+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
+    "last_validated_date": "2024-09-24T11:19:00+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_errors": {
     "last_validated_date": "2024-04-11T05:37:47+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_to_fix_11319": {
-    "last_validated_date": "2024-09-20T15:39:12+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_invalid_secret_name[ Inv *?!]Name\\\\-]": {
     "last_validated_date": "2024-03-15T08:12:44+00:00"

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -45,7 +45,7 @@
     "last_validated_date": "2024-03-15T08:12:01+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
-    "last_validated_date": "2024-09-19T20:19:26+00:00"
+    "last_validated_date": "2024-09-20T15:28:46+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_errors": {
     "last_validated_date": "2024-04-11T05:37:47+00:00"

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -44,6 +44,9 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_random_exclude_characters_and_symbols": {
     "last_validated_date": "2024-03-15T08:12:01+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
+    "last_validated_date": "2024-09-19T09:35:21+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_errors": {
     "last_validated_date": "2024-04-11T05:37:47+00:00"
   },

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -45,7 +45,7 @@
     "last_validated_date": "2024-03-15T08:12:01+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
-    "last_validated_date": "2024-09-19T09:35:21+00:00"
+    "last_validated_date": "2024-09-19T20:19:26+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_errors": {
     "last_validated_date": "2024-04-11T05:37:47+00:00"

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -44,11 +44,11 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_random_exclude_characters_and_symbols": {
     "last_validated_date": "2024-03-15T08:12:01+00:00"
   },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
-    "last_validated_date": "2024-09-20T15:28:46+00:00"
-  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_errors": {
     "last_validated_date": "2024-04-11T05:37:47+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_to_fix_11319": {
+    "last_validated_date": "2024-09-20T15:39:12+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_invalid_secret_name[ Inv *?!]Name\\\\-]": {
     "last_validated_date": "2024-03-15T08:12:44+00:00"


### PR DESCRIPTION
## Motivation
With this PR I am trying to fix the bug mentioned on this issue : https://github.com/localstack/localstack/issues/11319

## Changes
I have fetched request from different SDK and HTTP Api, it seems the behaviour is return decoded value when requested from SDK. So added the change, to make the SecretBinary decoded all time.


## Testing
1. Added a test to fetch a secret when the SecretBinary should not be decoded
2. Added a test to fetch secret as http api request, where the SecretBinary should be decoded.
