### PR TITLE
remove key-existence checks against dict.keys() calls

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -293,7 +293,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
         if integration_type in {IntegrationType.AWS, IntegrationType.AWS_PROXY}:
             to_validate = ILLEGAL_INTEGRATION_REQUESTS_AWS
 
-        for header in headers.keys():
+        for header in headers:
             if header.lower() in to_validate:
                 LOG.debug(
                     "Execution failed due to configuration error: %s header already present", header

--- a/localstack-core/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack-core/localstack/services/cloudformation/engine/transformers.py
@@ -72,7 +72,7 @@ def apply_intrinsic_transformations(
     """Resolve constructs using the 'Fn::Transform' intrinsic function."""
 
     def _visit(obj, path, **_):
-        if isinstance(obj, dict) and "Fn::Transform" in obj.keys():
+        if isinstance(obj, dict) and "Fn::Transform" in obj:
             transform = (
                 obj["Fn::Transform"]
                 if isinstance(obj["Fn::Transform"], dict)

--- a/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
@@ -105,13 +105,13 @@ class AlarmScheduler:
     def _is_alarm_supported(self, alarm_details: MetricAlarm) -> bool:
         required_parameters = ["Period", "Statistic", "MetricName", "Threshold"]
         for param in required_parameters:
-            if param not in alarm_details.keys():
+            if param not in alarm_details:
                 LOG.debug(
                     "Currently only simple MetricAlarm are supported. Alarm is missing '%s'. ExtendedStatistic is not yet supported.",
                     param,
                 )
                 return False
-        if alarm_details["ComparisonOperator"] not in COMPARISON_OPS.keys():
+        if alarm_details["ComparisonOperator"] not in COMPARISON_OPS:
             LOG.debug(
                 "ComparisonOperator '%s' not yet supported.",
                 alarm_details["ComparisonOperator"],

--- a/localstack-core/localstack/services/dynamodb/provider.py
+++ b/localstack-core/localstack/services/dynamodb/provider.py
@@ -823,7 +823,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
 
                         match key:
                             case "Create":
-                                if target_region in replicas.keys():
+                                if target_region in replicas:
                                     raise ValidationException(
                                         f"Failed to create a the new replica of table with name: '{table_name}' because one or more replicas already existed as tables."
                                     )

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -214,7 +214,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         region = context.region
         account_id = context.account_id
         store = self.get_store(region, account_id)
-        if name in store.event_buses.keys():
+        if name in store.event_buses:
             raise ResourceAlreadyExistsException(f"Event bus {name} already exists.")
         event_bus_service = self.create_event_bus_service(
             name, region, account_id, event_source_name, tags
@@ -591,7 +591,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         region = context.region
         account_id = context.account_id
         store = self.get_store(region, account_id)
-        if archive_name in store.archives.keys():
+        if archive_name in store.archives:
             raise ResourceAlreadyExistsException(f"Archive {archive_name} already exists.")
         self._check_event_bus_exists(event_source_arn, store)
         archive_service = self.create_archive_service(
@@ -821,7 +821,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         region = context.region
         account_id = context.account_id
         store = self.get_store(region, account_id)
-        if replay_name in store.replays.keys():
+        if replay_name in store.replays:
             raise ResourceAlreadyExistsException(f"Replay {replay_name} already exists.")
         self._validate_replay_time(event_start_time, event_end_time)
         if event_source_arn not in self._archive_service_store:
@@ -912,7 +912,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         store = events_store[account_id][region]
         # create default event bus for account region on first call
         default_event_bus_name = "default"
-        if default_event_bus_name not in store.event_buses.keys():
+        if default_event_bus_name not in store.event_buses:
             event_bus_service = self.create_event_bus_service(
                 default_event_bus_name, region, account_id, None, None
             )
@@ -1159,7 +1159,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         archive_service = self._archive_service_store[event_source_arn]
         if destination_arn := destination.get("Arn"):
             if destination_arn != archive_service.archive.event_source_arn:
-                if destination_arn in self._event_bus_services_store.keys():
+                if destination_arn in self._event_bus_services_store:
                     raise ValidationException(
                         "Parameter Destination.Arn is not valid. Reason: Cross event bus replay is not permitted."
                     )

--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -488,7 +488,7 @@ def moto_smb_create_secret(fn, self, name, *args, **kwargs):
     if secret is not None and secret.deleted_date is not None:
         raise InvalidRequestException(AWS_INVALID_REQUEST_MESSAGE_CREATE_WITH_SCHEDULED_DELETION)
 
-    if name in self.secrets.keys():
+    if name in self.secrets:
         raise ResourceExistsException(
             f"The operation failed because the secret {name} already exists."
         )

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -802,7 +802,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         """
         store = SqsProvider.get_store(account_id, region_name)
         with _STORE_LOCK:
-            if name not in store.queues.keys():
+            if name not in store.queues:
                 if is_query:
                     message = "The specified queue does not exist for this wsdl version."
                 else:

--- a/localstack-core/localstack/services/stepfunctions/resource_providers/aws_stepfunctions_statemachine.py
+++ b/localstack-core/localstack/services/stepfunctions/resource_providers/aws_stepfunctions_statemachine.py
@@ -224,7 +224,7 @@ def _apply_substitutions(definition: str, substitutions: dict[str, str]) -> str:
     result = definition
     for token in tokens:
         raw_token = token[2:-1]  # strip ${ and }
-        if raw_token not in substitutions.keys():
+        if raw_token not in substitutions:
             raise
         result = result.replace(token, substitutions[raw_token])
 

--- a/localstack-core/localstack/services/stores.py
+++ b/localstack-core/localstack/services/stores.py
@@ -94,7 +94,7 @@ class CrossRegionAttribute:
     def __get__(self, obj: BaseStoreType, objtype=None) -> Any:
         self._check_region_store_association(obj)
 
-        if self.name not in obj._global.keys():
+        if self.name not in obj._global:
             if isinstance(self.default, Callable):
                 obj._global[self.name] = self.default()
             else:
@@ -135,7 +135,7 @@ class CrossAccountAttribute:
     def __get__(self, obj: BaseStoreType, objtype=None) -> Any:
         self._check_account_store_association(obj)
 
-        if self.name not in obj._universal.keys():
+        if self.name not in obj._universal:
             if isinstance(self.default, Callable):
                 obj._universal[self.name] = self.default()
             else:

--- a/localstack-core/localstack/utils/aws/message_forwarding.py
+++ b/localstack-core/localstack/utils/aws/message_forwarding.py
@@ -298,7 +298,7 @@ def add_target_http_parameters(http_parameters: Dict, endpoint: str, headers: Di
     endpoint = add_query_params_to_url(endpoint, query_params)
 
     target_headers = http_parameters.get("HeaderParameters", {})
-    for target_header in target_headers.keys():
+    for target_header in target_headers:
         if target_header not in headers:
             headers.update({target_header: target_headers.get(target_header)})
 

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -268,7 +268,7 @@ class TestDynamoDB:
         assert len(rs["Tags"]) == len(TEST_DDB_TAGS) + 1
 
         tags = {tag["Key"]: tag["Value"] for tag in rs["Tags"]}
-        assert "NewKey" in tags.keys()
+        assert "NewKey" in tags
         assert tags["NewKey"] == "TestValue"
 
         aws_client.dynamodb.untag_resource(ResourceArn=table_arn, TagKeys=["Name", "NewKey"])


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While looking over some performance improvements for SQS, I've stumbled into a key existence checks like that `if key in dict.keys()`. 

Calling `dict.keys()` will create a dict view of the dict keys. In itself, this is not terrible, but it has a bit of a cost performance. 

Giving it a small benchmark:
<details><summary>Small benchmarking code</summary>
<p>

```python
import timeit


test_dict = {f"key{k}": k for k in range(1000)}
last_key = list(test_dict)[-1]


def check_in_keys():
    p = last_key in test_dict.keys()


def check_in_dict():
    p = last_key in test_dict


def check_not_in_keys():
    p = last_key not in test_dict.keys()


def check_not_in_dict():
    p = last_key not in test_dict
```

</p>
</details> 

Give the following results for a dictionary with 1000 entries:

- Check `in dict.keys()`: 0.04537 (+62%)
- Check `in dict` 0.02794

(Changing the dict size does not change the results too much, it's always at least +50%)

I thought about introducing a lint rule for it, I found the following `SIM118`, but it's a bit too eager and will also change `for` loops, which I believe sometimes makes it a bit more readable and I haven't touched yet. 

https://docs.astral.sh/ruff/rules/in-dict-keys/

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- remove occurrences of key-existence checks against `dict.keys()` in favor of `in dict`. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
