### PR TITLE
APIGW: improve parity for GetApiKeys and GetUsagePlanKeys

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -948,7 +948,7 @@ class TestAPIGateway:
 
     @markers.aws.needs_fixing
     # Doesn't use a fixture that cleans up after itself, and most likely missing roles. Should be moved to common
-    def test_multiple_api_keys_validate(self, aws_client, create_iam_role_with_policy):
+    def test_multiple_api_keys_validate(self, aws_client, create_iam_role_with_policy, cleanups):
         request_templates = {
             "application/json": json.dumps(
                 {
@@ -1004,6 +1004,7 @@ class TestAPIGateway:
             }
             aws_client.apigateway.create_usage_plan_key(**payload)
             api_keys.append(api_key["value"])
+            cleanups.append(lambda: aws_client.apigateway.delete_api_key(apiKey=api_key["id"]))
 
         response = requests.put(
             url,

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -553,6 +553,7 @@ class TestUsagePlans:
         snapshot,
         create_rest_apigw,
         apigw_redeploy_api,
+        cleanups,
     ):
         snapshot.add_transformer(snapshot.transform.apigateway_api())
         snapshot.add_transformers_list(
@@ -625,6 +626,7 @@ class TestUsagePlans:
         )
         snapshot.match("create-api-key", api_key_response)
         api_key_id = api_key_response["id"]
+        cleanups.append(lambda: aws_client.apigateway.delete_api_key(apiKey=api_key_id))
 
         create_usage_plan_key_resp = aws_client.apigateway.create_usage_plan_key(
             usagePlanId=usage_plan_id,

--- a/tests/aws/services/apigateway/test_apigateway_extended.py
+++ b/tests/aws/services/apigateway/test_apigateway_extended.py
@@ -200,6 +200,12 @@ class TestApigatewayApiKeysCrud:
         api_keys_prefix = aws_client.apigateway.get_api_keys(nameQuery=api_key_name[:8])
         snapshot.match("get-api-keys-prefix-name-query", api_keys_prefix)
 
+        # test prefix cased
+        api_keys_prefix_cased = aws_client.apigateway.get_api_keys(
+            nameQuery=api_key_name[:8].upper()
+        )
+        snapshot.match("get-api-keys-prefix-name-query-cased", api_keys_prefix_cased)
+
         # test postfix
         api_keys_postfix = aws_client.apigateway.get_api_keys(nameQuery=api_key_name[2:])
         snapshot.match("get-api-keys-postfix-name-query", api_keys_postfix)
@@ -283,6 +289,11 @@ class TestApigatewayApiKeysCrud:
             usagePlanId=usage_plan_id, nameQuery="test-key"
         )
         snapshot.match("get-up-keys-name-query", get_up_keys_query)
+
+        get_up_keys_query_cased = aws_client.apigateway.get_usage_plan_keys(
+            usagePlanId=usage_plan_id, nameQuery="TEST-key"
+        )
+        snapshot.match("get-up-keys-name-query-cased", get_up_keys_query_cased)
 
         get_up_keys_query_name = aws_client.apigateway.get_usage_plan_keys(
             usagePlanId=usage_plan_id, nameQuery=api_key_name

--- a/tests/aws/services/apigateway/test_apigateway_extended.py
+++ b/tests/aws/services/apigateway/test_apigateway_extended.py
@@ -170,6 +170,11 @@ def test_get_domain_name(aws_client):
 
 
 class TestApigatewayApiKeysCrud:
+    @pytest.fixture(scope="class", autouse=True)
+    def cleanup_api_keys(self, aws_client):
+        for api_key in aws_client.apigateway.get_api_keys()["items"]:
+            aws_client.apigateway.delete_api_key(apiKey=api_key["id"])
+
     @markers.aws.validated
     def test_get_api_keys(self, aws_client, apigw_create_api_key, snapshot):
         snapshot.add_transformers_list(

--- a/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
@@ -1632,7 +1632,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::TestApigatewayApiKeysCrud::test_get_api_keys": {
-    "recorded-date": "10-10-2024, 18:29:03",
+    "recorded-date": "10-10-2024, 18:53:36",
     "recorded-content": {
       "get-api-keys": {
         "items": [],
@@ -1688,6 +1688,13 @@
             "stageKeys": []
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-api-keys-prefix-name-query-cased": {
+        "items": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1820,7 +1827,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::TestApigatewayApiKeysCrud::test_get_usage_plan_api_keys": {
-    "recorded-date": "10-10-2024, 18:41:23",
+    "recorded-date": "10-10-2024, 18:54:42",
     "recorded-content": {
       "get-api-keys": {
         "items": [],
@@ -1950,6 +1957,13 @@
             "value": "<value:1>"
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-up-keys-name-query-cased": {
+        "items": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
@@ -1630,5 +1630,366 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_extended.py::TestApigatewayApiKeysCrud::test_get_api_keys": {
+    "recorded-date": "10-10-2024, 18:29:03",
+    "recorded-content": {
+      "get-api-keys": {
+        "items": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-api-key": {
+        "createdDate": "datetime",
+        "enabled": false,
+        "id": "<id:1>",
+        "lastUpdatedDate": "datetime",
+        "name": "<name:1>",
+        "stageKeys": [],
+        "value": "<value:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-api-keys-after-create-1": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "enabled": false,
+            "id": "<id:1>",
+            "lastUpdatedDate": "datetime",
+            "name": "<name:1>",
+            "stageKeys": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-api-keys-wrong-name-query": {
+        "items": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-api-keys-prefix-name-query": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "enabled": false,
+            "id": "<id:1>",
+            "lastUpdatedDate": "datetime",
+            "name": "<name:1>",
+            "stageKeys": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-api-keys-postfix-name-query": {
+        "items": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-api-keys-infix-name-query": {
+        "items": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-api-key-2": {
+        "createdDate": "datetime",
+        "enabled": false,
+        "id": "<id:2>",
+        "lastUpdatedDate": "datetime",
+        "name": "<name:2>",
+        "stageKeys": [],
+        "value": "<value:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-api-keys-after-create-2": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "enabled": false,
+            "id": "<id:2>",
+            "lastUpdatedDate": "datetime",
+            "name": "<name:2>",
+            "stageKeys": []
+          },
+          {
+            "createdDate": "datetime",
+            "enabled": false,
+            "id": "<id:1>",
+            "lastUpdatedDate": "datetime",
+            "name": "<name:1>",
+            "stageKeys": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-api-keys-name-query": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "enabled": false,
+            "id": "<id:2>",
+            "lastUpdatedDate": "datetime",
+            "name": "<name:2>",
+            "stageKeys": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-api-keys-prefix-name-query-2": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "enabled": false,
+            "id": "<id:2>",
+            "lastUpdatedDate": "datetime",
+            "name": "<name:2>",
+            "stageKeys": []
+          },
+          {
+            "createdDate": "datetime",
+            "enabled": false,
+            "id": "<id:1>",
+            "lastUpdatedDate": "datetime",
+            "name": "<name:1>",
+            "stageKeys": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-apis-keys-pagination": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "enabled": false,
+            "id": "<id:2>",
+            "lastUpdatedDate": "datetime",
+            "name": "<name:2>",
+            "stageKeys": []
+          }
+        ],
+        "position": "<position:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-apis-keys-pagination-2": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "enabled": false,
+            "id": "<id:1>",
+            "lastUpdatedDate": "datetime",
+            "name": "<name:1>",
+            "stageKeys": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_extended.py::TestApigatewayApiKeysCrud::test_get_usage_plan_api_keys": {
+    "recorded-date": "10-10-2024, 18:41:23",
+    "recorded-content": {
+      "get-api-keys": {
+        "items": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-api-key": {
+        "createdDate": "datetime",
+        "enabled": false,
+        "id": "<id:1>",
+        "lastUpdatedDate": "datetime",
+        "name": "<name:1>",
+        "stageKeys": [],
+        "value": "<value:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-api-key-2": {
+        "createdDate": "datetime",
+        "enabled": false,
+        "id": "<id:1>",
+        "lastUpdatedDate": "datetime",
+        "name": "<name:1>",
+        "stageKeys": [],
+        "value": "<value:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-api-keys-after-create-1": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "enabled": false,
+            "id": "<id:2>",
+            "lastUpdatedDate": "datetime",
+            "name": "<name:2>",
+            "stageKeys": []
+          },
+          {
+            "createdDate": "datetime",
+            "enabled": false,
+            "id": "<id:1>",
+            "lastUpdatedDate": "datetime",
+            "name": "<name:1>",
+            "stageKeys": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-usage-plan": {
+        "apiStages": [],
+        "id": "<id:3>",
+        "name": "<name:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-up-keys-before-create": {
+        "items": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-up-key": {
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "type": "API_KEY",
+        "value": "<value:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-up-key-2": {
+        "id": "<id:2>",
+        "name": "<name:2>",
+        "type": "API_KEY",
+        "value": "<value:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-up-keys": {
+        "items": [
+          {
+            "id": "<id:2>",
+            "name": "<name:2>",
+            "type": "API_KEY",
+            "value": "<value:2>"
+          },
+          {
+            "id": "<id:1>",
+            "name": "<name:1>",
+            "type": "API_KEY",
+            "value": "<value:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-up-keys-name-query": {
+        "items": [
+          {
+            "id": "<id:2>",
+            "name": "<name:2>",
+            "type": "API_KEY",
+            "value": "<value:2>"
+          },
+          {
+            "id": "<id:1>",
+            "name": "<name:1>",
+            "type": "API_KEY",
+            "value": "<value:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-up-keys-name-query-key-name": {
+        "items": [
+          {
+            "id": "<id:1>",
+            "name": "<name:1>",
+            "type": "API_KEY",
+            "value": "<value:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-up-keys-bad-query": {
+        "items": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-up-keys-after-delete": {
+        "items": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-up-keys-bad-usage-plan": {
+        "items": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_extended.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.validation.json
@@ -1,4 +1,10 @@
 {
+  "tests/aws/services/apigateway/test_apigateway_extended.py::TestApigatewayApiKeysCrud::test_get_api_keys": {
+    "last_validated_date": "2024-10-10T18:29:03+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_extended.py::TestApigatewayApiKeysCrud::test_get_usage_plan_api_keys": {
+    "last_validated_date": "2024-10-10T18:41:22+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
     "last_validated_date": "2024-04-15T21:45:02+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_extended.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.validation.json
@@ -1,9 +1,9 @@
 {
   "tests/aws/services/apigateway/test_apigateway_extended.py::TestApigatewayApiKeysCrud::test_get_api_keys": {
-    "last_validated_date": "2024-10-10T18:29:03+00:00"
+    "last_validated_date": "2024-10-10T18:53:36+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::TestApigatewayApiKeysCrud::test_get_usage_plan_api_keys": {
-    "last_validated_date": "2024-10-10T18:41:22+00:00"
+    "last_validated_date": "2024-10-10T18:54:41+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
     "last_validated_date": "2024-04-15T21:45:02+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Based on #11659 to not have conflicts.

As there was a small regression with #11659, I've improved the existing test and added one regarding UsagePlanKeys, and improved the logic in the provider. 

Seems like current test failure is due to targeting another branch, I'll see when the bump is merged. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- improve existing API keys tests
- add new test for UsagePlanKeys
- fix provider behavior

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
