### PR TITLE
CFn: fix unresolvable refs

### DIFF
--- a/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_usageplan.py
+++ b/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_usageplan.py
@@ -210,6 +210,6 @@ class ApiGatewayUsagePlanProvider(ResourceProvider[ApiGatewayUsagePlanProperties
 
         return ProgressEvent(
             status=OperationStatus.SUCCESS,
-            resource_model=model,
+            resource_model={**request.previous_state, **request.desired_state},
             custom_context=request.custom_context,
         )

--- a/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_codesigningconfig.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_codesigningconfig.py
@@ -64,6 +64,7 @@ class LambdaCodeSigningConfigProvider(ResourceProvider[LambdaCodeSigningConfigPr
 
         response = lambda_client.create_code_signing_config(**model)
         model["CodeSigningConfigArn"] = response["CodeSigningConfig"]["CodeSigningConfigArn"]
+        model["CodeSigningConfigId"] = response["CodeSigningConfig"]["CodeSigningConfigId"]
 
         return ProgressEvent(
             status=OperationStatus.SUCCESS,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

With the previous template deployer implementation (supersceded in #10849) we iterated over the resources, and it was sometimes the case that we could not resolve a `Ref` (or `GetAtt` etc.) because the dependant resource had not been deployed yet.

However, with #10849 we deploy resources in the correct order, so we should not need to handle this case any more.

I added breakpoints in every position we raise a `DependencyNotYetSatisfied` exception, and uncovered the errors fixed in this PR.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Update `AWS::ApiGateway::UsagePlan` to correctly return the updated state from the `update` method
* Update `AWS::Lambda::CodeSigningConfig` to set the `CodeSigningConfigId` property

Note: this PR is not a complete fix, as we likely don't have test coverage of everything.

Closes #11560

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
