### PR TITLE
fix proxied requests forwarding to Moto

### DIFF
--- a/localstack-core/localstack/services/moto.py
+++ b/localstack-core/localstack/services/moto.py
@@ -110,7 +110,7 @@ def dispatch_to_moto(context: RequestContext) -> Response:
 
     raw_path = get_full_raw_path(request)
     # this is where we skip the HTTP roundtrip between the moto server and the boto client
-    dispatch = get_dispatcher(service.service_name, raw_path)
+    dispatch = get_dispatcher(service.service_name, raw_path.split("?")[0])
     try:
         # we use the full_raw_url as moto might do some path decoding (in S3 for example)
         raw_url = get_raw_current_url(request.scheme, request.host, request.root_path, raw_path)

--- a/localstack-core/localstack/services/moto.py
+++ b/localstack-core/localstack/services/moto.py
@@ -108,13 +108,12 @@ def dispatch_to_moto(context: RequestContext) -> Response:
     service = context.service
     request = context.request
 
+    raw_path = get_full_raw_path(request)
     # this is where we skip the HTTP roundtrip between the moto server and the boto client
-    dispatch = get_dispatcher(service.service_name, request.path)
+    dispatch = get_dispatcher(service.service_name, raw_path)
     try:
         # we use the full_raw_url as moto might do some path decoding (in S3 for example)
-        raw_url = get_raw_current_url(
-            request.scheme, request.host, request.root_path, get_full_raw_path(request)
-        )
+        raw_url = get_raw_current_url(request.scheme, request.host, request.root_path, raw_path)
         response = dispatch(request, raw_url, request.headers)
         if not response:
             # some operations are only partially implemented by moto

--- a/localstack-core/localstack/services/moto.py
+++ b/localstack-core/localstack/services/moto.py
@@ -108,12 +108,18 @@ def dispatch_to_moto(context: RequestContext) -> Response:
     service = context.service
     request = context.request
 
-    raw_path = get_full_raw_path(request)
+    # Werkzeug might have an issue (to be determined where the responsibility lies) with proxied requests where the
+    # HTTP location is a full URI and not only a path.
+    # We need to use the full_raw_url as moto does some path decoding (in S3 for example)
+    full_raw_path = get_full_raw_path(request)
+    # remove the query string from the full path to do the matching of the request
+    raw_path_only = full_raw_path.split("?")[0]
     # this is where we skip the HTTP roundtrip between the moto server and the boto client
-    dispatch = get_dispatcher(service.service_name, raw_path.split("?")[0])
+    dispatch = get_dispatcher(service.service_name, raw_path_only)
     try:
-        # we use the full_raw_url as moto might do some path decoding (in S3 for example)
-        raw_url = get_raw_current_url(request.scheme, request.host, request.root_path, raw_path)
+        raw_url = get_raw_current_url(
+            request.scheme, request.host, request.root_path, full_raw_path
+        )
         response = dispatch(request, raw_url, request.headers)
         if not response:
             # some operations are only partially implemented by moto

--- a/tests/aws/test_moto.py
+++ b/tests/aws/test_moto.py
@@ -3,10 +3,12 @@ from typing import Optional
 
 import pytest
 from moto.core import DEFAULT_ACCOUNT_ID as DEFAULT_MOTO_ACCOUNT_ID
+from rolo import Request
 
 import localstack.aws.accounts
-from localstack.aws.api import ServiceException, handler
+from localstack.aws.api import RequestContext, ServiceException, handler
 from localstack.aws.forwarder import NotImplementedAvoidFallbackError
+from localstack.aws.spec import load_service
 from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services import moto
 from localstack.services.moto import MotoFallbackDispatcher
@@ -227,6 +229,33 @@ def test_call_with_sqs_returns_service_response():
 
     assert "QueueUrl" in create_queue_response
     assert create_queue_response["QueueUrl"].endswith(qname)
+
+
+@markers.aws.only_localstack
+def test_call_with_sns_with_full_uri():
+    # when requests are being forwarded by a Proxy, the HTTP request can contain the full URI and not only the path
+    # see https://github.com/localstack/localstack/pull/8962
+    # by using `request.path`, we would use a full URI in the request, as Werkzeug has issue parsing those proxied
+    # requests
+    topic_name = f"queue-{short_uid()}"
+    sns_request = Request(
+        "POST",
+        "/",
+        raw_path="http://localhost:4566/",
+        body=f"Action=CreateTopic&Name={topic_name}&Version=2010-03-31",
+        headers={"Content-Type": "application/x-www-form-urlencoded; charset=utf-8"},
+    )
+    sns_service = load_service("sns")
+    context = RequestContext()
+    context.account = "test"
+    context.region = "us-west-1"
+    context.service = sns_service
+    context.request = sns_request
+    context.operation = sns_service.operation_model("CreateTopic")
+
+    create_topic_response = moto.call_moto(context)
+
+    assert create_topic_response["TopicArn"].endswith(topic_name)
 
 
 class FakeSqsApi:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #11652, we have an issue forwarding requests to `moto` when those have a full URI in the HTTP request, as explained in #8962.
(Example HTTP request: `POST http://sns.eu-central-1.amazonaws.com/ HTTP/1.1` instead of the usual `POST / HTTP/1.1`)

This PR uses the helper created with the above PR to get the request path to send towards the moto dispatcher, so that we only get the `path` part of the request. It only changes the logic to get the actual endpoint to call, as we were already using that helper to forward the request to moto. The logic change is very minimal. 

Looking at it, I believe this is an issue in how Werkzeug handles those requests, putting the full `RAW_URI` in the `path` and not doing sanitization beforehand, as we've seen with https://www.ietf.org/rfc/rfc2616.txt that web servers should handle those. 
Also, the question comes as to what changed in `3.7.2`, as this used to work with versions before, tested by the user down to `3.4`. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update the logic to properly sanitize the path used to get the proper endpoint for moto, to be sure it is only a path and not a full URI
- add a regression test for it (I also confirmed the user sample now works with the fix)


_fixes #11652_

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
