### PR TITLE
bug: Second update of UsagePlan fails #11560

### DIFF
--- a/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_usageplan.py
+++ b/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_usageplan.py
@@ -168,6 +168,8 @@ class ApiGatewayUsagePlanProvider(ResourceProvider[ApiGatewayUsagePlanProperties
         updated_tags = update_config_props.pop("Tags", [])
 
         usage_plan_id = request.previous_state["Id"]
+        # when storing the Id in the model, subsequent update will find it in previous_state
+        model["Id"] = usage_plan_id
 
         patch_operations = []
 


### PR DESCRIPTION
## Motivation
Please take this PR as a guide for fixing the #11560. I'm not so deep into the localstack to find where the Id should have been added to the desired_state..

## Changes
- storing Id to the model of the UsagePlan update operation

What's left to do:
- implement it the right way :)
- write test
