### PR TITLE
ESM v2: Test Lambda runtime where provided bootstrap returns nothing

### DIFF
--- a/tests/aws/services/lambda_/event_source_mapping/conftest.py
+++ b/tests/aws/services/lambda_/event_source_mapping/conftest.py
@@ -21,6 +21,6 @@ def snapshot(request, _snapshot_session: SnapshotSession, account_id, region_nam
         RegexTransformer(f"arn:{get_partition(region_name)}:", "arn:<partition>:"), priority=2
     )
 
-    _snapshot_session.add_transformer(SNAPSHOT_BASIC_TRANSFORMER_NEW, priority=2)
+    _snapshot_session.add_transformer(SNAPSHOT_BASIC_TRANSFORMER_NEW, priority=0)
 
     return _snapshot_session

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -35,6 +35,7 @@ TEST_LAMBDA_KINESIS_LOG = FUNCTIONS_PATH / "kinesis_log.py"
 TEST_LAMBDA_KINESIS_BATCH_ITEM_FAILURE = (
     FUNCTIONS_PATH / "lambda_report_batch_item_failures_kinesis.py"
 )
+TEST_LAMBDA_PROVIDED_BOOTSTRAP_EMPTY = FUNCTIONS_PATH / "provided_bootstrap_empty"
 
 
 @pytest.fixture(autouse=True)
@@ -64,6 +65,7 @@ def _snapshot_transformers(snapshot):
         "$..BisectBatchOnFunctionError",
         "$..DestinationConfig",
         "$..LastProcessingResult",
+        "$..EventSourceMappingArn",
         "$..MaximumBatchingWindowInSeconds",
         "$..MaximumRecordAgeInSeconds",
         "$..ResponseMetadata.HTTPStatusCode",
@@ -893,6 +895,7 @@ class TestKinesisSource:
         "set_lambda_response",
         [
             # Successes
+            "",
             [],
             None,
             {},
@@ -901,6 +904,7 @@ class TestKinesisSource:
         ],
         ids=[
             # Successes
+            "empty_string_success",
             "empty_list_success",
             "null_success",
             "empty_dict_success",
@@ -970,6 +974,71 @@ class TestKinesisSource:
         invocation_events = retry(_verify_messages_received, retries=30, sleep=5)
         snapshot.match("kinesis_events", invocation_events)
 
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..Messages..Body.KinesisBatchInfo.shardId",
+        ],
+    )
+    def test_kinesis_empty_provided(
+        self,
+        create_lambda_function,
+        kinesis_create_stream,
+        lambda_su_role,
+        wait_for_stream_ready,
+        cleanups,
+        snapshot,
+        aws_client,
+    ):
+        function_name = f"lambda_func-{short_uid()}"
+        stream_name = f"test-foobar-{short_uid()}"
+        record_data = "hello"
+
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PROVIDED_BOOTSTRAP_EMPTY,
+            func_name=function_name,
+            runtime=Runtime.provided_al2023,
+            role=lambda_su_role,
+        )
+
+        kinesis_create_stream(StreamName=stream_name, ShardCount=1)
+        wait_for_stream_ready(stream_name=stream_name)
+        stream_summary = aws_client.kinesis.describe_stream_summary(StreamName=stream_name)
+        assert stream_summary["StreamDescriptionSummary"]["OpenShardCount"] == 1
+        stream_arn = aws_client.kinesis.describe_stream(StreamName=stream_name)[
+            "StreamDescription"
+        ]["StreamARN"]
+
+        create_event_source_mapping_response = aws_client.lambda_.create_event_source_mapping(
+            EventSourceArn=stream_arn,
+            FunctionName=function_name,
+            StartingPosition="TRIM_HORIZON",
+            BatchSize=1,
+            MaximumBatchingWindowInSeconds=1,
+            MaximumRetryAttempts=2,
+        )
+        snapshot.match("create_event_source_mapping_response", create_event_source_mapping_response)
+        uuid = create_event_source_mapping_response["UUID"]
+        cleanups.append(lambda: aws_client.lambda_.delete_event_source_mapping(UUID=uuid))
+        _await_event_source_mapping_enabled(aws_client.lambda_, uuid)
+
+        aws_client.kinesis.put_record(
+            Data=record_data,
+            PartitionKey="test",
+            StreamName=stream_name,
+        )
+
+        def _verify_invoke():
+            log_events = aws_client.logs.filter_log_events(
+                logGroupName=f"/aws/lambda/{function_name}",
+            )["events"]
+            assert len([e["message"] for e in log_events if e["message"].startswith("REPORT")]) == 1
+
+        retry(_verify_invoke, retries=30, sleep=5)
+
+        get_esm_result = aws_client.lambda_.get_event_source_mapping(UUID=uuid)
+        snapshot.match("get_esm_result", get_esm_result)
+
 
 # TODO: add tests for different edge cases in filtering (e.g. message isn't json => needs to be dropped)
 # https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html#filtering-kinesis
