### PR TITLE
Skip test_cfn_lambda_sqs_source

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -589,6 +589,7 @@ class TestCfnLambdaIntegrations:
 
         assert wait_until(wait_logs)
 
+    @pytest.mark.skip(reason="Race in ESMv2 causing intermittent failures")
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..MaximumRetryAttempts",


### PR DESCRIPTION
`test_cfn_lambda_sqs_source` has been failing intermittently due to a race in ESMv2.

This PR skips this test for now.

cc: @gregfurman 