### PR TITLE
upgrade kinesis-mock from 0.4.6 to 0.4.7

### DIFF
--- a/localstack-core/localstack/services/kinesis/packages.py
+++ b/localstack-core/localstack/services/kinesis/packages.py
@@ -5,7 +5,7 @@ from typing import List
 from localstack.packages import Package, PackageInstaller
 from localstack.packages.core import NodePackageInstaller
 
-_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.6"
+_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.7"
 
 
 class KinesisMockPackage(Package):


### PR DESCRIPTION
## Motivation
@etspaceman just [released a new version](https://github.com/etspaceman/kinesis-mock/releases/tag/v0.4.7) of `kinesis-mock` which basically only contains dependency updates (see release notes [here](https://github.com/etspaceman/kinesis-mock/releases/tag/v0.4.7)).
We should still make sure that we always stay up to date with this great piece of open-source software!
This PR just bumps the version, similar to these PRs (linked to cross-link them together):
- https://github.com/localstack/localstack/pull/7224
- https://github.com/localstack/localstack/pull/7346
- https://github.com/localstack/localstack/pull/7375
- https://github.com/localstack/localstack/pull/7546
- https://github.com/localstack/localstack/pull/7577
- https://github.com/localstack/localstack/pull/7748
- https://github.com/localstack/localstack/pull/8915
- https://github.com/localstack/localstack/pull/9906
- https://github.com/localstack/localstack/pull/10363

In the future, I think we should think about introducing a generalized approach to update our package installer versions (to update all of them regularly and in an automated fashion).

## Changes
- Bump the version of kinesis-mock from `0.4.6` to `0.4.7`.