### PR TITLE
CFn: propagate lambda tags to function

### DIFF
--- a/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_function.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_function.py
@@ -350,6 +350,11 @@ class LambdaFunctionProvider(ResourceProvider[LambdaFunctionProperties]):
                 kwargs["Timeout"] = int(kwargs["Timeout"])
             if "MemorySize" in kwargs:
                 kwargs["MemorySize"] = int(kwargs["MemorySize"])
+            if model_tags := model.get("Tags"):
+                tags = {}
+                for tag in model_tags:
+                    tags[tag["Key"]] = tag["Value"]
+                kwargs["Tags"] = tags
 
             # botocore/data/lambda/2015-03-31/service-2.json:1161 (EnvironmentVariableValue)
             # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html
@@ -362,6 +367,7 @@ class LambdaFunctionProvider(ResourceProvider[LambdaFunctionProperties]):
             kwargs["Code"] = _get_lambda_code_param(model)
             create_response = lambda_client.create_function(**kwargs)
             model["Arn"] = create_response["FunctionArn"]
+
         get_fn_response = lambda_client.get_function(FunctionName=model["Arn"])
         match get_fn_response["Configuration"]["State"]:
             case "Pending":

--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -486,6 +486,25 @@ def test_multiple_lambda_permissions_for_singlefn(deploy_cfn_template, snapshot,
     snapshot.match("policy", policy)
 
 
+@markers.aws.validated
+def test_lambda_function_tags(deploy_cfn_template, aws_client):
+    function_name = f"fn-{short_uid()}"
+    environment = f"dev-{short_uid()}"
+    deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__),
+            "../../../templates/cfn_lambda_with_tags.yml",
+        ),
+        parameters={
+            "FunctionName": function_name,
+            "Environment": environment,
+        },
+    )
+
+    get_function_result = aws_client.lambda_.get_function(FunctionName=function_name)
+    assert get_function_result["Tags"]["Environment"] == environment
+
+
 class TestCfnLambdaIntegrations:
     @markers.snapshot.skip_snapshot_verify(
         paths=[

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -32,6 +32,9 @@
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_code_signing_config": {
     "last_validated_date": "2024-04-09T07:19:51+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_function_tags": {
+    "last_validated_date": "2024-09-26T16:33:07+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_version": {
     "last_validated_date": "2024-04-09T07:21:37+00:00"
   },

--- a/tests/aws/templates/cfn_lambda_with_tags.yml
+++ b/tests/aws/templates/cfn_lambda_with_tags.yml
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  FunctionName:
+      Type: String
+  Environment:
+      Type: String
+
+Resources:
+  TestFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Ref FunctionName
+      InlineCode: |
+        def handler(event, context):
+            return {'body': 'Hello World!', 'statusCode': 200}
+      Handler: index.handler
+      Runtime: python3.11
+      Tags:
+        Environment: !Ref Environment
+
+Outputs:
+  FunctionName:
+    Value: !Ref TestFunction


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In #11459 we find that tags are not propagated to lambda functions when deployed via CloudFormation.

This superscedes #11529.

Closes #11459 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Propagate the tags from the CFn resource payload to the `create_function` call.
* Add integration test capturing this

Note: the test is not a snapshot test because CFn adds default tags which we have to ignore, and the tags contain `:` characters, which the jsonpath-based snapshot library does not cope with.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->