### PR TITLE
Add tags and operationId properties to all OpenAPI paths

### DIFF
--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -600,7 +600,7 @@ paths:
   /_localstack/diagnose:
     get:
       description: Get diagnostics report
-      operationId: get_diagnose
+      operationId: get_diagnostic
       tags: [internal]
       responses:
         '200':

--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -254,7 +254,7 @@ paths:
   /_aws/dynamodb/expired:
     delete:
       description: Delete expired items from TTL-enabled DynamoDB tables
-      operationId: delete_expired_items
+      operationId: delete_ddb_expired_items
       tags: [aws]
       responses:
         '200':
@@ -555,7 +555,7 @@ paths:
           description: Current LocalStack configuration
     post:
       description: Configuration option to update with new value
-      operationId: update_configuration_option
+      operationId: update_config_option
       tags: [internal]
       requestBody:
         content:
@@ -702,7 +702,7 @@ paths:
   /_localstack/health:
     get:
       description: Get available LocalStack features and AWS services
-      operationId: get_ls_features_and_services
+      operationId: get_features_and_services
       tags: [internal]
       parameters:
       - allowEmptyValue: true
@@ -748,7 +748,7 @@ paths:
           description: ''
     post:
       description: Restart or terminate LocalStack session
-      operationId: restart_or_terminate_session
+      operationId: manage_session
       tags: [internal]
       requestBody:
         content:

--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -273,7 +273,7 @@ paths:
   /_aws/events/rules/{rule_arn}/trigger:
     get:
       description: Trigger a scheduled EventBridge rule
-      operationId: trigger_event_bridge_Rule
+      operationId: trigger_event_bridge_rule
       tags: [aws]
       parameters:
       - description: EventBridge rule ARN
@@ -702,7 +702,7 @@ paths:
   /_localstack/health:
     get:
       description: Get available LocalStack features and AWS services
-      operationId: health
+      operationId: get_ls_features_and_services
       tags: [internal]
       parameters:
       - allowEmptyValue: true
@@ -740,6 +740,7 @@ paths:
           description: Available LocalStack features and AWS services
     head:
       tags: [internal]
+      operationId: heath
       responses:
         '200':
           content:

--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -190,6 +190,8 @@ paths:
   /_aws/cloudwatch/metrics/raw:
     get:
       description: Retrieve CloudWatch metrics
+      operationId: get_cloudwatch_metrics
+      tags: [aws]
       responses:
         '200':
           content:
@@ -252,6 +254,8 @@ paths:
   /_aws/dynamodb/expired:
     delete:
       description: Delete expired items from TTL-enabled DynamoDB tables
+      operationId: delete_expired_items
+      tags: [aws]
       responses:
         '200':
           content:
@@ -269,6 +273,8 @@ paths:
   /_aws/events/rules/{rule_arn}/trigger:
     get:
       description: Trigger a scheduled EventBridge rule
+      operationId: trigger_event_bridge_Rule
+      tags: [aws]
       parameters:
       - description: EventBridge rule ARN
         in: path
@@ -284,6 +290,8 @@ paths:
   /_aws/lambda/init:
     get:
       description: Retrieve Lambda runtime init binary
+      operationId: get_lambda_init
+      tags: [aws]
       responses:
         '200':
           content:
@@ -292,6 +300,8 @@ paths:
   /_aws/lambda/runtimes:
     get:
       description: List available Lambda runtimes
+      operationId: get_lambda_runtimes
+      tags: [aws]
       parameters:
       - in: query
         name: filter
@@ -321,6 +331,8 @@ paths:
   /_aws/ses:
     delete:
       description: Discard sent SES messages
+      operationId: discard_ses_messages
+      tags: [aws]
       parameters:
       - $ref: '#/components/parameters/SesMessageId'
       responses:
@@ -328,6 +340,8 @@ paths:
           description: Message was successfully discarded
     get:
       description: Retrieve sent SES messages
+      operationId: get_ses_messages
+      tags: [aws]
       parameters:
       - $ref: '#/components/parameters/SesMessageId'
       - description: Source of the message (`source` field of SES message)
@@ -354,6 +368,8 @@ paths:
   /_aws/sns/platform-endpoint-messages:
     delete:
       description: Discard SNS platform endpoint messages
