### PR TITLE
fix EC2 FlowLogs with S3 destination

### DIFF
--- a/localstack-core/localstack/services/ec2/provider.py
+++ b/localstack-core/localstack/services/ec2/provider.py
@@ -525,8 +525,14 @@ class Ec2Provider(Ec2Api, ABC, ServiceLifecycleHook):
                     ],
                 )
 
-            response = call_moto_with_request(context, service_request)
-
+            response: CreateFlowLogsResult = call_moto_with_request(context, service_request)
+            moto_backend = get_moto_backend(context)
+            for flow_log_id in response["FlowLogIds"]:
+                if flow_log := moto_backend.flow_logs.get(flow_log_id):
+                    # just to be sure to not override another value, we only replace if it's the placeholder
+                    flow_log.log_destination_type = flow_log.log_destination_type.replace(
+                        "__placeholder__", "s3"
+                    )
         else:
             response = call_moto(context)
 

--- a/localstack-core/localstack/services/ec2/provider.py
+++ b/localstack-core/localstack/services/ec2/provider.py
@@ -1,4 +1,6 @@
+import copy
 import json
+import logging
 import re
 from abc import ABC
 from datetime import datetime, timezone
@@ -8,6 +10,7 @@ from moto.core.utils import camelcase_to_underscores, underscores_to_camelcase
 from moto.ec2.exceptions import InvalidVpcEndPointIdError
 from moto.ec2.models import (
     EC2Backend,
+    FlowLogsBackend,
     SubnetBackend,
     TransitGatewayAttachmentBackend,
     VPCBackend,
@@ -16,10 +19,12 @@ from moto.ec2.models import (
 from moto.ec2.models.launch_templates import LaunchTemplate as MotoLaunchTemplate
 from moto.ec2.models.subnets import Subnet
 
-from localstack.aws.api import RequestContext, handler
+from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.ec2 import (
     AvailabilityZone,
     Boolean,
+    CreateFlowLogsRequest,
+    CreateFlowLogsResult,
     CreateLaunchTemplateRequest,
     CreateLaunchTemplateResult,
     CreateSubnetRequest,
@@ -68,12 +73,15 @@ from localstack.aws.api.ec2 import (
     String,
     SubnetConfigurationsList,
     Tenancy,
+    UnsuccessfulItem,
+    UnsuccessfulItemError,
     VpcEndpointId,
     VpcEndpointRouteTableIdList,
     VpcEndpointSecurityGroupIdList,
     VpcEndpointSubnetIdList,
     scope,
 )
+from localstack.aws.connect import connect_to
 from localstack.services.ec2.exceptions import (
     InvalidLaunchTemplateIdError,
     InvalidLaunchTemplateNameError,
@@ -81,10 +89,12 @@ from localstack.services.ec2.exceptions import (
 )
 from localstack.services.ec2.models import get_ec2_backend
 from localstack.services.ec2.patches import apply_patches
-from localstack.services.moto import call_moto
+from localstack.services.moto import call_moto, call_moto_with_request
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.patch import patch
 from localstack.utils.strings import first_char_to_upper, long_uid, short_uid
+
+LOG = logging.getLogger(__name__)
 
 # additional subnet attributes not yet supported upstream
 ADDITIONAL_SUBNET_ATTRS = ("private_dns_name_options_on_launch", "enable_dns64")
@@ -463,6 +473,65 @@ class Ec2Provider(Ec2Api, ABC, ServiceLifecycleHook):
 
         return result
 
+    @handler("CreateFlowLogs", expand=False)
+    def create_flow_logs(
+        self,
+        context: RequestContext,
+        request: CreateFlowLogsRequest,
+        **kwargs,
+    ) -> CreateFlowLogsResult:
+        if request.get("LogDestination") and request.get("LogGroupName"):
+            raise CommonServiceException(
+                code="InvalidParameter",
+                message="Please only provide LogGroupName or only provide LogDestination.",
+            )
+        if request.get("LogDestinationType") == "s3":
+            if request.get("LogGroupName"):
+                raise CommonServiceException(
+                    code="InvalidParameter",
+                    message="LogDestination type must be cloud-watch-logs if LogGroupName is provided.",
+                )
+            elif not (bucket_arn := request.get("LogDestination")):
+                raise CommonServiceException(
+                    code="InvalidParameter",
+                    message="LogDestination can't be empty if LogGroupName is not provided.",
+                )
+
+            # Moto will check in memory whether the bucket exists in Moto itself
+            # we modify the request to not send a destination, so that the validation does not happen
+            # we can add the validation ourselves
+            service_request = copy.deepcopy(request)
+            service_request["LogDestinationType"] = "__placeholder__"
+            bucket_name = bucket_arn.split(":", 5)[5].split("/")[0]
+            # TODO: validate how IAM is enforced? probably with DeliverLogsPermissionArn
+            s3_client = connect_to().s3
+            try:
+                s3_client.head_bucket(Bucket=bucket_name)
+            except Exception as e:
+                LOG.debug(
+                    "An exception occured when trying to create FlowLogs with S3 destination: %s", e
+                )
+                return CreateFlowLogsResult(
+                    FlowLogIds=[],
+                    Unsuccessful=[
+                        UnsuccessfulItem(
+                            Error=UnsuccessfulItemError(
+                                Code="400",
+                                Message=f"Access Denied for LogDestination: {bucket_name}. Please check LogDestination permission",
+                            ),
+                            ResourceId=resource_id,
+                        )
+                        for resource_id in request.get("ResourceIds", [])
+                    ],
+                )
+
+            response = call_moto_with_request(context, service_request)
+
+        else:
+            response = call_moto(context)
+
+        return response
+
 
 @patch(SubnetBackend.modify_subnet_attribute)
 def modify_subnet_attribute(fn, self, subnet_id, attr_name, attr_value):
@@ -501,3 +570,27 @@ def delete_transit_gateway_vpc_attachment(fn, self, transit_gateway_attachment_i
     transit_gateway_attachment = self.transit_gateway_attachments.get(transit_gateway_attachment_id)
     transit_gateway_attachment.state = "deleted"
     return transit_gateway_attachment
+
+
+@patch(FlowLogsBackend._validate_request)
+def _validate_request(
+    fn,
+    self,
+    log_group_name: str,
+    log_destination: str,
+    log_destination_type: str,
+    max_aggregation_interval: str,
+    deliver_logs_permission_arn: str,
+) -> None:
+    if not log_destination_type and log_destination:
+        # this is to fix the S3 destination issue, the validation will occur in the provider
+        return
+
+    fn(
+        self,
+        log_group_name,
+        log_destination,
+        log_destination_type,
+        max_aggregation_interval,
+        deliver_logs_permission_arn,
+    )

--- a/localstack-core/localstack/services/ec2/provider.py
+++ b/localstack-core/localstack/services/ec2/provider.py
@@ -509,7 +509,8 @@ class Ec2Provider(Ec2Api, ABC, ServiceLifecycleHook):
                 s3_client.head_bucket(Bucket=bucket_name)
             except Exception as e:
                 LOG.debug(
-                    "An exception occured when trying to create FlowLogs with S3 destination: %s", e
+                    "An exception occurred when trying to create FlowLogs with S3 destination: %s",
+                    e,
                 )
                 return CreateFlowLogsResult(
                     FlowLogIds=[],
@@ -517,7 +518,7 @@ class Ec2Provider(Ec2Api, ABC, ServiceLifecycleHook):
                         UnsuccessfulItem(
                             Error=UnsuccessfulItemError(
                                 Code="400",
-                                Message=f"Access Denied for LogDestination: {bucket_name}. Please check LogDestination permission",
+                                Message=f"LogDestination: {bucket_name} does not exist",
                             ),
                             ResourceId=resource_id,
                         )

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -618,6 +618,10 @@ class TestEc2FlowLogs:
                 snapshot.transform.key_value("FlowLogId"),
                 snapshot.transform.key_value("ResourceId"),
                 snapshot.transform.resource_name(),
+                snapshot.transform.jsonpath(
+                    "$.create-flow-logs-s3-subfolder.FlowLogIds[0]",
+                    value_replacement="flow-log-id-sub",
+                ),
             ]
         )
         vpc = create_vpc(
@@ -637,6 +641,15 @@ class TestEc2FlowLogs:
 
         describe_flow_logs = aws_client.ec2.describe_flow_logs(FlowLogIds=response["FlowLogIds"])
         snapshot.match("describe-flow-logs", describe_flow_logs)
+
+        response = create_flow_logs(
+            ResourceIds=[vpc_id],
+            ResourceType="VPC",
+            LogDestinationType="s3",
+            LogDestination=f"arn:aws:s3:::{s3_bucket}/subfolder/",
+            TrafficType="ALL",
+        )
+        snapshot.match("create-flow-logs-s3-subfolder", response)
 
     @markers.aws.validated
     def test_ec2_flow_logs_s3_validation(

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 
 import pytest
 from botocore.exceptions import ClientError
@@ -13,6 +14,8 @@ from localstack.constants import TAG_KEY_CUSTOM_ID
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
+
+LOG = logging.getLogger(__name__)
 
 # public amazon image used for ec2 launch templates
 PUBLIC_AMAZON_LINUX_IMAGE = "ami-06c39ed6b42908a36"
@@ -577,6 +580,107 @@ class TestEc2Integrations:
 
         assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
         assert e.value.response["Error"]["Code"] == "InvalidSecurityGroupId.DuplicateCustomId"
+
+
+@markers.snapshot.skip_snapshot_verify(
+    # Moto and LS do not return the ClientToken
+    paths=["$..ClientToken"],
+)
+class TestEc2FlowLogs:
+    @pytest.fixture
+    def create_flow_logs(self, aws_client):
+        flow_logs = []
+
+        def _create(**kwargs):
+            response = aws_client.ec2.create_flow_logs(**kwargs)
+            flow_logs.extend(response.get("FlowLogIds", []))
+            return response
+
+        yield _create
+
+        try:
+            aws_client.ec2.delete_flow_logs(FlowLogIds=flow_logs)
+        except Exception:
+            LOG.debug("Error while cleaning up FlowLogs %s", flow_logs)
+
+    @markers.aws.validated
+    def test_ec2_flow_logs_s3(self, aws_client, create_vpc, s3_bucket, create_flow_logs, snapshot):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("ClientToken"),
+                snapshot.transform.jsonpath("$..FlowLogIds[0]", value_replacement="flow-log-id"),
+            ]
+        )
+        vpc = create_vpc(
+            cidr_block="10.0.0.0/24",
+            tag_specifications=[],
+        )
+        vpc_id = vpc["Vpc"]["VpcId"]
+
+        response = create_flow_logs(
+            ResourceIds=[vpc_id],
+            ResourceType="VPC",
+            LogDestinationType="s3",
+            LogDestination=f"arn:aws:s3:::{s3_bucket}",
+            TrafficType="ALL",
+        )
+        snapshot.match("create-flow-logs-s3", response)
+
+    @markers.aws.validated
+    def test_ec2_flow_logs_s3_validation(
+        self, aws_client, create_vpc, create_flow_logs, s3_bucket, snapshot
+    ):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("ClientToken"),
+                snapshot.transform.key_value("ResourceId"),
+            ]
+        )
+
+        vpc = create_vpc(
+            cidr_block="10.0.0.0/24",
+            tag_specifications=[],
+        )
+        vpc_id = vpc["Vpc"]["VpcId"]
+
+        non_existent_bucket = create_flow_logs(
+            ResourceIds=[vpc_id],
+            ResourceType="VPC",
+            LogDestinationType="s3",
+            LogDestination="arn:aws:s3:::bad-bucket",
+            TrafficType="ALL",
+        )
+        snapshot.match("non-existent-bucket", non_existent_bucket)
+
+        with pytest.raises(ClientError) as e:
+            create_flow_logs(
+                ResourceIds=[vpc_id],
+                ResourceType="VPC",
+                LogDestinationType="s3",
+                LogDestination=f"arn:aws:s3:::{s3_bucket}",
+                LogGroupName="test-group-name",
+                TrafficType="ALL",
+            )
+        snapshot.match("with-log-group-name", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            create_flow_logs(
+                ResourceIds=[vpc_id],
+                ResourceType="VPC",
+                LogDestinationType="s3",
+                TrafficType="ALL",
+            )
+        snapshot.match("no-log-destination", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            create_flow_logs(
+                ResourceIds=[vpc_id],
+                ResourceType="VPC",
+                LogDestinationType="s3",
+                LogGroupName="test",
+                TrafficType="ALL",
+            )
+        snapshot.match("log-group-name-s3-destination", e.value.response)
 
 
 @markers.aws.validated

--- a/tests/aws/services/ec2/test_ec2.snapshot.json
+++ b/tests/aws/services/ec2/test_ec2.snapshot.json
@@ -215,5 +215,73 @@
         "VpnGatewayId": "<vpn-gateway-id:1>"
       }
     }
+  },
+  "tests/aws/services/ec2/test_ec2.py::TestEc2FlowLogs::test_ec2_flow_logs_s3": {
+    "recorded-date": "24-09-2024, 22:58:17",
+    "recorded-content": {
+      "create-flow-logs-s3": {
+        "ClientToken": "<client-token:1>",
+        "FlowLogIds": [
+          "<flow-log-id:1>"
+        ],
+        "Unsuccessful": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/ec2/test_ec2.py::TestEc2FlowLogs::test_ec2_flow_logs_s3_validation": {
+    "recorded-date": "24-09-2024, 23:02:25",
+    "recorded-content": {
+      "non-existent-bucket": {
+        "ClientToken": "<client-token:1>",
+        "FlowLogIds": [],
+        "Unsuccessful": [
+          {
+            "Error": {
+              "Code": "400",
+              "Message": "Access Denied for LogDestination: bad-bucket. Please check LogDestination permission"
+            },
+            "ResourceId": "<resource-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "with-log-group-name": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Please only provide LogGroupName or only provide LogDestination."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "no-log-destination": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "LogDestination can't be empty if LogGroupName is not provided."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "log-group-name-s3-destination": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "LogDestination type must be cloud-watch-logs if LogGroupName is provided."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/ec2/test_ec2.snapshot.json
+++ b/tests/aws/services/ec2/test_ec2.snapshot.json
@@ -217,7 +217,7 @@
     }
   },
   "tests/aws/services/ec2/test_ec2.py::TestEc2FlowLogs::test_ec2_flow_logs_s3": {
-    "recorded-date": "24-09-2024, 22:58:17",
+    "recorded-date": "24-09-2024, 23:10:19",
     "recorded-content": {
       "create-flow-logs-s3": {
         "ClientToken": "<client-token:1>",
@@ -225,6 +225,32 @@
           "<flow-log-id:1>"
         ],
         "Unsuccessful": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-flow-logs": {
+        "FlowLogs": [
+          {
+            "CreationTime": "<datetime>",
+            "DeliverLogsStatus": "SUCCESS",
+            "DestinationOptions": {
+              "FileFormat": "plain-text",
+              "HiveCompatiblePartitions": false,
+              "PerHourPartition": false
+            },
+            "FlowLogId": "<flow-log-id:1>",
+            "FlowLogStatus": "ACTIVE",
+            "LogDestination": "arn:<partition>:s3:::<resource:1>",
+            "LogDestinationType": "s3",
+            "LogFormat": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+            "MaxAggregationInterval": 600,
+            "ResourceId": "<resource-id:1>",
+            "Tags": [],
+            "TrafficType": "ALL"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/ec2/test_ec2.snapshot.json
+++ b/tests/aws/services/ec2/test_ec2.snapshot.json
@@ -270,7 +270,7 @@
     }
   },
   "tests/aws/services/ec2/test_ec2.py::TestEc2FlowLogs::test_ec2_flow_logs_s3_validation": {
-    "recorded-date": "24-09-2024, 23:02:25",
+    "recorded-date": "24-09-2024, 23:26:43",
     "recorded-content": {
       "non-existent-bucket": {
         "ClientToken": "<client-token:1>",
@@ -279,7 +279,7 @@
           {
             "Error": {
               "Code": "400",
-              "Message": "Access Denied for LogDestination: bad-bucket. Please check LogDestination permission"
+              "Message": "LogDestination: <bad-bucket-name> does not exist"
             },
             "ResourceId": "<resource-id:1>"
           }

--- a/tests/aws/services/ec2/test_ec2.snapshot.json
+++ b/tests/aws/services/ec2/test_ec2.snapshot.json
@@ -217,7 +217,7 @@
     }
   },
   "tests/aws/services/ec2/test_ec2.py::TestEc2FlowLogs::test_ec2_flow_logs_s3": {
-    "recorded-date": "24-09-2024, 23:10:19",
+    "recorded-date": "24-09-2024, 23:19:46",
     "recorded-content": {
       "create-flow-logs-s3": {
         "ClientToken": "<client-token:1>",
@@ -251,6 +251,17 @@
             "TrafficType": "ALL"
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-flow-logs-s3-subfolder": {
+        "ClientToken": "<client-token:1>",
+        "FlowLogIds": [
+          "<flow-log-id-sub:1>"
+        ],
+        "Unsuccessful": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/ec2/test_ec2.validation.json
+++ b/tests/aws/services/ec2/test_ec2.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/ec2/test_ec2.py::TestEc2FlowLogs::test_ec2_flow_logs_s3": {
-    "last_validated_date": "2024-09-24T22:58:17+00:00"
+    "last_validated_date": "2024-09-24T23:10:19+00:00"
   },
   "tests/aws/services/ec2/test_ec2.py::TestEc2FlowLogs::test_ec2_flow_logs_s3_validation": {
     "last_validated_date": "2024-09-24T23:02:24+00:00"

--- a/tests/aws/services/ec2/test_ec2.validation.json
+++ b/tests/aws/services/ec2/test_ec2.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/ec2/test_ec2.py::TestEc2FlowLogs::test_ec2_flow_logs_s3": {
-    "last_validated_date": "2024-09-24T23:10:19+00:00"
+    "last_validated_date": "2024-09-24T23:19:46+00:00"
   },
   "tests/aws/services/ec2/test_ec2.py::TestEc2FlowLogs::test_ec2_flow_logs_s3_validation": {
     "last_validated_date": "2024-09-24T23:02:24+00:00"

--- a/tests/aws/services/ec2/test_ec2.validation.json
+++ b/tests/aws/services/ec2/test_ec2.validation.json
@@ -3,7 +3,7 @@
     "last_validated_date": "2024-09-24T23:19:46+00:00"
   },
   "tests/aws/services/ec2/test_ec2.py::TestEc2FlowLogs::test_ec2_flow_logs_s3_validation": {
-    "last_validated_date": "2024-09-24T23:02:24+00:00"
+    "last_validated_date": "2024-09-24T23:26:43+00:00"
   },
   "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_create_route_table_association": {
     "last_validated_date": "2024-06-06T19:21:49+00:00"

--- a/tests/aws/services/ec2/test_ec2.validation.json
+++ b/tests/aws/services/ec2/test_ec2.validation.json
@@ -1,4 +1,10 @@
 {
+  "tests/aws/services/ec2/test_ec2.py::TestEc2FlowLogs::test_ec2_flow_logs_s3": {
+    "last_validated_date": "2024-09-24T22:58:17+00:00"
+  },
+  "tests/aws/services/ec2/test_ec2.py::TestEc2FlowLogs::test_ec2_flow_logs_s3_validation": {
+    "last_validated_date": "2024-09-24T23:02:24+00:00"
+  },
   "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_create_route_table_association": {
     "last_validated_date": "2024-06-06T19:21:49+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #10773, we had an issue since migrating S3 to LocalStack, as moto was directly accessing the bucket in memory to verify its existence.

It needs a fair amount of patching and overriding in the provider, but this seems like the safest bet. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add 2 AWS validated tests, one positive and one negative
- implement `CreateFlowLogs` in the provider, and intercepted the request to remove the `s3` destination to avoid patching the whole method in `moto`
  - we now remove `s3` in order to pass the validation in `moto`, pre-validate ourselves, and put back the `s3` value after
  - we also validate the existence of the bucket, removing subfolders if there are any


_fixes #10773_
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
