### PR TITLE
remove assigning a ServiceModel for `execute-api` APIGW routes

### DIFF
--- a/localstack-core/localstack/aws/protocol/service_router.py
+++ b/localstack-core/localstack/aws/protocol/service_router.py
@@ -14,7 +14,7 @@ from localstack.aws.spec import (
     build_service_index_cache,
     load_service_index_cache,
 )
-from localstack.constants import LOCALHOST_HOSTNAME, PATH_USER_REQUEST, VERSION
+from localstack.constants import VERSION
 from localstack.http import Request
 from localstack.services.s3.utils import uses_host_addressing
 from localstack.services.sqs.utils import is_sqs_queue_url
@@ -178,13 +178,6 @@ def legacy_rules(request: Request) -> Optional[ServiceModelIdentifier]:
     path = request.path
     method = request.method
     host = hostname_from_url(request.host)
-
-    # API Gateway invocation URLs
-    # TODO: deprecated with #6040, where API GW user routes are served through the gateway directly
-    if ("/%s/" % PATH_USER_REQUEST) in request.path or (
-        host.endswith(LOCALHOST_HOSTNAME) and "execute-api" in host
-    ):
-        return ServiceModelIdentifier("apigateway")
 
     if ".lambda-url." in host:
         return ServiceModelIdentifier("lambda")

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -59,8 +59,7 @@ class ApiGatewayEndpoint:
             self.rest_gateway.process_with_context(context, response)
             return response
         else:
-            # TODO: return right response
-            return Response("Not authorized", status=403)
+            return self.create_not_found_response(api_id)
 
     def prepare_rest_api_invocation(
         self, request: Request, api_id: str, stage: str
@@ -100,6 +99,14 @@ class ApiGatewayEndpoint:
             # There appears to be in issue in Localstack, where setting "close" will result in "close, close"
             response.headers.set("Connection", "keep-alive")
         return response
+
+    @staticmethod
+    def create_not_found_response(api_id: str) -> Response:
+        not_found = Response(status=404)
+        not_found.set_json(
+            {"message": f"The API id '{api_id}' does not correspond to a deployed API Gateway API"}
+        )
+        return not_found
 
 
 class ApiGatewayRouter:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Due to legacy code when we didn't have the ASF framework and Edge routes, we would assign the service model for any "data plane" kind of routes (`execute-api`) for APIGW for example. 

Nowadays, if we have a service set in the context, and we did not match an edge route, we will forward the invocation to the skeleton/provider. This can lead to weird issues and confuse users with this kind of error:

```python
Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo/gateway/chain.py", line 166, in handle
    handler(self, self.context, response)
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/handlers/service.py", line 63, in __call__
    return self.parse_and_enrich(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/handlers/service.py", line 67, in parse_and_enrich
    operation, instance = parser.parse(context.request)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/protocol/parser.py", line 174, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/protocol/parser.py", line 567, in parse
    raise OperationNotFoundParserError(
localstack.aws.protocol.parser.OperationNotFoundParserError: Unable to find operation for request to service apigateway: POST /hello
2024-09-27T20:51:19.434  INFO --- [et.reactor-8] localstack.request.http    : POST /hello => 500; Request(b'', headers={'Host': 'https://apiid.execute-api.localhost.localstack.cloud:4566', 'User-Agent': 'curl/8.9.1', 'Accept': '*/*', 'Authorization': 'AWS4-HMAC-SHA256 Credential=injectedaccesskey/20160623/us-east-1/apigateway/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=1234', 'x-moto-account-id': '000000000000'}); Response(Bytes(2.187KB), headers={'Content-Type': 'application/json', 'X-Amzn-Errortype': 'InternalError', 'Content-Length': '2187', 'x-amzn-requestid': '3869759f-8b6b-4d2e-9acc-e07063de53b8', 'x-amz-request-id': '3869759f-8b6b-4d2e-9acc-e07063de53b8'})
```

This is not what we want: if the request goes to an `execute-api` route, it should never be forward to the provider, and instead just be caught by the router. We still have the "provider" loading issue, but this is unrelated to this particular problem. 

Also, it would then add a fake `Authorization` header populated with `apigateway` service, leading to even more confusion 😄 as there was a service model set when entering the `localstack.aws.handlers.auth.MissingAuthHeaderInjector` handler. 

Note: I believe we should maybe flag those request with the `execute-api` service identifier, as this is how AWS flags those with signing (for [IAM authorization](https://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html)):
> `execute-api` designates the underlying API execution component of API Gateway.

You need to sign your request with the `execute-api` service. I've tried replacing the rule above, but I believe it's going to try to load the `execute-api` service which doesn't exist, so it could maybe also be a specific IAM rule somewhere. Anyway, I thought it was worth mentioning!
See for the signature with `execute-api`:
- https://martinjt.me/2022/01/20/authenticating-with-aws-api-gateway-with-iam-credentials-using-javascript-and-node/
- https://medium.com/@jun711.g/how-to-secure-aws-api-gateway-requests-with-signature-version-4-using-aws-amplify-62d79f92966c

\cc @cloutierMat 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- remove the legacy rule to assign the `apigateway` service to `execute-api` routes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
