### PR TITLE
Bump moto-ext to 5.0.15.post4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.15.post3",
+    "moto-ext[all]==5.0.15.post4",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.15.post2",
+    "moto-ext[all]==5.0.15.post3",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -255,7 +255,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.15.post3
+moto-ext==5.0.15.post4
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -255,7 +255,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.15.post2
+moto-ext==5.0.15.post3
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -189,7 +189,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.15.post3
+moto-ext==5.0.15.post4
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -189,7 +189,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.15.post2
+moto-ext==5.0.15.post3
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -239,7 +239,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.15.post3
+moto-ext==5.0.15.post4
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -239,7 +239,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.15.post2
+moto-ext==5.0.15.post3
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -259,7 +259,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.15.post3
+moto-ext==5.0.15.post4
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -259,7 +259,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.15.post2
+moto-ext==5.0.15.post3
     # via localstack-core
 mpmath==1.3.0
     # via sympy


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.0.15.post4. This is the final bump ahead of v3.8 release.

Contains:

- https://github.com/getmoto/moto/pull/8163
- https://github.com/getmoto/moto/pull/8167

## To do

- [x] Ext integration tests  AWS / Ext Integration Tests # 1155 
- [x] Randomised account ID and region run https://app.circleci.com/pipelines/github/localstack/localstack/28409/workflows/9386974f-4e09-4a06-8853-2daa2fdde0cf