### PR TITLE
CFn: improve lambda tag matching

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -496,6 +496,7 @@ def test_multiple_lambda_permissions_for_singlefn(deploy_cfn_template, snapshot,
     ]
 )
 def test_lambda_function_tags(deploy_cfn_template, aws_client, snapshot):
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
     snapshot.add_transformer(snapshot.transform.lambda_api())
     snapshot.add_transformer(snapshot.transform.key_value("CodeSha256"))
 
@@ -503,7 +504,7 @@ def test_lambda_function_tags(deploy_cfn_template, aws_client, snapshot):
     environment = f"dev-{short_uid()}"
     snapshot.add_transformer(snapshot.transform.regex(environment, "<environment>"))
 
-    deploy_cfn_template(
+    deployment = deploy_cfn_template(
         template_path=os.path.join(
             os.path.dirname(__file__),
             "../../../templates/cfn_lambda_with_tags.yml",
@@ -513,6 +514,7 @@ def test_lambda_function_tags(deploy_cfn_template, aws_client, snapshot):
             "Environment": environment,
         },
     )
+    snapshot.add_transformer(snapshot.transform.regex(deployment.stack_name, "<stack-name>"))
 
     get_function_result = aws_client.lambda_.get_function(FunctionName=function_name)
     snapshot.match("get_function_result", get_function_result)

--- a/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
@@ -1529,5 +1529,65 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_function_tags": {
+    "recorded-date": "01-10-2024, 11:13:51",
+    "recorded-content": {
+      "get_function_result": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "index.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 3,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "Tags": {
+          "Environment": "<environment>",
+          "aws:cloudformation:logical-id": "TestFunction",
+          "aws:cloudformation:stack-id": "arn:<partition>:cloudformation:<region>:111111111111:stack/stack-df418b45/<resource:3>",
+          "aws:cloudformation:stack-name": "stack-df418b45",
+          "lambda:createdBy": "SAM"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
@@ -1531,7 +1531,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_function_tags": {
-    "recorded-date": "01-10-2024, 11:13:51",
+    "recorded-date": "01-10-2024, 12:52:51",
     "recorded-content": {
       "get_function_result": {
         "Code": {
@@ -1548,22 +1548,22 @@
           "EphemeralStorage": {
             "Size": 512
           },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
+          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:1>",
+          "FunctionName": "<resource:1>",
           "Handler": "index.handler",
           "LastModified": "date",
           "LastUpdateStatus": "Successful",
           "LoggingConfig": {
             "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
+            "LogGroup": "/aws/lambda/<resource:1>"
           },
           "MemorySize": 128,
           "PackageType": "Zip",
           "RevisionId": "<uuid:1>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+          "Role": "arn:<partition>:iam::111111111111:role/<resource:2>",
           "Runtime": "python3.11",
           "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:3>"
           },
           "SnapStart": {
             "ApplyOn": "None",
@@ -1579,8 +1579,8 @@
         "Tags": {
           "Environment": "<environment>",
           "aws:cloudformation:logical-id": "TestFunction",
-          "aws:cloudformation:stack-id": "arn:<partition>:cloudformation:<region>:111111111111:stack/stack-df418b45/<resource:3>",
-          "aws:cloudformation:stack-name": "stack-df418b45",
+          "aws:cloudformation:stack-id": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name>/<resource:4>",
+          "aws:cloudformation:stack-name": "<stack-name>",
           "lambda:createdBy": "SAM"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -33,7 +33,7 @@
     "last_validated_date": "2024-04-09T07:19:51+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_function_tags": {
-    "last_validated_date": "2024-10-01T11:13:51+00:00"
+    "last_validated_date": "2024-10-01T12:52:51+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_version": {
     "last_validated_date": "2024-04-09T07:21:37+00:00"

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -33,7 +33,7 @@
     "last_validated_date": "2024-04-09T07:19:51+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_function_tags": {
-    "last_validated_date": "2024-09-26T16:33:07+00:00"
+    "last_validated_date": "2024-10-01T11:13:51+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_version": {
     "last_validated_date": "2024-04-09T07:21:37+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

PR #11588 implemented tag propagation for Lambda Functions using CFn. The test added was validated, but not snapshot tested because I did not know how to handle the automatic CloudFormation tags when matching snapshots.

A [very useful comment](https://github.com/localstack/localstack/pull/11588#issuecomment-2385454876) pointed out how to achieve this, so this PR upgrades the test to use snapshot validation of the created resource.

Thanks @bentsku!


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Capture the `get_function` response in a snapshot, and correctly skip matching the CFn tags

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->