### PR TITLE
fix APIGW test with hardcoded role name in CFN template

### DIFF
--- a/tests/aws/templates/apigw-awsintegration-request-parameters.yaml
+++ b/tests/aws/templates/apigw-awsintegration-request-parameters.yaml
@@ -21,7 +21,6 @@ Resources:
             Principal:
               AWS: "*"
         Version: "2012-10-17"
-      RoleName: MyRole
   MyRoleDefaultPolicyA36BE1DD:
     Type: AWS::IAM::Policy
     Properties:
@@ -52,12 +51,12 @@ Resources:
   RestApi0C43BF4B:
     Type: AWS::ApiGateway::RestApi
     Properties:
-      Name: 
+      Name:
         Ref: ApiName
       Tags:
-      - Key: 
-          Ref: CustomTagKey 
-        Value: 
+      - Key:
+          Ref: CustomTagKey
+        Value:
           Ref: CustomTagValue
   RestApiCloudWatchRoleE3ED6605:
     Type: AWS::IAM::Role
@@ -145,9 +144,9 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: arn:aws:acm:us-east-1:000000000000:certificate/00000000-0000-0000-0000-000000000000
       Tags:
-      - Key: 
-          Ref: CustomTagKey 
-        Value: 
+      - Key:
+          Ref: CustomTagKey
+        Value:
           Ref: CustomTagValue
   RestApiCustomDomainMapMyStackLocalRestApiE67E15D45F8B292A:
     Type: AWS::ApiGateway::BasePathMapping


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes this issue: https://github.com/localstack/localstack/runs/30611307634
It seems we've had an APIGW test with a CFN template with a hardcoded role name set to `MyRole`, which most probably triggered a resource conflict issue

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- remove the role name attribute so that it is auto generated

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
