### PR TITLE
There is a small issue in the html segment of diff_metrics_coverage.py

### DIFF
--- a/scripts/metrics_coverage/diff_metrics_coverage.py
+++ b/scripts/metrics_coverage/diff_metrics_coverage.py
@@ -216,7 +216,7 @@ def create_readable_report(
                 "<div>     Note: this is probalby wrong usage of the script. It includes operations that have been covered with the acceptance tests only"
             )
             fd.write(f"<p>{additional_test_details}</p></div>\n")
-        fd.write("</body></html")
+        fd.write("</body></html>")
 
 
 def main():


### PR DESCRIPTION
There is a small issue in the HTML generation section at the end of the `create_readable_report` function. The closing `>` for the last `fd.write("</body></html")` is missing. It should be `fd.write("</body></html>")`.