@@ -985,6 +1054,7 @@ class TestKinesisEventFiltering:
         paths=[
             "$..Messages..Body.KinesisBatchInfo.shardId",
             "$..Messages..Body.KinesisBatchInfo.streamArn",
+            "$..EventSourceMappingArn",
         ],
     )
     @markers.aws.validated

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
@@ -2944,5 +2944,117 @@
         }
       ]
     }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_string_success]": {
+    "recorded-date": "11-10-2024, 12:38:15",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 1,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {}
+        },
+        "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures"
+        ],
+        "LastModified": "<datetime>",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumRecordAgeInSeconds": -1,
+        "MaximumRetryAttempts": 2,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "kinesis_events": [
+        {
+          "Records": [
+            {
+              "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "test",
+                "sequenceNumber": "<sequence-number:1>",
+                "data": "aGVsbG8=",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
+              "eventSource": "aws:kinesis",
+              "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:1>",
+              "eventName": "aws:kinesis:record",
+              "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:3>",
+              "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_empty_provided": {
+    "recorded-date": "11-10-2024, 11:04:55",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 1,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {}
+        },
+        "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumRecordAgeInSeconds": -1,
+        "MaximumRetryAttempts": 2,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "get_esm_result": {
+        "BatchSize": 1,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {}
+        },
+        "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "LastProcessingResult": "OK",
+        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumRecordAgeInSeconds": -1,
+        "MaximumRetryAttempts": 2,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Enabled",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -17,6 +17,9 @@
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_duplicate_event_source_mappings": {
     "last_validated_date": "2024-01-04T23:37:20+00:00"
   },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_empty_provided": {
+    "last_validated_date": "2024-10-11T11:04:52+00:00"
+  },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_async_invocation": {
     "last_validated_date": "2023-02-27T15:55:08+00:00"
   },
@@ -58,6 +61,9 @@
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_list_success]": {
     "last_validated_date": "2024-09-11T17:42:39+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_string_success]": {
+    "last_validated_date": "2024-10-11T12:38:13+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[null_batch_item_failure_success]": {
     "last_validated_date": "2024-09-11T17:48:35+00:00"

--- a/tests/aws/services/lambda_/functions/provided_bootstrap_empty
+++ b/tests/aws/services/lambda_/functions/provided_bootstrap_empty
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -euo pipefail
+
+# Processing
+while true
+do
+  HEADERS="$(mktemp)"
+  # Get an event. The HTTP request will block until one is received
+  EVENT_DATA=$(curl -sS -LD "$HEADERS" -X GET "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/next")
+
+  REQUEST_ID=$(grep -Fi Lambda-Runtime-Aws-Request-Id "$HEADERS" | tr -d '[:space:]' | cut -d: -f2)
+
+  # Send an empty response (using stdin to circumvent max input length)
+  curl -X POST "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/$REQUEST_ID/response"
+done


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR tests how behaviou when a target Lambda function of an Event Source Mapping handles a Lambda runtime where nothing is returned by a Lambda invocation.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Adds a new parity test `test_kinesis_empty_provided` to snapshot how an ESM handles a Lambda runtime that does not send any data to the invocation API. 
   - This uses a custom `bootstrap`, that sends empty response to the runtime API on invocation
   - Custom `bootstrap` resides in `tests/aws/services/lambda_/functions/provided_bootstrap_empty`
- Skips new `EventSourceMappingArn` this field for tests where parity snapshots are not yet updated.
- Changes transformer settings in ESM's `conftest.py` to better cater for this case of multiple UUIDs being snapshot.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
