### PR TITLE
Fix memory leak caused by S3 DownloadFileObj

### DIFF
--- a/localstack-core/localstack/utils/testutil.py
+++ b/localstack-core/localstack/utils/testutil.py
@@ -435,15 +435,13 @@ def delete_all_s3_objects(s3_client, buckets: str | List[str]):
 
 
 def download_s3_object(s3_client, bucket, path):
-    with tempfile.SpooledTemporaryFile() as tmpfile:
-        s3_client.download_fileobj(bucket, path, tmpfile)
-        tmpfile.seek(0)
-        result = tmpfile.read()
-        try:
-            result = to_str(result)
-        except Exception:
-            pass
-        return result
+    body = s3_client.get_object(Bucket=bucket, Key=path)["Body"]
+    result = body.read()
+    try:
+        result = to_str(result)
+    except Exception:
+        pass
+    return result
 
 
 def all_s3_object_keys(s3_client, bucket: str) -> List[str]:


### PR DESCRIPTION
## Background

We started experiencing BigData test suite OOM failures in the CI since 9th October 3PM CET. Investigations revealed that there was a memory leak in boto3 `DownloadFileObj` and `DownloadFile` but only when running in the same pytest process as LocalStack.

There are some untested hypothesis around why this is happening. These operations are implemented in S3 Transfer library (which can fall back to awscrt). This also uses a thread pool executor, is Pytest interfering somehow?

## Changes

For now, the workaround is to use S3 `GetObject`. There is a slight performance impact, but since the affected code is a testutil and used in the test suite. There will be no impact on LocalStack.

## Related

Possibly related to:
- https://github.com/boto/boto3/issues/4132