### PR TITLE
fix Events v2 APIGW target test and update snapshots

### DIFF
--- a/tests/aws/services/events/test_events_targets.snapshot.json
+++ b/tests/aws/services/events/test_events_targets.snapshot.json
@@ -671,7 +671,7 @@
     }
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
-    "recorded-date": "30-09-2024, 07:53:35",
+    "recorded-date": "03-10-2024, 20:10:40",
     "recorded-content": {
       "create_lambda_response": {
         "CreateEventSourceMappingResponse": null,
@@ -688,7 +688,7 @@
           "EphemeralStorage": {
             "Size": 512
           },
-          "FunctionArn": "arn:<partition>:lambda:<region>:<account-id:1>:function:<function-name:1>",
+          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
           "FunctionName": "<function-name:1>",
           "Handler": "lambda_aws_proxy_format.handler",
           "LastModified": "date",
@@ -699,8 +699,8 @@
           "MemorySize": 128,
           "PackageType": "Zip",
           "RevisionId": "<uuid:1>",
-          "Role": "arn:<partition>:iam::<account-id:1>:role/<resource:1>",
-          "Runtime": "python3.9",
+          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.12",
           "RuntimeVersionConfig": {
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
           },
@@ -731,14 +731,14 @@
         }
       },
       "event_bus_response": {
-        "EventBusArn": "arn:<partition>:events:<region>:<account-id:1>:event-bus/<resource:3>",
+        "EventBusArn": "arn:<partition>:events:<region>:111111111111:event-bus/<resource:3>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
       "rule_response": {
-        "RuleArn": "arn:<partition>:events:<region>:<account-id:1>:rule/<resource:3>/<resource:4>",
+        "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<resource:3>/<resource:4>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -769,13 +769,67 @@
           "resource": "/test",
           "path": "/test/",
           "httpMethod": "POST",
-          "headers": "<headers>",
+          "headers": {
+            "amz-sdk-invocation-id": "amz-sdk-invocation-id",
+            "amz-sdk-request": "<amz-sdk-request:1>",
+            "amz-sdk-retry": "<amz-sdk-retry:1>",
+            "CloudFront-Forwarded-Proto": "https",
+            "CloudFront-Is-Desktop-Viewer": "true",
+            "CloudFront-Is-Mobile-Viewer": "false",
+            "CloudFront-Is-SmartTV-Viewer": "false",
+            "CloudFront-Is-Tablet-Viewer": "false",
+            "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
+            "CloudFront-Viewer-Country": "<cloudfront-country:1>",
+            "Content-Type": "application/json",
+            "Host": "<domain-name:1>",
+            "User-Agent": "<user--agent:1>",
+            "Via": "<via:1>",
+            "X-Amz-Cf-Id": "<cf-id:1>",
+            "x-amz-date": "<x-amz-date:1>",
+            "X-Amz-Security-Token": "x--amz--security--token",
+            "X-Amz-Source-Account": "111111111111",
+            "X-Amz-Source-Arn": "arn:<partition>:events:<region>:111111111111:rule/<resource:3>/<resource:4>",
+            "X-Amzn-Trace-Id": "<trace-id:1>",
+            "X-Forwarded-For": "x--forwarded--for",
+            "X-Forwarded-Port": "x--forwarded--port",
+            "X-Forwarded-Proto": "x--forwarded--proto"
+          },
           "multiValueHeaders": "<multiValueHeaders>",
           "queryStringParameters": null,
           "multiValueQueryStringParameters": null,
-          "pathParameters": "<pathParameters>",
-          "stageVariables": "<stageVariables>",
-          "requestContext": "<requestContext>",
+          "pathParameters": null,
+          "stageVariables": null,
+          "requestContext": {
+            "resourceId": "<resource-id:1>",
+            "resourcePath": "/test",
+            "httpMethod": "POST",
+            "extendedRequestId": "<extended-request-id:1>",
+            "requestTime": "<request-time>",
+            "path": "/test/test/",
+            "accountId": "111111111111",
+            "protocol": "HTTP/1.1",
+            "stage": "test",
+            "domainPrefix": "<api-id:1>",
+            "requestTimeEpoch": "<request-time-epoch>",
+            "requestId": "<uuid:2>",
+            "identity": {
+              "cognitoIdentityPoolId": null,
+              "accountId": null,
+              "cognitoIdentityId": null,
+              "caller": null,
+              "sourceIp": "<source-ip:1>",
+              "principalOrgId": null,
+              "accessKey": null,
+              "cognitoAuthenticationType": null,
+              "cognitoAuthenticationProvider": null,
+              "userArn": null,
+              "userAgent": "<user--agent:1>",
+              "user": null
+            },
+            "domainName": "<domain-name:1>",
+            "deploymentId": "<id:1>",
+            "apiId": "<api-id:1>"
+          },
           "body": {
             "message": "Hello from EventBridge"
           },

--- a/tests/aws/services/events/test_events_targets.validation.json
+++ b/tests/aws/services/events/test_events_targets.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
-    "last_validated_date": "2024-09-30T07:53:35+00:00"
+    "last_validated_date": "2024-10-03T20:10:39+00:00"
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetEvents::test_put_events_with_target_events[bus_combination0]": {
     "last_validated_date": "2024-07-11T08:59:28+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When running a new test in Events v2 with APIGW NG enabled, I've encountered test failures due to bad replacement in the snapshots (it would replace the `HTTP` value across the whole snapshot string, leading to very weird error in `ResponseMetadata`), see the run here: https://app.circleci.com/pipelines/github/localstack/localstack/28547/workflows/b21fae5b-918f-4356-8a18-51b324914127/jobs/249483

I've refactored the snapshot logic a bit in order to delete less information from it, for us to be able to validate some assumptions in the `requestContext`, and have a clear idea of what is wrong/need to be fixed in the snapshot via the `skip_verify`. 

It showed that `events` will send specific headers to APIGW, like `X-Amz-Source-Arn` and `X-Amz-Source-Account` which might be used by the user's API Gateway integration. As a side-note, it also showed `events` is directly using the Java SDK to send/sign the requests 😄 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update the transformers to use v1 lambda proxy transform instead of v2
- added snapshot skips instead of transforming the whole problematic payload without replacement
- updated the Python runtime used in the lambda

\cc @cloutierMat 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