+      operationId: discard_sns_messages
+      tags: [aws]
       parameters:
       - $ref: '#/components/parameters/SnsAccountId'
       - $ref: '#/components/parameters/SnsRegion'
@@ -363,6 +379,8 @@ paths:
           description: Platform endpoint message was discarded
     get:
       description: Retrieve SNS platform endpoint messages
+      operationId: get_sns_messages
+      tags: [aws]
       parameters:
       - $ref: '#/components/parameters/SnsAccountId'
       - $ref: '#/components/parameters/SnsRegion'
@@ -386,6 +404,8 @@ paths:
   /_aws/sns/sms-messages:
     delete:
       description: Discard SNS SMS messages
+      operationId: discard_sns_sms_messages
+      tags: [aws]
       parameters:
       - $ref: '#/components/parameters/SnsAccountId'
       - $ref: '#/components/parameters/SnsRegion'
@@ -397,6 +417,8 @@ paths:
           description: SMS message was discarded
     get:
       description: Retrieve SNS SMS messages
+      operationId: get_sns_sms_messages
+      tags: [aws]
       parameters:
       - $ref: '#/components/parameters/SnsAccountId'
       - $ref: '#/components/parameters/SnsRegion'
@@ -420,6 +442,8 @@ paths:
   /_aws/sns/subscription-tokens/{subscription_arn}:
     get:
       description: Retrieve SNS subscription token for confirmation
+      operationId: get_sns_subscription_token
+      tags: [aws]
       parameters:
       - description: '`subscriptionArn` resource of subscription token'
         in: path
@@ -458,6 +482,8 @@ paths:
   /_aws/sqs/messages:
     get:
       description: List SQS queue messages without side effects
+      operationId: list_all_sqs_messages
+      tags: [aws]
       parameters:
       - description: SQS queue URL
         in: query
@@ -481,6 +507,8 @@ paths:
   /_aws/sqs/messages/{region}/{account_id}/{queue_name}:
     get:
       description: List SQS messages without side effects
+      operationId: list_sqs_queue_messages
+      tags: [aws]
       parameters:
       - description: SQS queue region
         in: path
@@ -516,6 +544,8 @@ paths:
   /_localstack/config:
     get:
       description: Get current LocalStack configuration
+      operationId: get_localstack_config
+      tags: [internal]
       responses:
         '200':
           content:
@@ -524,6 +554,9 @@ paths:
                 type: object
           description: Current LocalStack configuration
     post:
+      description: Configuration option to update with new value
+      operationId: update_configuration_option
+      tags: [internal]
       requestBody:
         content:
           application/json:
@@ -541,7 +574,6 @@ paths:
               - variable
               - value
               type: object
-        description: Configuration option to update with new value
         required: true
       responses:
         '200':
@@ -568,6 +600,8 @@ paths:
   /_localstack/diagnose:
     get:
       description: Get diagnostics report
+      operationId: get_diagnose
+      tags: [internal]
       responses:
         '200':
           content:
@@ -668,6 +702,8 @@ paths:
   /_localstack/health:
     get:
       description: Get available LocalStack features and AWS services
+      operationId: health
+      tags: [internal]
       parameters:
       - allowEmptyValue: true
         in: query
@@ -703,6 +739,7 @@ paths:
                 type: object
           description: Available LocalStack features and AWS services
     head:
+      tags: [internal]
       responses:
         '200':
           content:
@@ -710,6 +747,8 @@ paths:
           description: ''
     post:
       description: Restart or terminate LocalStack session
+      operationId: restart_or_terminate_session
+      tags: [internal]
       requestBody:
         content:
           application/json:
@@ -737,6 +776,8 @@ paths:
           description: Bad request
     put:
       description: Store arbitrary data to in-memory state
+      operationId: store_data
+      tags: [internal]
       requestBody:
         content:
           application/json:
@@ -759,6 +800,8 @@ paths:
   /_localstack/info:
     get:
       description: Get information about the current LocalStack session
+      operationId: get_session_info
+      tags: [internal]
       responses:
         '200':
           content:
@@ -769,6 +812,8 @@ paths:
   /_localstack/init:
     get:
       description: Get information about init scripts
+      operationId: get_init_script_info
+      tags: [internal]
       responses:
         '200':
           content:
