### PR TITLE
fix lambda function extra resources upload in s3

### DIFF
--- a/localstack-core/localstack/testing/scenario/cdk_lambda_helper.py
+++ b/localstack-core/localstack/testing/scenario/cdk_lambda_helper.py
@@ -68,6 +68,7 @@ def load_nodejs_lambda_to_s3(
     bucket_name: str,
     key_name: str,
     code_path: str,
+    additional_nodjs_packages: list[str] = None,
     additional_nodejs_packages: list[str] = None,
     additional_resources: list[str] = None,
 ):
@@ -80,11 +81,16 @@ def load_nodejs_lambda_to_s3(
     :param bucket_name: bucket name (bucket will be created)
     :param key_name: key name for the uploaded zip file
     :param code_path: the path to the source code that should be included
+    :param additional_nodjs_packages: a list of strings with nodeJS packages that are required to run the lambda
     :param additional_nodejs_packages: a list of strings with nodeJS packages that are required to run the lambda
     :param additional_resources: list of path-strings to resources or internal libs that should be packaged into the lambda
     :return: None
     """
     additional_resources = additional_resources or []
+
+    if additional_nodjs_packages:
+        additional_nodejs_packages = additional_nodejs_packages or []
+        additional_nodejs_packages.extend(additional_nodjs_packages)
 
     try:
         temp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
**Motivation**

This PR addresses two main issues:

1. **Fixing Typos**
   - Corrects typographical errors in the function arguments.
2. **Resolving the Directory Copying Bug**
   - Previously, when providing a path to a directory in `load_nodejs_lambda_to_s3` for copying into the lambda folder, the directory was not copied.
   - With this change, supplying a directory path to `load_nodejs_lambda_to_s3` will correctly copy the entire directory into the lambda function environment.

**Additional Information**

This bug was discovered while working on [localstack/localstack-ext#3527](https://github.com/localstack/localstack-ext/issues/3527), where we are generating a frontend build using this lambda function.

**Changes Made**

- **Typos Fixed**
  - Corrected errors in function argument names.
- **Enhanced Directory Copying Support**
  - Updated `load_nodejs_lambda_to_s3` to support copying entire directories when a directory path is provided.