### PR TITLE
logs: fix `put_metric_data client` for multi account/region

### DIFF
--- a/localstack-core/localstack/services/logs/provider.py
+++ b/localstack-core/localstack/services/logs/provider.py
@@ -81,9 +81,10 @@ class LogsProvider(LogsApi, ServiceLifecycleHook):
                         value = float(value) if is_number(value) else 1
                         data = [{"MetricName": tf["metricName"], "Value": value}]
                         try:
-                            self.cw_client.put_metric_data(
-                                Namespace=tf["metricNamespace"], MetricData=data
-                            )
+                            client = connect_to(
+                                aws_access_key_id=context.account_id, region_name=context.region
+                            ).cloudwatch
+                            client.put_metric_data(Namespace=tf["metricNamespace"], MetricData=data)
                         except Exception as e:
                             LOG.info(
                                 "Unable to put metric data for matching CloudWatch log events", e


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As an initiative to make the -ext multi-account/multi-region compatible this PR fixes functionality for logs service.
So whenever we use values other than `000000000000` for account ID or `us-east-1` for region, it should still create the consequent resources in these accounts and region.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Add the region and account id from context to the `connect_to` client in `put_log_events` used to put the metrics data. 
This fixes: `tests.aws.services.logs.test_logs.TestCloudWatchLogsPro.test_json_metric_filters` in -ext for non-default credentials. 

## Testing
Set the environment variables
`TEST_AWS_ACCOUNT_ID=111111111111`, `TEST_AWS_ACCESS_KEY_ID=111111111111`, `TEST_AWS_REGION=us-west-1`

<!-- Optional section: How to test these changes? -->
<!--

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
