### PR TITLE
Remove downloaded package archives after extracting them

### DIFF
--- a/localstack-core/localstack/packages/core.py
+++ b/localstack-core/localstack/packages/core.py
@@ -110,12 +110,14 @@ class ArchiveDownloadAndExtractInstaller(ExecutableInstaller):
         mkdir(target_directory)
         download_url = self._get_download_url()
         archive_name = os.path.basename(download_url)
+        archive_path = os.path.join(config.dirs.tmp, archive_name)
         download_and_extract(
             download_url,
             retries=3,
-            tmp_archive=os.path.join(config.dirs.tmp, archive_name),
+            tmp_archive=archive_path,
             target_dir=target_directory,
         )
+        rm_rf(archive_path)
         if self.extract_single_directory:
             dir_contents = os.listdir(target_directory)
             if len(dir_contents) != 1:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

As mentioned in https://github.com/localstack/localstack/issues/11639, I have noticed that `python -m localstack.cli.lpm install` is leaving behind the downloaded package archives. This results in those files ending up in the published Docker image.

```
$ docker run --entrypoint bash -it localstack/localstack:3.8.0
root@40c78125f557:/opt/code/localstack# ls -lah /tmp/localstack
total 184M
drwxrwxrwx 1 root root  116 Oct  3 19:57 .
drwxrwxrwt 1 root root   50 Oct  3 19:57 ..
-rw-r--r-- 1 root root    0 Oct  3 17:38 .marker
-rw-r--r-- 1 root root 184M Oct  3 19:57 OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.24_8.tar.gz
drwxr-xr-x 1 root root    0 Oct  3 19:57 state
```

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

This PR solves the issue by removing the archive after extracting a package. This should result in a 184 MB reduction of the localstack docker image.


## Testing

1. Build the image: 
```sh
IMAGE_NAME="localstack/localstack" ./bin/docker-helper.sh build
```
3. Make sure that there are no archives in `/tmp/localstack`:
```sh
docker run --entrypoint ls -it localstack/localstack:latest -lah /tmp/localstack
```