### PR TITLE
Fix: Make secret value decoded for specific usecases

### DIFF
--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import re
 import time
-from typing import Final, Optional, Union
+from typing import Any, Dict, Final, Optional, Union
 
 import moto.secretsmanager.exceptions as moto_exception
 from botocore.utils import InvalidArnException
@@ -246,6 +247,8 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         self._raise_if_default_kms_key(secret_id, context, backend)
         try:
             response = backend.get_secret_value(secret_id, version_id, version_stage)
+            if should_decode_secret_binary(context):
+                response = decode_secret_binary_from_response(response)
         except moto_exception.SecretNotFoundException:
             raise ResourceNotFoundException(
                 f"Secrets Manager can't find the specified secret value for staging label: {version_stage}"
@@ -861,6 +864,19 @@ def get_resource_policy_model(self, secret_id):
 def get_resource_policy_response(self):
     secret_id = self._get_param("SecretId")
     return self.backend.get_resource_policy(secret_id=secret_id)
+
+
+def should_decode_secret_binary(context: RequestContext):
+    headers = context.request.headers
+    user_agents = headers.get("User-Agent", "").split(" ")
+    return not any(ua_val.startswith(("boto3", "botocore", "aws-cli")) for ua_val in user_agents)
+
+
+def decode_secret_binary_from_response(response: Dict[str, Any]):
+    if "SecretBinary" in response:
+        response["SecretBinary"] = base64.b64decode(response["SecretBinary"])
+
+    return response
 
 
 def delete_resource_policy_model(self, secret_id):

--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -247,8 +247,7 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         self._raise_if_default_kms_key(secret_id, context, backend)
         try:
             response = backend.get_secret_value(secret_id, version_id, version_stage)
-            if should_decode_secret_binary(context):
-                response = decode_secret_binary_from_response(response)
+            response = decode_secret_binary_from_response(response)
         except moto_exception.SecretNotFoundException:
             raise ResourceNotFoundException(
                 f"Secrets Manager can't find the specified secret value for staging label: {version_stage}"
@@ -864,12 +863,6 @@ def get_resource_policy_model(self, secret_id):
 def get_resource_policy_response(self):
     secret_id = self._get_param("SecretId")
     return self.backend.get_resource_policy(secret_id=secret_id)
-
-
-def should_decode_secret_binary(context: RequestContext):
-    headers = context.request.headers
-    user_agents = headers.get("User-Agent", "").split(" ")
-    return not any(ua_val.startswith(("boto3", "botocore", "aws-cli")) for ua_val in user_agents)
 
 
 def decode_secret_binary_from_response(response: Dict[str, Any]):

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -2396,7 +2396,7 @@ class TestSecretsManager:
             )
         sm_snapshot.match("mismatch_version_id_and_stage", exc.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_get_secret_value(self, aws_client, create_secret, sm_snapshot):
         secret_name = short_uid()
         secret_string = b"footest"
@@ -2412,9 +2412,11 @@ class TestSecretsManager:
 
         secret_arn = response["ARN"]
 
-        value_response = aws_client.secretsmanager.get_secret_value(SecretId=secret_arn)
+        secret_value_response = aws_client.secretsmanager.get_secret_value(SecretId=secret_arn)
 
-        assert value_response["SecretBinary"] == secret_string_b64_encoded
+        sm_snapshot.match("secret_value_response", secret_value_response)
+
+        assert secret_value_response["SecretBinary"] == secret_string_b64_encoded
 
 
 class TestSecretsManagerMultiAccounts:

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4509,5 +4509,24 @@
       "get_secret_value_version_not_found_ex": "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret value for VersionId: <version-id>",
       "get_secret_value_stage_not_found_ex": "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret value for staging label: AWSPENDING"
     }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
+    "recorded-date": "19-09-2024, 09:35:21",
+    "recorded-content": {
+      "secret_value_response": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "CreatedDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "SecretBinary": "b'Zm9vdGVzdA=='",
+        "VersionId": "<version_uuid:1>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4511,13 +4511,13 @@
     }
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
-    "recorded-date": "19-09-2024, 09:35:21",
+    "recorded-date": "19-09-2024, 20:19:26",
     "recorded-content": {
       "secret_value_response": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "CreatedDate": "datetime",
         "Name": "<SecretId-0idx>",
-        "SecretBinary": "b'Zm9vdGVzdA=='",
+        "SecretBinary": "b'footest'",
         "VersionId": "<version_uuid:1>",
         "VersionStages": [
           "AWSCURRENT"
@@ -4526,6 +4526,16 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "secret_value_http_response": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "CreatedDate": 1726777166.068,
+        "Name": "<SecretId-0idx>",
+        "SecretBinary": "Zm9vdGVzdA==",
+        "VersionId": "<version_uuid:1>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ]
       }
     }
   }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -44,6 +44,9 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_random_exclude_characters_and_symbols": {
     "last_validated_date": "2024-03-15T08:12:01+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
+    "last_validated_date": "2024-09-19T09:35:21+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_errors": {
     "last_validated_date": "2024-04-11T05:37:47+00:00"
   },

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -45,7 +45,7 @@
     "last_validated_date": "2024-03-15T08:12:01+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value": {
-    "last_validated_date": "2024-09-19T09:35:21+00:00"
+    "last_validated_date": "2024-09-19T20:19:26+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_errors": {
     "last_validated_date": "2024-04-11T05:37:47+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With this PR I am trying to fix the bug mentioned on this issue : https://github.com/localstack/localstack/issues/11319

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Previously localstack assumed the behaviour of SecretBinary field is same for all the sdk request, but the behaviour differs. According to AWS docs:

```
When you retrieve a SecretBinary using the HTTP API, the Python SDK, or the AWS CLI, the value is Base64-encoded. Otherwise, it is not encoded.
```

So on this PR, I am adding a check to identify what entity is making the request, and localstack will decode the value if needed.
<!-- Optional section: How to test these changes? -->

## Testing
* Added a test to fetch a secret when the SecretBinary should not be decoded
* [Todo] Add a test to fetch a secret when SecretBinary should be decoded



<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
