### PR TITLE
fix APIGW NG test_cors_apigw_not_applied

### DIFF
--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -178,10 +178,7 @@ class TestCSRF:
                 "Origin": "https://app.localstack.cloud",
             },
         )
-        if config.APIGW_NEXT_GEN_PROVIDER:
-            assert response.status_code == 403
-        else:
-            assert response.status_code == 404
+        assert response.status_code == 404
 
         assert not any(response.headers.get(cors_header) for cors_header in cors_headers)
 
@@ -196,10 +193,7 @@ class TestCSRF:
             },
         )
 
-        if config.APIGW_NEXT_GEN_PROVIDER:
-            assert response.status_code == 403
-        else:
-            assert response.status_code == 404
+        assert response.status_code == 404
         assert not any(response.headers.get(cors_header) for cors_header in cors_headers)
 
         # now we give it a try with a route from the provider defined in the specs: GetRestApi, and an authorized origin


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #11604, I've missed this one as we did not run the CI with the flag applied: 

Here's the failed run: https://app.circleci.com/pipelines/github/localstack/localstack/28439/workflows/ee18ae42-968c-4eda-96bf-fbae9ad40952/jobs/248146/tests


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- remove the special check for NextGen and always assert it is `404`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
