### PR TITLE
Fix: CFn improperly formats account_id causing IAM engine to fail when using cdk

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -758,8 +758,10 @@ def resolve_placeholders_in_string(
     """
 
     def _validate_result_type(value: str):
-        if value == account_id:
-            return account_id
+        is_another_account_id = value.isdigit() and len(value) == len(account_id)
+        if value == account_id or is_another_account_id:
+            return value
+
         if value.isdigit():
             return int(value)
         else:

--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -758,6 +758,8 @@ def resolve_placeholders_in_string(
     """
 
     def _validate_result_type(value: str):
+        if value == account_id:
+            return account_id
         if value.isdigit():
             return int(value)
         else:


### PR DESCRIPTION
## Motivation
- Currently CFn will inproperly format account id to int `0` instead of keeping it `000000000000` string


## Changes
- Removed casting of account_id to int

## Testing
- Running `cdklocal boostrap` with IAM enabled and then trying to deploy a stack will cause IAM to crash

## TODO

What's left to do:

- [ ] make sure that other account ids are not cast to int (when using cross account permissions in template)
- [ ] validate that boostraping and template deploying works with IAM enabled

