### PR TITLE
fix(cors): append lambda logs header in the CORS headers list

### DIFF
--- a/localstack-core/localstack/aws/handlers/cors.py
+++ b/localstack-core/localstack/aws/handlers/cors.py
@@ -55,7 +55,7 @@ CORS_ALLOWED_HEADERS = [
     "amz-sdk-invocation-id",
     "amz-sdk-request",
     # for lambda
-    "x-amz-log-type"
+    "x-amz-log-type",
 ]
 if EXTRA_CORS_ALLOWED_HEADERS:
     CORS_ALLOWED_HEADERS += EXTRA_CORS_ALLOWED_HEADERS.split(",")

--- a/localstack-core/localstack/aws/handlers/cors.py
+++ b/localstack-core/localstack/aws/handlers/cors.py
@@ -54,6 +54,8 @@ CORS_ALLOWED_HEADERS = [
     # for AWS SDK v3
     "amz-sdk-invocation-id",
     "amz-sdk-request",
+    # for lambda
+    "x-amz-log-type"
 ]
 if EXTRA_CORS_ALLOWED_HEADERS:
     CORS_ALLOWED_HEADERS += EXTRA_CORS_ALLOWED_HEADERS.split(",")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
During the implementation of the invoke function feature in the web app, lambda `invoke` call with `"LogType": "Tail"` option was setting a header `x-amz-log-type` causing a CORS error because this header is not in the CORS allowed headers list

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This PR adds the `x-amz-log-type` header to the list so the CORS error goes away
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
