### PR TITLE
Eventbridge apig lambda parity test

### DIFF
--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -326,19 +326,16 @@ class ApiGatewayTargetSender(TargetSender):
         # Serialize the event, converting datetime objects to strings
         event_json = json.dumps(event, default=str)
 
-        try:
-            # Send the HTTP request
-            response = requests.request(
-                method=http_method, url=url, headers=headers, data=event_json, timeout=5
+         # Send the HTTP request
+        response = requests.request(
+            method=http_method, url=url, headers=headers, data=event_json, timeout=5
+        )
+        if not response.ok:
+            LOG.warning(
+                "API Gateway target invocation failed with status code %s, response: %s",
+                response.status_code,
+                response.text,
             )
-            if not response.ok:
-                LOG.warning(
-                    "API Gateway target invocation failed with status code %s, response: %s",
-                    response.status_code,
-                    response.text,
-                )
-        except requests.RequestException as e:
-            LOG.warning("Request failed: %s", e)
 
     def _validate_input(self, target: Target):
         super()._validate_input(target)

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -11,7 +11,6 @@ import requests
 from botocore.client import BaseClient
 
 from localstack import config
-from localstack.aws.api import RequestContext
 from localstack.aws.api.events import Arn, InputTransformer, RuleName, Target, TargetInputPath
 from localstack.aws.connect import connect_to
 from localstack.services.events.models import FormattedEvent, TransformedEvent, ValidationException
@@ -326,7 +325,7 @@ class ApiGatewayTargetSender(TargetSender):
         # Serialize the event, converting datetime objects to strings
         event_json = json.dumps(event, default=str)
 
-         # Send the HTTP request
+        # Send the HTTP request
         response = requests.request(
             method=http_method, url=url, headers=headers, data=event_json, timeout=5
         )

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -345,31 +345,6 @@ class ApiGatewayTargetSender(TargetSender):
         if not collections.get_safe(target, "$.RoleArn"):
             raise ValueError("RoleArn is required for ApiGateway target")
 
-    def process_event(self, event: Dict[str, Any], context: RequestContext):
-        """Processes the event, applies transformations, and sends it to the target."""
-        # Remove the 'event-bus-name' field if present
-        if isinstance(event, dict):
-            event.pop("event-bus-name", None)
-        # Handle 'Input' parameter
-        if "Input" in self.target:
-            event = json.loads(self.target["Input"])
-        elif "InputTransformer" in self.target:
-            input_transformer = self.target["InputTransformer"]
-            template_replacements = get_template_replacements(input_transformer, event)
-            predefined_template_replacements = self._get_predefined_template_replacements(event)
-            template_replacements.update(predefined_template_replacements)
-            input_template = input_transformer["InputTemplate"]
-            is_json_format = input_template.strip().startswith(("{"))
-            event = replace_template_placeholders(
-                input_template, template_replacements, is_json_format
-            )
-        elif "InputPath" in self.target:
-            event = transform_event_with_target_input_path(self.target["InputPath"], event)
-        else:
-            pass
-
-        self.send_event(event)
-
     def _get_predefined_template_replacements(self, event: Dict[str, Any]) -> Dict[str, Any]:
         """Extracts predefined values from the event."""
         predefined_template_replacements = {}

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -146,9 +146,9 @@ class TargetSender(ABC):
         """Processes the event and send it to the target."""
         if input_ := self.target.get("Input"):
             event = json.loads(input_)
-        else:
-            if isinstance(event, dict):
-                event.pop("event-bus-name", None)
+        if isinstance(event, dict):
+            event.pop("event-bus-name", None)
+        if not input_:
             if input_path := self.target.get("InputPath"):
                 event = transform_event_with_target_input_path(input_path, event)
             if input_transformer := self.target.get("InputTransformer"):

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -145,12 +145,15 @@ class TargetSender(ABC):
 
     def process_event(self, event: FormattedEvent):
         """Processes the event and send it to the target."""
-        if isinstance(event, dict):
-            event.pop("event-bus-name", None)
-        if input_path := self.target.get("InputPath"):
-            event = transform_event_with_target_input_path(input_path, event)
-        if input_transformer := self.target.get("InputTransformer"):
-            event = self.transform_event_with_target_input_transformer(input_transformer, event)
+        if input_ := self.target.get("Input"):
+            event = json.loads(input_)
+        else:
+            if isinstance(event, dict):
+                event.pop("event-bus-name", None)
+            if input_path := self.target.get("InputPath"):
+                event = transform_event_with_target_input_path(input_path, event)
+            if input_transformer := self.target.get("InputTransformer"):
+                event = self.transform_event_with_target_input_transformer(input_transformer, event)
         self.send_event(event)
 
     def transform_event_with_target_input_transformer(

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -17,7 +17,6 @@ from localstack.utils.aws import arns
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
 from localstack.utils.testutil import check_expected_lambda_log_events_length
-from localstack_snapshot.snapshots.transformer import TimestampTransformer
 from tests.aws.scenario.kinesis_firehose.conftest import get_all_expected_messages_from_s3
 from tests.aws.services.events.helper_functions import is_old_provider, sqs_collect_messages
 from tests.aws.services.events.test_events import EVENT_DETAIL, TEST_EVENT_PATTERN
@@ -35,41 +34,24 @@ from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON_ECHO_JSON_
 #   - Container (pro)
 #   - Redshift (pro)
 #   - Sagemaker (pro)
-
-import boto3
-import botocore.config
-
-
 class TestEventsTargetApiGateway:
     @markers.aws.validated
     def test_put_events_with_target_api_gateway(
         self,
         create_lambda_function,
+        create_rest_apigw,
         events_create_event_bus,
         events_put_rule,
         aws_client,
         snapshot,
-        create_role,
+        create_role_with_policy,
+        region_name,
+        account_id,
+        cleanups,
     ):
         # Add transformers for snapshot testing
         snapshot.add_transformer(snapshot.transform.lambda_api())
         snapshot.add_transformer(snapshot.transform.apigateway_api())
-
-        # Create a custom configuration with retries disabled
-        config = botocore.config.Config(
-            retries={
-                'max_attempts': 1,  # Disable retries
-                'mode': 'standard'
-            }
-        )
-
-        # Create AWS clients with the custom configuration
-        events_client = boto3.client('events', config=config)
-        lambda_client = boto3.client('lambda', config=config)
-        apigateway_client = boto3.client('apigateway', config=config)
-        logs_client = boto3.client('logs', config=config)
-        iam_client = boto3.client('iam', config=config)
-        sts_client = boto3.client('sts', config=config)
 
         # Step a: Create a Lambda function with a unique name using the existing fixture
         function_name = f"test-lambda-{short_uid()}"
@@ -77,7 +59,7 @@ class TestEventsTargetApiGateway:
         # Create the Lambda function with the correct handler
         create_lambda_response = create_lambda_function(
             func_name=function_name,
-            handler_file=TEST_LAMBDA_PYTHON_ECHO_JSON_BODY,
+            handler_file=TEST_LAMBDA_PYTHON_ECHO_JSON_BODY, 
             handler="lambda_echo_json_body.handler",
             runtime=Runtime.python3_9,
         )
@@ -86,24 +68,20 @@ class TestEventsTargetApiGateway:
         snapshot.match("create_lambda_response", create_lambda_response)
 
         # Step b: Set up an API Gateway
-        api_name = f"test-api-{short_uid()}"
-        api_response = apigateway_client.create_rest_api(
-            name=api_name,
-            description='Test API for EventBridge target',
+        api_id, _, root = create_rest_apigw(
+            name=f"test-api-${short_uid()}",
+            description="Test Integration with SQS",
         )
-        snapshot.match("api_response", api_response)
-        api_id = api_response['id']
-        stage_name = 'test'
 
         # Get the root resource ID
-        resources = apigateway_client.get_resources(restApiId=api_id)
+        resources = aws_client.apigateway.get_resources(restApiId=api_id)
         root_resource_id = next(
             (resource['id'] for resource in resources['items'] if resource['path'] == '/'),
             None
         )
 
         # Create a resource under the root
-        resource_response = apigateway_client.create_resource(
+        resource_response = aws_client.apigateway.create_resource(
             restApiId=api_id,
             parentId=root_resource_id,
             pathPart='test',
@@ -111,52 +89,48 @@ class TestEventsTargetApiGateway:
         resource_id = resource_response['id']
 
         # Set up POST method
-        apigateway_client.put_method(
+        aws_client.apigateway.put_method(
             restApiId=api_id,
             resourceId=resource_id,
             httpMethod='POST',
             authorizationType='NONE',
         )
 
+        # Define source_arn
+        source_arn = f'arn:aws:execute-api:{region_name}:{account_id}:{api_id}/*/POST/test'
+
         # Integrate the method with the Lambda function
-        apigateway_client.put_integration(
+        aws_client.apigateway.put_integration(
             restApiId=api_id,
             resourceId=resource_id,
             httpMethod='POST',
             type='AWS_PROXY',
             integrationHttpMethod='POST',
-            uri=f'arn:aws:apigateway:{apigateway_client.meta.region_name}:lambda:path/2015-03-31/functions/{lambda_arn}/invocations',
+            uri=f'arn:aws:apigateway:{region_name}:lambda:path/2015-03-31/functions/{lambda_arn}/invocations',
         )
 
         # Give permission to API Gateway to invoke Lambda
-        lambda_client.add_permission(
+        aws_client.lambda_.add_permission(
             FunctionName=function_name,
             StatementId=f'sid-{short_uid()}',
             Action='lambda:InvokeFunction',
             Principal='apigateway.amazonaws.com',
-            SourceArn=f'arn:aws:execute-api:{apigateway_client.meta.region_name}:{sts_client.get_caller_identity()["Account"]}:{api_id}/*/POST/test',
+            SourceArn=source_arn,
         )
 
         # Deploy the API to a 'test' stage
-        deployment = apigateway_client.create_deployment(
+        stage_name = 'test'
+        deployment = aws_client.apigateway.create_deployment(
             restApiId=api_id,
             stageName=stage_name,
         )
         snapshot.match("deployment_response", deployment)
 
-        # Construct the API invoke URL
-        api_invoke_url = f'https://{api_id}.execute-api.{apigateway_client.meta.region_name}.amazonaws.com/{stage_name}/test'
-
-        # Optionally test the API Gateway directly
-        # response = requests.post(api_invoke_url, json={"test": "data"})
-        # logger.info(f"API Gateway Invocation Response: {response.status_code}, {response.text}")
-
         # Step c: Create an EventBridge rule using the existing fixture
         # Create a new event bus
         event_bus_name = f"test-bus-{short_uid()}"
         event_bus_response = events_create_event_bus(Name=event_bus_name)
-        event_bus_arn = event_bus_response['EventBusArn']
-
+        snapshot.match("event_bus_response", event_bus_response)
         # Create a rule on this bus using the existing fixture
         rule_name = f"test-rule-{short_uid()}"
         event_pattern = {
@@ -170,10 +144,9 @@ class TestEventsTargetApiGateway:
             EventPattern=json.dumps(event_pattern),
         )
         snapshot.match("rule_response", rule_response)
-        rule_arn = rule_response['RuleArn']
 
         # Step d: Create an IAM Role for EventBridge to invoke API Gateway using the existing fixture
-        assume_role_policy_document = json.dumps({
+        assume_role_policy_document = {
             "Version": "2012-10-17",
             "Statement": [
                 {
@@ -182,33 +155,15 @@ class TestEventsTargetApiGateway:
                     "Action": "sts:AssumeRole"
                 }
             ]
-        })
+        }
 
-        # Policy to allow EventBridge to invoke the API Gateway endpoint
-        policy_document = json.dumps({
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Action": "execute-api:Invoke",
-                    "Resource": f'arn:aws:execute-api:{apigateway_client.meta.region_name}:{sts_client.get_caller_identity()["Account"]}:{api_id}/*/*/*'
-                }
-            ]
-        })
-
-        iam_role_name = f"EventBridge_Invoke_API_{short_uid()}"
-
-        # Use the existing 'create_role' fixture
-        create_role_response = create_role(
-            RoleName=iam_role_name,
-            AssumeRolePolicyDocument=assume_role_policy_document
-        )
-        role_arn = create_role_response['Role']['Arn']
-
-        iam_client.put_role_policy(
-            RoleName=iam_role_name,
-            PolicyName='InvokeApiPolicy',
-            PolicyDocument=policy_document
+        # Use the create_role_with_policy fixture
+        role_name, role_arn = create_role_with_policy(
+            effect="Allow",
+            actions="execute-api:Invoke",
+            assume_policy_doc=json.dumps(assume_role_policy_document),
+            resource=source_arn,
+            attach=False  # Since we're using put_role_policy, not attach_role_policy
         )
 
         # Allow some time for IAM role propagation (only needed in AWS)
@@ -219,9 +174,9 @@ class TestEventsTargetApiGateway:
         target_id = f"target-{short_uid()}"
 
         # Construct the API target ARN
-        api_target_arn = f'arn:aws:execute-api:{apigateway_client.meta.region_name}:{sts_client.get_caller_identity()["Account"]}:{api_id}/{stage_name}/POST/test'
+        api_target_arn = f'arn:aws:execute-api:{region_name}:{account_id}:{api_id}/{stage_name}/POST/test'
 
-        put_targets_response = events_client.put_targets(
+        put_targets_response = aws_client.events.put_targets(
             Rule=rule_name,
             EventBusName=event_bus_name,
             Targets=[
@@ -231,7 +186,7 @@ class TestEventsTargetApiGateway:
                     "RoleArn": role_arn,
                     "Input": json.dumps({"message": "Hello from EventBridge"}),
                     "RetryPolicy": {
-                        'MaximumRetryAttempts': 0 
+                        'MaximumRetryAttempts': 0
                     }
                 }
             ]
@@ -240,69 +195,38 @@ class TestEventsTargetApiGateway:
         assert put_targets_response['FailedEntryCount'] == 0
 
         # Step f: Send an event to EventBridge
-        import uuid
-
         event_entry = {
             "EventBusName": event_bus_name,
             "Source": "test.source",
             "DetailType": "test.detail.type",
             "Detail": json.dumps({"message": "Hello from EventBridge"})
         }
-        put_events_response = events_client.put_events(
+        put_events_response = aws_client.events.put_events(
             Entries=[event_entry]
         )
         snapshot.match("put_events_response", put_events_response)
         assert put_events_response['FailedEntryCount'] == 0
 
         # Step g: Verify the Lambda invocation
-        time.sleep(30) 
-        try:
-            events = retry(
-                check_expected_lambda_log_events_length,
-                retries=10,
-                sleep=10,
-                function_name=function_name,
-                expected_length=1,
-                logs_client=logs_client,
-            )
-            snapshot.match("lambda_logs", events)
-        except Exception as e:
-            pytest.fail(f"Lambda invocation verification failed: {e}")
+        events = retry(
+            check_expected_lambda_log_events_length,
+            retries=10,
+            sleep=10,
+            sleep_before=10,
+            function_name=function_name,
+            expected_length=1,
+            logs_client=aws_client.logs,
+        )
+        snapshot.match("lambda_logs", events)
 
         # Step h: Clean up resources
-        # Remove targets
-        events_client.remove_targets(
-            Rule=rule_name,
-            EventBusName=event_bus_name,
-            Ids=[target_id]
-        )
-        # Delete the rule
-        events_client.delete_rule(
-            Name=rule_name,
-            EventBusName=event_bus_name,
-            Force=True
-        )
-        # Delete the event bus
-        events_client.delete_event_bus(
-            Name=event_bus_name
-        )
-        # Delete the API Gateway
-        apigateway_client.delete_rest_api(
-            restApiId=api_id
-        )
-        # Delete the Lambda function
-        lambda_client.delete_function(
-            FunctionName=function_name
-        )
-        # Delete IAM role and policy
-        iam_client.delete_role_policy(
-            RoleName=iam_role_name,
-            PolicyName='InvokeApiPolicy'
-        )
-        iam_client.delete_role(
-            RoleName=iam_role_name
-        )
-
+        cleanups.append(lambda: aws_client.events.remove_targets(Rule=rule_name, EventBusName=event_bus_name, Ids=[target_id]))
+        cleanups.append(lambda: aws_client.events.delete_rule(Name=rule_name, EventBusName=event_bus_name))
+        cleanups.append(lambda: aws_client.events.delete_event_bus(Name=event_bus_name))
+        cleanups.append(lambda: aws_client.apigateway.delete_rest_api(restApiId=api_id))
+        cleanups.append(lambda: aws_client.lambda_.delete_function(FunctionName=function_name))
+        cleanups.append(lambda: aws_client.iam.delete_role_policy(RoleName=role_name, PolicyName=f'p-{role_name}'))
+        cleanups.append(lambda: aws_client.iam.delete_role(RoleName=role_name))
 
 class TestEventsTargetEvents:
     # cross region and cross account event bus to event buss tests are in test_events_cross_account_region.py
@@ -339,8 +263,6 @@ class TestEventsTargetEvents:
             event_bus_arn_target = events_create_event_bus(Name=event_bus_name_target)[
                 "EventBusArn"
             ]
-        
-        snapshot.add_transformer(transformers.DateTimeIsoTransformer())
 
         # Create permission for event bus source to send events to event bus target
         role_arn_bus_source_to_bus_target = create_role_event_bus_source_to_bus_target()
@@ -716,13 +638,13 @@ class TestEventsTargetLambda:
         # Get lambda's log events
         events = retry(
             check_expected_lambda_log_events_length,
-            retries=3,
-            sleep=1,
+            retries=10,
+            sleep=10,
+            sleep_before=10,
             function_name=function_name,
             expected_length=1,
             logs_client=aws_client.logs,
         )
-
         snapshot.match("events", events)
 
     @markers.aws.validated

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -59,7 +59,7 @@ class TestEventsTargetApiGateway:
             snapshot.transform.apigateway_api(),
             snapshot.transform.apigatewayv2_lambda_proxy_event(),
             snapshot.transform.key_value("CodeSha256"),
-            snapshot.transform.regex(r'"EventId":\s*"[^"]+"', '"EventId": "<event-id>"'),
+            snapshot.transform.key_value("EventId", reference_replacement=False),
             snapshot.transform.key_value(
                 "headers", value_replacement="<headers>", reference_replacement=False
             ),
@@ -104,7 +104,7 @@ class TestEventsTargetApiGateway:
         # Step b: Set up an API Gateway
         api_id, _, root = create_rest_apigw(
             name=f"test-api-${short_uid()}",
-            description="Test Integration with SQS",
+            description="Test Integration with EventBridge",
         )
 
         # Get the root resource ID

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -42,6 +42,7 @@ from tests.aws.services.lambda_.test_lambda import (
 #   - Sagemaker (pro)
 class TestEventsTargetApiGateway:
     @markers.aws.validated
+    @pytest.mark.skipif(is_old_provider(), reason="not supported by the old provider")
     def test_put_events_with_target_api_gateway(
         self,
         create_lambda_function,

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -69,7 +69,7 @@ class TestEventsTargetApiGateway:
         snapshot.match("create_lambda_response", create_lambda_response)
 
         # Register cleanup for Lambda function immediately after creation
-        cleanups.append(lambda: aws_client.lambda_.delete_function(FunctionName=function_name))
+        # cleanups.append(lambda: aws_client.lambda_.delete_function(FunctionName=function_name))
 
         # Step b: Set up an API Gateway
         api_id, _, root = create_rest_apigw(
@@ -78,7 +78,7 @@ class TestEventsTargetApiGateway:
         )
 
         # Register cleanup for API Gateway immediately after creation
-        cleanups.append(lambda: aws_client.apigateway.delete_rest_api(restApiId=api_id))
+        # cleanups.append(lambda: aws_client.apigateway.delete_rest_api(restApiId=api_id))
 
         # Get the root resource ID
         resources = aws_client.apigateway.get_resources(restApiId=api_id)
@@ -139,7 +139,7 @@ class TestEventsTargetApiGateway:
         snapshot.match("event_bus_response", event_bus_response)
 
         # Register cleanup for Event Bus immediately after creation
-        cleanups.append(lambda: aws_client.events.delete_event_bus(Name=event_bus_name))
+        # cleanups.append(lambda: aws_client.events.delete_event_bus(Name=event_bus_name))
 
         # Step d: Create a rule on this bus
         rule_name = f"test-rule-{short_uid()}"
@@ -155,7 +155,7 @@ class TestEventsTargetApiGateway:
         snapshot.match("rule_response", rule_response)
 
         # Register cleanup for Rule immediately after creation
-        cleanups.append(lambda: aws_client.events.delete_rule(Name=rule_name, EventBusName=event_bus_name))
+        # cleanups.append(lambda: aws_client.events.delete_rule(Name=rule_name, EventBusName=event_bus_name))
 
         # Step e: Create an IAM Role for EventBridge to invoke API Gateway
         assume_role_policy_document = {
@@ -177,8 +177,8 @@ class TestEventsTargetApiGateway:
         )
 
         # Register cleanups for IAM Role and Policy immediately after creation
-        cleanups.append(lambda: aws_client.iam.delete_role_policy(RoleName=role_name, PolicyName=f'p-{role_name}'))
-        cleanups.append(lambda: aws_client.iam.delete_role(RoleName=role_name))
+        # cleanups.append(lambda: aws_client.iam.delete_role_policy(RoleName=role_name, PolicyName=f'p-{role_name}'))
+        # cleanups.append(lambda: aws_client.iam.delete_role(RoleName=role_name))
 
         # Allow some time for IAM role propagation (only needed in AWS)
         if is_aws_cloud():
@@ -205,7 +205,7 @@ class TestEventsTargetApiGateway:
         assert put_targets_response['FailedEntryCount'] == 0
 
         # Register cleanup for the EventBridge target immediately after adding
-        cleanups.append(lambda: aws_client.events.remove_targets(Rule=rule_name, EventBusName=event_bus_name, Ids=[target_id]))
+        # cleanups.append(lambda: aws_client.events.remove_targets(Rule=rule_name, EventBusName=event_bus_name, Ids=[target_id]))
 
         # Step g: Send an event to EventBridge
         event_entry = {

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -38,16 +38,7 @@ from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON_ECHO_JSON_
 
 import boto3
 import botocore.config
-import json
-import time
-import pytest
-from localstack.utils.aws import aws_stack
-from localstack.utils.common import short_uid, retry
-from localstack.utils.aws.aws_utils import is_aws_cloud
-from localstack.services.awslambda.lambda_utils import Runtime
-from tests.integration.awslambda.test_lambda import TEST_LAMBDA_PYTHON_ECHO_JSON_BODY
-from tests.integration.events.test_events import check_expected_lambda_log_events_length
-from tests import markers
+
 
 class TestEventsTargetApiGateway:
     @markers.aws.validated
@@ -255,8 +246,7 @@ class TestEventsTargetApiGateway:
             "EventBusName": event_bus_name,
             "Source": "test.source",
             "DetailType": "test.detail.type",
-            "Detail": json.dumps({"message": "Hello from EventBridge"}),
-            "Id": str(uuid.uuid4())  # Unique identifier for the event
+            "Detail": json.dumps({"message": "Hello from EventBridge"})
         }
         put_events_response = events_client.put_events(
             Entries=[event_entry]

--- a/tests/aws/services/events/test_events_targets.snapshot.json
+++ b/tests/aws/services/events/test_events_targets.snapshot.json
@@ -671,7 +671,7 @@
     }
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
-    "recorded-date": "20-09-2024, 19:00:12",
+    "recorded-date": "21-09-2024, 00:08:15",
     "recorded-content": {
       "create_lambda_response": {
         "CreateEventSourceMappingResponse": null,
@@ -688,7 +688,7 @@
           "EphemeralStorage": {
             "Size": 512
           },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionArn": "arn:<partition>:lambda:<region>:<account-id:1>:function:<function-name:1>",
           "FunctionName": "<function-name:1>",
           "Handler": "lambda_aws_proxy_format.handler",
           "LastModified": "date",
@@ -699,7 +699,7 @@
           "MemorySize": 128,
           "PackageType": "Zip",
           "RevisionId": "<uuid:1>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+          "Role": "arn:<partition>:iam::<account-id:1>:role/<resource:1>",
           "Runtime": "python3.9",
           "RuntimeVersionConfig": {
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
@@ -731,14 +731,14 @@
         }
       },
       "event_bus_response": {
-        "EventBusArn": "arn:<partition>:events:<region>:111111111111:event-bus/<resource:3>",
+        "EventBusArn": "arn:<partition>:events:<region>:<account-id:1>:event-bus/<resource:3>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
       "rule_response": {
-        "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<resource:3>/<resource:4>",
+        "RuleArn": "arn:<partition>:events:<region>:<account-id:1>:rule/<resource:3>/<resource:4>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -755,7 +755,7 @@
       "put_events_response": {
         "Entries": [
           {
-            "EventId": "<uuid:2>"
+            "EventId": "<event-id>"
           }
         ],
         "FailedEntryCount": 0,
@@ -769,136 +769,42 @@
           "resource": "/test",
           "path": "/test/",
           "httpMethod": "POST",
-          "headers": {
-            "amz-sdk-invocation-id": "<uuid:3>",
-            "amz-sdk-request": "ttl=20240920T190046Z;attempt=1;max=4",
-            "amz-sdk-retry": "0/0/500",
-            "CloudFront-Forwarded-Proto": "https",
-            "CloudFront-Is-Desktop-Viewer": "true",
-            "CloudFront-Is-Mobile-Viewer": "false",
-            "CloudFront-Is-SmartTV-Viewer": "false",
-            "CloudFront-Is-Tablet-Viewer": "false",
-            "CloudFront-Viewer-ASN": "0",
-            "CloudFront-Viewer-Country": "US",
-            "Content-Type": "application/json",
-            "Host": "f84avh0zn0.execute-api.<region>.amazonaws.com",
-            "User-Agent": "aws-sdk-java/1.12.769 Linux/5.10.224-190.876.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.12+8-LTS java/17.0.12 scala/2.12.17 kotlin/1.5.32 vendor/Amazon.com_Inc. cfg/retry-mode/legacy",
-            "Via": "1.1 87231a08ea3c7f15402d76db2a29d98c.cloudfront.net (CloudFront)",
-            "X-Amz-Cf-Id": "Ardf8cUQXLrSCkK9ArbSlGGTgMOrUsOPbqhDQTbmhkQF8La-0EWyBw==",
-            "X-Amz-Date": "20240920T185956Z",
-            "X-Amz-Security-Token": "IQoJb3JpZ2luX2VjEEMaCXVzLWVhc3QtMSJGMEQCIEOkieAMGZmsiBnBldd7bODIH9Ge2BFMx1yWaYn3Iek2AiALWJgLoo5bttOW5HhwE4K88ZIQP5Ti3At/iRiNsGcZdyrjAgh8EAAaDDUzNTAwMjg2NjY4MiIMDLDWmOxilUAawlgKKsACR7cRgcmw73t+9nEuiL9ZycwfUBYycCV4cCdZOQi8pE+vSb0FgEEVfwaFPsNRtfLasu/lb9ZrxhkqtbU0axil5PDCUbnZlFsQC4VUAom9SS+qODRrOmw+/vgEsQKMj1h9gy1sKAWcy+XXecEFb9jdrYf62JJZZLIf9DhukA4IlGhAa8Qz0XnUNU9jzzTVbYxBlix8C5UdtWivlDXdgflK6bQz0/8z4RmxImJWq1stx/zZ9nOD/WjFhEccOE+hC7pL/tsaCI5/3q/2Y5AiVkekua8ZSbTppUL2qYYCbd2tWWGZHcyf51giQjsZyi9aioCylyXqMyB9JkTMfu1KIr6DWfelsIj4r7IUlnYRJDxZYbDS2y6hcnla7LzIeszeS+yvHqt/geDSPA4gODEiS+R4Zlpx3F0WaGFmi94ehbaIP7MwrIy3twY6wAHrQgfUSnDWsKeRqC0fVhAIddnjkDiWVVPEreVhL2XaKtRzV90tyWxxD94d8Zwpv4RSFlefhXzfQcg3Vh7H8NBdXSzBxGmLJ72q13G1YuP6NGK+7h3DPXKII4PdiXeykNnySTfoi4DXiWJct2J7Ij0mT6IZfpFy0PcRDhi/Gd8tJ7W/3bPFw28elgxpycGsD/N7zuvS/thwiHWZWA+p5bQ4xWdewerkTffKGhE4IUPeNghwvcuazIsOyDl9BkoNcl8=",
-            "X-Amz-Source-Account": "111111111111",
-            "X-Amz-Source-Arn": "arn:<partition>:events:<region>:111111111111:rule/<resource:3>/<resource:4>",
-            "X-Amzn-Trace-Id": "Root=1-66edc62c-4f6e17ee0bf9652c7a19217d",
-            "X-Forwarded-For": "15.221.161.50, 18.68.30.240",
-            "X-Forwarded-Port": "443",
-            "X-Forwarded-Proto": "https"
-          },
-          "multiValueHeaders": {
-            "amz-sdk-invocation-id": [
-              "<uuid:3>"
-            ],
-            "amz-sdk-request": [
-              "ttl=20240920T190046Z;attempt=1;max=4"
-            ],
-            "amz-sdk-retry": [
-              "0/0/500"
-            ],
-            "CloudFront-Forwarded-Proto": [
-              "https"
-            ],
-            "CloudFront-Is-Desktop-Viewer": [
-              "true"
-            ],
-            "CloudFront-Is-Mobile-Viewer": [
-              "false"
-            ],
-            "CloudFront-Is-SmartTV-Viewer": [
-              "false"
-            ],
-            "CloudFront-Is-Tablet-Viewer": [
-              "false"
-            ],
-            "CloudFront-Viewer-ASN": [
-              "0"
-            ],
-            "CloudFront-Viewer-Country": [
-              "US"
-            ],
-            "Content-Type": [
-              "application/json"
-            ],
-            "Host": [
-              "f84avh0zn0.execute-api.<region>.amazonaws.com"
-            ],
-            "User-Agent": [
-              "aws-sdk-java/1.12.769 Linux/5.10.224-190.876.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.12+8-LTS java/17.0.12 scala/2.12.17 kotlin/1.5.32 vendor/Amazon.com_Inc. cfg/retry-mode/legacy"
-            ],
-            "Via": [
-              "1.1 87231a08ea3c7f15402d76db2a29d98c.cloudfront.net (CloudFront)"
-            ],
-            "X-Amz-Cf-Id": [
-              "Ardf8cUQXLrSCkK9ArbSlGGTgMOrUsOPbqhDQTbmhkQF8La-0EWyBw=="
-            ],
-            "X-Amz-Date": [
-              "20240920T185956Z"
-            ],
-            "X-Amz-Security-Token": [
-              "IQoJb3JpZ2luX2VjEEMaCXVzLWVhc3QtMSJGMEQCIEOkieAMGZmsiBnBldd7bODIH9Ge2BFMx1yWaYn3Iek2AiALWJgLoo5bttOW5HhwE4K88ZIQP5Ti3At/iRiNsGcZdyrjAgh8EAAaDDUzNTAwMjg2NjY4MiIMDLDWmOxilUAawlgKKsACR7cRgcmw73t+9nEuiL9ZycwfUBYycCV4cCdZOQi8pE+vSb0FgEEVfwaFPsNRtfLasu/lb9ZrxhkqtbU0axil5PDCUbnZlFsQC4VUAom9SS+qODRrOmw+/vgEsQKMj1h9gy1sKAWcy+XXecEFb9jdrYf62JJZZLIf9DhukA4IlGhAa8Qz0XnUNU9jzzTVbYxBlix8C5UdtWivlDXdgflK6bQz0/8z4RmxImJWq1stx/zZ9nOD/WjFhEccOE+hC7pL/tsaCI5/3q/2Y5AiVkekua8ZSbTppUL2qYYCbd2tWWGZHcyf51giQjsZyi9aioCylyXqMyB9JkTMfu1KIr6DWfelsIj4r7IUlnYRJDxZYbDS2y6hcnla7LzIeszeS+yvHqt/geDSPA4gODEiS+R4Zlpx3F0WaGFmi94ehbaIP7MwrIy3twY6wAHrQgfUSnDWsKeRqC0fVhAIddnjkDiWVVPEreVhL2XaKtRzV90tyWxxD94d8Zwpv4RSFlefhXzfQcg3Vh7H8NBdXSzBxGmLJ72q13G1YuP6NGK+7h3DPXKII4PdiXeykNnySTfoi4DXiWJct2J7Ij0mT6IZfpFy0PcRDhi/Gd8tJ7W/3bPFw28elgxpycGsD/N7zuvS/thwiHWZWA+p5bQ4xWdewerkTffKGhE4IUPeNghwvcuazIsOyDl9BkoNcl8="
-            ],
-            "X-Amz-Source-Account": [
-              "111111111111"
-            ],
-            "X-Amz-Source-Arn": [
-              "arn:<partition>:events:<region>:111111111111:rule/<resource:3>/<resource:4>"
-            ],
-            "X-Amzn-Trace-Id": [
-              "Root=1-66edc62c-4f6e17ee0bf9652c7a19217d"
-            ],
-            "X-Forwarded-For": [
-              "15.221.161.50, 18.68.30.240"
-            ],
-            "X-Forwarded-Port": [
-              "443"
-            ],
-            "X-Forwarded-Proto": [
-              "https"
-            ]
-          },
+          "headers": "<headers>",
+          "multiValueHeaders": "<multiValueHeaders>",
           "queryStringParameters": null,
           "multiValueQueryStringParameters": null,
           "pathParameters": null,
           "stageVariables": null,
           "requestContext": {
-            "resourceId": "6lce7i",
+            "resourceId": "<resource-id:1>",
             "resourcePath": "/test",
             "httpMethod": "POST",
-            "extendedRequestId": "eavnBH7RoAMEM_g=",
-            "requestTime": "20/Sep/2024:18:59:56 +0000",
+            "extendedRequestId": "<extended-request-id:1>",
+            "requestTime": "<request-time>",
             "path": "/test/test/",
-            "accountId": "111111111111",
+            "accountId": "<account-id:1>",
             "protocol": "HTTP/1.1",
             "stage": "test",
-            "domainPrefix": "f84avh0zn0",
-            "requestTimeEpoch": 1726858796693,
-            "requestId": "<uuid:4>",
+            "domainPrefix": "<api-id:1>",
+            "requestTimeEpoch": "<request-time-epoch>",
+            "requestId": "<request-id:1>",
             "identity": {
               "cognitoIdentityPoolId": null,
               "accountId": null,
               "cognitoIdentityId": null,
               "caller": null,
-              "sourceIp": "15.221.161.50",
+              "sourceIp": "<source-ip:1>",
               "principalOrgId": null,
               "accessKey": null,
               "cognitoAuthenticationType": null,
               "cognitoAuthenticationProvider": null,
               "userArn": null,
-              "userAgent": "aws-sdk-java/1.12.769 Linux/5.10.224-190.876.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.12+8-LTS java/17.0.12 scala/2.12.17 kotlin/1.5.32 vendor/Amazon.com_Inc. cfg/retry-mode/legacy",
+              "userAgent": "<user-agent:1>",
               "user": null
             },
-            "domainName": "f84avh0zn0.execute-api.<region>.amazonaws.com",
+            "domainName": "<api-id:1>.execute-api.<region>.amazonaws.com",
             "deploymentId": "<id:1>",
-            "apiId": "f84avh0zn0"
+            "apiId": "<api-id:1>"
           },
           "body": {
             "message": "Hello from EventBridge"

--- a/tests/aws/services/events/test_events_targets.snapshot.json
+++ b/tests/aws/services/events/test_events_targets.snapshot.json
@@ -671,7 +671,7 @@
     }
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
-    "recorded-date": "19-09-2024, 19:32:01",
+    "recorded-date": "20-09-2024, 19:00:12",
     "recorded-content": {
       "create_lambda_response": {
         "CreateEventSourceMappingResponse": null,
@@ -679,7 +679,7 @@
           "Architectures": [
             "x86_64"
           ],
-          "CodeSha256": "sXbjOPfOag8wOGYl3EzZyMHpQOsmtwP4xiaKKO8DZsM=",
+          "CodeSha256": "<code-sha256:1>",
           "CodeSize": "<code-size>",
           "Description": "",
           "Environment": {
@@ -690,7 +690,7 @@
           },
           "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
           "FunctionName": "<function-name:1>",
-          "Handler": "lambda_echo_json_body.handler",
+          "Handler": "lambda_aws_proxy_format.handler",
           "LastModified": "date",
           "LoggingConfig": {
             "LogFormat": "Text",
@@ -765,7 +765,146 @@
         }
       },
       "lambda_logs": [
-        "Received event: {\"resource\": \"/test\", \"path\": \"/test/\", \"httpMethod\": \"POST\", \"headers\": {\"amz-sdk-invocation-id\": \"56c9681d-874c-ef1b-876b-f3985d9d1fa0\", \"amz-sdk-request\": \"ttl=20240919T193234Z;attempt=1;max=4\", \"amz-sdk-retry\": \"0/0/500\", \"CloudFront-Forwarded-Proto\": \"https\", \"CloudFront-Is-Desktop-Viewer\": \"true\", \"CloudFront-Is-Mobile-Viewer\": \"false\", \"CloudFront-Is-SmartTV-Viewer\": \"false\", \"CloudFront-Is-Tablet-Viewer\": \"false\", \"CloudFront-Viewer-ASN\": \"16509\", \"CloudFront-Viewer-Country\": \"US\", \"Content-Type\": \"application/json\", \"Host\": \"sp260dl21k.execute-api.<region>.amazonaws.com\", \"User-Agent\": \"aws-sdk-java/1.12.769 Linux/5.10.224-190.876.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.12+8-LTS java/17.0.12 scala/2.12.17 kotlin/1.5.32 vendor/Amazon.com_Inc. cfg/retry-mode/legacy\", \"Via\": \"1.1 a929b4bfaa0111e3feb7c4dbffdbd8d8.cloudfront.net (CloudFront)\", \"X-Amz-Cf-Id\": \"BKQQYBXKENj_W1ZK2LDm_YMuNXI1XHU9isWbrESHAhr5lfFoNcg0vg==\", \"X-Amz-Date\": \"20240919T193144Z\", \"X-Amz-Security-Token\": \"IQoJb3JpZ2luX2VjECwaCXVzLWVhc3QtMSJIMEYCIQDvt7mWI5G/D00yl23M9LKlTTPdeqQg49Vt7NJ8CxvBRQIhAIM/C7B3vq8swY/BwtVMQ1pRJGTkVLRlc2K91GP73/4OKuMCCGUQABoMNTM1MDAyODY2NjgyIgxSjjvKlfZx7lJImTwqwAJuXUDPlL7a9zlcLfiIa5IGDlKRzQKumT+0Hs0bcH4k90qBGqocF4CE785VDt70RSyTsdNY33m3v03W2e+D3gk+Fygkld5xasYKt6Uhd0FuoVFvNeY/dKhfQUVukvdCuc3aVo86KUHWQY2Ot2ZHKjXKsbnuiS57kVsgayS4sOMLuVsCv9hrSG5Ek85l/+TAdtOHekNU2hV5Bus2iPhsI7HL+vjgMCsdvZDz9Pq4tF56lnXEF41LJahHJc01nAd2RaNJysgWmEjKeylo0zTvKb17xWywGsb31cHonmnLj1bhB0nfzOBhwKZdzfEOVw54OR5BLLb1+14t4RmivjZfXoRlJUMKQ+mgVt1Td4k5aTUXN4vo9gcvN8GRQA7xuLHoGCZpTuEz0UyHSrG5596xtZ1pvilNAJnTBrkuRImmB2h3JTCg+LG3Bjq+AUOgEmpmLhONNqo12HBQg93wD87quqtbU5xaAxEKGngF2nG+oDV/iRYpkgP3jhCzYY0PyXdmPgYMVO6RJpB/mt5LyURq0qz9or/J0qbXW2aYufyqGnfxfx0Swcdr5dIPKWsu+YpScElR9LP33wiUZpvNWee/qcXO2S7Y8vHVTsOuRfml5W7Tlz53xfVgvVg9JA/Iv0LS2sYaiwKoGH+TC4tbXvBBBOVPcGFoUFu2wBC1XtVX+MAKRcxM0LTkfEM=\", \"X-Amz-Source-Account\": \"111111111111\", \"X-Amz-Source-Arn\": \"arn:<partition>:events:<region>:111111111111:rule/<resource:3>/<resource:4>\", \"X-Amzn-Trace-Id\": \"Root=1-66ec7c21-44b7c5793da6158925dd8353\", \"X-Forwarded-For\": \"72.21.217.42, 70.132.32.74\", \"X-Forwarded-Port\": \"443\", \"X-Forwarded-Proto\": \"https\"}, \"multiValueHeaders\": {\"amz-sdk-invocation-id\": [\"56c9681d-874c-ef1b-876b-f3985d9d1fa0\"], \"amz-sdk-request\": [\"ttl=20240919T193234Z;attempt=1;max=4\"], \"amz-sdk-retry\": [\"0/0/500\"], \"CloudFront-Forwarded-Proto\": [\"https\"], \"CloudFront-Is-Desktop-Viewer\": [\"true\"], \"CloudFront-Is-Mobile-Viewer\": [\"false\"], \"CloudFront-Is-SmartTV-Viewer\": [\"false\"], \"CloudFront-Is-Tablet-Viewer\": [\"false\"], \"CloudFront-Viewer-ASN\": [\"16509\"], \"CloudFront-Viewer-Country\": [\"US\"], \"Content-Type\": [\"application/json\"], \"Host\": [\"sp260dl21k.execute-api.<region>.amazonaws.com\"], \"User-Agent\": [\"aws-sdk-java/1.12.769 Linux/5.10.224-190.876.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.12+8-LTS java/17.0.12 scala/2.12.17 kotlin/1.5.32 vendor/Amazon.com_Inc. cfg/retry-mode/legacy\"], \"Via\": [\"1.1 a929b4bfaa0111e3feb7c4dbffdbd8d8.cloudfront.net (CloudFront)\"], \"X-Amz-Cf-Id\": [\"BKQQYBXKENj_W1ZK2LDm_YMuNXI1XHU9isWbrESHAhr5lfFoNcg0vg==\"], \"X-Amz-Date\": [\"20240919T193144Z\"], \"X-Amz-Security-Token\": [\"IQoJb3JpZ2luX2VjECwaCXVzLWVhc3QtMSJIMEYCIQDvt7mWI5G/D00yl23M9LKlTTPdeqQg49Vt7NJ8CxvBRQIhAIM/C7B3vq8swY/BwtVMQ1pRJGTkVLRlc2K91GP73/4OKuMCCGUQABoMNTM1MDAyODY2NjgyIgxSjjvKlfZx7lJImTwqwAJuXUDPlL7a9zlcLfiIa5IGDlKRzQKumT+0Hs0bcH4k90qBGqocF4CE785VDt70RSyTsdNY33m3v03W2e+D3gk+Fygkld5xasYKt6Uhd0FuoVFvNeY/dKhfQUVukvdCuc3aVo86KUHWQY2Ot2ZHKjXKsbnuiS57kVsgayS4sOMLuVsCv9hrSG5Ek85l/+TAdtOHekNU2hV5Bus2iPhsI7HL+vjgMCsdvZDz9Pq4tF56lnXEF41LJahHJc01nAd2RaNJysgWmEjKeylo0zTvKb17xWywGsb31cHonmnLj1bhB0nfzOBhwKZdzfEOVw54OR5BLLb1+14t4RmivjZfXoRlJUMKQ+mgVt1Td4k5aTUXN4vo9gcvN8GRQA7xuLHoGCZpTuEz0UyHSrG5596xtZ1pvilNAJnTBrkuRImmB2h3JTCg+LG3Bjq+AUOgEmpmLhONNqo12HBQg93wD87quqtbU5xaAxEKGngF2nG+oDV/iRYpkgP3jhCzYY0PyXdmPgYMVO6RJpB/mt5LyURq0qz9or/J0qbXW2aYufyqGnfxfx0Swcdr5dIPKWsu+YpScElR9LP33wiUZpvNWee/qcXO2S7Y8vHVTsOuRfml5W7Tlz53xfVgvVg9JA/Iv0LS2sYaiwKoGH+TC4tbXvBBBOVPcGFoUFu2wBC1XtVX+MAKRcxM0LTkfEM=\"], \"X-Amz-Source-Account\": [\"111111111111\"], \"X-Amz-Source-Arn\": [\"arn:<partition>:events:<region>:111111111111:rule/<resource:3>/<resource:4>\"], \"X-Amzn-Trace-Id\": [\"Root=1-66ec7c21-44b7c5793da6158925dd8353\"], \"X-Forwarded-For\": [\"72.21.217.42, 70.132.32.74\"], \"X-Forwarded-Port\": [\"443\"], \"X-Forwarded-Proto\": [\"https\"]}, \"queryStringParameters\": null, \"multiValueQueryStringParameters\": null, \"pathParameters\": null, \"stageVariables\": null, \"requestContext\": {\"resourceId\": \"7a07rd\", \"resourcePath\": \"/test\", \"httpMethod\": \"POST\", \"extendedRequestId\": \"eXhVNFPooAMELnA=\", \"requestTime\": \"19/Sep/2024:19:31:45 +0000\", \"path\": \"/test/test/\", \"accountId\": \"111111111111\", \"protocol\": \"HTTP/1.1\", \"stage\": \"test\", \"domainPrefix\": \"sp260dl21k\", \"requestTimeEpoch\": 1726774305007, \"requestId\": \"3ae58bde-9ef6-4867-af27-361dd207f942\", \"identity\": {\"cognitoIdentityPoolId\": null, \"accountId\": null, \"cognitoIdentityId\": null, \"caller\": null, \"sourceIp\": \"72.21.217.42\", \"principalOrgId\": null, \"accessKey\": null, \"cognitoAuthenticationType\": null, \"cognitoAuthenticationProvider\": null, \"userArn\": null, \"userAgent\": \"aws-sdk-java/1.12.769 Linux/5.10.224-190.876.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.12+8-LTS java/17.0.12 scala/2.12.17 kotlin/1.5.32 vendor/Amazon.com_Inc. cfg/retry-mode/legacy\", \"user\": null}, \"domainName\": \"sp260dl21k.execute-api.<region>.amazonaws.com\", \"deploymentId\": \"<id:1>\", \"apiId\": \"sp260dl21k\"}, \"body\": \"{\\\"message\\\": \\\"Hello from EventBridge\\\"}\", \"isBase64Encoded\": false}\n"
+        {
+          "resource": "/test",
+          "path": "/test/",
+          "httpMethod": "POST",
+          "headers": {
+            "amz-sdk-invocation-id": "<uuid:3>",
+            "amz-sdk-request": "ttl=20240920T190046Z;attempt=1;max=4",
+            "amz-sdk-retry": "0/0/500",
+            "CloudFront-Forwarded-Proto": "https",
+            "CloudFront-Is-Desktop-Viewer": "true",
+            "CloudFront-Is-Mobile-Viewer": "false",
+            "CloudFront-Is-SmartTV-Viewer": "false",
+            "CloudFront-Is-Tablet-Viewer": "false",
+            "CloudFront-Viewer-ASN": "0",
+            "CloudFront-Viewer-Country": "US",
+            "Content-Type": "application/json",
+            "Host": "f84avh0zn0.execute-api.<region>.amazonaws.com",
+            "User-Agent": "aws-sdk-java/1.12.769 Linux/5.10.224-190.876.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.12+8-LTS java/17.0.12 scala/2.12.17 kotlin/1.5.32 vendor/Amazon.com_Inc. cfg/retry-mode/legacy",
+            "Via": "1.1 87231a08ea3c7f15402d76db2a29d98c.cloudfront.net (CloudFront)",
+            "X-Amz-Cf-Id": "Ardf8cUQXLrSCkK9ArbSlGGTgMOrUsOPbqhDQTbmhkQF8La-0EWyBw==",
+            "X-Amz-Date": "20240920T185956Z",
+            "X-Amz-Security-Token": "IQoJb3JpZ2luX2VjEEMaCXVzLWVhc3QtMSJGMEQCIEOkieAMGZmsiBnBldd7bODIH9Ge2BFMx1yWaYn3Iek2AiALWJgLoo5bttOW5HhwE4K88ZIQP5Ti3At/iRiNsGcZdyrjAgh8EAAaDDUzNTAwMjg2NjY4MiIMDLDWmOxilUAawlgKKsACR7cRgcmw73t+9nEuiL9ZycwfUBYycCV4cCdZOQi8pE+vSb0FgEEVfwaFPsNRtfLasu/lb9ZrxhkqtbU0axil5PDCUbnZlFsQC4VUAom9SS+qODRrOmw+/vgEsQKMj1h9gy1sKAWcy+XXecEFb9jdrYf62JJZZLIf9DhukA4IlGhAa8Qz0XnUNU9jzzTVbYxBlix8C5UdtWivlDXdgflK6bQz0/8z4RmxImJWq1stx/zZ9nOD/WjFhEccOE+hC7pL/tsaCI5/3q/2Y5AiVkekua8ZSbTppUL2qYYCbd2tWWGZHcyf51giQjsZyi9aioCylyXqMyB9JkTMfu1KIr6DWfelsIj4r7IUlnYRJDxZYbDS2y6hcnla7LzIeszeS+yvHqt/geDSPA4gODEiS+R4Zlpx3F0WaGFmi94ehbaIP7MwrIy3twY6wAHrQgfUSnDWsKeRqC0fVhAIddnjkDiWVVPEreVhL2XaKtRzV90tyWxxD94d8Zwpv4RSFlefhXzfQcg3Vh7H8NBdXSzBxGmLJ72q13G1YuP6NGK+7h3DPXKII4PdiXeykNnySTfoi4DXiWJct2J7Ij0mT6IZfpFy0PcRDhi/Gd8tJ7W/3bPFw28elgxpycGsD/N7zuvS/thwiHWZWA+p5bQ4xWdewerkTffKGhE4IUPeNghwvcuazIsOyDl9BkoNcl8=",
+            "X-Amz-Source-Account": "111111111111",
+            "X-Amz-Source-Arn": "arn:<partition>:events:<region>:111111111111:rule/<resource:3>/<resource:4>",
+            "X-Amzn-Trace-Id": "Root=1-66edc62c-4f6e17ee0bf9652c7a19217d",
+            "X-Forwarded-For": "15.221.161.50, 18.68.30.240",
+            "X-Forwarded-Port": "443",
+            "X-Forwarded-Proto": "https"
+          },
+          "multiValueHeaders": {
+            "amz-sdk-invocation-id": [
+              "<uuid:3>"
+            ],
+            "amz-sdk-request": [
+              "ttl=20240920T190046Z;attempt=1;max=4"
+            ],
+            "amz-sdk-retry": [
+              "0/0/500"
+            ],
+            "CloudFront-Forwarded-Proto": [
+              "https"
+            ],
+            "CloudFront-Is-Desktop-Viewer": [
+              "true"
+            ],
+            "CloudFront-Is-Mobile-Viewer": [
+              "false"
+            ],
+            "CloudFront-Is-SmartTV-Viewer": [
+              "false"
+            ],
+            "CloudFront-Is-Tablet-Viewer": [
+              "false"
+            ],
+            "CloudFront-Viewer-ASN": [
+              "0"
+            ],
+            "CloudFront-Viewer-Country": [
+              "US"
+            ],
+            "Content-Type": [
+              "application/json"
+            ],
+            "Host": [
+              "f84avh0zn0.execute-api.<region>.amazonaws.com"
+            ],
+            "User-Agent": [
+              "aws-sdk-java/1.12.769 Linux/5.10.224-190.876.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.12+8-LTS java/17.0.12 scala/2.12.17 kotlin/1.5.32 vendor/Amazon.com_Inc. cfg/retry-mode/legacy"
+            ],
+            "Via": [
+              "1.1 87231a08ea3c7f15402d76db2a29d98c.cloudfront.net (CloudFront)"
+            ],
+            "X-Amz-Cf-Id": [
+              "Ardf8cUQXLrSCkK9ArbSlGGTgMOrUsOPbqhDQTbmhkQF8La-0EWyBw=="
+            ],
+            "X-Amz-Date": [
+              "20240920T185956Z"
+            ],
+            "X-Amz-Security-Token": [
+              "IQoJb3JpZ2luX2VjEEMaCXVzLWVhc3QtMSJGMEQCIEOkieAMGZmsiBnBldd7bODIH9Ge2BFMx1yWaYn3Iek2AiALWJgLoo5bttOW5HhwE4K88ZIQP5Ti3At/iRiNsGcZdyrjAgh8EAAaDDUzNTAwMjg2NjY4MiIMDLDWmOxilUAawlgKKsACR7cRgcmw73t+9nEuiL9ZycwfUBYycCV4cCdZOQi8pE+vSb0FgEEVfwaFPsNRtfLasu/lb9ZrxhkqtbU0axil5PDCUbnZlFsQC4VUAom9SS+qODRrOmw+/vgEsQKMj1h9gy1sKAWcy+XXecEFb9jdrYf62JJZZLIf9DhukA4IlGhAa8Qz0XnUNU9jzzTVbYxBlix8C5UdtWivlDXdgflK6bQz0/8z4RmxImJWq1stx/zZ9nOD/WjFhEccOE+hC7pL/tsaCI5/3q/2Y5AiVkekua8ZSbTppUL2qYYCbd2tWWGZHcyf51giQjsZyi9aioCylyXqMyB9JkTMfu1KIr6DWfelsIj4r7IUlnYRJDxZYbDS2y6hcnla7LzIeszeS+yvHqt/geDSPA4gODEiS+R4Zlpx3F0WaGFmi94ehbaIP7MwrIy3twY6wAHrQgfUSnDWsKeRqC0fVhAIddnjkDiWVVPEreVhL2XaKtRzV90tyWxxD94d8Zwpv4RSFlefhXzfQcg3Vh7H8NBdXSzBxGmLJ72q13G1YuP6NGK+7h3DPXKII4PdiXeykNnySTfoi4DXiWJct2J7Ij0mT6IZfpFy0PcRDhi/Gd8tJ7W/3bPFw28elgxpycGsD/N7zuvS/thwiHWZWA+p5bQ4xWdewerkTffKGhE4IUPeNghwvcuazIsOyDl9BkoNcl8="
+            ],
+            "X-Amz-Source-Account": [
+              "111111111111"
+            ],
+            "X-Amz-Source-Arn": [
+              "arn:<partition>:events:<region>:111111111111:rule/<resource:3>/<resource:4>"
+            ],
+            "X-Amzn-Trace-Id": [
+              "Root=1-66edc62c-4f6e17ee0bf9652c7a19217d"
+            ],
+            "X-Forwarded-For": [
+              "15.221.161.50, 18.68.30.240"
+            ],
+            "X-Forwarded-Port": [
+              "443"
+            ],
+            "X-Forwarded-Proto": [
+              "https"
+            ]
+          },
+          "queryStringParameters": null,
+          "multiValueQueryStringParameters": null,
+          "pathParameters": null,
+          "stageVariables": null,
+          "requestContext": {
+            "resourceId": "6lce7i",
+            "resourcePath": "/test",
+            "httpMethod": "POST",
+            "extendedRequestId": "eavnBH7RoAMEM_g=",
+            "requestTime": "20/Sep/2024:18:59:56 +0000",
+            "path": "/test/test/",
+            "accountId": "111111111111",
+            "protocol": "HTTP/1.1",
+            "stage": "test",
+            "domainPrefix": "f84avh0zn0",
+            "requestTimeEpoch": 1726858796693,
+            "requestId": "<uuid:4>",
+            "identity": {
+              "cognitoIdentityPoolId": null,
+              "accountId": null,
+              "cognitoIdentityId": null,
+              "caller": null,
+              "sourceIp": "15.221.161.50",
+              "principalOrgId": null,
+              "accessKey": null,
+              "cognitoAuthenticationType": null,
+              "cognitoAuthenticationProvider": null,
+              "userArn": null,
+              "userAgent": "aws-sdk-java/1.12.769 Linux/5.10.224-190.876.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.12+8-LTS java/17.0.12 scala/2.12.17 kotlin/1.5.32 vendor/Amazon.com_Inc. cfg/retry-mode/legacy",
+              "user": null
+            },
+            "domainName": "f84avh0zn0.execute-api.<region>.amazonaws.com",
+            "deploymentId": "<id:1>",
+            "apiId": "f84avh0zn0"
+          },
+          "body": {
+            "message": "Hello from EventBridge"
+          },
+          "isBase64Encoded": false
+        }
       ]
     }
   }

--- a/tests/aws/services/events/test_events_targets.snapshot.json
+++ b/tests/aws/services/events/test_events_targets.snapshot.json
@@ -671,7 +671,7 @@
     }
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
-    "recorded-date": "21-09-2024, 00:08:15",
+    "recorded-date": "21-09-2024, 07:40:28",
     "recorded-content": {
       "create_lambda_response": {
         "CreateEventSourceMappingResponse": null,
@@ -773,39 +773,9 @@
           "multiValueHeaders": "<multiValueHeaders>",
           "queryStringParameters": null,
           "multiValueQueryStringParameters": null,
-          "pathParameters": null,
-          "stageVariables": null,
-          "requestContext": {
-            "resourceId": "<resource-id:1>",
-            "resourcePath": "/test",
-            "httpMethod": "POST",
-            "extendedRequestId": "<extended-request-id:1>",
-            "requestTime": "<request-time>",
-            "path": "/test/test/",
-            "accountId": "<account-id:1>",
-            "protocol": "HTTP/1.1",
-            "stage": "test",
-            "domainPrefix": "<api-id:1>",
-            "requestTimeEpoch": "<request-time-epoch>",
-            "requestId": "<request-id:1>",
-            "identity": {
-              "cognitoIdentityPoolId": null,
-              "accountId": null,
-              "cognitoIdentityId": null,
-              "caller": null,
-              "sourceIp": "<source-ip:1>",
-              "principalOrgId": null,
-              "accessKey": null,
-              "cognitoAuthenticationType": null,
-              "cognitoAuthenticationProvider": null,
-              "userArn": null,
-              "userAgent": "<user-agent:1>",
-              "user": null
-            },
-            "domainName": "<api-id:1>.execute-api.<region>.amazonaws.com",
-            "deploymentId": "<id:1>",
-            "apiId": "<api-id:1>"
-          },
+          "pathParameters": "<pathParameters>",
+          "stageVariables": "<stageVariables>",
+          "requestContext": "<requestContext>",
           "body": {
             "message": "Hello from EventBridge"
           },

--- a/tests/aws/services/events/test_events_targets.snapshot.json
+++ b/tests/aws/services/events/test_events_targets.snapshot.json
@@ -669,5 +669,104 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
+    "recorded-date": "19-09-2024, 19:32:01",
+    "recorded-content": {
+      "create_lambda_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "sXbjOPfOag8wOGYl3EzZyMHpQOsmtwP4xiaKKO8DZsM=",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "lambda_echo_json_body.handler",
+          "LastModified": "date",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "deployment_response": {
+        "createdDate": "datetime",
+        "id": "<id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "event_bus_response": {
+        "EventBusArn": "arn:<partition>:events:<region>:111111111111:event-bus/<resource:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "rule_response": {
+        "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<resource:3>/<resource:4>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put_targets_response": {
+        "FailedEntries": [],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put_events_response": {
+        "Entries": [
+          {
+            "EventId": "<uuid:2>"
+          }
+        ],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "lambda_logs": [
+        "Received event: {\"resource\": \"/test\", \"path\": \"/test/\", \"httpMethod\": \"POST\", \"headers\": {\"amz-sdk-invocation-id\": \"56c9681d-874c-ef1b-876b-f3985d9d1fa0\", \"amz-sdk-request\": \"ttl=20240919T193234Z;attempt=1;max=4\", \"amz-sdk-retry\": \"0/0/500\", \"CloudFront-Forwarded-Proto\": \"https\", \"CloudFront-Is-Desktop-Viewer\": \"true\", \"CloudFront-Is-Mobile-Viewer\": \"false\", \"CloudFront-Is-SmartTV-Viewer\": \"false\", \"CloudFront-Is-Tablet-Viewer\": \"false\", \"CloudFront-Viewer-ASN\": \"16509\", \"CloudFront-Viewer-Country\": \"US\", \"Content-Type\": \"application/json\", \"Host\": \"sp260dl21k.execute-api.<region>.amazonaws.com\", \"User-Agent\": \"aws-sdk-java/1.12.769 Linux/5.10.224-190.876.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.12+8-LTS java/17.0.12 scala/2.12.17 kotlin/1.5.32 vendor/Amazon.com_Inc. cfg/retry-mode/legacy\", \"Via\": \"1.1 a929b4bfaa0111e3feb7c4dbffdbd8d8.cloudfront.net (CloudFront)\", \"X-Amz-Cf-Id\": \"BKQQYBXKENj_W1ZK2LDm_YMuNXI1XHU9isWbrESHAhr5lfFoNcg0vg==\", \"X-Amz-Date\": \"20240919T193144Z\", \"X-Amz-Security-Token\": \"IQoJb3JpZ2luX2VjECwaCXVzLWVhc3QtMSJIMEYCIQDvt7mWI5G/D00yl23M9LKlTTPdeqQg49Vt7NJ8CxvBRQIhAIM/C7B3vq8swY/BwtVMQ1pRJGTkVLRlc2K91GP73/4OKuMCCGUQABoMNTM1MDAyODY2NjgyIgxSjjvKlfZx7lJImTwqwAJuXUDPlL7a9zlcLfiIa5IGDlKRzQKumT+0Hs0bcH4k90qBGqocF4CE785VDt70RSyTsdNY33m3v03W2e+D3gk+Fygkld5xasYKt6Uhd0FuoVFvNeY/dKhfQUVukvdCuc3aVo86KUHWQY2Ot2ZHKjXKsbnuiS57kVsgayS4sOMLuVsCv9hrSG5Ek85l/+TAdtOHekNU2hV5Bus2iPhsI7HL+vjgMCsdvZDz9Pq4tF56lnXEF41LJahHJc01nAd2RaNJysgWmEjKeylo0zTvKb17xWywGsb31cHonmnLj1bhB0nfzOBhwKZdzfEOVw54OR5BLLb1+14t4RmivjZfXoRlJUMKQ+mgVt1Td4k5aTUXN4vo9gcvN8GRQA7xuLHoGCZpTuEz0UyHSrG5596xtZ1pvilNAJnTBrkuRImmB2h3JTCg+LG3Bjq+AUOgEmpmLhONNqo12HBQg93wD87quqtbU5xaAxEKGngF2nG+oDV/iRYpkgP3jhCzYY0PyXdmPgYMVO6RJpB/mt5LyURq0qz9or/J0qbXW2aYufyqGnfxfx0Swcdr5dIPKWsu+YpScElR9LP33wiUZpvNWee/qcXO2S7Y8vHVTsOuRfml5W7Tlz53xfVgvVg9JA/Iv0LS2sYaiwKoGH+TC4tbXvBBBOVPcGFoUFu2wBC1XtVX+MAKRcxM0LTkfEM=\", \"X-Amz-Source-Account\": \"111111111111\", \"X-Amz-Source-Arn\": \"arn:<partition>:events:<region>:111111111111:rule/<resource:3>/<resource:4>\", \"X-Amzn-Trace-Id\": \"Root=1-66ec7c21-44b7c5793da6158925dd8353\", \"X-Forwarded-For\": \"72.21.217.42, 70.132.32.74\", \"X-Forwarded-Port\": \"443\", \"X-Forwarded-Proto\": \"https\"}, \"multiValueHeaders\": {\"amz-sdk-invocation-id\": [\"56c9681d-874c-ef1b-876b-f3985d9d1fa0\"], \"amz-sdk-request\": [\"ttl=20240919T193234Z;attempt=1;max=4\"], \"amz-sdk-retry\": [\"0/0/500\"], \"CloudFront-Forwarded-Proto\": [\"https\"], \"CloudFront-Is-Desktop-Viewer\": [\"true\"], \"CloudFront-Is-Mobile-Viewer\": [\"false\"], \"CloudFront-Is-SmartTV-Viewer\": [\"false\"], \"CloudFront-Is-Tablet-Viewer\": [\"false\"], \"CloudFront-Viewer-ASN\": [\"16509\"], \"CloudFront-Viewer-Country\": [\"US\"], \"Content-Type\": [\"application/json\"], \"Host\": [\"sp260dl21k.execute-api.<region>.amazonaws.com\"], \"User-Agent\": [\"aws-sdk-java/1.12.769 Linux/5.10.224-190.876.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.12+8-LTS java/17.0.12 scala/2.12.17 kotlin/1.5.32 vendor/Amazon.com_Inc. cfg/retry-mode/legacy\"], \"Via\": [\"1.1 a929b4bfaa0111e3feb7c4dbffdbd8d8.cloudfront.net (CloudFront)\"], \"X-Amz-Cf-Id\": [\"BKQQYBXKENj_W1ZK2LDm_YMuNXI1XHU9isWbrESHAhr5lfFoNcg0vg==\"], \"X-Amz-Date\": [\"20240919T193144Z\"], \"X-Amz-Security-Token\": [\"IQoJb3JpZ2luX2VjECwaCXVzLWVhc3QtMSJIMEYCIQDvt7mWI5G/D00yl23M9LKlTTPdeqQg49Vt7NJ8CxvBRQIhAIM/C7B3vq8swY/BwtVMQ1pRJGTkVLRlc2K91GP73/4OKuMCCGUQABoMNTM1MDAyODY2NjgyIgxSjjvKlfZx7lJImTwqwAJuXUDPlL7a9zlcLfiIa5IGDlKRzQKumT+0Hs0bcH4k90qBGqocF4CE785VDt70RSyTsdNY33m3v03W2e+D3gk+Fygkld5xasYKt6Uhd0FuoVFvNeY/dKhfQUVukvdCuc3aVo86KUHWQY2Ot2ZHKjXKsbnuiS57kVsgayS4sOMLuVsCv9hrSG5Ek85l/+TAdtOHekNU2hV5Bus2iPhsI7HL+vjgMCsdvZDz9Pq4tF56lnXEF41LJahHJc01nAd2RaNJysgWmEjKeylo0zTvKb17xWywGsb31cHonmnLj1bhB0nfzOBhwKZdzfEOVw54OR5BLLb1+14t4RmivjZfXoRlJUMKQ+mgVt1Td4k5aTUXN4vo9gcvN8GRQA7xuLHoGCZpTuEz0UyHSrG5596xtZ1pvilNAJnTBrkuRImmB2h3JTCg+LG3Bjq+AUOgEmpmLhONNqo12HBQg93wD87quqtbU5xaAxEKGngF2nG+oDV/iRYpkgP3jhCzYY0PyXdmPgYMVO6RJpB/mt5LyURq0qz9or/J0qbXW2aYufyqGnfxfx0Swcdr5dIPKWsu+YpScElR9LP33wiUZpvNWee/qcXO2S7Y8vHVTsOuRfml5W7Tlz53xfVgvVg9JA/Iv0LS2sYaiwKoGH+TC4tbXvBBBOVPcGFoUFu2wBC1XtVX+MAKRcxM0LTkfEM=\"], \"X-Amz-Source-Account\": [\"111111111111\"], \"X-Amz-Source-Arn\": [\"arn:<partition>:events:<region>:111111111111:rule/<resource:3>/<resource:4>\"], \"X-Amzn-Trace-Id\": [\"Root=1-66ec7c21-44b7c5793da6158925dd8353\"], \"X-Forwarded-For\": [\"72.21.217.42, 70.132.32.74\"], \"X-Forwarded-Port\": [\"443\"], \"X-Forwarded-Proto\": [\"https\"]}, \"queryStringParameters\": null, \"multiValueQueryStringParameters\": null, \"pathParameters\": null, \"stageVariables\": null, \"requestContext\": {\"resourceId\": \"7a07rd\", \"resourcePath\": \"/test\", \"httpMethod\": \"POST\", \"extendedRequestId\": \"eXhVNFPooAMELnA=\", \"requestTime\": \"19/Sep/2024:19:31:45 +0000\", \"path\": \"/test/test/\", \"accountId\": \"111111111111\", \"protocol\": \"HTTP/1.1\", \"stage\": \"test\", \"domainPrefix\": \"sp260dl21k\", \"requestTimeEpoch\": 1726774305007, \"requestId\": \"3ae58bde-9ef6-4867-af27-361dd207f942\", \"identity\": {\"cognitoIdentityPoolId\": null, \"accountId\": null, \"cognitoIdentityId\": null, \"caller\": null, \"sourceIp\": \"72.21.217.42\", \"principalOrgId\": null, \"accessKey\": null, \"cognitoAuthenticationType\": null, \"cognitoAuthenticationProvider\": null, \"userArn\": null, \"userAgent\": \"aws-sdk-java/1.12.769 Linux/5.10.224-190.876.amzn2int.x86_64 OpenJDK_64-Bit_Server_VM/17.0.12+8-LTS java/17.0.12 scala/2.12.17 kotlin/1.5.32 vendor/Amazon.com_Inc. cfg/retry-mode/legacy\", \"user\": null}, \"domainName\": \"sp260dl21k.execute-api.<region>.amazonaws.com\", \"deploymentId\": \"<id:1>\", \"apiId\": \"sp260dl21k\"}, \"body\": \"{\\\"message\\\": \\\"Hello from EventBridge\\\"}\", \"isBase64Encoded\": false}\n"
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events_targets.snapshot.json
+++ b/tests/aws/services/events/test_events_targets.snapshot.json
@@ -671,7 +671,7 @@
     }
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
-    "recorded-date": "21-09-2024, 07:40:28",
+    "recorded-date": "30-09-2024, 07:53:35",
     "recorded-content": {
       "create_lambda_response": {
         "CreateEventSourceMappingResponse": null,
@@ -755,7 +755,7 @@
       "put_events_response": {
         "Entries": [
           {
-            "EventId": "<event-id>"
+            "EventId": "event-id"
           }
         ],
         "FailedEntryCount": 0,

--- a/tests/aws/services/events/test_events_targets.validation.json
+++ b/tests/aws/services/events/test_events_targets.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
-    "last_validated_date": "2024-09-19T19:31:58+00:00"
+    "last_validated_date": "2024-09-20T19:00:10+00:00"
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetEvents::test_put_events_with_target_events[bus_combination0]": {
     "last_validated_date": "2024-07-11T08:59:28+00:00"

--- a/tests/aws/services/events/test_events_targets.validation.json
+++ b/tests/aws/services/events/test_events_targets.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
+    "last_validated_date": "2024-09-19T19:31:58+00:00"
+  },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetEvents::test_put_events_with_target_events[bus_combination0]": {
     "last_validated_date": "2024-07-11T08:59:28+00:00"
   },

--- a/tests/aws/services/events/test_events_targets.validation.json
+++ b/tests/aws/services/events/test_events_targets.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
-    "last_validated_date": "2024-09-21T00:08:14+00:00"
+    "last_validated_date": "2024-09-21T07:40:27+00:00"
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetEvents::test_put_events_with_target_events[bus_combination0]": {
     "last_validated_date": "2024-07-11T08:59:28+00:00"

--- a/tests/aws/services/events/test_events_targets.validation.json
+++ b/tests/aws/services/events/test_events_targets.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
-    "last_validated_date": "2024-09-21T07:40:27+00:00"
+    "last_validated_date": "2024-09-30T07:53:35+00:00"
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetEvents::test_put_events_with_target_events[bus_combination0]": {
     "last_validated_date": "2024-07-11T08:59:28+00:00"

--- a/tests/aws/services/events/test_events_targets.validation.json
+++ b/tests/aws/services/events/test_events_targets.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
-    "last_validated_date": "2024-09-20T19:00:10+00:00"
+    "last_validated_date": "2024-09-21T00:08:14+00:00"
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetEvents::test_put_events_with_target_events[bus_combination0]": {
     "last_validated_date": "2024-07-11T08:59:28+00:00"

--- a/tests/aws/services/lambda_/functions/lambda_echo_json_body.py
+++ b/tests/aws/services/lambda_/functions/lambda_echo_json_body.py
@@ -18,8 +18,8 @@ dynamically simulate functions that look like::
 
 import json
 
+
 def handler(event, context):
     # Just print the event that was passed to the Lambda
-
     print(json.dumps(event))
     return json.loads(event["body"])

--- a/tests/aws/services/lambda_/functions/lambda_echo_json_body.py
+++ b/tests/aws/services/lambda_/functions/lambda_echo_json_body.py
@@ -19,17 +19,7 @@ dynamically simulate functions that look like::
 import json
 
 def handler(event, context):
-    print(f"Received event: {json.dumps(event)}")
+    # Just print the event that was passed to the Lambda
 
-    response_body = {
-        "message": "Hello from Lambda!",
-        "input": event
-    }
-    return {
-        "isBase64Encoded": False,
-        "statusCode": 200,
-        "headers": {
-            "Content-Type": "application/json"
-        },
-        "body": json.dumps(response_body)
-    }
+    print(json.dumps(event))
+    return json.loads(event["body"])

--- a/tests/aws/services/lambda_/functions/lambda_echo_json_body.py
+++ b/tests/aws/services/lambda_/functions/lambda_echo_json_body.py
@@ -18,8 +18,18 @@ dynamically simulate functions that look like::
 
 import json
 
-
 def handler(event, context):
-    # Just print the event that was passed to the Lambda
-    print(json.dumps(event))
-    return json.loads(event["body"])
+    print(f"Received event: {json.dumps(event)}")
+
+    response_body = {
+        "message": "Hello from Lambda!",
+        "input": event
+    }
+    return {
+        "isBase64Encoded": False,
+        "statusCode": 200,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": json.dumps(response_body)
+    }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR introduces basic support for the Amazon EventBridge API Gateway target within LocalStack's new EventBridge v2 implementation. The primary goal is to enable the successful delivery of events from an EventBridge bus to an API Gateway endpoint, ensuring parity with AWS's behavior through comprehensive testing.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- **Implementation of `ApiGatewayTargetSender` Class:**
  - Parses the API Gateway ARN to extract `api_id`, `stage_name`, `http_method`, and `resource_path`.
  - Dynamically replaces wildcards (`*`) in the resource path with provided `PathParameterValues`, allowing flexible URL construction.
  - Constructs the API Gateway endpoint URL using `config.internal_service_url()` and sets the appropriate `Host` header for proper routing within LocalStack.
  - Utilizes the Python `requests` library to send serialized JSON events to the API Gateway endpoint with a 5-second timeout.
  - Excludes prohibited HTTP headers and ensures necessary headers like `Content-Type` are set.
  - Implements error handling and logging for failed HTTP requests and exceptions.

- **Parity Test Addition:**
  - Added a parity test in `tests/aws/services/events/test_events_targets.py` to validate the integration between EventBridge and API Gateway.
  - The test sets up AWS resources (Lambda function, API Gateway, EventBridge rule), sends an event, and verifies that the Lambda function receives the correct payload via API Gateway.
  - Generated a snapshot capturing all essential interactions and responses, ensuring LocalStack's behavior matches AWS's expected outcomes with appropriate redactions.

- **Configuration Adjustments:**
  - Ensured LocalStack is started with the `PROVIDER_OVERRIDE_EVENTS=v2` environment variable to opt into the new EventBridge v2 implementation.

<!-- Optional section: How to test these changes? -->
## Testing
1. **Set Up LocalStack:**
   - Start LocalStack with EventBridge v2 enabled:
     ```bash
     make clean
     make install
     PROVIDER_OVERRIDE_EVENTS=v2 make start
     ```

2. **Run Parity Test:**
   - Execute the parity test to verify the implementation:
     ```bash
     PROVIDER_OVERRIDE_EVENTS=v2 WARN=1 make test TEST_PATH=tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway
     ```

3. **Verify Snapshot:**
   - Ensure the generated snapshot accurately reflects the expected AWS behavior and that all sensitive fields are appropriately redacted.

4. **Generating Snapshot (Optional):**
```bash
make test TEST_PATH="tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway" TEST_TARGET=AWS_CLOUD SNAPSHOT_UPDATE=1 AWS_PROFILE=ls-sandbox PROVIDER_OVERRIDE_EVENTS=v2
```

<!-- Optional section: What's left to do before it can be merged? -->
## TODO
- [ ] Update inline documentation and comments within the code for clarity.
- [ ] Add validations for input.
- [ ] Add retrying logic


---
