### PR TITLE
fix S3 GetObject deadlock when using invalid Range

### DIFF
--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -531,6 +531,10 @@ class TestS3ObjectCRUD:
             aws_client.s3.get_object(Bucket=s3_bucket, Key=key, Range="bytes=100-200")
         snapshot.match("get-100-200", e.value.response)
 
+        # test that we can still put an object on the same key that failed GetObject with range request
+        put_obj = aws_client.s3.put_object(Bucket=s3_bucket, Key=key, Body=content * 2)
+        snapshot.match("put-after-failed", put_obj)
+
 
 @markers.snapshot.skip_snapshot_verify(condition=is_v2_provider, paths=["$..ServerSideEncryption"])
 class TestS3Multipart:

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -2798,7 +2798,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectCRUD::test_get_object_range": {
-    "recorded-date": "07-09-2023, 17:40:46",
+    "recorded-date": "18-09-2024, 13:05:07",
     "recorded-content": {
       "get-0-8": {
         "AcceptRanges": "bytes",
@@ -3026,6 +3026,14 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 416
+        }
+      },
+      "put-after-failed": {
+        "ETag": "\"be497c2168e374f414a351c49379c01a\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -90,7 +90,7 @@
     "last_validated_date": "2023-08-01T20:22:24+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectCRUD::test_get_object_range": {
-    "last_validated_date": "2023-09-07T15:40:46+00:00"
+    "last_validated_date": "2024-09-18T13:05:07+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectCRUD::test_get_object_with_version_unversioned_bucket": {
     "last_validated_date": "2023-07-26T22:53:12+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #11534, we entered a deadlock when calling `GetObject` with an invalid range, as we never released the lock that we purposefully do not release until the object has been released. However, there was an issue as we added validation after acquiring the lock, leading to LocalStack not returning the object, and the web server not calling `.close` on the S3 object. 

If in the future we need to add validation after acquiring the lock, we need to make sure to maybe wrap everything in a `try...except` block with the `return` in the `try` block, and release the lock in the `except` block. For now, this still seems safe to do how we are doing it, as if we have exceptions here, those should be fixed instead of putting tape over them, and a deadlock might not be the biggest issue. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update the validation to happen before acquiring the lock, thus removing the issue, and added a small test case to avoid regression

_fixes #11534_

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
