### PR TITLE
Fix libexpat1 CVEs from our debian bookworm base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN --mount=type=cache,target=/var/cache/apt \
         # Install dependencies to add additional repos
         apt-get install -y --no-install-recommends \
             # Runtime packages (groff-base is necessary for AWS CLI help)
-            ca-certificates curl gnupg git make openssl tar pixz zip unzip groff-base iputils-ping nss-passwords procps iproute2 xz-utils libatomic1 binutils
+            ca-certificates curl gnupg git make openssl tar pixz zip unzip groff-base iputils-ping nss-passwords procps iproute2 xz-utils libatomic1 binutils && \
+        # patch for CVE-2024-45490, CVE-2024-45491, CVE-2024-45492
+        apt-get install --only-upgrade libexpat1
 
 # FIXME Node 18 actually shouldn't be necessary in Community, but we assume its presence in lots of tests
 # Install nodejs package from the dist release server. Note: we're installing from dist binaries, and not via


### PR DESCRIPTION
## Motivation
During a CVE scan we noticed these vulnerabilities and this PR attempts to fix them by upgrading the corresponding package (`libexpat1`), used for XML parsing.


### CVEs addressed

- CVE-2024-45490
- CVE-2024-45491
- CVE-2024-45492

## Changes

Installs the upgraded version of `libexpat1` via `apt-get`. Currently this will resolve to `2.5.0-1+deb12u1` which includes the fix for the above mentioned CVEs.
