### PR TITLE
Add configuration value for manually selecting runtime components

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -397,6 +397,9 @@ except ImportError:
     # dotenv may not be available in lambdas or other environments where config is loaded
     LOADED_PROFILES = None
 
+# loaded components name - default aws
+LOADED_COMPONENTS_NAME = os.environ.get("LOADED_COMPONENTS_NAME", "aws")
+
 # directory for persisting data (TODO: deprecated, simply use PERSISTENCE=1)
 DATA_DIR = os.environ.get("DATA_DIR", "").strip()
 

--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -397,8 +397,8 @@ except ImportError:
     # dotenv may not be available in lambdas or other environments where config is loaded
     LOADED_PROFILES = None
 
-# loaded components name - default aws
-LOADED_COMPONENTS_NAME = os.environ.get("LOADED_COMPONENTS_NAME", "aws")
+# loaded components name - default: all components are loaded and the first one is chosen
+RUNTIME_COMPONENTS = os.environ.get("RUNTIME_COMPONENTS", "").strip()
 
 # directory for persisting data (TODO: deprecated, simply use PERSISTENCE=1)
 DATA_DIR = os.environ.get("DATA_DIR", "").strip()

--- a/localstack-core/localstack/runtime/runtime.py
+++ b/localstack-core/localstack/runtime/runtime.py
@@ -182,12 +182,10 @@ def create_from_environment() -> LocalstackRuntime:
         try:
             component = plugin_manager.load(config.RUNTIME_COMPONENTS)
             return LocalstackRuntime(component)
-        except ValueError as e:
-            LOG.error(
-                "Could not load runtime component %s: %s. Falling back to loading all components.",
-                config.RUNTIME_COMPONENTS,
-                e,
-            )
+        except Exception as e:
+            raise ValueError(
+                f"Could not load runtime components from config RUNTIME_COMPONENTS={config.RUNTIME_COMPONENTS}: {e}."
+            ) from e
     components = plugin_manager.load_all()
 
     if not components:

--- a/localstack-core/localstack/runtime/runtime.py
+++ b/localstack-core/localstack/runtime/runtime.py
@@ -189,8 +189,15 @@ def create_from_environment() -> LocalstackRuntime:
         )
 
     if len(components) > 1:
+        for component in components:
+            if config.LOADED_COMPONENTS_NAME == component.name:
+                LOG.warning(
+                    "There are more than one component plugins, choosing %s from configuration.",
+                    component.name,
+                )
+                return LocalstackRuntime(component)
         LOG.warning(
-            "There are more than one component plugins, using the first one which is %s",
+            "There are more than one component plugins, choosing the first one: %s.",
             components[0].name,
         )
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When loading multiple components in the python path and launching localstack, we currently just select the first component that was found. 
When working in a repository which has multiple exclusive components, however, this means that we need to manually remove one of the components from the python path to specify which component we want to run exactly.

Ideally, in a development environment we'd just want to set some configuration value in a run configuration to select the correct component.

/cc @dfangl 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

This PR adds a configuration value to manually select a single runtime components set to start: `RUNTIME_COMPONENTS`

Without setting it, the old behavior remains, i.e., all components are loaded and the first is chosen.

When specifying a value, however, that one gets loaded and chosen.


## Testing

In a repository with multiple defined components sets, put both in the python path, select first one and then the other. See if that causes different sets of components to be loaded.


<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
