### PR TITLE
Test force deletion of deleted secrets, force delete secrets in CFN by default

### DIFF
--- a/localstack-core/localstack/services/secretsmanager/resource_providers/aws_secretsmanager_secret.py
+++ b/localstack-core/localstack/services/secretsmanager/resource_providers/aws_secretsmanager_secret.py
@@ -204,7 +204,7 @@ class SecretsManagerSecretProvider(ResourceProvider[SecretsManagerSecretProperti
         model = request.desired_state
         secrets_manager = request.aws_client_factory.secretsmanager
 
-        secrets_manager.delete_secret(SecretId=model["Name"])
+        secrets_manager.delete_secret(SecretId=model["Name"], ForceDeleteWithoutRecovery=True)
 
         return ProgressEvent(
             status=OperationStatus.SUCCESS,

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -2446,6 +2446,32 @@ class TestSecretsManager:
         )
         sm_snapshot.match("secret_value_http_response", json_response)
 
+    @markers.aws.validated
+    def test_force_delete_deleted_secret(self, sm_snapshot, secret_name, aws_client):
+        """Test if a deleted secret can be force deleted afterwards."""
+        create_secret_response = aws_client.secretsmanager.create_secret(
+            Name=secret_name, SecretString=f"secretstr-{short_uid()}"
+        )
+        sm_snapshot.match("create_secret_response", create_secret_response)
+        secret_id = create_secret_response["ARN"]
+
+        sm_snapshot.add_transformer(
+            sm_snapshot.transform.secretsmanager_secret_id_arn(create_secret_response, 0)
+        )
+
+        delete_secret_response = aws_client.secretsmanager.delete_secret(SecretId=secret_id)
+        sm_snapshot.match("delete_secret_response", delete_secret_response)
+
+        describe_secret_response = aws_client.secretsmanager.describe_secret(SecretId=secret_id)
+        sm_snapshot.match("describe_secret_response", describe_secret_response)
+
+        force_delete_secret_response = aws_client.secretsmanager.delete_secret(
+            SecretId=secret_id, ForceDeleteWithoutRecovery=True
+        )
+        sm_snapshot.match("force_delete_secret_response", force_delete_secret_response)
+
+        self._wait_force_deletion_completed(aws_client.secretsmanager, secret_id)
+
 
 class TestSecretsManagerMultiAccounts:
     @markers.aws.validated

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4538,5 +4538,53 @@
         ]
       }
     }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_force_delete_deleted_secret": {
+    "recorded-date": "11-10-2024, 14:33:45",
+    "recorded-content": {
+      "create_secret_response": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_secret_response": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "DeletionDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_secret_response": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "CreatedDate": "datetime",
+        "DeletedDate": "datetime",
+        "LastChangedDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "VersionIdsToStages": {
+          "<version_uuid:1>": [
+            "AWSCURRENT"
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "force_delete_secret_response": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "DeletionDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -41,6 +41,9 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_exp_raised_on_creation_of_secret_scheduled_for_deletion": {
     "last_validated_date": "2024-03-15T08:13:16+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_force_delete_deleted_secret": {
+    "last_validated_date": "2024-10-11T14:33:45+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_random_exclude_characters_and_symbols": {
     "last_validated_date": "2024-03-15T08:12:01+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
AWS allows force-deletion of already deleted secrets, but LocalStack does not.

Also, CloudFormation will per default force-delete a secret, so they do not show up anymore after stack deletion.

The respective change for allowing force deletion of secrets already marked for deletion in moto is getmoto/moto#8223.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* LocalStack will allow force deletion of secrets already marked for deletion
* Cloudformation will force delete secrets, instead of just marking them for deletion.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
