### PR TITLE
[SFN] No Output Reductions for Successful Catch Blocks

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state.py
@@ -178,7 +178,7 @@ class CommonStateField(EvalComponent, ABC):
         output = env.stack[-1]
 
         # CatcherOutputs (i.e. outputs of Catch blocks) are never subjects of output normalisers,
-        # the entire value is instead passed by value as input ot the next state, or program output.
+        # the entire value is instead passed by value as input to the next state, or program output.
         if isinstance(output, CatcherOutput):
             env.inp = copy.deepcopy(output)
         else:

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state.py
@@ -81,7 +81,6 @@ class CommonStateField(EvalComponent, ABC):
         self.comment = None
         self.input_path = InputPath(InputPath.DEFAULT_PATH)
         self.output_path = OutputPath(OutputPath.DEFAULT_PATH)
-        self.output_path = OutputPath(OutputPath.DEFAULT_PATH)
         self.state_entered_event_type = state_entered_event_type
         self.state_exited_event_type = state_exited_event_type
 

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import copy
 import datetime
 import json
 import logging
@@ -14,6 +15,7 @@ from localstack.aws.api.stepfunctions import (
     StateEnteredEventDetails,
     StateExitedEventDetails,
 )
+from localstack.services.stepfunctions.asl.component.common.catch.catcher_decl import CatcherOutput
 from localstack.services.stepfunctions.asl.component.common.comment import Comment
 from localstack.services.stepfunctions.asl.component.common.error_name.failure_event import (
     FailureEvent,
@@ -57,24 +59,31 @@ class CommonStateField(EvalComponent, ABC):
     # be used in a state. Some state types, such as Choice, don't support or use the End field.
     continue_with: ContinueWith
 
+    # Holds a human-readable description of the state.
+    comment: Optional[Comment]
+
+    # A path that selects a portion of the state's input to be passed to the state's state_task for processing.
+    # If omitted, it has the value $ which designates the entire input.
+    input_path: InputPath
+
+    # A path that selects a portion of the state's output to be passed to the next state.
+    # If omitted, it has the value $ which designates the entire output.
+    output_path: OutputPath
+
+    state_entered_event_type: Final[HistoryEventType]
+    state_exited_event_type: Final[Optional[HistoryEventType]]
+
     def __init__(
         self,
         state_entered_event_type: HistoryEventType,
         state_exited_event_type: Optional[HistoryEventType],
     ):
-        # Holds a human-readable description of the state.
-        self.comment: Optional[Comment] = None
-
-        # A path that selects a portion of the state's input to be passed to the state's state_task for processing.
-        # If omitted, it has the value $ which designates the entire input.
-        self.input_path: InputPath = InputPath(InputPath.DEFAULT_PATH)
-
-        # A path that selects a portion of the state's output to be passed to the next state.
-        # If omitted, it has the value $ which designates the entire output.
-        self.output_path: OutputPath = OutputPath(OutputPath.DEFAULT_PATH)
-
-        self.state_entered_event_type: Final[HistoryEventType] = state_entered_event_type
-        self.state_exited_event_type: Final[Optional[HistoryEventType]] = state_exited_event_type
+        self.comment = None
+        self.input_path = InputPath(InputPath.DEFAULT_PATH)
+        self.output_path = OutputPath(OutputPath.DEFAULT_PATH)
+        self.output_path = OutputPath(OutputPath.DEFAULT_PATH)
+        self.state_entered_event_type = state_entered_event_type
+        self.state_exited_event_type = state_exited_event_type
 
     def from_state_props(self, state_props: StateProps) -> None:
         self.name = state_props.name
@@ -165,13 +174,20 @@ class CommonStateField(EvalComponent, ABC):
         if not isinstance(env.program_state(), ProgramRunning):
             return
 
-        # Ensure the state's output is within state size quotas.
+        # Obtain a reference to the state output.
         output = env.stack[-1]
-        self._verify_size_quota(env=env, value=output)
 
-        # Filter the input onto the input.
-        if self.output_path:
-            self.output_path.eval(env)
+        # CatcherOutputs (i.e. outputs of Catch blocks) are never subjects of output normalisers,
+        # the entire value is instead passed by value as input ot the next state, or program output.
+        if isinstance(output, CatcherOutput):
+            env.inp = copy.deepcopy(output)
+        else:
+            # Ensure the state's output is within state size quotas.
+            self._verify_size_quota(env=env, value=output)
+
+            # Filter the input onto the input.
+            if self.output_path:
+                self.output_path.eval(env)
 
         if self.state_exited_event_type is not None:
             env.event_manager.add_event(

--- a/tests/aws/services/stepfunctions/templates/errorhandling/error_handling_templates.py
+++ b/tests/aws/services/stepfunctions/templates/errorhandling/error_handling_templates.py
@@ -36,6 +36,10 @@ class ErrorHandlingTemplate(TemplateLoader):
         _THIS_FOLDER, "statemachines/task_service_lambda_invoke_catch_all.json5"
     )
 
+    AWS_SERVICE_LAMBDA_INVOKE_CATCH_ALL_OUTPUT_PATH: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/task_service_lambda_invoke_catch_all_output_path.json5"
+    )
+
     AWS_SERVICE_LAMBDA_INVOKE_CATCH_DATA_LIMIT_EXCEEDED: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/task_service_lambda_invoke_catch_data_limit_exceeded.json5"
     )

