### PR TITLE
ESM v2: Add EventSourceMappingArn field

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_config_factory.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_config_factory.py
@@ -5,24 +5,29 @@ from localstack.aws.api.lambda_ import (
     DestinationConfig,
     EventSourceMappingConfiguration,
     EventSourcePosition,
+    RequestContext,
 )
 from localstack.services.lambda_ import hooks as lambda_hooks
 from localstack.services.lambda_.event_source_mapping.esm_worker import EsmState, EsmStateReason
 from localstack.services.lambda_.event_source_mapping.pipe_utils import (
     get_standardized_service_name,
 )
-from localstack.utils.aws.arns import parse_arn
+from localstack.utils.aws.arns import lambda_event_source_mapping_arn, parse_arn
 from localstack.utils.collections import merge_recursive
 from localstack.utils.strings import long_uid
 
 
 class EsmConfigFactory:
     request: CreateEventSourceMappingRequest
+    context: RequestContext
     function_arn: str
 
-    def __init__(self, request: CreateEventSourceMappingRequest, function_arn: str):
+    def __init__(
+        self, request: CreateEventSourceMappingRequest, context: RequestContext, function_arn: str
+    ):
         self.request = request
         self.function_arn = function_arn
+        self.context = context
 
     def get_esm_config(self) -> EventSourceMappingConfiguration:
         """Creates an Event Source Mapping (ESM) configuration based on a create ESM request.
@@ -30,15 +35,20 @@ class EsmConfigFactory:
         * CreatePipe API: https://docs.aws.amazon.com/eventbridge/latest/pipes-reference/API_CreatePipe.html
         The CreatePipe API covers largely the same parameters, but is better structured using hierarchical parameters.
         """
-
         service = ""
         if source_arn := self.request.get("EventSourceArn"):
             parsed_arn = parse_arn(source_arn)
             service = get_standardized_service_name(parsed_arn["service"])
 
+        uuid = long_uid()
+
         default_source_parameters = {}
-        default_source_parameters["UUID"] = long_uid()
+        default_source_parameters["UUID"] = uuid
+        default_source_parameters["EventSourceMappingArn"] = lambda_event_source_mapping_arn(
+            uuid, self.context.account_id, self.context.region
+        )
         default_source_parameters["StateTransitionReason"] = EsmStateReason.USER_ACTION
+
         if service == "sqs":
             default_source_parameters["BatchSize"] = 10
             default_source_parameters["MaximumBatchingWindowInSeconds"] = 0

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -220,7 +220,10 @@ from localstack.services.lambda_.runtimes import (
 from localstack.services.lambda_.urlrouter import FunctionUrlRouter
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.state import StateVisitor
-from localstack.utils.aws.arns import extract_service_from_arn, get_partition
+from localstack.utils.aws.arns import (
+    extract_service_from_arn,
+    get_partition,
+)
 from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.collections import PaginatedList
 from localstack.utils.files import load_file
@@ -1859,7 +1862,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         # Validations
         function_arn, function_name, state = self.validate_event_source_mapping(context, request)
 
-        esm_config = EsmConfigFactory(request, function_arn).get_esm_config()
+        esm_config = EsmConfigFactory(request, context, function_arn).get_esm_config()
 
         # Copy esm_config to avoid a race condition with potential async update in the store
         state.event_source_mappings[esm_config["UUID"]] = esm_config.copy()

--- a/localstack-core/localstack/utils/aws/arns.py
+++ b/localstack-core/localstack/utils/aws/arns.py
@@ -267,6 +267,11 @@ def lambda_code_signing_arn(code_signing_id: str, account_id: str, region_name: 
     return _resource_arn(code_signing_id, pattern, account_id=account_id, region_name=region_name)
 
 
+def lambda_event_source_mapping_arn(uuid: str, account_id: str, region_name: str) -> str:
+    pattern = "arn:%s:lambda:%s:%s:event-source-mapping:%s"
+    return _resource_arn(uuid, pattern, account_id=account_id, region_name=region_name)
+
+
 def lambda_function_or_layer_arn(
     type: str,
     entity_name: str,

--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -58,7 +58,10 @@ def test_lambda_w_dynamodb_event_filter(deploy_cfn_template, aws_client):
 
 
 @markers.snapshot.skip_snapshot_verify(
-    ["$..EventSourceMappings..FunctionArn", "$..EventSourceMappings..LastProcessingResult"]
+    [
+        "$..EventSourceMappings..FunctionArn",
+        "$..EventSourceMappings..LastProcessingResult",
+    ]
 )
 @markers.aws.validated
 def test_lambda_w_dynamodb_event_filter_update(deploy_cfn_template, snapshot, aws_client):

--- a/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
@@ -825,7 +825,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_dynamodb_source": {
-    "recorded-date": "09-04-2024, 07:34:20",
+    "recorded-date": "12-10-2024, 10:46:17",
     "recorded-content": {
       "stack_resources": {
         "StackResources": [
@@ -846,7 +846,7 @@
               "StackResourceDriftStatus": "NOT_CHECKED"
             },
             "LogicalResourceId": "fnDynamoDBEventSourceLambdaDynamodbSourceStacktable153BBA79064FDF1D",
-            "PhysicalResourceId": "<uuid:1>",
+            "PhysicalResourceId": "<resource:6>",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::Lambda::EventSourceMapping",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
@@ -882,7 +882,7 @@
               "StackResourceDriftStatus": "NOT_CHECKED"
             },
             "LogicalResourceId": "table8235A42E",
-            "PhysicalResourceId": "<resource:6>",
+            "PhysicalResourceId": "<resource:7>",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::DynamoDB::Table",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
@@ -912,7 +912,7 @@
                     "dynamodb:GetShardIterator"
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:6>/stream/<resource:2>"
+                  "Resource": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:7>/stream/<resource:2>"
                 }
               ],
               "Version": "2012-10-17"
@@ -949,7 +949,7 @@
           },
           "MemorySize": 128,
           "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
+          "RevisionId": "<uuid:1>",
           "Role": "arn:<partition>:iam::111111111111:role/<resource:4>",
           "Runtime": "python3.9",
           "RuntimeVersionConfig": {
@@ -982,7 +982,8 @@
         "DestinationConfig": {
           "OnFailure": {}
         },
-        "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:6>/stream/<resource:2>",
+        "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:7>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:6>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
@@ -995,7 +996,7 @@
         "State": "Enabled",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:1>",
+        "UUID": "<resource:6>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1018,7 +1019,7 @@
               "KeyType": "HASH"
             }
           ],
-          "LatestStreamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:6>/stream/<resource:2>",
+          "LatestStreamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:7>/stream/<resource:2>",
           "LatestStreamLabel": "<resource:2>",
           "ProvisionedThroughput": {
             "NumberOfDecreasesToday": 0,
@@ -1029,9 +1030,9 @@
             "StreamEnabled": true,
             "StreamViewType": "NEW_AND_OLD_IMAGES"
           },
-          "TableArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:6>",
-          "TableId": "<uuid:3>",
-          "TableName": "<resource:6>",
+          "TableArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:7>",
+          "TableId": "<uuid:2>",
+          "TableName": "<resource:7>",
           "TableSizeBytes": 0,
           "TableStatus": "ACTIVE"
         },
@@ -1057,11 +1058,11 @@
               "ShardId": "shard-id"
             }
           ],
-          "StreamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:6>/stream/<resource:2>",
+          "StreamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:7>/stream/<resource:2>",
           "StreamLabel": "<resource:2>",
           "StreamStatus": "ENABLED",
           "StreamViewType": "NEW_AND_OLD_IMAGES",
