### PR TITLE
revert StrEnum for Python compatibility

### DIFF
--- a/localstack-core/localstack/utils/aws/client_types.py
+++ b/localstack-core/localstack/utils/aws/client_types.py
@@ -1,5 +1,4 @@
 import abc
-from enum import StrEnum
 from typing import TYPE_CHECKING, Union
 
 """
@@ -250,7 +249,7 @@ class TypedServiceClientFactory(abc.ABC):
     xray: Union["XRayClient", "MetadataRequestInjector[XRayClient]"]
 
 
-class ServicePrincipal(StrEnum):
+class ServicePrincipal(str):
     """
     Class containing defined service principals.
     To add to this list, please look up the correct service principal name for the service.


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR reverts switching `ServicePrincipal` base class from `str` to `StrEnum`, as this is not available before 3.11, and this is in the import path of the CLI.

> ImportError: cannot import name 'StrEnum' from 'enum' 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- revert `StrEnum` change

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
