### PR TITLE
Update retrieve_legacy_data_from_circleci.py

### DIFF
--- a/scripts/tinybird/retrieve_legacy_data_from_circleci.py
+++ b/scripts/tinybird/retrieve_legacy_data_from_circleci.py
@@ -34,7 +34,7 @@ def send_request_to_connection(conn, url):
         data = res.read()
         return data
     else:
-        print(f"connection failed: {res.getcode}")
+        print(f"connection failed: {res.getcode()}")
         return None
 
 


### PR DESCRIPTION
Response Code Handling: In the `send_request_to_connection` function, the error message when the response fails should use parentheses: `print(f"connection failed: {res.getcode()}")` instead of `print(f"connection failed: {res.getcode}")`.