### PR TITLE
Move dns server import inside resolving function to avoid import in CLI

### DIFF
--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -37,7 +37,6 @@ from localstack.constants import (
     INTERNAL_AWS_SECRET_ACCESS_KEY,
     MAX_POOL_CONNECTIONS,
 )
-from localstack.dns.server import get_fallback_dns_server
 from localstack.utils.aws.aws_stack import get_s3_hostname
 from localstack.utils.aws.client_types import ServicePrincipal, TypedServiceClientFactory
 from localstack.utils.patch import patch
@@ -653,6 +652,8 @@ class ExternalAwsClientFactory(ClientFactory):
 
 
 def resolve_dns_from_upstream(hostname: str) -> str:
+    from localstack.dns.server import get_fallback_dns_server
+
     upstream_dns = get_fallback_dns_server()
     request = dns.message.make_query(hostname, "A")
     response = dns.query.udp(request, upstream_dns, port=53, timeout=5)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With #11581, we introduced the option to bypass our own DNS for certain AWS clients.
However, importing the DNS server from the connect.py module leads to issues for older python versions in the CLI, as the CLI needs to be able to import connect.py, and the DNS server uses syntax only supported in later python versions.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Using python versions 3.8 and 3.9, using the CLI should be possible again without issues (this was never actually published, so it only affected development versions)

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
