### PR TITLE
Add tests to test urlencoded IAM policies

### DIFF
--- a/localstack-core/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack-core/localstack/testing/snapshots/transformer_utility.py
@@ -345,6 +345,7 @@ class TransformerUtility:
             TransformerUtility.key_value("RoleName"),
             TransformerUtility.key_value("PolicyName"),
             TransformerUtility.key_value("PolicyId"),
+            TransformerUtility.key_value("GroupName"),
         ]
 
     @staticmethod

--- a/tests/aws/services/iam/test_iam.snapshot.json
+++ b/tests/aws/services/iam/test_iam.snapshot.json
@@ -387,8 +387,8 @@
       }
     }
   },
-  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_put_policy_encoding": {
-    "recorded-date": "23-09-2024, 12:33:47",
+  "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_user_policy_encoding": {
+    "recorded-date": "25-09-2024, 15:10:45",
     "recorded-content": {
       "get-policy-response": {
         "PolicyDocument": {
@@ -407,6 +407,92 @@
         },
         "PolicyName": "<policy-name:1>",
         "UserName": "<user-name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_role_policy_encoding": {
+    "recorded-date": "25-09-2024, 15:10:46",
+    "recorded-content": {
+      "get-policy-response": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "apigatway:PUT"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "arn:<partition>:apigateway:<region>::/tags/arn%3Aaws%3Aapigateway%3A<region>%3A%3A%2Frestapis%2Faaeeieije"
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "<policy-name:1>",
+        "RoleName": "<role-name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-role-response": {
+        "Role": {
+          "Arn": "arn:<partition>:iam::111111111111:role/<role-name:1>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": "sts:AssumeRole",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:SourceArn": "arn%3Aaws%3Aapigateway%3A<region>%3A%3A%2Frestapis%2Faaeeieije"
+                  }
+                },
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": "lambda.amazonaws.com"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "datetime",
+          "MaxSessionDuration": 3600,
+          "Path": "/",
+          "RoleId": "<role-id:1>",
+          "RoleLastUsed": {},
+          "RoleName": "<role-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_group_policy_encoding": {
+    "recorded-date": "25-09-2024, 15:10:47",
+    "recorded-content": {
+      "get-policy-response": {
+        "GroupName": "<group-name:1>",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "apigatway:PUT"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "arn:<partition>:apigateway:<region>::/tags/arn%3Aaws%3Aapigateway%3A<region>%3A%3A%2Frestapis%2Faaeeieije"
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "<policy-name:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/iam/test_iam.snapshot.json
+++ b/tests/aws/services/iam/test_iam.snapshot.json
@@ -386,5 +386,32 @@
         }
       }
     }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_put_policy_encoding": {
+    "recorded-date": "23-09-2024, 12:33:47",
+    "recorded-content": {
+      "get-policy-response": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "apigatway:PUT"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "arn:<partition>:apigateway:<region>::/tags/arn%3Aaws%3Aapigateway%3A<region>%3A%3A%2Frestapis%2Faaeeieije"
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "<policy-name:1>",
+        "UserName": "<user-name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/iam/test_iam.snapshot.json
+++ b/tests/aws/services/iam/test_iam.snapshot.json
@@ -415,8 +415,38 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_role_policy_encoding": {
-    "recorded-date": "25-09-2024, 15:10:46",
+    "recorded-date": "30-09-2024, 15:17:42",
     "recorded-content": {
+      "create-role-response": {
+        "Role": {
+          "Arn": "arn:<partition>:iam::111111111111:role<path:1><role-name:1>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": "sts:AssumeRole",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:SourceArn": "arn%3Aaws%3Aapigateway%3A<region>%3A%3A%2Frestapis%2Faaeeieije"
+                  }
+                },
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": "lambda.amazonaws.com"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "datetime",
+          "Path": "<path:1>",
+          "RoleId": "<role-id:1>",
+          "RoleName": "<role-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "get-policy-response": {
         "PolicyDocument": {
           "Statement": [
@@ -441,7 +471,7 @@
       },
       "get-role-response": {
         "Role": {
-          "Arn": "arn:<partition>:iam::111111111111:role/<role-name:1>",
+          "Arn": "arn:<partition>:iam::111111111111:role<path:1><role-name:1>",
           "AssumeRolePolicyDocument": {
             "Statement": [
               {
@@ -461,11 +491,45 @@
           },
           "CreateDate": "datetime",
           "MaxSessionDuration": 3600,
-          "Path": "/",
+          "Path": "<path:1>",
           "RoleId": "<role-id:1>",
           "RoleLastUsed": {},
           "RoleName": "<role-name:1>"
         },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-roles-response": {
+        "IsTruncated": false,
+        "Roles": [
+          {
+            "Arn": "arn:<partition>:iam::111111111111:role<path:1><role-name:1>",
+            "AssumeRolePolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "sts:AssumeRole",
+                  "Condition": {
+                    "StringEquals": {
+                      "aws:SourceArn": "arn%3Aaws%3Aapigateway%3A<region>%3A%3A%2Frestapis%2Faaeeieije"
+                    }
+                  },
+                  "Effect": "Allow",
+                  "Principal": {
+                    "Service": "lambda.amazonaws.com"
+                  }
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "CreateDate": "datetime",
+            "MaxSessionDuration": 3600,
+            "Path": "<path:1>",
+            "RoleId": "<role-id:1>",
+            "RoleName": "<role-name:1>"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/iam/test_iam.validation.json
+++ b/tests/aws/services/iam/test_iam.validation.json
@@ -11,6 +11,9 @@
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_list_roles_with_permission_boundary": {
     "last_validated_date": "2023-09-14T15:42:39+00:00"
   },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_put_policy_encoding": {
+    "last_validated_date": "2024-09-23T12:34:15+00:00"
+  },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_role_attach_policy": {
     "last_validated_date": "2023-09-14T15:42:42+00:00"
   },

--- a/tests/aws/services/iam/test_iam.validation.json
+++ b/tests/aws/services/iam/test_iam.validation.json
@@ -11,9 +11,6 @@
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_list_roles_with_permission_boundary": {
     "last_validated_date": "2023-09-14T15:42:39+00:00"
   },
-  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_put_policy_encoding": {
-    "last_validated_date": "2024-09-23T12:34:15+00:00"
-  },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_role_attach_policy": {
     "last_validated_date": "2023-09-14T15:42:42+00:00"
   },
@@ -22,5 +19,14 @@
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_user_attach_policy": {
     "last_validated_date": "2023-09-14T15:42:45+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_group_policy_encoding": {
+    "last_validated_date": "2024-09-25T15:12:26+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_role_policy_encoding": {
+    "last_validated_date": "2024-09-25T15:12:24+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_user_policy_encoding": {
+    "last_validated_date": "2024-09-25T15:12:23+00:00"
   }
 }

--- a/tests/aws/services/iam/test_iam.validation.json
+++ b/tests/aws/services/iam/test_iam.validation.json
@@ -24,7 +24,7 @@
     "last_validated_date": "2024-09-25T15:12:26+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_role_policy_encoding": {
-    "last_validated_date": "2024-09-25T15:12:24+00:00"
+    "last_validated_date": "2024-09-30T15:17:41+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_user_policy_encoding": {
     "last_validated_date": "2024-09-25T15:12:23+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
During investigation of an IAM issue, I noticed our IAM implementation not returning exactly the same policies as submitted.

This happens, when parts of the policy are already urlencoded, and the response removes this encoding, returning the actual value.
This behavior however does not match AWS, which does return the policies as they were submitted.

A fix for this behavior is in getmoto/moto#8157, this PR only contains AWS validated tests for this behavior. The tests will fail, as long as the PR in moto is not merged and moto updated in LocalStack.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Add AWS validated tests to verify the policies being unchanged, even if they contain urlencoded parts

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
