### PR TITLE
Feature: Decompose submit notification for s3 to be able to patch it in extension

### DIFF
--- a/localstack-core/localstack/services/s3/notifications.py
+++ b/localstack-core/localstack/services/s3/notifications.py
@@ -845,7 +845,11 @@ class NotificationDispatcher:
             for config in configurations:
                 if notifier.should_notify(ctx, config):  # we check before sending it to the thread
                     LOG.debug("Submitting task to the executor for notifier %s", notifier)
-                    self.executor.submit(notifier.notify, ctx, config)
+                    self._submit_notification(notifier, ctx, config)
+
+    def _submit_notification(self, notifier, ctx, config):
+        "Required for patching submit with local thread context for EventStudio"
+        self.executor.submit(notifier.notify, ctx, config)
 
     def verify_configuration(
         self,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We need to be able to submit the threading.local context to the child thread where the notification is handled so we can pass trace context. We can do this by patching the `elf.executor.submit` method and only calling the patched method, for this we need to decompose the `send_notifications` method. 
