### PR TITLE
Replicator user defined id generator

### DIFF
--- a/localstack-core/localstack/services/apigateway/patches.py
+++ b/localstack-core/localstack/services/apigateway/patches.py
@@ -145,6 +145,7 @@ def apply_patches():
 
         return result
 
+    # TODO remove this patch when the behavior is implemented in moto
     @patch(apigateway_models.APIGatewayBackend.create_rest_api)
     def create_rest_api(fn, self, *args, tags=None, **kwargs):
         """

--- a/localstack-core/localstack/services/cloudformation/engine/entities.py
+++ b/localstack-core/localstack/services/cloudformation/engine/entities.py
@@ -9,6 +9,7 @@ from localstack.services.cloudformation.engine.parameters import (
 )
 from localstack.utils.aws import arns
 from localstack.utils.collections import select_attributes
+from localstack.utils.id_generator import generate_short_uid
 from localstack.utils.json import clone_safe
 from localstack.utils.objects import recurse_object
 from localstack.utils.strings import long_uid, short_uid
@@ -93,7 +94,13 @@ class Stack:
         # initialize stack template attributes
         stack_id = self.metadata.get("StackId") or arns.cloudformation_stack_arn(
             self.stack_name,
-            stack_id=short_uid(),
+            stack_id=generate_short_uid(
+                account_id=account_id,
+                region=region_name,
+                service="cloudformation",
+                resource="stack",
+                name=metadata.get("StackName"),
+            ),
             account_id=account_id,
             region_name=region_name,
         )

--- a/localstack-core/localstack/services/cloudformation/engine/entities.py
+++ b/localstack-core/localstack/services/cloudformation/engine/entities.py
@@ -107,7 +107,7 @@ class Stack:
             self.stack_name,
             stack_id=StackIdentifier(
                 account_id=account_id, region=region_name, stack_name=metadata.get("StackName")
-            ).generate(metadata.get("tags")),
+            ).generate(tags=metadata.get("tags")),
             account_id=account_id,
             region_name=region_name,
         )

--- a/localstack-core/localstack/services/cloudformation/engine/entities.py
+++ b/localstack-core/localstack/services/cloudformation/engine/entities.py
@@ -9,7 +9,7 @@ from localstack.services.cloudformation.engine.parameters import (
 )
 from localstack.utils.aws import arns
 from localstack.utils.collections import select_attributes
-from localstack.utils.id_generator import generate_short_uid
+from localstack.utils.id_generator import ExistingIds, ResourceIdentifier, Tags, generate_short_uid
 from localstack.utils.json import clone_safe
 from localstack.utils.objects import recurse_object
 from localstack.utils.strings import long_uid, short_uid
@@ -59,6 +59,17 @@ class StackTemplate(TypedDict):
     Resources: dict
 
 
+class StackIdentifier(ResourceIdentifier):
+    service = "cloudformation"
+    resource = "stack"
+
+    def __init__(self, account_id: str, region: str, stack_name: str):
+        super().__init__(account_id, region, stack_name)
+
+    def generate(self, existing_ids: ExistingIds = None, tags: Tags = None) -> str:
+        return generate_short_uid(resource_identifier=self, existing_ids=existing_ids, tags=tags)
+
+
 # TODO: remove metadata (flatten into individual fields)
 class Stack:
     change_sets: list["StackChangeSet"]
@@ -94,13 +105,9 @@ class Stack:
         # initialize stack template attributes
         stack_id = self.metadata.get("StackId") or arns.cloudformation_stack_arn(
             self.stack_name,
-            stack_id=generate_short_uid(
-                account_id=account_id,
-                region=region_name,
-                service="cloudformation",
-                resource="stack",
-                name=metadata.get("StackName"),
-            ),
+            stack_id=StackIdentifier(
+                account_id=account_id, region=region_name, stack_name=metadata.get("StackName")
+            ).generate(metadata.get("tags")),
             account_id=account_id,
             region_name=region_name,
         )

--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -66,8 +66,6 @@ from localstack.aws.api.secretsmanager import (
 from localstack.aws.connect import connect_to
 from localstack.services.moto import call_moto
 from localstack.utils.aws import arns
-from localstack.utils.aws.arns import get_partition
-from localstack.utils.id_generator import generate_uid
 from localstack.utils.patch import patch
 from localstack.utils.time import today_no_time
 
@@ -435,18 +433,6 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         return call_moto(context, request)
 
 
-def generate_secret_arn(account_id, region, secret_id):
-    id_string = generate_uid(
-        account_id=account_id,
-        region=region,
-        service="secretsmanager",
-        resource="secret",
-        name=secret_id,
-        length=6,
-    )
-    return f"arn:{get_partition(region)}:secretsmanager:{region}:{account_id}:secret:{secret_id}-{id_string}"
-
-
 @patch(FakeSecret.__init__)
 def fake_secret__init__(fn, self: FakeSecret, *args, **kwargs):
     fn(self, *args, **kwargs)
@@ -466,9 +452,6 @@ def fake_secret__init__(fn, self: FakeSecret, *args, **kwargs):
     # in which case this field is non-null, but an integer.
     self.auto_rotate_after_days = None
     self.rotation_lambda_arn = None
-
-    # override the arn creation to allow for custom ids
-    self.arn = generate_secret_arn(self.account_id, self.region, self.secret_id)
 
 
 @patch(FakeSecret.update)

--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -434,7 +434,7 @@ class SecretsmanagerProvider(SecretsmanagerApi):
 
 
 @patch(FakeSecret.__init__)
-def fake_secret__init__(fn, self: FakeSecret, *args, **kwargs):
+def fake_secret__init__(fn, self, *args, **kwargs):
     fn(self, *args, **kwargs)
 
     # Fix time not including millis.

--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -66,6 +66,8 @@ from localstack.aws.api.secretsmanager import (
 from localstack.aws.connect import connect_to
 from localstack.services.moto import call_moto
 from localstack.utils.aws import arns
+from localstack.utils.aws.arns import get_partition
+from localstack.utils.id_generator import generate_uid
 from localstack.utils.patch import patch
 from localstack.utils.time import today_no_time
 
@@ -433,8 +435,20 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         return call_moto(context, request)
 
 
+def generate_secret_arn(account_id, region, secret_id):
+    id_string = generate_uid(
+        account_id=account_id,
+        region=region,
+        service="secretsmanager",
+        resource="secret",
+        name=secret_id,
+        length=6,
+    )
+    return f"arn:{get_partition(region)}:secretsmanager:{region}:{account_id}:secret:{secret_id}-{id_string}"
+
+
 @patch(FakeSecret.__init__)
-def fake_secret__init__(fn, self, *args, **kwargs):
+def fake_secret__init__(fn, self: FakeSecret, *args, **kwargs):
     fn(self, *args, **kwargs)
 
     # Fix time not including millis.
@@ -452,6 +466,9 @@ def fake_secret__init__(fn, self, *args, **kwargs):
     # in which case this field is non-null, but an integer.
     self.auto_rotate_after_days = None
     self.rotation_lambda_arn = None
+
+    # override the arn creation to allow for custom ids
+    self.arn = generate_secret_arn(self.account_id, self.region, self.secret_id)
 
 
 @patch(FakeSecret.update)

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -45,6 +45,7 @@ from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.collections import ensure_list
 from localstack.utils.functions import call_safe, run_safe
 from localstack.utils.http import safe_requests as requests
+from localstack.utils.id_generator import ResourceIdentifier, localstack_id_manager
 from localstack.utils.json import CustomEncoder, json_safe
 from localstack.utils.net import wait_for_port_open
 from localstack.utils.strings import short_uid, to_str
@@ -2291,3 +2292,19 @@ def clean_up(
 def openapi_validate(monkeypatch):
     monkeypatch.setattr(config, "OPENAPI_VALIDATE_RESPONSE", "true")
     monkeypatch.setattr(config, "OPENAPI_VALIDATE_REQUEST", "true")
+
+
+@pytest.fixture
+def set_resource_custom_id():
+    set_ids = []
+
+    def _set_custom_id(resource_identifier: ResourceIdentifier, custom_id):
+        localstack_id_manager.set_custom_id(
+            resource_identifier=resource_identifier, custom_id=custom_id
+        )
+        set_ids.append(resource_identifier)
+
+    yield _set_custom_id
+
+    for resource_identifier in set_ids:
+        localstack_id_manager.unset_custom_id(resource_identifier)

--- a/localstack-core/localstack/utils/id_generator.py
+++ b/localstack-core/localstack/utils/id_generator.py
@@ -1,0 +1,46 @@
+import random
+import string
+
+from localstack.utils.strings import long_uid, short_uid
+
+USER_PROVIDED_IDS = {}
+
+
+def get_custom_id(account_id, region, service, resource, name) -> str | None:
+    # retrieves a custom_id for a resource. Returns None
+    return USER_PROVIDED_IDS.get(".".join([account_id, region, service, resource, name]))
+
+
+def set_custom_id(account_id, region, service, resource, name, custom_id):
+    # sets a custom_id for a resource
+    USER_PROVIDED_IDS[".".join([account_id, region, service, resource, name])] = custom_id
+
+
+def unset_custom_id(account_id, region, service, resource, name):
+    # removes a set custom_id for a resource
+    USER_PROVIDED_IDS.pop(".".join([account_id, region, service, resource, name]), None)
+
+
+def localstack_id(fn):
+    # Decorator for helping in creation of static ids within localstack.
+    def _wrapper(account_id, region, service, resource, name, **kwargs):
+        if found_id := get_custom_id(account_id, region, service, resource, name):
+            return found_id
+        return fn(account_id, region, service, resource, name, **kwargs)
+
+    return _wrapper
+
+
+@localstack_id
+def generate_uid(account_id, region, service, resource, name, length=16):
+    return long_uid()[:length]
+
+
+@localstack_id
+def generate_short_uid(account_id, region, service, resource, name):
+    return short_uid()
+
+
+@localstack_id
+def generate_str_id(account_id, region, service, resource, name, length=8):
+    return "".join(random.choice(string.ascii_letters) for _ in range(length))

--- a/tests/aws/services/apigateway/test_apigateway_custom_ids.py
+++ b/tests/aws/services/apigateway/test_apigateway_custom_ids.py
@@ -1,0 +1,60 @@
+from moto.apigateway.utils import (
+    ApigwApiKeyIdentifier,
+    ApigwResourceIdentifier,
+    ApigwRestApiIdentifier,
+)
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import long_uid, short_uid
+
+API_ID = "ApiId"
+ROOT_RESOURCE_ID = "RootId"
+PET_1_RESOURCE_ID = "Pet1Id"
+PET_2_RESOURCE_ID = "Pet2Id"
+API_KEY_ID = "ApiKeyId"
+
+
+# Custom ids can't be set on aws.
+@markers.aws.only_localstack
+def test_apigateway_custom_ids(
+    aws_client, set_resource_custom_id, create_rest_apigw, account_id, region_name
+):
+    rest_api_name = f"apigw-{short_uid()}"
+    api_key_value = long_uid()
+
+    set_resource_custom_id(ApigwRestApiIdentifier(account_id, region_name, rest_api_name), API_ID)
+    set_resource_custom_id(
+        ApigwResourceIdentifier(account_id, region_name, path_name="/"), ROOT_RESOURCE_ID
+    )
+    set_resource_custom_id(
+        ApigwResourceIdentifier(
+            account_id, region_name, parent_id=ROOT_RESOURCE_ID, path_name="pet"
+        ),
+        PET_1_RESOURCE_ID,
+    )
+    set_resource_custom_id(
+        ApigwResourceIdentifier(
+            account_id, region_name, parent_id=PET_1_RESOURCE_ID, path_name="pet"
+        ),
+        PET_2_RESOURCE_ID,
+    )
+    set_resource_custom_id(
+        ApigwApiKeyIdentifier(account_id, region_name, value=api_key_value), API_KEY_ID
+    )
+
+    api_id, name, root_id = create_rest_apigw(name=rest_api_name)
+    pet_resource_1 = aws_client.apigateway.create_resource(
+        restApiId=api_id, parentId=ROOT_RESOURCE_ID, pathPart="pet"
+    )
+    # we create a second resource with the same path part to ensure we can pass different ids
+    pet_resource_2 = aws_client.apigateway.create_resource(
+        restApiId=api_id, parentId=PET_1_RESOURCE_ID, pathPart="pet"
+    )
+    api_key = aws_client.apigateway.create_api_key(name="api-key", value=api_key_value)
+
+    assert api_id == API_ID
+    assert name == rest_api_name
+    assert root_id == ROOT_RESOURCE_ID
+    assert pet_resource_1["id"] == PET_1_RESOURCE_ID
+    assert pet_resource_2["id"] == PET_2_RESOURCE_ID
+    assert api_key["id"] == API_KEY_ID

--- a/tests/aws/services/apigateway/test_apigateway_custom_ids.py
+++ b/tests/aws/services/apigateway/test_apigateway_custom_ids.py
@@ -17,7 +17,7 @@ API_KEY_ID = "ApiKeyId"
 # Custom ids can't be set on aws.
 @markers.aws.only_localstack
 def test_apigateway_custom_ids(
-    aws_client, set_resource_custom_id, create_rest_apigw, account_id, region_name
+    aws_client, set_resource_custom_id, create_rest_apigw, account_id, region_name, cleanups
 ):
     rest_api_name = f"apigw-{short_uid()}"
     api_key_value = long_uid()
@@ -51,6 +51,7 @@ def test_apigateway_custom_ids(
         restApiId=api_id, parentId=PET_1_RESOURCE_ID, pathPart="pet"
     )
     api_key = aws_client.apigateway.create_api_key(name="api-key", value=api_key_value)
+    cleanups.append(lambda: aws_client.apigateway.delete_api_key(apiKey=api_key["id"]))
 
     assert api_id == API_ID
     assert name == rest_api_name

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -10,11 +10,11 @@ from botocore.exceptions import WaiterError
 from localstack_snapshot.snapshots.transformer import SortingTransformer
 
 from localstack.aws.api.cloudformation import Capability
+from localstack.services.cloudformation.engine.entities import StackIdentifier
 from localstack.services.cloudformation.engine.yaml_parser import parse_yaml
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.files import load_file
-from localstack.utils.id_generator import set_custom_id
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry, wait_until
 
@@ -402,17 +402,14 @@ class TestStacksApi:
         assert len(updated_resources) == length_expected
 
     @markers.aws.only_localstack
-    def test_create_stack_with_custom_id(self, aws_client, cleanups, account_id, region_name):
+    def test_create_stack_with_custom_id(
+        self, aws_client, cleanups, account_id, region_name, set_resource_custom_id
+    ):
         stack_name = f"stack-{short_uid()}"
         custom_id = short_uid()
 
-        set_custom_id(
-            account_id=account_id,
-            region=region_name,
-            service="cloudformation",
-            resource="stack",
-            name=stack_name,
-            custom_id=custom_id,
+        set_resource_custom_id(
+            StackIdentifier(account_id, region_name, stack_name), custom_id=custom_id
         )
         template = open(
             os.path.join(os.path.dirname(__file__), "../../../templates/sns_topic_simple.yaml"),

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -424,6 +424,13 @@ class TestStacksApi:
 
         assert stack["StackId"].split("/")[-1] == custom_id
 
+        # We need to wait until the stack is created otherwise we can end up in a scenario
+        # where we delete the stack before creating it
+        def _assert_stack_process_finished():
+            return stack_process_is_finished(aws_client.cloudformation, stack_name)
+
+        assert wait_until(_assert_stack_process_finished)
+
 
 def stack_process_is_finished(cfn_client, stack_name):
     return (

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -425,11 +425,8 @@ class TestStacksApi:
         assert stack["StackId"].split("/")[-1] == custom_id
 
         # We need to wait until the stack is created otherwise we can end up in a scenario
-        # where we delete the stack before creating it
-        def _assert_stack_process_finished():
-            return stack_process_is_finished(aws_client.cloudformation, stack_name)
-
-        assert wait_until(_assert_stack_process_finished)
+        # where we try to delete the stack before creating its resources, failing the test
+        aws_client.cloudformation.get_waiter("stack_create_complete").wait(StackName=stack_name)
 
 
 def stack_process_is_finished(cfn_client, stack_name):

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -11,6 +11,7 @@ import pytest
 import requests
 from botocore.auth import SigV4Auth
 from botocore.exceptions import ClientError
+from moto.secretsmanager.utils import SecretsManagerSecretIdentifier
 
 from localstack.aws.api.lambda_ import Runtime
 from localstack.aws.api.secretsmanager import (
@@ -26,7 +27,6 @@ from localstack.testing.snapshots.transformer_utility import TransformerUtility
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.collections import select_from_typed_dict
-from localstack.utils.id_generator import set_custom_id
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import poll_condition
 from localstack.utils.time import today_no_time
@@ -2448,10 +2448,17 @@ class TestSecretsManager:
         sm_snapshot.match("secret_value_http_response", json_response)
 
     @markers.aws.only_localstack
-    def test_create_secret_with_custom_id(self, account_id, region_name, create_secret):
+    def test_create_secret_with_custom_id(
+        self, account_id, region_name, create_secret, set_resource_custom_id
+    ):
         secret_name = short_uid()
         custom_id = "TestID"
-        set_custom_id(account_id, region_name, "secretsmanager", "secret", secret_name, custom_id)
+        set_resource_custom_id(
+            SecretsManagerSecretIdentifier(
+                account_id=account_id, region=region_name, secret_id=secret_name
+            ),
+            custom_id,
+        )
 
         secret = create_secret(Name=secret_name, SecretBinary="test-secret")
 

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -26,6 +26,7 @@ from localstack.testing.snapshots.transformer_utility import TransformerUtility
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.collections import select_from_typed_dict
+from localstack.utils.id_generator import set_custom_id
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import poll_condition
 from localstack.utils.time import today_no_time
@@ -2445,6 +2446,16 @@ class TestSecretsManager:
             TransformerUtility.jsonpath("$..CreatedDate", "datetime", reference_replacement=False)
         )
         sm_snapshot.match("secret_value_http_response", json_response)
+
+    @markers.aws.only_localstack
+    def test_create_secret_with_custom_id(self, account_id, region_name, create_secret):
+        secret_name = short_uid()
+        custom_id = "TestID"
+        set_custom_id(account_id, region_name, "secretsmanager", "secret", secret_name, custom_id)
+
+        secret = create_secret(Name=secret_name, SecretBinary="test-secret")
+
+        assert secret["ARN"].split(":")[-1] == "-".join((secret_name, custom_id))
 
     @markers.aws.validated
     def test_force_delete_deleted_secret(self, sm_snapshot, secret_name, aws_client):

--- a/tests/unit/utils/test_id_generator.py
+++ b/tests/unit/utils/test_id_generator.py
@@ -4,6 +4,7 @@ from localstack.constants import TAG_KEY_CUSTOM_ID
 from localstack.services.cloudformation.engine.entities import StackIdentifier
 from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.utils.id_generator import (
+    ResourceIdentifier,
     generate_short_uid,
     generate_str_id,
     generate_uid,
@@ -39,7 +40,7 @@ def configure_custom_id(unset_configured_custom_id, default_resource_identifier)
 
 @pytest.fixture
 def unset_configured_custom_id(default_resource_identifier):
-    def _unset(resource_identifier=None):
+    def _unset(resource_identifier: ResourceIdentifier = None):
         localstack_id_manager.unset_custom_id(resource_identifier or default_resource_identifier)
 
     return _unset
@@ -103,5 +104,18 @@ def test_generate_with_custom_id_tag(
         default_resource_identifier, tags={TAG_KEY_CUSTOM_ID: tag_custom_id}
     )
     assert generated == tag_custom_id
+    generated = generate_str_id(default_resource_identifier)
+    assert generated == custom_id
+
+
+def test_generate_from_unique_identifier_string(
+    unset_configured_custom_id, default_resource_identifier, cleanups
+):
+    custom_id = "set_id"
+    unique_identifier_string = default_resource_identifier.unique_identifier
+
+    localstack_id_manager.set_custom_id_by_unique_identifier(unique_identifier_string, custom_id)
+    cleanups.append(lambda: unset_configured_custom_id(default_resource_identifier))
+
     generated = generate_str_id(default_resource_identifier)
     assert generated == custom_id

--- a/tests/unit/utils/test_id_generator.py
+++ b/tests/unit/utils/test_id_generator.py
@@ -1,101 +1,107 @@
 import pytest
 
+from localstack.constants import TAG_KEY_CUSTOM_ID
+from localstack.services.cloudformation.engine.entities import StackIdentifier
 from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.utils.id_generator import (
     generate_short_uid,
     generate_str_id,
     generate_uid,
-    set_custom_id,
-    unset_custom_id,
+    localstack_id_manager,
 )
 from localstack.utils.strings import long_uid, short_uid
 
-TEST_SERVICE = "test-service"
 TEST_NAME = "test-name"
-TEST_RESOURCE = "test-resource"
 
 
 @pytest.fixture
-def configure_custom_id(unset_configured_custom_id):
-    def _configure_custom_id(custom_id: str):
-        set_custom_id(
-            account_id=TEST_AWS_ACCOUNT_ID,
-            region=TEST_AWS_REGION_NAME,
-            service=TEST_SERVICE,
-            resource=TEST_RESOURCE,
-            name=TEST_NAME,
-            custom_id=custom_id,
+def default_resource_identifier():
+    return StackIdentifier(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_NAME)
+
+
+@pytest.fixture
+def configure_custom_id(unset_configured_custom_id, default_resource_identifier):
+    set_identifier = [default_resource_identifier]
+
+    def _configure_custom_id(custom_id: str, resource_identifier=None):
+        localstack_id_manager.set_custom_id(
+            resource_identifier or default_resource_identifier, custom_id=custom_id
         )
+        if resource_identifier:
+            set_identifier.append(resource_identifier)
 
     yield _configure_custom_id
 
     # we reset the ids after each test
-    unset_configured_custom_id()
+    for identifier in set_identifier:
+        unset_configured_custom_id(identifier)
 
 
 @pytest.fixture
-def unset_configured_custom_id():
-    def _unset():
-        unset_custom_id(
-            account_id=TEST_AWS_ACCOUNT_ID,
-            region=TEST_AWS_REGION_NAME,
-            service=TEST_SERVICE,
-            resource=TEST_RESOURCE,
-            name=TEST_NAME,
-        )
+def unset_configured_custom_id(default_resource_identifier):
+    def _unset(resource_identifier=None):
+        localstack_id_manager.unset_custom_id(resource_identifier or default_resource_identifier)
 
     return _unset
 
 
-def test_generate_short_id(configure_custom_id, unset_configured_custom_id):
+def test_generate_short_id(
+    configure_custom_id, unset_configured_custom_id, default_resource_identifier
+):
     custom_id = short_uid()
     configure_custom_id(custom_id)
 
-    generated = generate_short_uid(
-        TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_SERVICE, TEST_RESOURCE, TEST_NAME
-    )
+    generated = generate_short_uid(default_resource_identifier)
     assert generated == custom_id
 
     unset_configured_custom_id()
-    generated = generate_short_uid(
-        TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_SERVICE, TEST_RESOURCE, TEST_NAME
-    )
+    generated = generate_short_uid(default_resource_identifier)
     assert generated != custom_id
 
 
-def test_generate_uid(configure_custom_id, unset_configured_custom_id):
+def test_generate_uid(configure_custom_id, unset_configured_custom_id, default_resource_identifier):
     custom_id = long_uid()
     configure_custom_id(custom_id)
 
-    generated = generate_uid(
-        TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_SERVICE, TEST_RESOURCE, TEST_NAME
-    )
+    generated = generate_uid(default_resource_identifier)
     assert generated == custom_id
 
     unset_configured_custom_id()
 
     # test configured length
-    generated = generate_uid(
-        TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_SERVICE, TEST_RESOURCE, TEST_NAME, length=9
-    )
+    generated = generate_uid(default_resource_identifier, length=9)
     assert generated != custom_id
     assert len(generated) == 9
 
 
-def test_generate_str_id(configure_custom_id, unset_configured_custom_id):
+def test_generate_str_id(
+    configure_custom_id, unset_configured_custom_id, default_resource_identifier
+):
     custom_id = "RandomString"
     configure_custom_id(custom_id)
 
-    generated = generate_str_id(
-        TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_SERVICE, TEST_RESOURCE, TEST_NAME
-    )
+    generated = generate_str_id(default_resource_identifier)
     assert generated == custom_id
 
     unset_configured_custom_id()
 
     # test configured length
-    generated = generate_str_id(
-        TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_SERVICE, TEST_RESOURCE, TEST_NAME, length=9
-    )
+    generated = generate_str_id(default_resource_identifier, length=9)
     assert generated != custom_id
     assert len(generated) == 9
+
+
+def test_generate_with_custom_id_tag(
+    configure_custom_id, unset_configured_custom_id, default_resource_identifier
+):
+    custom_id = "set_id"
+    tag_custom_id = "id_from_tag"
+    configure_custom_id(custom_id)
+
+    # If the tags are passed, they should have priority
+    generated = generate_str_id(
+        default_resource_identifier, tags={TAG_KEY_CUSTOM_ID: tag_custom_id}
+    )
+    assert generated == tag_custom_id
+    generated = generate_str_id(default_resource_identifier)
+    assert generated == custom_id

--- a/tests/unit/utils/test_id_generator.py
+++ b/tests/unit/utils/test_id_generator.py
@@ -1,0 +1,101 @@
+import pytest
+
+from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
+from localstack.utils.id_generator import (
+    generate_short_uid,
+    generate_str_id,
+    generate_uid,
+    set_custom_id,
+    unset_custom_id,
+)
+from localstack.utils.strings import long_uid, short_uid
+
+TEST_SERVICE = "test-service"
+TEST_NAME = "test-name"
+TEST_RESOURCE = "test-resource"
+
+
+@pytest.fixture
+def configure_custom_id(unset_configured_custom_id):
+    def _configure_custom_id(custom_id: str):
+        set_custom_id(
+            account_id=TEST_AWS_ACCOUNT_ID,
+            region=TEST_AWS_REGION_NAME,
+            service=TEST_SERVICE,
+            resource=TEST_RESOURCE,
+            name=TEST_NAME,
+            custom_id=custom_id,
+        )
+
+    yield _configure_custom_id
+
+    # we reset the ids after each test
+    unset_configured_custom_id()
+
+
+@pytest.fixture
+def unset_configured_custom_id():
+    def _unset():
+        unset_custom_id(
+            account_id=TEST_AWS_ACCOUNT_ID,
+            region=TEST_AWS_REGION_NAME,
+            service=TEST_SERVICE,
+            resource=TEST_RESOURCE,
+            name=TEST_NAME,
+        )
+
+    return _unset
+
+
+def test_generate_short_id(configure_custom_id, unset_configured_custom_id):
+    custom_id = short_uid()
+    configure_custom_id(custom_id)
+
+    generated = generate_short_uid(
+        TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_SERVICE, TEST_RESOURCE, TEST_NAME
+    )
+    assert generated == custom_id
+
+    unset_configured_custom_id()
+    generated = generate_short_uid(
+        TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_SERVICE, TEST_RESOURCE, TEST_NAME
+    )
+    assert generated != custom_id
+
+
+def test_generate_uid(configure_custom_id, unset_configured_custom_id):
+    custom_id = long_uid()
+    configure_custom_id(custom_id)
+
+    generated = generate_uid(
+        TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_SERVICE, TEST_RESOURCE, TEST_NAME
+    )
+    assert generated == custom_id
+
+    unset_configured_custom_id()
+
+    # test configured length
+    generated = generate_uid(
+        TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_SERVICE, TEST_RESOURCE, TEST_NAME, length=9
+    )
+    assert generated != custom_id
+    assert len(generated) == 9
+
+
+def test_generate_str_id(configure_custom_id, unset_configured_custom_id):
+    custom_id = "RandomString"
+    configure_custom_id(custom_id)
+
+    generated = generate_str_id(
+        TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_SERVICE, TEST_RESOURCE, TEST_NAME
+    )
+    assert generated == custom_id
+
+    unset_configured_custom_id()
+
+    # test configured length
+    generated = generate_str_id(
+        TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_SERVICE, TEST_RESOURCE, TEST_NAME, length=9
+    )
+    assert generated != custom_id
+    assert len(generated) == 9


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

As we are starting to build the replicator, we need a mechanism to create resources with custom ids. This pr introduces a set of resource agnostic utils that can be used to handle custom id registration and id generation.

By providing a simple decorator that will return a custom id if one was registered or the result of the decorated function if none are found.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Added utils around id generator
- Added a sample for Cfn to see what implementation can look like for a service with an LS backend
- Added a sample for secrets manager to see what implementation can look like for a service with a Moto Backend

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
