### PR TITLE
Validate SQS dev endpoints

### DIFF
--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -8,7 +8,7 @@ info:
     checks, plugins, initialisation hooks, service introspection, and more.
   termsOfService: https://www.localstack.cloud/legal/tos
   title: LocalStack REST API for Community
-  version: 3.6.1.dev
+  version: latest
 externalDocs:
   description: LocalStack Documentation
   url: https://docs.localstack.cloud

--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -211,6 +211,29 @@ components:
       - error
       - subscription_arn
       type: object
+    ReceiveMessageResult:
+      type: object
+      description: https://github.com/boto/botocore/blob/develop/botocore/data/sqs/2012-11-05/service-2.json
+      properties:
+        Messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+    Message:
+      type: object
+      properties:
+        MessageId:
+          type: [string, 'null']
+        ReceiptHandle:
+          type: [string, 'null']
+        MD5OfBody:
+          type: [string, 'null']
+        Body:
+          type: [string, 'null']
+        Attributes:
+          type: object
+        MessageAttributes:
+          type: object
     CloudWatchMetrics:
       additionalProperties: false
       properties:
@@ -529,7 +552,9 @@ paths:
         '200':
           content:
             text/xml: {}
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReceiveMessageResult'
           description: SQS queue messages
         '400':
           content:
@@ -569,7 +594,9 @@ paths:
         '200':
           content:
             text/xml: {}
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReceiveMessageResult'
           description: SQS queue messages
         '400':
           content:

--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -529,14 +529,17 @@ paths:
         '200':
           content:
             text/xml: {}
+            application/json: {}
           description: SQS queue messages
         '400':
           content:
             text/xml: {}
+            application/json: {}
           description: Bad request
         '404':
           content:
             text/xml: {}
+            application/json: {}
           description: Not found
   /_aws/sqs/messages/{region}/{account_id}/{queue_name}:
     get:
@@ -566,14 +569,17 @@ paths:
         '200':
           content:
             text/xml: {}
+            application/json: {}
           description: SQS queue messages
         '400':
           content:
             text/xml: {}
+            application/json: {}
           description: Bad request
         '404':
           content:
             text/xml: {}
+            application/json: {}
           description: Not found
   /_localstack/config:
     get:

--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -211,6 +211,35 @@ components:
       - error
       - subscription_arn
       type: object
+    ReceiveMessageRequest:
+      type: object
+      description: https://github.com/boto/botocore/blob/develop/botocore/data/sqs/2012-11-05/service-2.json
+      required:
+        - QueueUrl
+      properties:
+        QueueUrl:
+          type: string
+          format: uri
+        AttributeNames:
+          type: array
+          items:
+            type: string
+        MessageSystemAttributeNames:
+          type: array
+          items:
+            type: string
+        MessageAttributeNames:
+          type: array
+          items:
+            type: string
+        MaxNumberOfMessages:
+          type: integer
+        VisibilityTimeout:
+          type: integer
+        WaitTimeSeconds:
+          type: integer
+        ReceiveRequestAttemptId:
+          type: string
     ReceiveMessageResult:
       type: object
       description: https://github.com/boto/botocore/blob/develop/botocore/data/sqs/2012-11-05/service-2.json
@@ -548,6 +577,39 @@ paths:
         required: false
         schema:
           type: string
+      responses:
+        '200':
+          content:
+            text/xml: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReceiveMessageResult'
+          description: SQS queue messages
+        '400':
+          content:
+            text/xml: {}
+            application/json: {}
+          description: Bad request
+        '404':
+          content:
+            text/xml: {}
+            application/json: {}
+          description: Not found
+    post:
+      summary: Retrieves one or more messages from the specified queue.
+      description: |
+        This API receives messages from an SQS queue.
+        https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html#API_ReceiveMessage_ResponseSyntax
+      operationId: receive_message
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+               $ref: '#/components/schemas/ReceiveMessageRequest'
+          application/json:
+            schema:
+               $ref: '#/components/schemas/ReceiveMessageRequest'
       responses:
         '200':
           content:

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -624,7 +624,7 @@ class SqsDeveloperEndpoints:
         self.service = load_service("sqs-query")
         self.serializer = create_serializer(self.service)
 
-    @route("/_aws/sqs/messages")
+    @route("/_aws/sqs/messages", methods=["GET", "POST"])
     @aws_response_serializer("sqs-query", "ReceiveMessage")
     def list_messages(self, request: Request) -> ReceiveMessageResult:
         """

--- a/tests/aws/services/sqs/test_sqs_backdoor.py
+++ b/tests/aws/services/sqs/test_sqs_backdoor.py
@@ -26,6 +26,7 @@ def _parse_attribute_map(json_message: dict) -> dict[str, str]:
     return {attr["Name"]: attr["Value"] for attr in json_message["Attribute"]}
 
 
+@pytest.mark.usefixtures("openapi_validate")
 class TestSqsDeveloperEndpoints:
     @markers.aws.only_localstack
     @pytest.mark.parametrize("strategy", ["standard", "domain", "path"])


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As we introduced specs for the developer endpoints, we want to make sure they match the actual implementation.
For this purpose, we can activate request and response verification in our handler chain and test our endpoint against the OpenAPI spec.

This PR activates the validation for the SQS dev endpoints.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Enable the validation for the `TestSqsDeveloperEndpoints` suite;
- Minor changes to the spec to let the suite pass;

🔈  I'd ask the service owners to check if this PR is already comprehensive and eventually, if not, please help me fill all possible gaps.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
