### PR TITLE
Bump moto-ext to 5.0.15.post2

### DIFF
--- a/localstack-core/localstack/services/apigateway/provider.py
+++ b/localstack-core/localstack/services/apigateway/provider.py
@@ -253,9 +253,6 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         rest_api = get_moto_rest_api(context, rest_api_id=result["id"])
         rest_api.version = request.get("version")
         response: RestApi = rest_api.to_dict()
-        # TODO: remove once this is fixed upstream
-        if "rootResourceId" not in response:
-            response["rootResourceId"] = get_moto_rest_api_root_resource(rest_api)
         remove_empty_attributes_from_rest_api(response)
         store = get_apigateway_store(context=context)
         rest_api_container = RestApiContainer(rest_api=response)
@@ -291,10 +288,6 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def get_rest_api(self, context: RequestContext, rest_api_id: String, **kwargs) -> RestApi:
         rest_api: RestApi = call_moto(context)
         remove_empty_attributes_from_rest_api(rest_api)
-        # TODO: remove once this is fixed upstream
-        if "rootResourceId" not in rest_api:
-            moto_rest_api = get_moto_rest_api(context, rest_api_id=rest_api_id)
-            rest_api["rootResourceId"] = get_moto_rest_api_root_resource(moto_rest_api)
         return rest_api
 
     def update_rest_api(
@@ -372,8 +365,6 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             rest_api.minimum_compression_size = None
 
         response = rest_api.to_dict()
-        if "rootResourceId" not in response:
-            response["rootResourceId"] = get_moto_rest_api_root_resource(rest_api)
 
         remove_empty_attributes_from_rest_api(response, remove_tags=False)
         store = get_apigateway_store(context=context)
@@ -389,13 +380,11 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
         openapi_spec = parse_json_or_yaml(to_str(body_data))
         rest_api = import_api_from_openapi_spec(rest_api, openapi_spec, context=context)
+        rest_api.root_resource_id = get_moto_rest_api_root_resource(rest_api)
         response = rest_api.to_dict()
         remove_empty_attributes_from_rest_api(response)
         store = get_apigateway_store(context=context)
         store.rest_apis[request["restApiId"]].rest_api = response
-        # TODO: remove once this is fixed upstream
-        if "rootResourceId" not in response:
-            response["rootResourceId"] = get_moto_rest_api_root_resource(rest_api)
         # TODO: verify this
         response = to_rest_api_response_json(response)
         response.setdefault("tags", {})
@@ -498,9 +487,6 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         response: RestApis = call_moto(context)
         for rest_api in response["items"]:
             remove_empty_attributes_from_rest_api(rest_api)
-            if "rootResourceId" not in rest_api:
-                moto_rest_api = get_moto_rest_api(context, rest_api_id=rest_api["id"])
-                rest_api["rootResourceId"] = get_moto_rest_api_root_resource(moto_rest_api)
         return response
 
     # resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.13.post3",
+    "moto-ext[all]==5.0.15.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.15.post1",
+    "moto-ext[all]==5.0.15.post2",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -24,7 +24,7 @@ dnslib==0.9.25
     # via localstack-core (pyproject.toml)
 dnspython==2.6.1
     # via localstack-core (pyproject.toml)
-idna==3.8
+idna==3.10
     # via requests
 markdown-it-py==3.0.0
     # via rich
@@ -54,5 +54,5 @@ semver==3.0.2
     # via localstack-core (pyproject.toml)
 tailer==0.4.1
     # via localstack-core (pyproject.toml)
-urllib3==2.2.2
+urllib3==2.2.3
     # via requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -255,7 +255,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.13.post3
+moto-ext==5.0.15.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy
@@ -331,7 +331,7 @@ publication==0.0.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-py-partiql-parser==0.5.5
+py-partiql-parser==0.5.6
     # via moto-ext
 pyasn1==0.6.0
     # via rsa

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -255,7 +255,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.15.post1
+moto-ext==5.0.15.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -189,7 +189,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.15.post1
+moto-ext==5.0.15.post2
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -189,7 +189,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.13.post3
+moto-ext==5.0.15.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy
@@ -234,7 +234,7 @@ psutil==6.0.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
-py-partiql-parser==0.5.5
+py-partiql-parser==0.5.6
     # via moto-ext
 pyasn1==0.6.0
     # via rsa

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -239,7 +239,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.13.post3
+moto-ext==5.0.15.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy
@@ -301,7 +301,7 @@ publication==0.0.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-py-partiql-parser==0.5.5
+py-partiql-parser==0.5.6
     # via moto-ext
 pyasn1==0.6.0
     # via rsa

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -239,7 +239,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.15.post1
+moto-ext==5.0.15.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -259,7 +259,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.15.post1
+moto-ext==5.0.15.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -259,7 +259,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.13.post3
+moto-ext==5.0.15.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy
@@ -529,7 +529,7 @@ publication==0.0.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-py-partiql-parser==0.5.5
+py-partiql-parser==0.5.6
     # via moto-ext
 pyasn1==0.6.0
     # via rsa

--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -107,7 +107,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "recorded-date": "12-08-2024, 13:13:34",
+    "recorded-date": "24-09-2024, 20:22:38",
     "recorded-content": {
       "rest-api": {
         "apiKeySource": "HEADER",

--- a/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
@@ -9,7 +9,7 @@
     "last_validated_date": "2024-06-25T18:12:55+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "last_validated_date": "2024-08-12T13:13:32+00:00"
+    "last_validated_date": "2024-09-24T20:22:37+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_integration": {
     "last_validated_date": "2024-02-21T12:54:34+00:00"


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.0.15.post2

Contains:

- https://github.com/getmoto/moto/pull/8086 (closes https://github.com/localstack/localstack/issues/11445)
- https://github.com/getmoto/moto/pull/8142

## To do

- [x] Ext integration tests https://github.com/localstack/localstack-ext/actions/runs/11030368011
- [x] Randomised account ID and region run https://app.circleci.com/pipelines/github/localstack/localstack/28325/workflows/4411dd20-1b93-4f48-b616-b97c145f22b9