### PR TITLE
ESM-v2: Create hooks for downstream poller creation

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_config_factory.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_config_factory.py
@@ -6,6 +6,7 @@ from localstack.aws.api.lambda_ import (
     EventSourceMappingConfiguration,
     EventSourcePosition,
 )
+from localstack.services.lambda_ import hooks as lambda_hooks
 from localstack.services.lambda_.event_source_mapping.esm_worker import EsmState, EsmStateReason
 from localstack.services.lambda_.event_source_mapping.pipe_utils import (
     get_standardized_service_name,
@@ -29,10 +30,11 @@ class EsmConfigFactory:
         * CreatePipe API: https://docs.aws.amazon.com/eventbridge/latest/pipes-reference/API_CreatePipe.html
         The CreatePipe API covers largely the same parameters, but is better structured using hierarchical parameters.
         """
-        # TODO: handle special case where the "EventSourceArn" is optional (e.g., Apache Kafka: https://aws.amazon.com/blogs/compute/using-self-hosted-apache-kafka-as-an-event-source-for-aws-lambda/)
-        source_arn = self.request["EventSourceArn"]
-        parsed_arn = parse_arn(source_arn)
-        service = get_standardized_service_name(parsed_arn["service"])
+
+        service = ""
+        if source_arn := self.request.get("EventSourceArn"):
+            parsed_arn = parse_arn(source_arn)
+            service = get_standardized_service_name(parsed_arn["service"])
 
         default_source_parameters = {}
         user_state_reason = EsmStateReason.USER_ACTION
@@ -63,9 +65,14 @@ class EsmConfigFactory:
             default_source_parameters["StartingPosition"] = EventSourcePosition.TRIM_HORIZON
             default_source_parameters["TumblingWindowInSeconds"] = 0
         else:
-            raise Exception(
-                f"Default Lambda Event Source Mapping parameters not implemented for service {service}."
+            lambda_hooks.set_event_source_config_defaults.run(
+                default_source_parameters, self.request, service
             )
+
+            if not default_source_parameters:
+                raise Exception(
+                    f"Default Lambda Event Source Mapping parameters not implemented for service {service}. req={self.request} dict={default_source_parameters}"
+                )
 
         # TODO: test whether merging actually happens recursively. Examples:
         # a) What happens if only one of the parameters for DocumentDBEventSourceConfig change?
@@ -73,9 +80,10 @@ class EsmConfigFactory:
         # c) Are FilterCriteria.Filters merged or replaced upon update?
         # TODO: can we ignore extra parameters from the request (e.g., Kinesis params for SQS source)?
         derived_source_parameters = merge_recursive(default_source_parameters, self.request)
-        derived_source_parameters["FunctionResponseTypes"] = derived_source_parameters.get(
-            "FunctionResponseTypes", []
-        )
+        if service in ("sqs", "kinesis", "dynamodbstreams"):
+            derived_source_parameters["FunctionResponseTypes"] = derived_source_parameters.get(
+                "FunctionResponseTypes", []
+            )
 
         state = EsmState.CREATING if self.request.get("Enabled", True) else EsmState.DISABLED
         esm_config = EventSourceMappingConfiguration(

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
@@ -130,7 +130,8 @@ class EsmWorker:
             except Exception as e:
                 LOG.error(
                     "Error while polling messages for event source %s: %s",
-                    self.esm_config["EventSourceArn"],
+                    self.esm_config.get("EventSourceArn")
+                    or self.esm_config.get("SelfManagedEventSource"),
                     e,
                     exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/senders/lambda_sender.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/senders/lambda_sender.py
@@ -23,7 +23,7 @@ class LambdaSender(Sender):
         super().__init__(target_arn, target_parameters, target_client)
         self.payload_dict = payload_dict
 
-    def send_events(self, events: list[dict]) -> dict:
+    def send_events(self, events: list[dict] | dict) -> dict:
         if self.payload_dict:
             events = {"Records": events}
         # TODO: test qualified + unqualified Lambda invoke

--- a/localstack-core/localstack/services/lambda_/hooks.py
+++ b/localstack-core/localstack/services/lambda_/hooks.py
@@ -6,8 +6,15 @@ HOOKS_LAMBDA_START_DOCKER_EXECUTOR = "localstack.hooks.lambda_start_docker_execu
 HOOKS_LAMBDA_PREPARE_DOCKER_EXECUTOR = "localstack.hooks.lambda_prepare_docker_executors"
 HOOKS_LAMBDA_INJECT_LAYER_FETCHER = "localstack.hooks.lambda_inject_layer_fetcher"
 HOOKS_LAMBDA_PREBUILD_ENVIRONMENT_IMAGE = "localstack.hooks.lambda_prebuild_environment_image"
+HOOKS_LAMBDA_CREATE_EVENT_SOURCE_POLLER = "localstack.hooks.lambda_create_event_source_poller"
+HOOKS_LAMBDA_SET_EVENT_SOURCE_CONFIG_DEFAULTS = (
+    "localstack.hooks.lambda_set_event_source_config_defaults"
+)
+
 
 start_docker_executor = hook_spec(HOOKS_LAMBDA_START_DOCKER_EXECUTOR)
 prepare_docker_executor = hook_spec(HOOKS_LAMBDA_PREPARE_DOCKER_EXECUTOR)
 inject_layer_fetcher = hook_spec(HOOKS_LAMBDA_INJECT_LAYER_FETCHER)
 prebuild_environment_image = hook_spec(HOOKS_LAMBDA_PREBUILD_ENVIRONMENT_IMAGE)
+create_event_source_poller = hook_spec(HOOKS_LAMBDA_CREATE_EVENT_SOURCE_POLLER)
+set_event_source_config_defaults = hook_spec(HOOKS_LAMBDA_SET_EVENT_SOURCE_CONFIG_DEFAULTS)

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1819,7 +1819,9 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         return event_source_configuration
 
     def create_event_source_mapping_v2(
-        self, context: RequestContext, request: CreateEventSourceMappingRequest
+        self,
+        context: RequestContext,
+        request: CreateEventSourceMappingRequest,
     ) -> EventSourceMappingConfiguration:
         # Validations
         function_arn, function_name, state = self.validate_event_source_mapping(context, request)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR allows for hooks to be defined downstream that can be used for defining an event source mapping. This hooks approach is currently due to the contraints of the factory pattern that `EsmWorkerFactory` and `EsmConfigFactory` currently employ.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Include `create_event_source_poller` and `set_event_source_config_defaults` pollers for creation of ESM workers and config defined downstream, respectively.
- The base `Poller` class, `EsmWorkerFactory`, and `EsmConfigFactory` now handle when a `source_arn` is not defined.

## Testing
- [ ] Running community test against downstream branch https://github.com/localstack/localstack/actions/runs/11071710532

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
