### PR TITLE
ESM-v2: Add optional close function to Poller

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
@@ -139,6 +139,9 @@ class EsmWorker:
                 # Wait some time between retries to avoid running into the problem right again
                 self._shutdown_event.wait(2)
 
+        # Optionally closes internal components of Poller. This is a no-op for unimplemented pollers.
+        self.poller.close()
+
         try:
             # Update state in store after async stop or delete
             if self.enabled and self.current_state == EsmState.DELETING:

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/poller.py
@@ -70,6 +70,11 @@ class Poller(ABC):
         """Poll events polled from the event source and matching at least one filter criteria and invoke the target processor."""
         pass
 
+    def close(self) -> None:
+        """Closes a target poller alongside all associated internal polling/consuming clients.
+        Only implemented for supported pollers. Therefore, the default implementation is empty."""
+        pass
+
     def send_events_to_dlq(self, events, context) -> None:
         """Send failed events to a DLQ configured on the source.
         Only implemented for supported pollers. Therefore, the default implementation is empty."""


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Allows for a `Poller` to optionally close some internal components after the `poll_events` loop has exited.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Add a no-op `close()` method to the `Poller` base class.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
