### PR TITLE
refactor ref keys in conditional mappings and test

### DIFF
--- a/tests/aws/services/cloudformation/engine/test_mappings.py
+++ b/tests/aws/services/cloudformation/engine/test_mappings.py
@@ -183,3 +183,20 @@ class TestCloudFormationMappings:
             assert topic_arn is not None
 
             aws_client.sns.get_topic_attributes(TopicArn=topic_arn)
+
+    @markers.aws.validated
+    def test_aws_refs_in_mappings(self, deploy_cfn_template, account_id):
+        """
+        This test asserts that Pseudo references aka "AWS::" are supported inside a mapping inside a Conditional.
+        It's worth remembering that even with references being supported, AWS rejects names that are not alphanumeric
+        in Mapping name or the second level key.
+        """
+        stack_name = f"Stack{short_uid()}"
+        stack = deploy_cfn_template(
+            template_path=os.path.join(
+                THIS_DIR, "../../../templates/mappings/mapping-aws-ref-map-key.yaml"
+            ),
+            stack_name=stack_name,
+            template_mapping={"StackName": stack_name},
+        )
+        assert stack.outputs.get("TopicArn")

--- a/tests/aws/services/cloudformation/engine/test_mappings.validation.json
+++ b/tests/aws/services/cloudformation/engine/test_mappings.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_aws_refs_in_mappings": {
+    "last_validated_date": "2024-10-15T17:22:43+00:00"
+  },
   "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_mapping_maximum_nesting_depth": {
     "last_validated_date": "2023-06-12T14:47:24+00:00"
   },
@@ -6,10 +9,10 @@
     "last_validated_date": "2023-06-12T14:47:25+00:00"
   },
   "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_mapping_ref_map_key[should-deploy]": {
-    "last_validated_date": "2024-10-10T20:08:36+00:00"
+    "last_validated_date": "2024-10-15T15:33:20+00:00"
   },
   "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_mapping_ref_map_key[should-not-deploy]": {
-    "last_validated_date": "2024-10-10T20:09:34+00:00"
+    "last_validated_date": "2024-10-15T15:34:20+00:00"
   },
   "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_mapping_with_invalid_refs": {
     "last_validated_date": "2023-06-12T14:47:24+00:00"

--- a/tests/aws/services/cloudformation/engine/test_mappings.validation.json
+++ b/tests/aws/services/cloudformation/engine/test_mappings.validation.json
@@ -9,10 +9,10 @@
     "last_validated_date": "2023-06-12T14:47:25+00:00"
   },
   "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_mapping_ref_map_key[should-deploy]": {
-    "last_validated_date": "2024-10-15T15:33:20+00:00"
+    "last_validated_date": "2024-10-17T22:40:44+00:00"
   },
   "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_mapping_ref_map_key[should-not-deploy]": {
-    "last_validated_date": "2024-10-15T15:34:20+00:00"
+    "last_validated_date": "2024-10-17T22:41:45+00:00"
   },
   "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_mapping_with_invalid_refs": {
     "last_validated_date": "2023-06-12T14:47:24+00:00"

--- a/tests/aws/templates/mappings/mapping-aws-ref-map-key.yaml
+++ b/tests/aws/templates/mappings/mapping-aws-ref-map-key.yaml
@@ -1,0 +1,35 @@
+Mappings:
+  {{StackName}}:
+    us-east-1:
+      {{StackName}}: "true"
+    us-east-2:
+      {{StackName}}: "true"
+    us-west-1:
+      {{StackName}}: "true"
+    us-west-2:
+      {{StackName}}: "true"
+    ap-southeast-2:
+      {{StackName}}: "true"
+    ap-northeast-1:
+      {{StackName}}: "true"
+    eu-central-1:
+      {{StackName}}: "true"
+    eu-west-1:
+      {{StackName}}: "true"
+
+
+Conditions:
+  MyCondition: !Equals
+    - !FindInMap [ !Ref AWS::StackName, !Ref AWS::Region, !Ref AWS::StackName ]
+    - "true"
+
+Resources:
+  MyTopic:
+    Type: AWS::SNS::Topic
+    Condition: MyCondition
+
+
+Outputs:
+  TopicArn:
+    Value: !Ref MyTopic
+

--- a/tests/aws/templates/mappings/mapping-ref-map-key.yaml
+++ b/tests/aws/templates/mappings/mapping-ref-map-key.yaml
@@ -1,12 +1,9 @@
 Mappings:
   MyMap:
-<<<<<<< HEAD
-=======
     A:
       value: "true"
     B:
       value: "false"
->>>>>>> 742e9fc4b (refactor ref inside mapping and test)
 
 Conditions:
   MyCondition: !Equals

--- a/tests/aws/templates/mappings/mapping-ref-map-key.yaml
+++ b/tests/aws/templates/mappings/mapping-ref-map-key.yaml
@@ -1,33 +1,16 @@
 Mappings:
   MyMap:
-    us-east-1:
-      A: "true"
-      B: "false"
-    us-east-2:
-      A: "true"
-      B: "false"
-    us-west-1:
-      A: "true"
-      B: "false"
-    us-west-2:
-      A: "true"
-      B: "false"
-    ap-southeast-2:
-      A: "true"
-      B: "false"
-    ap-northeast-1:
-      A: "true"
-      B: "false"
-    eu-central-1:
-      A: "true"
-      B: "false"
-    eu-west-1:
-      A: "true"
-      B: "false"
+<<<<<<< HEAD
+=======
+    A:
+      value: "true"
+    B:
+      value: "false"
+>>>>>>> 742e9fc4b (refactor ref inside mapping and test)
 
 Conditions:
   MyCondition: !Equals
-    - !FindInMap [ !Ref MapName,  !Ref AWS::Region, !Ref MapKey]
+    - !FindInMap [ !Ref MapName, !Ref MapKey, value ]
     - "true"
 
 Parameters:


### PR DESCRIPTION
## Motivation
This PRs addresses the changes requested in #11671

## Changes
- refactoring of the reference search
- restore previous test and add a new one more focused on the refere


## Testing
- new test that asserts that Map name, top level key and second level key can be AWS:: refs