### PR TITLE
Fix: CFn repeated deployments breaking

### DIFF
--- a/localstack-core/localstack/services/cloudformation/provider.py
+++ b/localstack-core/localstack/services/cloudformation/provider.py
@@ -850,7 +850,11 @@ class CloudformationProvider(CloudformationApi):
         **kwargs,
     ) -> ExecuteChangeSetOutput:
         change_set = find_change_set(
-            context.account_id, context.region, change_set_name, stack_name=stack_name
+            context.account_id,
+            context.region,
+            change_set_name,
+            stack_name=stack_name,
+            active_only=True,
         )
         if not change_set:
             raise ChangeSetNotFoundException(f"ChangeSet [{change_set_name}] does not exist")

--- a/localstack-core/localstack/services/cloudformation/stores.py
+++ b/localstack-core/localstack/services/cloudformation/stores.py
@@ -103,10 +103,16 @@ def find_active_stack_by_name_or_id(
 
 
 def find_change_set(
-    account_id: str, region_name: str, cs_name: str, stack_name: Optional[str] = None
+    account_id: str,
+    region_name: str,
+    cs_name: str,
+    stack_name: Optional[str] = None,
+    active_only: bool = False,
 ) -> Optional[StackChangeSet]:
     store = get_cloudformation_store(account_id, region_name)
     for stack in store.stacks.values():
+        if active_only and stack.status == "DELETE_COMPLETE":
+            continue
         if stack_name in (stack.stack_name, stack.stack_id, None):
             for change_set in stack.change_sets:
                 if cs_name in (change_set.change_set_id, change_set.change_set_name):

--- a/localstack-core/localstack/services/cloudformation/stores.py
+++ b/localstack-core/localstack/services/cloudformation/stores.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 
+from localstack.aws.api.cloudformation import StackStatus
 from localstack.services.cloudformation.engine.entities import Stack, StackChangeSet, StackSet
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
 
@@ -111,7 +112,7 @@ def find_change_set(
 ) -> Optional[StackChangeSet]:
     store = get_cloudformation_store(account_id, region_name)
     for stack in store.stacks.values():
-        if active_only and stack.status == "DELETE_COMPLETE":
+        if active_only and stack.status == StackStatus.DELETE_COMPLETE:
             continue
         if stack_name in (stack.stack_name, stack.stack_id, None):
             for change_set in stack.change_sets:

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -433,7 +433,7 @@ def test_delete_change_set_exception(snapshot, aws_client):
 
 @markers.aws.validated
 def test_create_delete_create(aws_client, cleanups, deploy_cfn_template):
-    # create stack
+    """ test the re-use of a changeset name with a re-used stack name """
     stack_name = f"stack-{short_uid()}"
     change_set_name = f"cs-{short_uid()}"
 

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -432,6 +432,50 @@ def test_delete_change_set_exception(snapshot, aws_client):
 
 
 @markers.aws.validated
+def test_create_delete_create(aws_client, cleanups, deploy_cfn_template):
+    # create stack
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"cs-{short_uid()}"
+
+    template_path = os.path.join(
+        os.path.dirname(__file__), "../../../templates/sns_topic_simple.yaml"
+    )
+    with open(template_path) as infile:
+        template = infile.read()
+
+    # custom cloudformation deploy process since our `deploy_cfn_template` is too smart and uses IDs, unlike the CDK
+    def deploy():
+        client = aws_client.cloudformation
+        client.create_change_set(
+            StackName=stack_name,
+            TemplateBody=template,
+            ChangeSetName=change_set_name,
+            ChangeSetType="CREATE",
+        )
+        client.get_waiter("change_set_create_complete").wait(
+            StackName=stack_name, ChangeSetName=change_set_name
+        )
+
+        client.execute_change_set(StackName=stack_name, ChangeSetName=change_set_name)
+        client.get_waiter("stack_create_complete").wait(
+            StackName=stack_name,
+        )
+
+    def delete(suppress_exception: bool = False):
+        try:
+            aws_client.cloudformation.delete_stack(StackName=stack_name)
+            aws_client.cloudformation.get_waiter("stack_delete_complete").wait(StackName=stack_name)
+        except Exception:
+            if not suppress_exception:
+                raise
+
+    deploy()
+    cleanups.append(lambda: delete(suppress_exception=True))
+    delete()
+    deploy()
+
+
+@markers.aws.validated
 def test_create_and_then_remove_non_supported_resource_change_set(deploy_cfn_template):
     # first deploy cfn with a CodeArtifact resource that is not actually supported
     template_path = os.path.join(

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -433,7 +433,7 @@ def test_delete_change_set_exception(snapshot, aws_client):
 
 @markers.aws.validated
 def test_create_delete_create(aws_client, cleanups, deploy_cfn_template):
-    """ test the re-use of a changeset name with a re-used stack name """
+    """test the re-use of a changeset name with a re-used stack name"""
     stack_name = f"stack-{short_uid()}"
     change_set_name = f"cs-{short_uid()}"
 

--- a/tests/aws/services/cloudformation/api/test_changesets.validation.json
+++ b/tests/aws/services/cloudformation/api/test_changesets.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/cloudformation/api/test_changesets.py::test_create_changeset_with_stack_id": {
     "last_validated_date": "2023-11-28T06:48:23+00:00"
   },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_create_delete_create": {
+    "last_validated_date": "2024-08-13T10:46:31+00:00"
+  },
   "tests/aws/services/cloudformation/api/test_changesets.py::test_create_while_in_review": {
     "last_validated_date": "2023-11-22T07:49:15+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

As reported in https://github.com/localstack/localstack/issues/11333, performing a deployment of a previously deleted stack fails with the error message:

```
InvalidChangeSetStatus: ChangeSet [arn:aws:cloudformation:us-east-1:000000000000:changeSet/cdk-deploy-change-set/87846077] cannot be executed in its current status of [CREATE_COMPLETE]
```

This is because we don't filter out deleted changesets when looking for a changeset, and therefore assume the changeset already exists and incorrectly fail. Also this only happens when specifying changeset _names_, which CDK does.

This PR superscedes https://github.com/localstack/localstack/pull/11384, however @migraf wrote the initial implementation.

Closes #11333

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Fetch only active changesets
- Add validated test that performs the deploy/delete/deploy process

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->