@@ -779,6 +824,8 @@ paths:
   /_localstack/init/{stage}:
     get:
       description: Get information about init scripts in a specific stage
+      operationId: get_init_script_info_stage
+      tags: [internal]
       parameters:
       - in: path
         name: stage
@@ -795,6 +842,8 @@ paths:
   /_localstack/plugins:
     get:
       description: ''
+      operationId: get_plugins
+      tags: [internal]
       responses:
         '200':
           content:
@@ -803,6 +852,8 @@ paths:
   /_localstack/usage:
     get:
       description: ''
+      operationId: get_usage
+      tags: [internal]
       responses:
         '200':
           content:

--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -544,8 +544,8 @@ paths:
   /_localstack/config:
     get:
       description: Get current LocalStack configuration
-      operationId: get_localstack_config
-      tags: [internal]
+      operationId: get_config
+      tags: [localstack]
       responses:
         '200':
           content:
@@ -556,7 +556,7 @@ paths:
     post:
       description: Configuration option to update with new value
       operationId: update_config_option
-      tags: [internal]
+      tags: [localstack]
       requestBody:
         content:
           application/json:
@@ -601,7 +601,7 @@ paths:
     get:
       description: Get diagnostics report
       operationId: get_diagnostic
-      tags: [internal]
+      tags: [localstack]
       responses:
         '200':
           content:
@@ -703,7 +703,7 @@ paths:
     get:
       description: Get available LocalStack features and AWS services
       operationId: get_features_and_services
-      tags: [internal]
+      tags: [localstack]
       parameters:
       - allowEmptyValue: true
         in: query
@@ -739,7 +739,7 @@ paths:
                 type: object
           description: Available LocalStack features and AWS services
     head:
-      tags: [internal]
+      tags: [localstack]
       operationId: heath
       responses:
         '200':
@@ -749,7 +749,7 @@ paths:
     post:
       description: Restart or terminate LocalStack session
       operationId: manage_session
-      tags: [internal]
+      tags: [localstack]
       requestBody:
         content:
           application/json:
@@ -778,7 +778,7 @@ paths:
     put:
       description: Store arbitrary data to in-memory state
       operationId: store_data
-      tags: [internal]
+      tags: [localstack]
       requestBody:
         content:
           application/json:
@@ -802,7 +802,7 @@ paths:
     get:
       description: Get information about the current LocalStack session
       operationId: get_session_info
-      tags: [internal]
+      tags: [localstack]
       responses:
         '200':
           content:
@@ -814,7 +814,7 @@ paths:
     get:
       description: Get information about init scripts
       operationId: get_init_script_info
-      tags: [internal]
+      tags: [localstack]
       responses:
         '200':
           content:
@@ -826,7 +826,7 @@ paths:
     get:
       description: Get information about init scripts in a specific stage
       operationId: get_init_script_info_stage
-      tags: [internal]
+      tags: [localstack]
       parameters:
       - in: path
         name: stage
@@ -844,7 +844,7 @@ paths:
     get:
       description: ''
       operationId: get_plugins
-      tags: [internal]
+      tags: [localstack]
       responses:
         '200':
           content:
@@ -854,7 +854,7 @@ paths:
     get:
       description: ''
       operationId: get_usage
-      tags: [internal]
+      tags: [localstack]
       responses:
         '200':
           content:

--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -600,7 +600,7 @@ paths:
   /_localstack/diagnose:
     get:
       description: Get diagnostics report
-      operationId: get_diagnostic
+      operationId: get_diagnostics
       tags: [localstack]
       responses:
         '200':
@@ -740,7 +740,7 @@ paths:
           description: Available LocalStack features and AWS services
     head:
       tags: [localstack]
-      operationId: heath
+      operationId: health
       responses:
         '200':
           content:

--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -507,7 +507,7 @@ paths:
   /_aws/sqs/messages/{region}/{account_id}/{queue_name}:
     get:
       description: List SQS messages without side effects
-      operationId: list_sqs_queue_messages
+      operationId: list_sqs_messages
       tags: [aws]
       parameters:
       - description: SQS queue region


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The end goal of our OpenAPI spec is to generate SDKs from them.
Having `operationIds` and `tags` for each path help generate better code. In particular:
- `operationId` is used for naming the generated functions;
- `tags` are used to organize the code into modules.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- adding `operationId` and `tags` to all paths.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