--- a/tests/aws/services/stepfunctions/templates/errorhandling/statemachines/task_service_lambda_invoke_catch_all_output_path.json5
+++ b/tests/aws/services/stepfunctions/templates/errorhandling/statemachines/task_service_lambda_invoke_catch_all_output_path.json5
@@ -1,0 +1,36 @@
+{
+  "Comment": "TASK_SERVICE_LAMBDA_INVOKE_CATCH_ALL_OUTPUT_PATH",
+  "StartAt": "InvokeLambda",
+  "States": {
+    "InvokeLambda": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName.$": "$.FunctionName",
+        "Payload.$": "$.Payload",
+      },
+      "ResultPath": "$.Payload",
+      "OutputPath": "$.Payload",
+      "Catch": [
+      {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "HandleGeneralError"
+        }
+      ],
+      "Next": "ProcessResult"
+    },
+    "ProcessResult": {
+      "Type": "Pass",
+      "End": true
+    },
+    "HandleGeneralError": {
+      "Type": "Pass",
+      "Parameters": {
+        "InputValue.$": "$"
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py
@@ -1,7 +1,9 @@
 import json
 
+import pytest
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
+from localstack.aws.api.lambda_ import Runtime
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.stepfunctions.utils import (
     create_and_record_execution,
@@ -68,6 +70,41 @@ class TestTaskServiceLambda:
         definition = json.dumps(template)
 
         exec_input = json.dumps({"FunctionName": function_name, "Payload": None})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
+    @pytest.mark.parametrize("output_path_value", [None, "$.Payload", "$.no.such.path"])
+    def test_raise_exception_catch_output_path(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        create_lambda_function,
+        sfn_snapshot,
+        output_path_value,
+    ):
+        function_name = f"function_name_{short_uid()}"
+        create_lambda_function(
+            func_name=function_name,
+            handler_file=EHT.LAMBDA_FUNC_RAISE_EXCEPTION,
+            runtime=Runtime.python3_12,
+        )
+        sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
+
+        template = EHT.load_sfn_template(EHT.AWS_SERVICE_LAMBDA_INVOKE_CATCH_ALL_OUTPUT_PATH)
+        template["States"]["InvokeLambda"]["OutputPath"] = output_path_value
+        definition = json.dumps(template)
+
+        exec_input = json.dumps(
+            {"FunctionName": function_name, "Payload": {"payload_input_value_0": 0}}
+        )
         create_and_record_execution(
             aws_client.stepfunctions,
             create_iam_role_for_sfn,

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.snapshot.json
@@ -662,5 +662,491 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch_output_path[None]": {
+    "recorded-date": "20-09-2024, 15:50:50",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionName": "lambda_function_name",
+                "Payload": {
+                  "payload_input_value_0": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionName": "lambda_function_name",
+                "Payload": {
+                  "payload_input_value_0": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "InvokeLambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "FunctionName": "lambda_function_name",
+                "Payload": {
+                  "payload_input_value_0": 0
+                }
+              },
+              "region": "<region>",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskFailedEventDetails": {
+              "cause": {
+                "errorMessage": "Some exception was raised.",
+                "errorType": "Exception",
+                "requestId": "<uuid:1>",
+                "stackTrace": [
+                  "  File \"/var/task/handler.py\", line 2, in handler\n    raise Exception(\"Some exception was raised.\")\n"
+                ]
+              },
+              "error": "Exception",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "InvokeLambda",
+              "output": {
+                "Error": "Exception",
+                "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Error": "Exception",
+                "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "HandleGeneralError"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateExitedEventDetails": {
+              "name": "HandleGeneralError",
+              "output": {
+                "InputValue": {
+                  "Error": "Exception",
+                  "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "InputValue": {
+                  "Error": "Exception",
+                  "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 9,
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch_output_path[$.Payload]": {
+    "recorded-date": "20-09-2024, 15:51:07",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionName": "lambda_function_name",
+                "Payload": {
+                  "payload_input_value_0": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionName": "lambda_function_name",
+                "Payload": {
+                  "payload_input_value_0": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "InvokeLambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "FunctionName": "lambda_function_name",
+                "Payload": {
+                  "payload_input_value_0": 0
+                }
+              },
+              "region": "<region>",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskFailedEventDetails": {
+              "cause": {
+                "errorMessage": "Some exception was raised.",
+                "errorType": "Exception",
+                "requestId": "<uuid:1>",
+                "stackTrace": [
+                  "  File \"/var/task/handler.py\", line 2, in handler\n    raise Exception(\"Some exception was raised.\")\n"
+                ]
+              },
+              "error": "Exception",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "InvokeLambda",
+              "output": {
+                "Error": "Exception",
+                "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Error": "Exception",
+                "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "HandleGeneralError"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateExitedEventDetails": {
+              "name": "HandleGeneralError",
+              "output": {
+                "InputValue": {
+                  "Error": "Exception",
+                  "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "InputValue": {
+                  "Error": "Exception",
+                  "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 9,
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch_output_path[$.no.such.path]": {
+    "recorded-date": "20-09-2024, 15:51:29",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionName": "lambda_function_name",
+                "Payload": {
+                  "payload_input_value_0": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionName": "lambda_function_name",
+                "Payload": {
+                  "payload_input_value_0": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "InvokeLambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "FunctionName": "lambda_function_name",
+                "Payload": {
+                  "payload_input_value_0": 0
+                }
+              },
+              "region": "<region>",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskFailedEventDetails": {
+              "cause": {
+                "errorMessage": "Some exception was raised.",
+                "errorType": "Exception",
+                "requestId": "<uuid:1>",
+                "stackTrace": [
+                  "  File \"/var/task/handler.py\", line 2, in handler\n    raise Exception(\"Some exception was raised.\")\n"
+                ]
+              },
+              "error": "Exception",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "InvokeLambda",
+              "output": {
+                "Error": "Exception",
+                "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Error": "Exception",
+                "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "HandleGeneralError"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateExitedEventDetails": {
+              "name": "HandleGeneralError",
+              "output": {
+                "InputValue": {
+                  "Error": "Exception",
+                  "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "InputValue": {
+                  "Error": "Exception",
+                  "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 9,
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.validation.json
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.validation.json
@@ -13,5 +13,14 @@
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch": {
     "last_validated_date": "2023-06-22T11:29:36+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch_output_path[$.Payload]": {
+    "last_validated_date": "2024-09-20T15:51:07+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch_output_path[$.no.such.path]": {
+    "last_validated_date": "2024-09-20T15:51:29+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch_output_path[None]": {
+    "last_validated_date": "2024-09-20T15:50:50+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When an error in a state is successfully handled by a catch block, the error object containing the error message and cause string is directly passed as the state's output. This means that if the user defines output reduction logic, such as ResultPath and OutputPath, these are not applied. However, the current implementation of the SFN v2 interpreter mistakenly applies these reductions, which can lead to JsonPath errors and disrupt the state machine's logic, as seen in issue #11494.
These changes type the output handling for successful catch blocks so these can be detected and bypass output reductions.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Typed CatcherDecl outputs to be CatcherOutput objects
- Add bypass logic in the state's evaluation of the output
- Added relevant snapshot tests which test the use of OutputPath and ResultPath as output reductions

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
