### PR TITLE
[SFN] Improve responsiveness on shutdown

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/program/program.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/program/program.py
@@ -72,7 +72,7 @@ class Program(EvalComponent):
     def eval(self, env: Environment) -> None:
         timeout = self.timeout_seconds.timeout_seconds if self.timeout_seconds else None
         env.next_state_name = self.start_at.start_at_name
-        worker_thread = threading.Thread(target=super().eval, args=(env,))
+        worker_thread = threading.Thread(target=super().eval, args=(env,), daemon=True)
         TMP_THREADS.append(worker_thread)
         worker_thread.start()
         worker_thread.join(timeout=timeout)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/execute_state.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/execute_state.py
@@ -216,7 +216,7 @@ class ExecutionState(CommonStateField, abc.ABC):
         env.context_object_manager.context_object["State"]["RetryCount"] = 0
 
         # Attempt to evaluate the state's logic through until it's successful, caught, or retries have run out.
-        while True:
+        while env.is_running():
             try:
                 self._evaluate_with_timeout(env)
                 break

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/execute_state.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/execute_state.py
@@ -35,6 +35,7 @@ from localstack.services.stepfunctions.asl.component.state.state import CommonSt
 from localstack.services.stepfunctions.asl.component.state.state_props import StateProps
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.eval.event.event_detail import EventDetails
+from localstack.utils.common import TMP_THREADS
 
 LOG = logging.getLogger(__name__)
 
@@ -183,8 +184,10 @@ class ExecutionState(CommonStateField, abc.ABC):
                 execution_exceptions.append(ex)
             terminated_event.set()
 
-        thread = Thread(target=_exec_and_notify)
+        thread = Thread(target=_exec_and_notify, daemon=True)
+        TMP_THREADS.append(thread)
         thread.start()
+
         finished_on_time: bool = terminated_event.wait(timeout_seconds)
         frame.set_ended()
         env.close_frame(frame)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/inline_iteration_component.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/inline_iteration_component.py
@@ -77,7 +77,7 @@ class InlineIterationComponent(IterationComponent, abc.ABC):
 
     def _launch_worker(self, env: Environment) -> IterationWorker:
         worker = self._create_worker(env=env)
-        worker_thread = threading.Thread(target=worker.eval)
+        worker_thread = threading.Thread(target=worker.eval, daemon=True)
         TMP_THREADS.append(worker_thread)
         worker_thread.start()
         return worker

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/state_map.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/state_map.py
@@ -240,7 +240,7 @@ class StateMap(ExecutionState):
         env.context_object_manager.context_object["State"]["RetryCount"] = 0
 
         # Attempt to evaluate the state's logic through until it's successful, caught, or retries have run out.
-        while True:
+        while env.is_running():
             try:
                 self._evaluate_with_timeout(env)
                 break

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_parallel/branch_worker.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_parallel/branch_worker.py
@@ -38,7 +38,7 @@ class BranchWorker:
             raise RuntimeError(f"Attempted to rerun BranchWorker for program ${self._program}.")
 
         self._worker_thread = threading.Thread(
-            target=self._thread_routine, name=f"BranchWorker_${self._program}"
+            target=self._thread_routine, name=f"BranchWorker_${self._program}", daemon=True
         )
         TMP_THREADS.append(self._worker_thread)
         self._worker_thread.start()

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_parallel/state_parallel.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_parallel/state_parallel.py
@@ -65,7 +65,7 @@ class StateParallel(ExecutionState):
         input_value = copy.deepcopy(env.stack.pop())
 
         # Attempt to evaluate the state's logic through until it's successful, caught, or retries have run out.
-        while True:
+        while env.is_running():
             try:
                 env.stack.append(input_value)
                 self._evaluate_with_timeout(env)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_callback.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_callback.py
@@ -120,6 +120,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
             thread_wait_for_task_token = threading.Thread(
                 target=_local_update_wait_for_task_token,
                 name=f"WaitForTaskToken_SyncTask_{self.resource.resource_arn}",
+                daemon=True,
             )
             TMP_THREADS.append(thread_wait_for_task_token)
             thread_wait_for_task_token.start()

--- a/localstack-core/localstack/services/stepfunctions/asl/component/test_state/program/test_state_program.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/test_state/program/test_state_program.py
@@ -36,7 +36,7 @@ class TestStateProgram(EvalComponent):
 
     def eval(self, env: TestStateEnvironment) -> None:
         env.next_state_name = self.test_state.name
-        worker_thread = threading.Thread(target=super().eval, args=(env,))
+        worker_thread = threading.Thread(target=super().eval, args=(env,), daemon=True)
         TMP_THREADS.append(worker_thread)
         worker_thread.start()
         worker_thread.join(timeout=TEST_CASE_EXECUTION_TIMEOUT_SECONDS)

--- a/localstack-core/localstack/services/stepfunctions/backend/execution_worker.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/execution_worker.py
@@ -30,6 +30,7 @@ from localstack.services.stepfunctions.backend.activity import Activity
 from localstack.services.stepfunctions.backend.execution_worker_comm import (
     ExecutionWorkerCommunication,
 )
+from localstack.utils.common import TMP_THREADS
 
 
 class ExecutionWorker:
@@ -104,7 +105,9 @@ class ExecutionWorker:
         self._exec_comm.terminated()
 
     def start(self):
-        Thread(target=self._execution_logic).start()
+        execution_logic_thread = Thread(target=self._execution_logic, daemon=True)
+        TMP_THREADS.append(execution_logic_thread)
+        execution_logic_thread.start()
 
     def stop(self, stop_date: datetime.datetime, error: Optional[str], cause: Optional[str]):
         self.env.set_stop(stop_date=stop_date, cause=cause, error=error)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
I recently noticed that LocalStack is unable to terminate responsively to user input when Step Functions workflows are evaluating callback tasks. Upon closer inspection, I found that some daemon threads were not properly configured. I also took the opportunity to introduce more conservative behaviour for certain infinite threads, explicitly syncing their lifetimes to that of the state machine. This last change could also improve the responsiveness of stop API actions.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Ensure proper configuration of daemon threads and TMP_THREADS where relevant
- Modify infinite loops to terminate when the associated state machine halts

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
