### PR TITLE
fix(cors): append lambda invocation headers in the expose headers list

### DIFF
--- a/localstack-core/localstack/aws/handlers/cors.py
+++ b/localstack-core/localstack/aws/handlers/cors.py
@@ -65,6 +65,10 @@ CORS_ALLOWED_METHODS = ("HEAD", "GET", "PUT", "POST", "DELETE", "OPTIONS", "PATC
 CORS_EXPOSE_HEADERS = (
     "etag",
     "x-amz-version-id",
+    # for lambda
+    "x-amz-log-result",
+    "x-amz-executed-version",
+    "x-amz-function-error",
 )
 if EXTRA_CORS_EXPOSE_HEADERS:
     CORS_EXPOSE_HEADERS += tuple(EXTRA_CORS_EXPOSE_HEADERS.split(","))


### PR DESCRIPTION
## Motivation
After the implementation of https://github.com/localstack/localstack/pull/11577, CORS header was gone from lambda invocation implementation in the web app but a new problem came up where lambda invocation response was not returning full payload. The response should be returning 
```
export interface InvocationResponse {
    StatusCode?: Integer;
    FunctionError?: String;
    LogResult?: String;
    Payload?: _Blob;
    ExecutedVersion?: Version;
  }
```
but it was returning:
```
export interface InvocationResponse {
    StatusCode?: Integer;
    Payload?: _Blob;
  }
```
After some debugging, I found out the data was being returned in the response headers but not in the response. 

## Changes
This PR adds the required headers to the expose headers list so we get back the full payload.