### PR TITLE
minor: add ability to create tmp files inside specified dirs

### DIFF
--- a/localstack-core/localstack/utils/files.py
+++ b/localstack-core/localstack/utils/files.py
@@ -289,16 +289,16 @@ def cleanup_tmp_files():
     del TMP_FILES[:]
 
 
-def new_tmp_file(suffix: str = None) -> str:
+def new_tmp_file(suffix: str = None, dir: str = None) -> str:
     """Return a path to a new temporary file."""
-    tmp_file, tmp_path = tempfile.mkstemp(suffix=suffix)
+    tmp_file, tmp_path = tempfile.mkstemp(suffix=suffix, dir=dir)
     os.close(tmp_file)
     TMP_FILES.append(tmp_path)
     return tmp_path
 
 
-def new_tmp_dir():
-    folder = new_tmp_file()
+def new_tmp_dir(dir: str = None):
+    folder = new_tmp_file(dir=dir)
     rm_rf(folder)
     mkdir(folder)
     return folder


### PR DESCRIPTION
## Motivation

I have a use case where I want to create temporary files inside a certain specified directory. This PR tries to extend the files utility functions so that temporary files and dirs can be created inside desired directories.

## Changes

- Added optional argument `dir` to the `new_tmp_file`, `new_tmp_dir` methods that defaults to `None` so that the default value can take place in that case.