### PR TITLE
ESMv2: Fix UpdateEventSourceMapping request and batch size check for SQS

### DIFF
--- a/localstack-core/localstack/services/lambda_/api_utils.py
+++ b/localstack-core/localstack/services/lambda_/api_utils.py
@@ -637,7 +637,7 @@ def validate_and_set_batch_size(service: str, batch_size: Optional[int] = None) 
     BATCH_SIZE_RANGES = {
         "kafka": (100, 10_000),
         "kinesis": (100, 10_000),
-        "dynamodb": (100, 1_000),
+        "dynamodb": (100, 10_000),
         "sqs-fifo": (10, 10),
         "sqs": (10, 10_000),
         "mq": (100, 10_000),

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
@@ -103,12 +103,6 @@ class EsmWorker:
         )
         self._poller_thread.start()
 
-    def update(self):
-        with self._state_lock:
-            self.current_state = EsmState.UPDATING
-            self.state_transition_reason = self.user_state_reason
-        self.start()
-
     def stop(self):
         with self._state_lock:
             self.enabled = False

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
@@ -103,16 +103,24 @@ class EsmWorker:
         )
         self._poller_thread.start()
 
+    def update(self):
+        with self._state_lock:
+            self.current_state = EsmState.UPDATING
+            self.state_transition_reason = self.user_state_reason
+        self.start()
+
     def stop(self):
         with self._state_lock:
             self.enabled = False
             self.current_state = EsmState.DISABLING
+            self.update_esm_state_in_store(EsmState.DISABLING)
             self.state_transition_reason = self.user_state_reason
         self._shutdown_event.set()
 
     def delete(self):
         with self._state_lock:
             self.current_state = EsmState.DELETING
+            self.update_esm_state_in_store(EsmState.DELETING)
             self.state_transition_reason = self.user_state_reason
         self._shutdown_event.set()
 

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -2155,9 +2155,6 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 "The resource you requested does not exist.", Type="User"
             )  # TODO: test?
 
-        if old_event_source_mapping["State"] == EsmState.UPDATING:
-            raise ResourceConflictException("Already updating", Type="User")
-
         # normalize values to overwrite
         event_source_mapping = old_event_source_mapping | request_data
 
@@ -2202,7 +2199,8 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
 
         # We should stop() the worker since the delete() will remove the ESM from the state mapping.
         esm_worker.stop()
-        updated_esm_worker.start()
+        # This will either create an EsmWorker in the CREATING state if enabled. Otherwise, the DISABLING state is set.
+        updated_esm_worker.create()
 
         return {**event_source_mapping, **temp_params}
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR addresses some regressions in ESM v2 parity when compared with ESM v1.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- `UpdateEventSourceMapping` requests now work -- where an update request will re-create a new ESM from scratch and overwrite the previous version with its new state.
- `validate_event_source_mapping` has been extended to include `UpdateEventSourceMapping` requests

<!-- Optional section: How to test these changes? -->

## Testing
The following regressions have been remedied with the new changes:
- `test_event_source_mapping_default_batch_size`
-  `test_sqs_event_source_mapping_update`

ext test runs:
* [95b6b2e](https://github.com/localstack/localstack/pull/11637/commits/95b6b2eb44115a30564f8c6e594648b06231d232) https://github.com/localstack/localstack-ext/actions/runs/11183454628
* [c3265f8](https://github.com/localstack/localstack/pull/11637/commits/c3265f87db3c1fd9a3aa7007a691774e9864a89c) https://github.com/localstack/localstack-ext/actions/runs/11184439099

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