-          "TableName": "<resource:6>"
+          "TableName": "<resource:7>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1122,7 +1123,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_kinesis_source": {
-    "recorded-date": "09-04-2024, 07:37:55",
+    "recorded-date": "12-10-2024, 10:52:28",
     "recorded-content": {
       "stack_resources": {
         "StackResources": [
@@ -1143,7 +1144,7 @@
               "StackResourceDriftStatus": "NOT_CHECKED"
             },
             "LogicalResourceId": "fnKinesisEventSourceLambdaKinesisSourceStackstream996A3395ED86A30E",
-            "PhysicalResourceId": "<uuid:1>",
+            "PhysicalResourceId": "<resource:6>",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::Lambda::EventSourceMapping",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
@@ -1250,7 +1251,7 @@
           },
           "MemorySize": 128,
           "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
+          "RevisionId": "<uuid:1>",
           "Role": "arn:<partition>:iam::111111111111:role/<resource:4>",
           "Runtime": "python3.9",
           "RuntimeVersionConfig": {
@@ -1284,6 +1285,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:6>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
@@ -1296,7 +1298,7 @@
         "State": "Enabled",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:1>",
+        "UUID": "<resource:6>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1446,7 +1448,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_w_dynamodb_event_filter_update": {
-    "recorded-date": "11-04-2024, 18:29:12",
+    "recorded-date": "12-10-2024, 10:42:00",
     "recorded-content": {
       "source_mappings": {
         "EventSourceMappings": [
@@ -1457,6 +1459,7 @@
               "OnFailure": {}
             },
             "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table_name>/stream/<resource:1>",
+            "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:2>",
             "FilterCriteria": {
               "Filters": [
                 {
@@ -1468,7 +1471,7 @@
                 }
               ]
             },
-            "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+            "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
             "FunctionResponseTypes": [],
             "LastModified": "datetime",
             "LastProcessingResult": "No records processed",
@@ -1480,7 +1483,7 @@
             "State": "Enabled",
             "StateTransitionReason": "User action",
             "TumblingWindowInSeconds": 0,
-            "UUID": "<uuid:1>"
+            "UUID": "<resource:2>"
           }
         ],
         "ResponseMetadata": {
@@ -1497,6 +1500,7 @@
               "OnFailure": {}
             },
             "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table_name>/stream/<resource:1>",
+            "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:2>",
             "FilterCriteria": {
               "Filters": [
                 {
@@ -1508,7 +1512,7 @@
                 }
               ]
             },
-            "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+            "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
             "FunctionResponseTypes": [],
             "LastModified": "datetime",
             "LastProcessingResult": "No records processed",
@@ -1520,7 +1524,7 @@
             "State": "Enabled",
             "StateTransitionReason": "User action",
             "TumblingWindowInSeconds": 0,
-            "UUID": "<uuid:1>"
+            "UUID": "<resource:2>"
           }
         ],
         "ResponseMetadata": {

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -1,9 +1,9 @@
 {
   "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_dynamodb_source": {
-    "last_validated_date": "2024-04-09T07:34:20+00:00"
+    "last_validated_date": "2024-10-12T10:46:17+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_kinesis_source": {
-    "last_validated_date": "2024-04-09T07:37:55+00:00"
+    "last_validated_date": "2024-10-12T10:52:28+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_permissions": {
     "last_validated_date": "2024-04-09T07:26:03+00:00"
@@ -39,7 +39,7 @@
     "last_validated_date": "2024-04-09T07:21:37+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_w_dynamodb_event_filter_update": {
-    "last_validated_date": "2024-04-11T18:29:12+00:00"
+    "last_validated_date": "2024-10-12T10:42:00+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_multiple_lambda_permissions_for_singlefn": {
     "last_validated_date": "2024-04-09T07:25:05+00:00"

--- a/tests/aws/services/lambda_/event_source_mapping/conftest.py
+++ b/tests/aws/services/lambda_/event_source_mapping/conftest.py
@@ -2,11 +2,21 @@ import pytest
 from localstack_snapshot.snapshots import SnapshotSession
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
+from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer_utility import (
     SNAPSHOT_BASIC_TRANSFORMER_NEW,
     TransformerUtility,
 )
 from localstack.utils.aws.arns import get_partition
+from tests.aws.services.lambda_.event_source_mapping.utils import (
+    is_old_esm,
+)
+
+# Only match EventSourceMappingArn field if ESM v2+
+pytestmark = markers.snapshot.skip_snapshot_verify(
+    condition=is_old_esm,
+    paths=["$..EventSourceMappingArn"],
+)
 
 
 # Here, we overwrite the snapshot fixture to allow the event_source_mapping subdir

--- a/tests/aws/services/lambda_/event_source_mapping/conftest.py
+++ b/tests/aws/services/lambda_/event_source_mapping/conftest.py
@@ -31,6 +31,6 @@ def snapshot(request, _snapshot_session: SnapshotSession, account_id, region_nam
         RegexTransformer(f"arn:{get_partition(region_name)}:", "arn:<partition>:"), priority=2
     )
 
-    _snapshot_session.add_transformer(SNAPSHOT_BASIC_TRANSFORMER_NEW, priority=2)
+    _snapshot_session.add_transformer(SNAPSHOT_BASIC_TRANSFORMER_NEW, priority=0)
 
     return _snapshot_session

--- a/tests/aws/services/lambda_/event_source_mapping/conftest.py
+++ b/tests/aws/services/lambda_/event_source_mapping/conftest.py
@@ -2,21 +2,11 @@ import pytest
 from localstack_snapshot.snapshots import SnapshotSession
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
-from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer_utility import (
     SNAPSHOT_BASIC_TRANSFORMER_NEW,
     TransformerUtility,
 )
 from localstack.utils.aws.arns import get_partition
-from tests.aws.services.lambda_.event_source_mapping.utils import (
-    is_old_esm,
-)
-
-# Only match EventSourceMappingArn field if ESM v2+
-pytestmark = markers.snapshot.skip_snapshot_verify(
-    condition=is_old_esm,
-    paths=["$..EventSourceMappingArn"],
-)
 
 
 # Here, we overwrite the snapshot fixture to allow the event_source_mapping subdir

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -65,6 +65,11 @@ def get_lambda_logs_event(aws_client):
 
 
 @markers.snapshot.skip_snapshot_verify(
+    condition=is_old_esm,
+    # Only match EventSourceMappingArn field if ESM v2 and above
+    paths=["$..EventSourceMappingArn"],
+)
+@markers.snapshot.skip_snapshot_verify(
     condition=is_v2_esm,
     paths=[
         # Lifecycle updates not yet implemented in ESM v2

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -979,7 +979,6 @@ class TestDynamoDBEventSourceMapping:
     ):
         snapshot.add_transformer(snapshot.transform.key_value("MD5OfBody"))
         snapshot.add_transformer(snapshot.transform.key_value("ReceiptHandle"))
-        snapshot.add_transformer(snapshot.transform.key_value("startSequenceNumber"))
 
         function_name = f"lambda_func-{short_uid()}"
         table_name = f"test-table-{short_uid()}"

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping": {
-    "recorded-date": "03-09-2024, 14:52:49",
+    "recorded-date": "12-10-2024, 10:55:29",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -45,6 +45,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -99,7 +100,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_disabled_dynamodb_event_source_mapping": {
-    "recorded-date": "03-09-2024, 15:51:32",
+    "recorded-date": "12-10-2024, 10:57:16",
     "recorded-content": {
       "dynamodb_create_table_result": {
         "TableDescription": {
@@ -150,6 +151,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -175,6 +177,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -196,7 +199,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_deletion_event_source_mapping_with_dynamodb": {
-    "recorded-date": "03-09-2024, 14:55:15",
+    "recorded-date": "12-10-2024, 10:57:49",
     "recorded-content": {
       "create_dynamodb_table_response": {
         "TableDescription": {
@@ -247,6 +250,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -274,6 +278,7 @@
               "OnFailure": {}
             },
             "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
+            "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
             "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
             "FunctionResponseTypes": [],
             "LastModified": "<datetime>",
@@ -297,7 +302,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_on_failure_destination_config": {
-    "recorded-date": "03-09-2024, 14:58:10",
+    "recorded-date": "12-10-2024, 11:01:18",
     "recorded-content": {
       "create_table_response": {
         "TableDescription": {
@@ -387,6 +392,7 @@
           }
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:4>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -445,7 +451,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_invalid_event_filter[single-string]": {
-    "recorded-date": "03-09-2024, 15:10:19",
+    "recorded-date": "12-10-2024, 11:21:25",
     "recorded-content": {
       "exception_event_source_creation": {
         "Error": {
@@ -462,7 +468,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_invalid_event_filter[[{\"eventName\": [\"INSERT\"=123}]]": {
-    "recorded-date": "03-09-2024, 15:10:37",
+    "recorded-date": "12-10-2024, 11:21:41",
     "recorded-content": {
       "exception_event_source_creation": {
         "Error": {
@@ -479,7 +485,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_duplicate_event_source_mappings": {
-    "recorded-date": "03-09-2024, 14:53:08",
+    "recorded-date": "12-10-2024, 10:55:48",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -524,6 +530,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -557,7 +564,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[insert_same_entry_twice]": {
-    "recorded-date": "03-09-2024, 14:59:51",
+    "recorded-date": "12-10-2024, 11:03:08",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -602,6 +609,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -700,7 +708,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[content_or_filter]": {
-    "recorded-date": "03-09-2024, 15:01:39",
+    "recorded-date": "12-10-2024, 11:05:33",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -745,6 +753,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -874,7 +883,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[content_multiple_filters]": {
-    "recorded-date": "03-09-2024, 15:03:30",
+    "recorded-date": "12-10-2024, 11:07:07",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -919,6 +928,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1014,7 +1024,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[content_filter_type]": {
-    "recorded-date": "03-09-2024, 15:05:31",
+    "recorded-date": "12-10-2024, 11:08:12",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -1059,6 +1069,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1163,7 +1174,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[exists_filter_type]": {
-    "recorded-date": "03-09-2024, 15:06:46",
+    "recorded-date": "12-10-2024, 11:10:06",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -1208,6 +1219,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1645,7 +1657,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[prefix_filter]": {
-    "recorded-date": "03-09-2024, 15:08:36",
+    "recorded-date": "12-10-2024, 11:11:06",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -1690,6 +1702,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1796,7 +1809,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[date_time_conversion]": {
-    "recorded-date": "03-09-2024, 15:10:02",
+    "recorded-date": "12-10-2024, 11:20:10",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -1841,6 +1854,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1961,7 +1975,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_sns_on_failure_destination_config": {
-    "recorded-date": "16-09-2024, 15:49:14",
+    "recorded-date": "12-10-2024, 10:59:12",
     "recorded-content": {
       "create_table_response": {
         "TableDescription": {
@@ -2051,6 +2065,7 @@
           }
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:4>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -2106,7 +2121,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failures": {
-    "recorded-date": "11-09-2024, 18:47:32",
+    "recorded-date": "12-10-2024, 11:25:25",
     "recorded-content": {
       "create_table_response": {
         "TableDescription": {
@@ -2196,6 +2211,7 @@
           }
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:4>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -2680,7 +2696,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failure_scenarios[empty_string_item_identifier_failure]": {
-    "recorded-date": "12-09-2024, 21:07:42",
+    "recorded-date": "12-10-2024, 11:30:34",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -2884,7 +2900,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failure_scenarios[null_item_identifier_failure]": {
-    "recorded-date": "12-09-2024, 21:09:44",
+    "recorded-date": "12-10-2024, 11:33:20",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -3088,7 +3104,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failure_scenarios[invalid_key_foo_failure]": {
-    "recorded-date": "12-09-2024, 21:12:32",
+    "recorded-date": "12-10-2024, 11:35:08",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -3292,7 +3308,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failure_scenarios[invalid_key_foo_null_value_failure]": {
-    "recorded-date": "12-09-2024, 21:14:19",
+    "recorded-date": "14-10-2024, 21:33:18",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -3496,7 +3512,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failure_scenarios[unhandled_exception_in_function]": {
-    "recorded-date": "12-09-2024, 21:18:09",
+    "recorded-date": "12-10-2024, 11:39:13",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -3700,7 +3716,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_success_scenarios[empty_list_success]": {
-    "recorded-date": "11-09-2024, 19:13:50",
+    "recorded-date": "12-10-2024, 11:40:57",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -3774,7 +3790,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_success_scenarios[null_success]": {
-    "recorded-date": "11-09-2024, 19:15:36",
+    "recorded-date": "12-10-2024, 11:42:06",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -3848,7 +3864,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_success_scenarios[empty_dict_success]": {
-    "recorded-date": "11-09-2024, 19:17:40",
+    "recorded-date": "12-10-2024, 11:43:06",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -3922,7 +3938,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_success_scenarios[empty_batch_item_failure_success]": {
-    "recorded-date": "11-09-2024, 19:19:26",
+    "recorded-date": "12-10-2024, 11:44:06",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -3996,7 +4012,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_success_scenarios[null_batch_item_failure_success]": {
-    "recorded-date": "11-09-2024, 19:20:35",
+    "recorded-date": "12-10-2024, 11:45:51",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -4070,7 +4086,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failure_scenarios[item_identifier_not_present_failure]": {
-    "recorded-date": "01-10-2024, 17:32:22",
+    "recorded-date": "12-10-2024, 11:27:29",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.validation.json
@@ -1,89 +1,89 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_deletion_event_source_mapping_with_dynamodb": {
-    "last_validated_date": "2024-09-03T14:54:58+00:00"
+    "last_validated_date": "2024-10-12T10:57:32+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_disabled_dynamodb_event_source_mapping": {
-    "last_validated_date": "2024-09-03T15:51:30+00:00"
+    "last_validated_date": "2024-10-12T10:57:15+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_duplicate_event_source_mappings": {
-    "last_validated_date": "2024-09-03T14:53:04+00:00"
+    "last_validated_date": "2024-10-12T10:55:43+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[content_filter_type]": {
-    "last_validated_date": "2024-09-03T15:05:30+00:00"
+    "last_validated_date": "2024-10-12T11:08:10+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[content_multiple_filters]": {
-    "last_validated_date": "2024-09-03T15:03:28+00:00"
+    "last_validated_date": "2024-10-12T11:07:06+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[content_or_filter]": {
-    "last_validated_date": "2024-09-03T15:01:38+00:00"
+    "last_validated_date": "2024-10-12T11:05:31+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[date_time_conversion]": {
-    "last_validated_date": "2024-09-03T15:10:01+00:00"
+    "last_validated_date": "2024-10-12T11:19:06+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[exists_false_filter]": {
     "last_validated_date": "2024-04-11T20:56:30+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[exists_filter_type]": {
-    "last_validated_date": "2024-09-03T15:06:44+00:00"
+    "last_validated_date": "2024-10-12T11:10:04+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[insert_same_entry_twice]": {
-    "last_validated_date": "2024-09-03T14:59:49+00:00"
+    "last_validated_date": "2024-10-12T11:03:06+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[numeric_filter]": {
     "last_validated_date": "2024-04-11T20:57:38+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[prefix_filter]": {
-    "last_validated_date": "2024-09-03T15:08:34+00:00"
+    "last_validated_date": "2024-10-12T11:11:04+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping": {
-    "last_validated_date": "2024-09-03T14:52:46+00:00"
+    "last_validated_date": "2024-10-12T10:55:26+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_on_failure_destination_config": {
-    "last_validated_date": "2024-09-03T14:58:05+00:00"
+    "last_validated_date": "2024-10-12T11:01:14+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_sns_on_failure_destination_config": {
-    "last_validated_date": "2024-09-16T15:49:08+00:00"
+    "last_validated_date": "2024-10-12T10:59:07+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_invalid_event_filter[[{\"eventName\": [\"INSERT\"=123}]]": {
-    "last_validated_date": "2024-09-03T15:10:35+00:00"
+    "last_validated_date": "2024-10-12T11:21:39+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_invalid_event_filter[single-string]": {
-    "last_validated_date": "2023-02-27T17:44:12+00:00"
+    "last_validated_date": "2024-10-12T11:21:23+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failure_scenarios[empty_string_item_identifier_failure]": {
-    "last_validated_date": "2024-09-12T21:07:39+00:00"
+    "last_validated_date": "2024-10-12T11:30:32+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failure_scenarios[invalid_key_foo_failure]": {
-    "last_validated_date": "2024-09-12T21:12:30+00:00"
+    "last_validated_date": "2024-10-12T11:35:06+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failure_scenarios[invalid_key_foo_null_value_failure]": {
-    "last_validated_date": "2024-09-12T21:14:16+00:00"
+    "last_validated_date": "2024-10-14T21:33:15+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failure_scenarios[item_identifier_not_present_failure]": {
-    "last_validated_date": "2024-10-01T17:32:19+00:00"
+    "last_validated_date": "2024-10-12T11:27:26+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failure_scenarios[null_item_identifier_failure]": {
-    "last_validated_date": "2024-09-12T21:09:41+00:00"
+    "last_validated_date": "2024-10-12T11:33:17+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failure_scenarios[unhandled_exception_in_function]": {
-    "last_validated_date": "2024-09-12T21:18:06+00:00"
+    "last_validated_date": "2024-10-12T11:39:10+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_failures": {
-    "last_validated_date": "2024-09-11T18:47:28+00:00"
+    "last_validated_date": "2024-10-12T11:25:21+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_success_scenarios[empty_batch_item_failure_success]": {
-    "last_validated_date": "2024-09-11T19:19:23+00:00"
+    "last_validated_date": "2024-10-12T11:44:04+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_success_scenarios[empty_dict_success]": {
-    "last_validated_date": "2024-09-11T19:17:38+00:00"
+    "last_validated_date": "2024-10-12T11:43:04+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_success_scenarios[empty_list_success]": {
-    "last_validated_date": "2024-09-11T19:13:49+00:00"
+    "last_validated_date": "2024-10-12T11:40:54+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_success_scenarios[null_batch_item_failure_success]": {
-    "last_validated_date": "2024-09-11T19:20:33+00:00"
+    "last_validated_date": "2024-10-12T11:45:49+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_success_scenarios[null_success]": {
-    "last_validated_date": "2024-09-11T19:15:34+00:00"
+    "last_validated_date": "2024-10-12T11:42:04+00:00"
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -893,6 +893,7 @@ class TestKinesisSource:
         "set_lambda_response",
         [
             # Successes
+            "",
             [],
             None,
             {},
@@ -901,6 +902,7 @@ class TestKinesisSource:
         ],
         ids=[
             # Successes
+            "empty_string_success",
             "empty_list_success",
             "null_success",
             "empty_dict_success",

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -72,6 +72,11 @@ def _snapshot_transformers(snapshot):
         "$..TumblingWindowInSeconds",
     ],
 )
+@markers.snapshot.skip_snapshot_verify(
+    condition=is_old_esm,
+    # Only match EventSourceMappingArn field if ESM v2 and above
+    paths=["$..EventSourceMappingArn"],
+)
 class TestKinesisSource:
     @markers.aws.validated
     def test_create_kinesis_event_source_mapping(
@@ -982,6 +987,11 @@ class TestKinesisEventFiltering:
             # Lifecycle updates not yet implemented in ESM v2
             "$..LastProcessingResult",
         ],
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=is_old_esm,
+        # Only match EventSourceMappingArn field if ESM v2 and above
+        paths=["$..EventSourceMappingArn"],
     )
     @markers.snapshot.skip_snapshot_verify(
         paths=[

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping": {
-    "recorded-date": "03-09-2024, 15:27:35",
+    "recorded-date": "12-10-2024, 11:47:16",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 100,
@@ -9,6 +9,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -31,7 +32,7 @@
         "Records": [
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-111111111111:<sequence-number:1>",
+            "eventID": "shardId-000000000000:<sequence-number:1>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
@@ -47,7 +48,7 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-111111111111:<sequence-number:2>",
+            "eventID": "shardId-000000000000:<sequence-number:2>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
@@ -63,7 +64,7 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-111111111111:<sequence-number:3>",
+            "eventID": "shardId-000000000000:<sequence-number:3>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
@@ -79,7 +80,7 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-111111111111:<sequence-number:4>",
+            "eventID": "shardId-000000000000:<sequence-number:4>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
@@ -95,7 +96,7 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-111111111111:<sequence-number:5>",
+            "eventID": "shardId-000000000000:<sequence-number:5>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
@@ -111,7 +112,7 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-111111111111:<sequence-number:6>",
+            "eventID": "shardId-000000000000:<sequence-number:6>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
@@ -127,7 +128,7 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-111111111111:<sequence-number:7>",
+            "eventID": "shardId-000000000000:<sequence-number:7>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
@@ -143,7 +144,7 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-111111111111:<sequence-number:8>",
+            "eventID": "shardId-000000000000:<sequence-number:8>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
@@ -159,7 +160,7 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-111111111111:<sequence-number:9>",
+            "eventID": "shardId-000000000000:<sequence-number:9>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
@@ -175,7 +176,7 @@
           },
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-111111111111:<sequence-number:10>",
+            "eventID": "shardId-000000000000:<sequence-number:10>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
@@ -560,7 +561,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_trim_horizon": {
-    "recorded-date": "03-09-2024, 15:28:22",
+    "recorded-date": "12-10-2024, 11:50:52",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -569,6 +570,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -593,164 +595,164 @@
           "event": {
             "Records": [
               {
-                "eventID": "shardId-111111111111:<sequence-number:1>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
-                "eventSource": "aws:kinesis",
-                "eventVersion": "1.0",
-                "eventName": "aws:kinesis:record",
-                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
-                "awsRegion": "<region>",
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:1>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAwfQ==",
-                  "partitionKey": "test_0",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:2>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:1>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:2>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAxfQ==",
-                  "partitionKey": "test_0",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:3>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:2>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:3>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAyfQ==",
-                  "partitionKey": "test_0",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:4>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:3>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:4>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAzfQ==",
-                  "partitionKey": "test_0",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:5>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:4>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:5>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA0fQ==",
-                  "partitionKey": "test_0",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:6>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:5>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:6>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA1fQ==",
-                  "partitionKey": "test_0",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:7>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:6>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:7>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA2fQ==",
-                  "partitionKey": "test_0",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:8>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:7>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:8>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA3fQ==",
-                  "partitionKey": "test_0",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:9>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:8>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:9>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA4fQ==",
-                  "partitionKey": "test_0",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:10>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:9>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:10>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
-                  "partitionKey": "test_0",
-                  "kinesisSchemaVersion": "1.0"
-                }
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
+                "eventSource": "aws:kinesis",
+                "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:10>",
+                "eventName": "aws:kinesis:record",
+                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
+                "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
               }
             ]
           }
@@ -760,164 +762,164 @@
           "event": {
             "Records": [
               {
-                "eventID": "shardId-111111111111:<sequence-number:11>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
-                "eventSource": "aws:kinesis",
-                "eventVersion": "1.0",
-                "eventName": "aws:kinesis:record",
-                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
-                "awsRegion": "<region>",
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:11>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAwfQ==",
-                  "partitionKey": "test_1",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:12>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:11>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:12>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAxfQ==",
-                  "partitionKey": "test_1",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:13>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:12>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:13>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAyfQ==",
-                  "partitionKey": "test_1",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:14>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:13>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:14>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAzfQ==",
-                  "partitionKey": "test_1",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:15>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:14>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:15>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA0fQ==",
-                  "partitionKey": "test_1",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:16>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:15>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:16>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA1fQ==",
-                  "partitionKey": "test_1",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:17>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:16>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:17>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA2fQ==",
-                  "partitionKey": "test_1",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:18>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:17>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:18>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA3fQ==",
-                  "partitionKey": "test_1",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:19>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:18>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:19>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA4fQ==",
-                  "partitionKey": "test_1",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:20>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:19>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
-                  "sequenceNumber": "<sequence-number:20>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
-                  "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
+                  "kinesisSchemaVersion": "1.0",
                   "partitionKey": "test_1",
-                  "kinesisSchemaVersion": "1.0"
-                }
+                  "sequenceNumber": "<sequence-number:20>",
+                  "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
+                "eventSource": "aws:kinesis",
+                "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:20>",
+                "eventName": "aws:kinesis:record",
+                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
+                "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
               }
             ]
           }
@@ -927,164 +929,164 @@
           "event": {
             "Records": [
               {
-                "eventID": "shardId-111111111111:<sequence-number:21>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
-                "eventSource": "aws:kinesis",
-                "eventVersion": "1.0",
-                "eventName": "aws:kinesis:record",
-                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
-                "awsRegion": "<region>",
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:21>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAwfQ==",
-                  "partitionKey": "test_3",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:22>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:21>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:22>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAxfQ==",
-                  "partitionKey": "test_3",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:23>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:22>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:23>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAyfQ==",
-                  "partitionKey": "test_3",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:24>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:23>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:24>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiAzfQ==",
-                  "partitionKey": "test_3",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:25>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:24>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:25>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA0fQ==",
-                  "partitionKey": "test_3",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:26>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:25>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:26>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA1fQ==",
-                  "partitionKey": "test_3",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:27>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:26>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:27>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA2fQ==",
-                  "partitionKey": "test_3",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:28>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:27>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:28>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA3fQ==",
-                  "partitionKey": "test_3",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:29>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:28>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
+                  "kinesisSchemaVersion": "1.0",
+                  "partitionKey": "test_3",
                   "sequenceNumber": "<sequence-number:29>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                   "data": "eyJyZWNvcmRfaWQiOiA4fQ==",
-                  "partitionKey": "test_3",
-                  "kinesisSchemaVersion": "1.0"
-                }
-              },
-              {
-                "eventID": "shardId-111111111111:<sequence-number:30>",
-                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:29>",
                 "eventName": "aws:kinesis:record",
                 "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
                 "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+              },
+              {
                 "kinesis": {
-                  "sequenceNumber": "<sequence-number:30>",
-                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
-                  "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
+                  "kinesisSchemaVersion": "1.0",
                   "partitionKey": "test_3",
-                  "kinesisSchemaVersion": "1.0"
-                }
+                  "sequenceNumber": "<sequence-number:30>",
+                  "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+                },
+                "eventSource": "aws:kinesis",
+                "eventVersion": "1.0",
+                "eventID": "shardId-000000000000:<sequence-number:30>",
+                "eventName": "aws:kinesis:record",
+                "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
+                "awsRegion": "<region>",
+                "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
               }
             ]
           }
@@ -1093,7 +1095,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_disable_kinesis_event_source_mapping": {
-    "recorded-date": "03-09-2024, 15:28:51",
+    "recorded-date": "12-10-2024, 11:54:22",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1102,6 +1104,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -1124,164 +1127,164 @@
         {
           "Records": [
             {
-              "eventID": "shardId-111111111111:<sequence-number:1>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
-              "eventSource": "aws:kinesis",
-              "eventVersion": "1.0",
-              "eventName": "aws:kinesis:record",
-              "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
-              "awsRegion": "<region>",
               "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:1>",
-                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiAwfQ==",
-                "partitionKey": "test",
-                "kinesisSchemaVersion": "1.0"
-              }
-            },
-            {
-              "eventID": "shardId-111111111111:<sequence-number:2>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:1>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+            },
+            {
               "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:2>",
-                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiAxfQ==",
-                "partitionKey": "test",
-                "kinesisSchemaVersion": "1.0"
-              }
-            },
-            {
-              "eventID": "shardId-111111111111:<sequence-number:3>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:2>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+            },
+            {
               "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:3>",
-                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiAyfQ==",
-                "partitionKey": "test",
-                "kinesisSchemaVersion": "1.0"
-              }
-            },
-            {
-              "eventID": "shardId-111111111111:<sequence-number:4>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:3>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+            },
+            {
               "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:4>",
-                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiAzfQ==",
-                "partitionKey": "test",
-                "kinesisSchemaVersion": "1.0"
-              }
-            },
-            {
-              "eventID": "shardId-111111111111:<sequence-number:5>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:4>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+            },
+            {
               "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:5>",
-                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiA0fQ==",
-                "partitionKey": "test",
-                "kinesisSchemaVersion": "1.0"
-              }
-            },
-            {
-              "eventID": "shardId-111111111111:<sequence-number:6>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:5>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+            },
+            {
               "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:6>",
-                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiA1fQ==",
-                "partitionKey": "test",
-                "kinesisSchemaVersion": "1.0"
-              }
-            },
-            {
-              "eventID": "shardId-111111111111:<sequence-number:7>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:6>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+            },
+            {
               "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:7>",
-                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiA2fQ==",
-                "partitionKey": "test",
-                "kinesisSchemaVersion": "1.0"
-              }
-            },
-            {
-              "eventID": "shardId-111111111111:<sequence-number:8>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:7>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+            },
+            {
               "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:8>",
-                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiA3fQ==",
-                "partitionKey": "test",
-                "kinesisSchemaVersion": "1.0"
-              }
-            },
-            {
-              "eventID": "shardId-111111111111:<sequence-number:9>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:8>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+            },
+            {
               "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "test",
                 "sequenceNumber": "<sequence-number:9>",
-                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
                 "data": "eyJyZWNvcmRfaWQiOiA4fQ==",
-                "partitionKey": "test",
-                "kinesisSchemaVersion": "1.0"
-              }
-            },
-            {
-              "eventID": "shardId-111111111111:<sequence-number:10>",
-              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:9>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
               "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+            },
+            {
               "kinesis": {
-                "sequenceNumber": "<sequence-number:10>",
-                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
-                "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
+                "kinesisSchemaVersion": "1.0",
                 "partitionKey": "test",
-                "kinesisSchemaVersion": "1.0"
-              }
+                "sequenceNumber": "<sequence-number:10>",
+                "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
+              "eventSource": "aws:kinesis",
+              "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:10>",
+              "eventName": "aws:kinesis:record",
+              "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
+              "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
             }
           ]
         }
@@ -1289,7 +1292,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_on_failure_destination_config": {
-    "recorded-date": "03-09-2024, 15:41:42",
+    "recorded-date": "12-10-2024, 12:29:14",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -1300,6 +1303,7 @@
           }
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -1358,7 +1362,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisEventFiltering::test_kinesis_event_filtering_json_pattern": {
-    "recorded-date": "03-09-2024, 15:29:09",
+    "recorded-date": "12-10-2024, 13:31:54",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -1367,6 +1371,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1405,6 +1410,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1440,7 +1446,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_duplicate_event_source_mappings": {
-    "recorded-date": "03-09-2024, 15:27:56",
+    "recorded-date": "12-10-2024, 11:48:49",
     "recorded-content": {
       "create": {
         "BatchSize": 100,
@@ -1449,6 +1455,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -1482,7 +1489,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping_multiple_lambdas_single_kinesis_event_stream": {
-    "recorded-date": "03-09-2024, 15:27:54",
+    "recorded-date": "12-10-2024, 13:58:19",
     "recorded-content": {
       "create_event_source_mapping_response-a": {
         "BatchSize": 100,
@@ -1491,6 +1498,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -1516,6 +1524,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -1538,7 +1547,7 @@
         "Records": [
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-111111111111:<sequence-number:1>",
+            "eventID": "shardId-000000000000:<sequence-number:1>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
@@ -1558,7 +1567,7 @@
         "Records": [
           {
             "awsRegion": "<region>",
-            "eventID": "shardId-111111111111:<sequence-number:1>",
+            "eventID": "shardId-000000000000:<sequence-number:1>",
             "eventName": "aws:kinesis:record",
             "eventSource": "aws:kinesis",
             "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
@@ -1577,7 +1586,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_sns_on_failure_destination_config": {
-    "recorded-date": "16-09-2024, 16:08:03",
+    "recorded-date": "12-10-2024, 13:17:57",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -1588,6 +1597,7 @@
           }
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -1643,7 +1653,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failures": {
-    "recorded-date": "11-09-2024, 18:00:26",
+    "recorded-date": "12-10-2024, 14:17:06",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 3,
@@ -1654,6 +1664,7 @@
           }
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -1878,7 +1889,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_list_success]": {
-    "recorded-date": "11-09-2024, 17:42:41",
+    "recorded-date": "12-10-2024, 13:21:25",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -1887,6 +1898,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -1932,7 +1944,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[null_success]": {
-    "recorded-date": "11-09-2024, 17:44:31",
+    "recorded-date": "12-10-2024, 13:23:15",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -1941,6 +1953,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -1986,7 +1999,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_dict_success]": {
-    "recorded-date": "11-09-2024, 17:45:43",
+    "recorded-date": "12-10-2024, 13:25:13",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -1995,6 +2008,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -2040,7 +2054,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_batch_item_failure_success]": {
-    "recorded-date": "11-09-2024, 17:47:33",
+    "recorded-date": "12-10-2024, 13:27:12",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -2049,6 +2063,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -2094,7 +2109,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[null_batch_item_failure_success]": {
-    "recorded-date": "11-09-2024, 17:48:37",
+    "recorded-date": "12-10-2024, 13:28:05",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -2103,6 +2118,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -2148,7 +2164,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[empty_string_item_identifier_failure]": {
-    "recorded-date": "11-09-2024, 19:12:34",
+    "recorded-date": "12-10-2024, 13:08:09",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -2159,6 +2175,7 @@
           }
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -2281,7 +2298,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[null_item_identifier_failure]": {
-    "recorded-date": "11-09-2024, 19:15:41",
+    "recorded-date": "12-10-2024, 13:10:20",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -2292,6 +2309,7 @@
           }
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -2414,7 +2432,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[invalid_key_foo_failure]": {
-    "recorded-date": "11-09-2024, 19:19:39",
+    "recorded-date": "12-10-2024, 13:13:18",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -2425,6 +2443,7 @@
           }
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -2547,7 +2566,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[invalid_key_foo_null_value_failure]": {
-    "recorded-date": "11-09-2024, 19:22:51",
+    "recorded-date": "12-10-2024, 13:14:13",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -2558,6 +2577,7 @@
           }
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -2680,7 +2700,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[unhandled_exception_in_function]": {
-    "recorded-date": "11-09-2024, 19:25:09",
+    "recorded-date": "14-10-2024, 18:10:16",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -2691,6 +2711,7 @@
           }
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -2813,7 +2834,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[item_identifier_not_present_failure]": {
-    "recorded-date": "01-10-2024, 17:20:15",
+    "recorded-date": "12-10-2024, 13:06:13",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -2824,6 +2845,7 @@
           }
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -2939,6 +2961,61 @@
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:4>",
               "awsRegion": "<region>",
               "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_string_success]": {
+    "recorded-date": "12-10-2024, 13:19:37",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 1,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {}
+        },
+        "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures"
+        ],
+        "LastModified": "<datetime>",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumRecordAgeInSeconds": -1,
+        "MaximumRetryAttempts": 2,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "kinesis_events": [
+        {
+          "Records": [
+            {
+              "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "test",
+                "sequenceNumber": "<sequence-number:1>",
+                "data": "aGVsbG8=",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
+              "eventSource": "aws:kinesis",
+              "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:1>",
+              "eventName": "aws:kinesis:record",
+              "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
+              "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
             }
           ]
         }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -3,66 +3,69 @@
     "last_validated_date": "2023-02-27T16:01:08+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisEventFiltering::test_kinesis_event_filtering_json_pattern": {
-    "last_validated_date": "2024-09-03T13:36:58+00:00"
+    "last_validated_date": "2024-10-12T13:31:49+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping": {
-    "last_validated_date": "2024-07-31T13:52:23+00:00"
+    "last_validated_date": "2024-10-12T11:47:14+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping_multiple_lambdas_single_kinesis_event_stream": {
-    "last_validated_date": "2024-02-02T10:58:36+00:00"
+    "last_validated_date": "2024-10-12T13:58:15+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_disable_kinesis_event_source_mapping": {
-    "last_validated_date": "2023-02-27T15:59:49+00:00"
+    "last_validated_date": "2024-10-12T11:54:19+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_duplicate_event_source_mappings": {
-    "last_validated_date": "2024-01-04T23:37:20+00:00"
+    "last_validated_date": "2024-10-12T11:48:44+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_async_invocation": {
     "last_validated_date": "2023-02-27T15:55:08+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_on_failure_destination_config": {
-    "last_validated_date": "2024-09-03T15:41:37+00:00"
+    "last_validated_date": "2024-10-12T12:27:07+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_sns_on_failure_destination_config": {
-    "last_validated_date": "2024-09-16T16:07:56+00:00"
+    "last_validated_date": "2024-10-12T13:17:51+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_trim_horizon": {
-    "last_validated_date": "2023-02-27T15:56:17+00:00"
+    "last_validated_date": "2024-10-12T11:50:50+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[empty_string_item_identifier_failure]": {
-    "last_validated_date": "2024-09-11T19:12:32+00:00"
+    "last_validated_date": "2024-10-12T13:08:07+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[invalid_key_foo_failure]": {
-    "last_validated_date": "2024-09-11T19:19:37+00:00"
+    "last_validated_date": "2024-10-12T13:13:16+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[invalid_key_foo_null_value_failure]": {
-    "last_validated_date": "2024-09-11T19:22:48+00:00"
+    "last_validated_date": "2024-10-12T13:14:10+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[item_identifier_not_present_failure]": {
-    "last_validated_date": "2024-10-01T17:20:13+00:00"
+    "last_validated_date": "2024-10-12T13:06:11+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[null_item_identifier_failure]": {
-    "last_validated_date": "2024-09-11T19:15:38+00:00"
+    "last_validated_date": "2024-10-12T13:10:18+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[unhandled_exception_in_function]": {
-    "last_validated_date": "2024-09-11T19:25:06+00:00"
+    "last_validated_date": "2024-10-14T18:10:14+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failures": {
-    "last_validated_date": "2024-09-11T18:00:23+00:00"
+    "last_validated_date": "2024-10-12T14:17:03+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_batch_item_failure_success]": {
-    "last_validated_date": "2024-09-11T17:47:31+00:00"
+    "last_validated_date": "2024-10-12T13:27:09+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_dict_success]": {
-    "last_validated_date": "2024-09-11T17:45:41+00:00"
+    "last_validated_date": "2024-10-12T13:25:11+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_list_success]": {
-    "last_validated_date": "2024-09-11T17:42:39+00:00"
+    "last_validated_date": "2024-10-12T13:21:23+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_string_success]": {
+    "last_validated_date": "2024-10-12T13:19:35+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[null_batch_item_failure_success]": {
-    "last_validated_date": "2024-09-11T17:48:35+00:00"
+    "last_validated_date": "2024-10-12T13:28:03+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[null_success]": {
-    "last_validated_date": "2024-09-11T17:44:29+00:00"
+    "last_validated_date": "2024-10-12T13:23:12+00:00"
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py
@@ -71,6 +71,11 @@ def _snapshot_transformers(snapshot):
         "$..StateTransitionReason",
     ]
 )
+@markers.snapshot.skip_snapshot_verify(
+    condition=is_old_esm,
+    # Only match EventSourceMappingArn field if ESM v2 and above
+    paths=["$..EventSourceMappingArn"],
+)
 @markers.aws.validated
 def test_failing_lambda_retries_after_visibility_timeout(
     create_lambda_function,
@@ -436,6 +441,11 @@ def test_sqs_queue_as_lambda_dead_letter_queue(
         "$..create_event_source_mapping.State",
         "$..create_event_source_mapping.ResponseMetadata",
     ]
+)
+@markers.snapshot.skip_snapshot_verify(
+    condition=is_old_esm,
+    # Only match EventSourceMappingArn field if ESM v2 and above
+    paths=["$..EventSourceMappingArn"],
 )
 @markers.aws.validated
 def test_report_batch_item_failures(
@@ -861,6 +871,8 @@ def test_report_batch_item_failures_empty_json_batch_succeeds(
         "$..LastProcessingResult",
         # async update not implemented in old ESM
         "$..State",
+        # Only match EventSourceMappingArn field if ESM v2 and above
+        "$..EventSourceMappingArn",
     ],
 )
 @markers.aws.validated
@@ -950,6 +962,10 @@ def test_fifo_message_group_parallelism(
         # events attribute
         "$..Records..md5OfMessageAttributes",
     ],
+)
+@markers.snapshot.skip_snapshot_verify(
+    condition=is_old_esm,
+    paths=["$..EventSourceMappingArn"],
 )
 class TestSQSEventSourceMapping:
     @markers.aws.validated

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_failing_lambda_retries_after_visibility_timeout": {
-    "recorded-date": "06-09-2024, 13:40:40",
+    "recorded-date": "12-10-2024, 13:32:32",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -12,6 +12,7 @@
       "event_source_mapping": {
         "BatchSize": 1,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -99,7 +100,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_redrive_policy_with_failing_lambda": {
-    "recorded-date": "06-09-2024, 13:41:24",
+    "recorded-date": "12-10-2024, 13:33:30",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -200,7 +201,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_sqs_queue_as_lambda_dead_letter_queue": {
-    "recorded-date": "06-09-2024, 13:41:38",
+    "recorded-date": "12-10-2024, 13:33:41",
     "recorded-content": {
       "lambda-response-dlq-config": {
         "TargetArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>"
@@ -239,7 +240,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures": {
-    "recorded-date": "06-09-2024, 13:42:09",
+    "recorded-date": "12-10-2024, 13:34:15",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -283,6 +284,7 @@
       "create_event_source_mapping": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:5>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [
           "ReportBatchItemFailures"
@@ -529,7 +531,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_on_lambda_error": {
-    "recorded-date": "06-09-2024, 13:42:29",
+    "recorded-date": "12-10-2024, 13:34:40",
     "recorded-content": {
       "dlq_messages": [
         {
@@ -551,7 +553,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_invalid_result_json_batch_fails": {
-    "recorded-date": "06-09-2024, 13:42:52",
+    "recorded-date": "12-10-2024, 13:35:12",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -664,7 +666,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_empty_json_batch_succeeds": {
-    "recorded-date": "06-09-2024, 13:43:29",
+    "recorded-date": "12-10-2024, 13:35:43",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -712,11 +714,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_event_source_mapping_default_batch_size": {
-    "recorded-date": "06-09-2024, 13:45:16",
+    "recorded-date": "12-10-2024, 13:37:20",
     "recorded-content": {
       "create-event-source-mapping": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -756,11 +759,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping": {
-    "recorded-date": "06-09-2024, 13:46:02",
+    "recorded-date": "12-10-2024, 13:38:02",
     "recorded-content": {
       "create-event-source-mapping-response": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -801,11 +805,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter0-item_matching0-item_not_matching0]": {
-    "recorded-date": "06-09-2024, 13:46:44",
+    "recorded-date": "12-10-2024, 13:38:39",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -859,11 +864,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter1-item_matching1-item_not_matching1]": {
-    "recorded-date": "06-09-2024, 13:47:18",
+    "recorded-date": "12-10-2024, 13:39:28",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -906,8 +912,8 @@
                 "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
               },
               "messageAttributes": {},
-              "md5OfBody": "<md5-of-body:1>",
               "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
               "eventSource": "aws:sqs",
               "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
               "awsRegion": "<region>"
@@ -918,11 +924,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter2-item_matching2-item_not_matching2]": {
-    "recorded-date": "06-09-2024, 13:48:07",
+    "recorded-date": "12-10-2024, 13:40:02",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -981,11 +988,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter3-item_matching3-item_not_matching3]": {
-    "recorded-date": "06-09-2024, 13:48:45",
+    "recorded-date": "12-10-2024, 13:40:47",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1041,11 +1049,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter4-item_matching4-this is a test string]": {
-    "recorded-date": "06-09-2024, 13:49:17",
+    "recorded-date": "12-10-2024, 13:41:34",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1104,11 +1113,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter5-item_matching5-item_not_matching5]": {
-    "recorded-date": "06-09-2024, 13:49:57",
+    "recorded-date": "12-10-2024, 13:42:13",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1167,11 +1177,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter6-item_matching6-item_not_matching6]": {
-    "recorded-date": "06-09-2024, 13:50:34",
+    "recorded-date": "12-10-2024, 13:42:54",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1232,11 +1243,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter7-item_matching7-item_not_matching7]": {
-    "recorded-date": "06-09-2024, 13:51:23",
+    "recorded-date": "12-10-2024, 13:43:33",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1292,7 +1304,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[None]": {
-    "recorded-date": "06-09-2024, 13:51:28",
+    "recorded-date": "12-10-2024, 13:43:37",
     "recorded-content": {
       "create_event_source_mapping_exception": {
         "Error": {
@@ -1309,7 +1321,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[simple string]": {
-    "recorded-date": "06-09-2024, 13:51:33",
+    "recorded-date": "12-10-2024, 13:43:42",
     "recorded-content": {
       "create_event_source_mapping_exception": {
         "Error": {
@@ -1326,7 +1338,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[invalid_filter2]": {
-    "recorded-date": "06-09-2024, 13:51:39",
+    "recorded-date": "12-10-2024, 13:43:47",
     "recorded-content": {
       "create_event_source_mapping_exception": {
         "Error": {
@@ -1343,7 +1355,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[invalid_filter3]": {
-    "recorded-date": "06-09-2024, 13:51:44",
+    "recorded-date": "12-10-2024, 13:43:52",
     "recorded-content": {
       "create_event_source_mapping_exception": {
         "Error": {
@@ -1360,7 +1372,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_message_body_and_attributes_passed_correctly": {
-    "recorded-date": "06-09-2024, 13:40:58",
+    "recorded-date": "12-10-2024, 13:32:53",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -1428,11 +1440,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_update": {
-    "recorded-date": "06-09-2024, 13:53:43",
+    "recorded-date": "12-10-2024, 13:45:45",
     "recorded-content": {
       "create-event-source-mapping-response": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -1477,6 +1490,7 @@
       "updated_esm": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -1492,6 +1506,7 @@
       "updated_event_source_mapping": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -1563,11 +1578,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_duplicate_event_source_mappings": {
-    "recorded-date": "06-09-2024, 13:53:54",
+    "recorded-date": "12-10-2024, 13:45:56",
     "recorded-content": {
       "create": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -1595,11 +1611,12 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_fifo_message_group_parallelism": {
-    "recorded-date": "06-09-2024, 13:44:51",
+    "recorded-date": "12-10-2024, 13:37:01",
     "recorded-content": {
       "create_esm_disabled": {
         "BatchSize": 1,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -1615,6 +1632,7 @@
       "update_esm_enabling": {
         "BatchSize": 1,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
@@ -1630,6 +1648,7 @@
       "get_esm_enabled": {
         "BatchSize": 1,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.validation.json
@@ -1,77 +1,77 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_duplicate_event_source_mappings": {
-    "last_validated_date": "2024-09-06T13:53:49+00:00"
+    "last_validated_date": "2024-10-12T13:45:52+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_event_source_mapping_default_batch_size": {
-    "last_validated_date": "2024-09-06T13:45:13+00:00"
+    "last_validated_date": "2024-10-12T13:37:18+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter0-item_matching0-item_not_matching0]": {
-    "last_validated_date": "2024-09-06T13:46:42+00:00"
+    "last_validated_date": "2024-10-12T13:38:37+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter1-item_matching1-item_not_matching1]": {
-    "last_validated_date": "2024-09-06T13:47:16+00:00"
+    "last_validated_date": "2024-10-12T13:39:27+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter2-item_matching2-item_not_matching2]": {
-    "last_validated_date": "2024-09-06T13:48:05+00:00"
+    "last_validated_date": "2024-10-12T13:40:01+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter3-item_matching3-item_not_matching3]": {
-    "last_validated_date": "2024-09-06T13:48:43+00:00"
+    "last_validated_date": "2024-10-12T13:40:46+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter4-item_matching4-this is a test string]": {
-    "last_validated_date": "2024-09-06T13:49:16+00:00"
+    "last_validated_date": "2024-10-12T13:41:32+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter5-item_matching5-item_not_matching5]": {
-    "last_validated_date": "2024-09-06T13:49:56+00:00"
+    "last_validated_date": "2024-10-12T13:42:11+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter6-item_matching6-item_not_matching6]": {
-    "last_validated_date": "2024-09-06T13:50:32+00:00"
+    "last_validated_date": "2024-10-12T13:42:52+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter7-item_matching7-item_not_matching7]": {
-    "last_validated_date": "2024-09-06T13:51:21+00:00"
+    "last_validated_date": "2024-10-12T13:43:31+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping": {
-    "last_validated_date": "2024-09-06T13:46:01+00:00"
+    "last_validated_date": "2024-10-12T13:38:01+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_update": {
-    "last_validated_date": "2024-09-06T13:53:41+00:00"
+    "last_validated_date": "2024-10-12T13:45:43+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[None]": {
-    "last_validated_date": "2024-09-06T13:51:27+00:00"
+    "last_validated_date": "2024-10-12T13:43:35+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[invalid_filter2]": {
-    "last_validated_date": "2024-09-06T13:51:36+00:00"
+    "last_validated_date": "2024-10-12T13:43:45+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[invalid_filter3]": {
-    "last_validated_date": "2024-09-06T13:51:42+00:00"
+    "last_validated_date": "2024-10-12T13:43:50+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[simple string]": {
-    "last_validated_date": "2024-09-06T13:51:31+00:00"
+    "last_validated_date": "2024-10-12T13:43:40+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_failing_lambda_retries_after_visibility_timeout": {
-    "last_validated_date": "2024-09-06T13:40:37+00:00"
+    "last_validated_date": "2024-10-12T13:32:29+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_fifo_message_group_parallelism": {
-    "last_validated_date": "2024-09-06T13:44:50+00:00"
+    "last_validated_date": "2024-10-12T13:37:00+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_message_body_and_attributes_passed_correctly": {
-    "last_validated_date": "2024-09-06T13:40:55+00:00"
+    "last_validated_date": "2024-10-12T13:32:50+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_redrive_policy_with_failing_lambda": {
-    "last_validated_date": "2024-09-06T13:41:21+00:00"
+    "last_validated_date": "2024-10-12T13:33:27+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures": {
-    "last_validated_date": "2024-09-06T13:42:06+00:00"
+    "last_validated_date": "2024-10-12T13:34:12+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_empty_json_batch_succeeds": {
-    "last_validated_date": "2024-09-06T13:43:26+00:00"
+    "last_validated_date": "2024-10-12T13:35:40+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_invalid_result_json_batch_fails": {
-    "last_validated_date": "2024-09-06T13:42:49+00:00"
+    "last_validated_date": "2024-10-12T13:35:09+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_report_batch_item_failures_on_lambda_error": {
-    "last_validated_date": "2024-09-06T13:42:27+00:00"
+    "last_validated_date": "2024-10-12T13:34:37+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_sqs_queue_as_lambda_dead_letter_queue": {
-    "last_validated_date": "2024-09-06T13:41:36+00:00"
+    "last_validated_date": "2024-10-12T13:33:39+00:00"
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -54,7 +54,7 @@ from localstack.utils.functions import call_safe
 from localstack.utils.strings import long_uid, short_uid, to_str
 from localstack.utils.sync import ShortCircuitWaitException, wait_until
 from localstack.utils.testutil import create_lambda_archive
-from tests.aws.services.lambda_.event_source_mapping.utils import is_v2_esm
+from tests.aws.services.lambda_.event_source_mapping.utils import is_old_esm, is_v2_esm
 from tests.aws.services.lambda_.test_lambda import (
     TEST_LAMBDA_JAVA_WITH_LIB,
     TEST_LAMBDA_NODEJS,
@@ -5056,6 +5056,10 @@ class TestLambdaAccountSettings:
         )
 
 
+@markers.snapshot.skip_snapshot_verify(
+    condition=is_old_esm,
+    paths=["$..EventSourceMappingArn", "$..UUID", "$..FunctionArn"],
+)
 class TestLambdaEventSourceMappings:
     @markers.aws.validated
     def test_event_source_mapping_exceptions(self, snapshot, aws_client):

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -5856,7 +5856,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_event_source_mapping_lifecycle": {
-    "recorded-date": "10-04-2024, 09:19:52",
+    "recorded-date": "14-10-2024, 12:36:57",
     "recorded-content": {
       "update_table_response": {
         "TableDescription": {
@@ -5910,7 +5910,8 @@
           }
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:4>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:4>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:5>",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
         "LastProcessingResult": "No records processed",
@@ -5922,7 +5923,7 @@
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>",
+        "UUID": "<resource:4>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 202
@@ -5937,7 +5938,8 @@
           }
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:4>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:4>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:5>",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
         "LastProcessingResult": "No records processed",
@@ -5949,7 +5951,7 @@
         "State": "Enabled",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>",
+        "UUID": "<resource:4>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -5964,7 +5966,8 @@
           }
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:4>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:4>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:5>",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
         "LastProcessingResult": "No records processed",
@@ -5976,7 +5979,7 @@
         "State": "Deleting",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>",
+        "UUID": "<resource:4>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 202
@@ -14206,18 +14209,19 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_function_name_variations": {
-    "recorded-date": "10-04-2024, 09:21:48",
+    "recorded-date": "14-10-2024, 12:46:37",
     "recorded-content": {
       "name_only_create_esm": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:2>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
-        "UUID": "<uuid:1>",
+        "UUID": "<resource:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 202
@@ -14226,13 +14230,14 @@
       "partial_arn_latest_create_esm": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>:$LATEST",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:4>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>:$LATEST",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
-        "UUID": "<uuid:2>",
+        "UUID": "<resource:4>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 202
@@ -14241,13 +14246,14 @@
       "partial_arn_version_create_esm": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>:1",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:5>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>:1",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
-        "UUID": "<uuid:3>",
+        "UUID": "<resource:5>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 202
@@ -14256,13 +14262,14 @@
       "partial_arn_alias_create_esm": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>:myalias",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:7>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>:myalias",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
-        "UUID": "<uuid:4>",
+        "UUID": "<resource:7>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 202
@@ -14271,13 +14278,14 @@
       "full_arn_latest_create_esm": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:9>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
-        "UUID": "<uuid:5>",
+        "UUID": "<resource:9>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 202
@@ -14286,13 +14294,14 @@
       "full_arn_version_create_esm": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>:1",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:10>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>:1",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
-        "UUID": "<uuid:6>",
+        "UUID": "<resource:10>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 202
@@ -14301,13 +14310,14 @@
       "full_arn_alias_create_esm": {
         "BatchSize": 10,
         "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>:myalias",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:11>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>:myalias",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
         "MaximumBatchingWindowInSeconds": 0,
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
-        "UUID": "<uuid:7>",
+        "UUID": "<resource:11>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 202

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -39,10 +39,10 @@
     "last_validated_date": "2024-04-10T09:19:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_event_source_mapping_lifecycle": {
-    "last_validated_date": "2024-04-10T09:19:50+00:00"
+    "last_validated_date": "2024-10-14T12:36:54+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_function_name_variations": {
-    "last_validated_date": "2024-04-10T09:21:43+00:00"
+    "last_validated_date": "2024-10-14T12:46:32+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_advance_logging_configuration_format_switch": {
     "last_validated_date": "2024-04-10T08:58:47+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR introduces increases parity with AWS by includng a new field in ESM responses.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Add new `EventSourceMappingArn` field to config:
  - Skips this field for tests where parity snapshots are not yet updated and for appropriate ESM v1 cases.
  - Changes transformer settings in ESM's `conftest.py` to better cater for this case of multiple UUIDs being snapshot.