### PR TITLE
fix: mixed-content for the SwaggerUI

### DIFF
--- a/localstack-core/localstack/http/resources/swagger/endpoints.py
+++ b/localstack-core/localstack/http/resources/swagger/endpoints.py
@@ -1,22 +1,18 @@
 import os
 
 from jinja2 import Environment, FileSystemLoader
-from rolo import route
+from rolo import Request, route
 
 from localstack.config import external_service_url
 from localstack.http import Response
 
 
 class SwaggerUIApi:
-    init_path: str
-
-    def __init__(self) -> None:
-        self.init_path = f"{external_service_url()}/openapi.yaml"
-
     @route("/_localstack/swagger", methods=["GET"])
-    def server_swagger_ui(self, _request):
+    def server_swagger_ui(self, request: Request) -> Response:
+        init_path = f"{external_service_url(protocol=request.scheme)}/openapi.yaml"
         oas_path = os.path.join(os.path.dirname(__file__), "templates")
         env = Environment(loader=FileSystemLoader(oas_path))
         template = env.get_template("index.html")
-        rendered_template = template.render(swagger_url=self.init_path)
+        rendered_template = template.render(swagger_url=init_path)
         return Response(rendered_template, content_type="text/html")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With https://github.com/localstack/localstack/pull/11509 we started serving the SwaggerUI within LocalStack.
The Web UI is initialized with an OpenAPI spec, also served via LocalStack. However, the resolved URL always had a `http` protocol. This caused a mix-content issue (see below) when accessing the swagger URL (`localhost.localstack.cloud:4566/_localstack/swagger`) with `https`.

See the image below:

![image](https://github.com/user-attachments/assets/ee7e3c13-51a5-4e9a-85b2-db5b5cf57bac)


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- We now build the spec URL with the correct protocol based on the protocol of the request itself.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
