### PR TITLE
Add LD_LIBRARY_PATH to JavaInstallerMixin

### DIFF
--- a/localstack-core/localstack/packages/api.py
+++ b/localstack-core/localstack/packages/api.py
@@ -86,20 +86,24 @@ class PackageInstaller(abc.ABC):
             with self.install_lock:
                 # Skip the installation if it's already installed
                 if not self.is_installed():
-                    LOG.debug("Starting installation of %s...", self.name)
+                    LOG.debug("Starting installation of %s %s...", self.name, self.version)
                     self._prepare_installation(target)
                     self._install(target)
                     self._post_process(target)
-                    LOG.debug("Installation of %s finished.", self.name)
+                    LOG.debug("Installation of %s %s finished.", self.name, self.version)
                 else:
-                    LOG.debug("Installation of %s skipped (already installed).", self.name)
+                    LOG.debug(
+                        "Installation of %s %s skipped (already installed).",
+                        self.name,
+                        self.version,
+                    )
                     if not self._setup_for_target[target]:
                         LOG.debug("Performing runtime setup for already installed package.")
                         self._setup_existing_installation(target)
         except PackageException as e:
             raise e
         except Exception as e:
-            raise PackageException(f"Installation of {self.name} failed.") from e
+            raise PackageException(f"Installation of {self.name} {self.version} failed.") from e
 
     def is_installed(self) -> bool:
         """

--- a/localstack-core/localstack/packages/java.py
+++ b/localstack-core/localstack/packages/java.py
@@ -39,12 +39,13 @@ class JavaInstallerMixin:
         """
         return java_package.get_installer().get_java_home()
 
-    def get_java_env_vars(self, path: str = None) -> dict[str, str]:
+    def get_java_env_vars(self, path: str = None, ld_library_path: str = None) -> dict[str, str]:
         """
         Returns environment variables pointing to the Java installation. This is useful to build the environment where
         the application will run.
 
         :param path: If not specified, the value of PATH will be obtained from the environment
+        :param ld_library_path: If not specified, the value of LD_LIBRARY_PATH will be obtained from the environment
         :return: dict consisting of two items:
             - JAVA_HOME: path to JRE installation
             - PATH: the env path variable updated with JRE bin path
@@ -54,9 +55,16 @@ class JavaInstallerMixin:
 
         path = path or os.environ["PATH"]
 
+        ld_library_path = ld_library_path or os.environ.get("LD_LIBRARY_PATH")
+        # null paths (e.g. `:/foo`) have a special meaning according to the manpages
+        if ld_library_path is None:
+            ld_library_path = f"{java_home}/lib:{java_home}/lib/server"
+        else:
+            ld_library_path = f"{java_home}/lib:{java_home}/lib/server:{ld_library_path}"
+
         return {
             "JAVA_HOME": java_home,
-            "LD_LIBRARY_PATH": f"{java_home}/lib:{java_home}/lib/server",
+            "LD_LIBRARY_PATH": ld_library_path,
             "PATH": f"{java_bin}:{path}",
         }
 

--- a/localstack-core/localstack/packages/java.py
+++ b/localstack-core/localstack/packages/java.py
@@ -56,6 +56,7 @@ class JavaInstallerMixin:
 
         return {
             "JAVA_HOME": java_home,
+            "LD_LIBRARY_PATH": f"{java_home}/lib:{java_home}/lib/server",
             "PATH": f"{java_bin}:{path}",
         }
 

--- a/localstack-core/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack-core/localstack/utils/kinesis/kinesis_connector.py
@@ -255,7 +255,6 @@ def _start_kcl_client_process(
         "AWS_SECRET_ACCESS_KEY": account_id,
         "JAVA_HOME": java_home,
         "PATH": f"{java_home}/bin:{os.getenv('PATH')}",
-        "LD_LIBRARY_PATH": f"{java_home}/lib:{java_home}/lib/server",
     }
 
     events_file = os.path.join(tempfile.gettempdir(), f"kclipy.{short_uid()}.fifo")

--- a/localstack-core/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack-core/localstack/utils/kinesis/kinesis_connector.py
@@ -255,6 +255,7 @@ def _start_kcl_client_process(
         "AWS_SECRET_ACCESS_KEY": account_id,
         "JAVA_HOME": java_home,
         "PATH": f"{java_home}/bin:{os.getenv('PATH')}",
+        "LD_LIBRARY_PATH": f"{java_home}/lib:{java_home}/lib/server",
     }
 
     events_file = os.path.join(tempfile.gettempdir(), f"kclipy.{short_uid()}.fifo")


### PR DESCRIPTION
## Background

https://github.com/localstack/localstack-ext/pull/3419 removed the global default JRE installation. This caused certain tests to start failing for aarch64.

## Changes

This PR sets the `LD_LIBRARY_PATH` env var with Java libs and adds it to the `JavaInstallerMixin`.

Generally it is advisable to set `java.library.path` on the JVM's command line. But this approach should be a global fix. Besides this used to be set in the Dockerfile in the era of global JRE.

## Tests

This was detected with following failure:

```
FAILED tests/aws/services/qldb/test_qldb.py::TestQLDB::test_stream_journal - Exception: Timeout when waiting for KCL initialization.
```

Tested passing with following CI run:

https://github.com/localstack/localstack-ext/actions/runs/11272853744/job/31350949612 :green_circle: 