### PR TITLE
Fix streaming poller performance for low shard counts in ESM v2

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -125,17 +125,17 @@ class StreamPoller(Poller):
             self.iterator_over_shards = iter(self.shards.items())
 
         current_shard_tuple = next(self.iterator_over_shards, None)
-        if current_shard_tuple:
-            try:
-                self.poll_events_from_shard(*current_shard_tuple)
-            # TODO: implement exponential back-off for errors in general
-            except PipeInternalError:
-                # TODO: standardize logging
-                # Ignore and wait for the next polling interval, which will do retry
-                pass
-        else:
-            # Set current shard iterator to None to re-start round-robin at the first shard
-            self.iterator_over_shards = None
+        if not current_shard_tuple:
+            self.iterator_over_shards = iter(self.shards.items())
+            current_shard_tuple = next(self.iterator_over_shards, None)
+
+        try:
+            self.poll_events_from_shard(*current_shard_tuple)
+        # TODO: implement exponential back-off for errors in general
+        except PipeInternalError:
+            # TODO: standardize logging
+            # Ignore and wait for the next polling interval, which will do retry
+            pass
 
     def poll_events_from_shard(self, shard_id: str, shard_iterator: str):
         abort_condition = None

--- a/tests/aws/scenario/bookstore/test_bookstore.py
+++ b/tests/aws/scenario/bookstore/test_bookstore.py
@@ -210,7 +210,6 @@ class TestBookstoreApplication:
     # Flaky examples with 1-off assertion error: assert 25 == 26
     # https://app.circleci.com/pipelines/github/localstack/localstack?branch=switch-to-new-lambda-event-source-mapping
     # What's confusing is that I would expect 25 given the search query in `search.py` with size 25, but we expect 26.
-    @pytest.mark.skip(reason="flaky against ESM v2 with 1-off error")
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$.._shards.successful", "$.._shards.total"])
     def test_search_books(self, aws_client, infrastructure, snapshot):

--- a/tests/aws/scenario/bookstore/test_bookstore.py
+++ b/tests/aws/scenario/bookstore/test_bookstore.py
@@ -207,9 +207,6 @@ class TestBookstoreApplication:
         result = json.load(result["Payload"])
         assert len(json.loads(result["body"])) == 56
 
-    # Flaky examples with 1-off assertion error: assert 25 == 26
-    # https://app.circleci.com/pipelines/github/localstack/localstack?branch=switch-to-new-lambda-event-source-mapping
-    # What's confusing is that I would expect 25 given the search query in `search.py` with size 25, but we expect 26.
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$.._shards.successful", "$.._shards.total"])
     def test_search_books(self, aws_client, infrastructure, snapshot):
@@ -241,6 +238,7 @@ class TestBookstoreApplication:
             )
             res = json.load(res["Payload"])
             search_res = json.loads(res["body"])["hits"]["total"]["value"]
+            # compare total hits with expected results, total hits are not bound by the size limit of the query
             assert search_res == expected_amount
             return res
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We currently wait 1 extra second after each iteration over all shards, since the poll_events method just returns at the end of the iterator.

Instead, we should just directly restart with the first shard in our shard list, without sleeping another second.

For single shard operations, like dynamodb streams, this effectively doubles the performance, and puts it on par with the old ESM implementation again.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Improve stream poller performance for lambda ESM v2 (the new default)

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
