### PR TITLE
Fix creating subnet with custom ID for VPC with custom ID throwing 500 internal server error

### DIFF
--- a/localstack-core/localstack/services/ec2/patches.py
+++ b/localstack-core/localstack/services/ec2/patches.py
@@ -111,12 +111,7 @@ def apply_patches():
                 )
 
             # Delete route table if only main route table remains.
-            route_tables = self.describe_route_tables(filters={"vpc-id": vpc_id})  # type: ignore[attr-defined]
-            if len(route_tables) > 1:
-                raise DependencyViolationError(
-                    f"The vpc {vpc_id} has dependencies and cannot be deleted."
-                )
-            for route_table in route_tables:
+            for route_table in self.describe_route_tables(filters={"vpc-id": vpc_id}):
                 self.delete_route_table(route_table.id)  # type: ignore[attr-defined]
 
             # Remove the VPC from the default dict and add it back with the custom id

--- a/localstack-core/localstack/services/ec2/patches.py
+++ b/localstack-core/localstack/services/ec2/patches.py
@@ -38,7 +38,6 @@ def apply_patches():
             # From throwing an exception that it does not exist for the given custom-id VPC
             self.create_network_acl(
                 vpc_id=vpc_id,
-                # tags=tags,
                 default=True,
             )
 

--- a/localstack-core/localstack/services/ec2/patches.py
+++ b/localstack-core/localstack/services/ec2/patches.py
@@ -2,7 +2,6 @@ import logging
 from typing import Optional
 
 from moto.ec2 import models as ec2_models
-from moto.ec2.exceptions import DependencyViolationError
 
 from localstack.constants import TAG_KEY_CUSTOM_ID
 from localstack.services.ec2.exceptions import (

--- a/localstack-core/localstack/services/ec2/patches.py
+++ b/localstack-core/localstack/services/ec2/patches.py
@@ -28,12 +28,12 @@ def apply_patches():
         vpc_id: str = args[0] if len(args) >= 1 else kwargs["vpc_id"]
 
         if custom_id:
-             # Check if custom id is unique within a given VPC
+            # Check if custom id is unique within a given VPC
             for az_subnets in self.subnets.values():
                 for subnet in az_subnets.values():
                     if subnet.vpc_id == vpc_id and subnet.id == custom_id:
                         raise InvalidSubnetDuplicateCustomIdError(custom_id)
-            
+
             # Create default network ACL to prevent `self.associate_default_network_acl_with_subnet(subnet_id, vpc_id)`
             # From throwing an exception that it does not exist for the given custom-id VPC
             self.create_network_acl(

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -524,6 +524,48 @@ class TestEc2Integrations:
         assert e.value.response["Error"]["Code"] == "InvalidSubnet.DuplicateCustomId"
 
     @markers.aws.only_localstack
+    def test_create_subnet_with_custom_id_and_vpc_id(self, aws_client, create_vpc):
+        custom_subnet_id = random_subnet_id()
+        custom_vpc_id = random_vpc_id()
+
+        # Create the VPC with the custom ID.
+        vpc: dict = create_vpc(
+            cidr_block="10.0.0.0/16",
+            tag_specifications=[
+                {
+                    "ResourceType": "vpc",
+                    "Tags": [
+                        {"Key": TAG_KEY_CUSTOM_ID, "Value": custom_vpc_id},
+                    ],
+                }
+            ],
+        )
+        assert vpc["Vpc"]["VpcId"] == custom_vpc_id
+
+        # Check if subnet ID matches the custom ID
+        subnet: dict = aws_client.ec2.create_subnet(
+            VpcId=custom_vpc_id,
+            CidrBlock="10.0.0.0/24",
+            TagSpecifications=[
+                {
+                    "ResourceType": "subnet",
+                    "Tags": [
+                        {"Key": TAG_KEY_CUSTOM_ID, "Value": custom_subnet_id},
+                    ],
+                }
+            ],
+        )
+        assert subnet["Subnet"]["SubnetId"] == custom_subnet_id
+
+        # Check if the custom ID is present in the describe_subnets response as well
+        subnet: dict = aws_client.ec2.describe_subnets(
+            SubnetIds=[custom_subnet_id],
+        )["Subnets"][0]
+        assert subnet["SubnetId"] == custom_subnet_id
+        assert subnet["VpcId"] == custom_vpc_id
+
+
+    @markers.aws.only_localstack
     def test_create_security_group_with_custom_id(self, aws_client, create_vpc):
         custom_id = random_security_group_id()
 

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -564,7 +564,6 @@ class TestEc2Integrations:
         assert subnet["SubnetId"] == custom_subnet_id
         assert subnet["VpcId"] == custom_vpc_id
 
-
     @markers.aws.only_localstack
     def test_create_security_group_with_custom_id(self, aws_client, create_vpc):
         custom_id = random_security_group_id()


### PR DESCRIPTION
#### Description

When running:

```bash
awslocal ec2 create-vpc --cidr-block 10.0.0.0/16 --tag-specifications "ResourceType=vpc,Tags=[{Key=_custom_id_,Value=vpc-lsdefault}]"
awslocal ec2 describe-vpcs
awslocal ec2 create-subnet --vpc-id vpc-lsdefault --cidr-block 10.0.0.0/16 --tag-specifications "ResourceType=subnet,Tags=[{Key=_custom_id_,Value=mysubnet}]" 
```

The following error would be returned:

```python
2024-09-05T15:06:51.529  INFO --- [et.reactor-0] localstack.request.aws     : AWS ec2.CreateSubnet => 500 (InternalError)
2024-09-05T15:06:52.721 ERROR --- [et.reactor-0] l.aws.handlers.logging     : exception during call chain
Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo/gateway/chain.py", line 166, in handle
    handler(self, self.context, response)
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/handlers/service.py", line 113, in __call__
    handler(chain, context, response)
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/handlers/service.py", line 83, in __call__
    skeleton_response = self.skeleton.invoke(context)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/skeleton.py", line 154, in invoke
    return self.dispatch_request(serializer, context, instance)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/skeleton.py", line 168, in dispatch_request
    result = handler(context, instance) or {}
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/forwarder.py", line 133, in _call
    return handler(context, req)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/skeleton.py", line 118, in __call__
    return self.fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/api/core.py", line 160, in operation_marker
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/ec2/provider.py", line 286, in create_subnet
    response = call_moto(context)
               ^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/moto.py", line 48, in call_moto
    return dispatch_to_backend(context, dispatch_to_moto, include_response_metadata)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/forwarder.py", line 185, in dispatch_to_backend
    http_response = http_request_dispatcher(context)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/moto.py", line 118, in dispatch_to_moto
    response = dispatch(request, raw_url, request.headers)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/core/responses.py", line 290, in dispatch
    return cls()._dispatch(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/core/responses.py", line 502, in _dispatch
    return self.call_action()
           ^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/core/responses.py", line 588, in call_action
    response = method()
               ^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/ec2/responses/subnets.py", line 20, in create_subnet
    subnet = self.ec2_backend.create_subnet(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/utils/patch.py", line 61, in proxy
    return new(target, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/ec2/patches.py", line 38, in ec2_create_subnet
    result: ec2_models.subnets.Subnet = fn(self, *args, tags=tags, **kwargs)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/ec2/models/subnets.py", line 409, in create_subnet
    self.associate_default_network_acl_with_subnet(subnet_id, vpc_id)  # type: ignore[attr-defined]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/ec2/models/network_acls.py", line 184, in associate_default_network_acl_with_subnet
    acl = next(
          ^^^^^
StopIteration
```

This PR fixes this specific issue.