### PR TITLE
Add client factory to bypass LocalStack DNS server

### DIFF
--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -677,6 +677,7 @@ class ExternalBypassDnsClientFactory(ExternalAwsClientFactory):
         super().__init__(use_ssl=True, verify=True, session=session, config=config)
 
     def _get_client_post_hook(self, client: BaseClient) -> BaseClient:
+        client = super()._get_client_post_hook(client)
         client._endpoint.http_session = ExternalBypassDnsSession()
         return client
 

--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -729,7 +729,6 @@ class ExternalBypassDnsSession(URLLib3Session):
 
 connect_to = InternalClientFactory(use_ssl=localstack_config.DISTRIBUTED_MODE)
 connect_externally_to = ExternalClientFactory()
-connect_bypass_dns = ExternalBypassDnsClientFactory()
 
 
 #

--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -647,6 +647,7 @@ class ExternalAwsClientFactory(ClientFactory):
 
 
 IGNORE_DNS = ContextVar("ignore_dns", default=False)
+"""ContextVar that tracks whether HTTP requests should bypass the DNS server (i.e. transparent endpoint injection) or not."""
 
 
 def resolve_dns_from_upstream(hostname: str) -> str:

--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -699,6 +699,7 @@ class ExternalBypassDnsHTTPSConnection(AWSHTTPSConnection):
     """
     Connection class that bypasses the LocalStack DNS server for HTTPS connections
     """
+
     def _new_conn(self) -> socket:
         orig_host = self._dns_host
         try:
@@ -720,6 +721,7 @@ class ExternalBypassDnsSession(URLLib3Session):
     """
     urllib3 session wrapper that uses our custom connection pool.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We have the need for a boto client that bypasses the LocalStack DNS server. This client needs to be able to reach out to AWS (given valid user credentials).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes


* Add new `ExternalBypassDnsClientFactory` client factory that ignores the LocalStack DNS server
* Subclass/specialise a few classes required to support a custom HTTP(s) connection factory
* The custom connection factory creates instances of a custom connection type, which temporarily replaces the host name connect to with the IP address of the same hostname, resolved _outside of LocalStack_.
* This replacement is done temporarily in the case of HTTPS because otherwise the certificate returned by AWS would not be valid for the IP address of the server


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->