### PR TITLE
Moving OASPlugin definition

### DIFF
--- a/localstack-core/localstack/aws/handlers/validation.py
+++ b/localstack-core/localstack/aws/handlers/validation.py
@@ -3,11 +3,7 @@ Handlers for validating request and response schema against OpenAPI specs.
 """
 
 import logging
-import os
-import sys
-from pathlib import Path
 
-import yaml
 from openapi_core import OpenAPI
 from openapi_core.contrib.werkzeug import WerkzeugOpenAPIRequest, WerkzeugOpenAPIResponse
 from openapi_core.exceptions import OpenAPIError
@@ -15,7 +11,7 @@ from openapi_core.validation.request.exceptions import (
     RequestValidationError,
 )
 from openapi_core.validation.response.exceptions import ResponseValidationError
-from plux import Plugin, PluginManager
+from plux import PluginManager
 
 from localstack import config
 from localstack.aws.api import RequestContext
@@ -24,49 +20,6 @@ from localstack.constants import INTERNAL_RESOURCE_PATH
 from localstack.http import Response
 
 LOG = logging.getLogger(__name__)
-
-
-class OASPlugin(Plugin):
-    """
-    This plugin allows to register an arbitrary number of OpenAPI specs, e.g., the spec for the public endpoints
-    of localstack.core.
-    The OpenAPIValidator handler uses (as opt-in) all the collected specs to validate the requests and the responses
-    to these public endpoints.
-
-    An OAS plugin assumes the following directory layout.
-
-    my_package
-    ├── sub_package
-    │   ├── __init__.py       <-- spec file
-    │   ├── openapi.yaml
-    │   └── plugins.py        <-- plugins
-    ├── plugins.py            <-- plugins
-    └── openapi.yaml          <-- spec file
-
-    Each package can have its own OpenAPI yaml spec which is loaded by the correspondent plugin in plugins.py
-    You can simply create a plugin like the following:
-
-    class MyPackageOASPlugin(OASPlugin):
-        name = "my_package"
-
-    The only convention is that plugins.py and openapi.yaml have the same pathname.
-    """
-
-    namespace = "localstack.openapi.spec"
-
-    def __init__(self) -> None:
-        # By convention a plugins.py is at the same level (i.e., same pathname) of the openapi.yaml file.
-        # importlib.resources would be a better approach but has issues with namespace packages in editable mode
-        _module = sys.modules[self.__module__]
-        self.spec_path = Path(
-            os.path.join(os.path.dirname(os.path.abspath(_module.__file__)), "openapi.yaml")
-        )
-        assert self.spec_path.exists()
-        self.spec = {}
-
-    def load(self):
-        with self.spec_path.open("r") as f:
-            self.spec = yaml.safe_load(f)
 
 
 class OpenAPIValidator(Handler):

--- a/localstack-core/localstack/plugins.py
+++ b/localstack-core/localstack/plugins.py
@@ -1,7 +1,12 @@
 import logging
+import os
+import sys
+from pathlib import Path
+
+import yaml
+from plux import Plugin
 
 from localstack import config
-from localstack.aws.handlers.validation import OASPlugin
 from localstack.runtime import hooks
 from localstack.utils.files import rm_rf
 from localstack.utils.ssl import get_cert_pem_file_path
@@ -22,6 +27,49 @@ def delete_cached_certificate():
     LOG.debug("Removing the cached local SSL certificate")
     target_file = get_cert_pem_file_path()
     rm_rf(target_file)
+
+
+class OASPlugin(Plugin):
+    """
+    This plugin allows to register an arbitrary number of OpenAPI specs, e.g., the spec for the public endpoints
+    of localstack.core.
+    The OpenAPIValidator handler uses (as opt-in) all the collected specs to validate the requests and the responses
+    to these public endpoints.
+
+    An OAS plugin assumes the following directory layout.
+
+    my_package
+    ├── sub_package
+    │   ├── __init__.py       <-- spec file
+    │   ├── openapi.yaml
+    │   └── plugins.py        <-- plugins
+    ├── plugins.py            <-- plugins
+    └── openapi.yaml          <-- spec file
+
+    Each package can have its own OpenAPI yaml spec which is loaded by the correspondent plugin in plugins.py
+    You can simply create a plugin like the following:
+
+    class MyPackageOASPlugin(OASPlugin):
+        name = "my_package"
+
+    The only convention is that plugins.py and openapi.yaml have the same pathname.
+    """
+
+    namespace = "localstack.openapi.spec"
+
+    def __init__(self) -> None:
+        # By convention a plugins.py is at the same level (i.e., same pathname) of the openapi.yaml file.
+        # importlib.resources would be a better approach but has issues with namespace packages in editable mode
+        _module = sys.modules[self.__module__]
+        self.spec_path = Path(
+            os.path.join(os.path.dirname(os.path.abspath(_module.__file__)), "openapi.yaml")
+        )
+        assert self.spec_path.exists()
+        self.spec = {}
+
+    def load(self):
+        with self.spec_path.open("r") as f:
+            self.spec = yaml.safe_load(f)
 
 
 class CoreOASPlugin(OASPlugin):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We figured out, from our [CLI smoke tests](https://github.com/localstack/localstack-cli/actions/runs/11163193747/job/31029543533), that having the OAS base plugin in the handler would cause CLI import errors, this one not-installing runtime dependencies (e.g., `rolo`).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Moving the plugin definition in `plugins.py`.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
