### PR TITLE
cfn: fix failing `test_mapping_ref_map_key` for multi-account/region

### DIFF
--- a/tests/aws/services/cloudformation/engine/test_mappings.py
+++ b/tests/aws/services/cloudformation/engine/test_mappings.py
@@ -2,7 +2,6 @@ import os
 
 import pytest
 
-from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.testing.pytest import markers
 from localstack.utils.files import load_file
 from localstack.utils.strings import short_uid
@@ -174,7 +173,6 @@ class TestCloudFormationMappings:
                 "MapName": "MyMap",
                 "MapKey": map_key,
                 "TopicName": topic_name,
-                "Region": AWS_REGION_US_EAST_1,
             },
         )
 

--- a/tests/aws/services/cloudformation/engine/test_mappings.py
+++ b/tests/aws/services/cloudformation/engine/test_mappings.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.testing.pytest import markers
 from localstack.utils.files import load_file
 from localstack.utils.strings import short_uid
@@ -173,6 +174,7 @@ class TestCloudFormationMappings:
                 "MapName": "MyMap",
                 "MapKey": map_key,
                 "TopicName": topic_name,
+                "Region": AWS_REGION_US_EAST_1,
             },
         )
 

--- a/tests/aws/templates/mappings/mapping-ref-map-key.yaml
+++ b/tests/aws/templates/mappings/mapping-ref-map-key.yaml
@@ -3,10 +3,31 @@ Mappings:
     us-east-1:
       A: "true"
       B: "false"
+    us-east-2:
+      A: "true"
+      B: "false"
+    us-west-1:
+      A: "true"
+      B: "false"
+    us-west-2:
+      A: "true"
+      B: "false"
+    ap-southeast-2:
+      A: "true"
+      B: "false"
+    ap-northeast-1:
+      A: "true"
+      B: "false"
+    eu-central-1:
+      A: "true"
+      B: "false"
+    eu-west-1:
+      A: "true"
+      B: "false"
 
 Conditions:
   MyCondition: !Equals
-    - !FindInMap [ !Ref MapName,  !Ref Region, !Ref MapKey]
+    - !FindInMap [ !Ref MapName,  !Ref AWS::Region, !Ref MapKey]
     - "true"
 
 Parameters:
@@ -17,9 +38,6 @@ Parameters:
     Type: String
 
   TopicName:
-    Type: String
-
-  Region:
     Type: String
 
 Resources:

--- a/tests/aws/templates/mappings/mapping-ref-map-key.yaml
+++ b/tests/aws/templates/mappings/mapping-ref-map-key.yaml
@@ -3,9 +3,10 @@ Mappings:
     us-east-1:
       A: "true"
       B: "false"
+
 Conditions:
   MyCondition: !Equals
-    - !FindInMap [ !Ref MapName,  !Ref AWS::Region, !Ref MapKey]
+    - !FindInMap [ !Ref MapName,  !Ref Region, !Ref MapKey]
     - "true"
 
 Parameters:
@@ -16,6 +17,9 @@ Parameters:
     Type: String
 
   TopicName:
+    Type: String
+
+  Region:
     Type: String
 
 Resources:
@@ -32,4 +36,3 @@ Outputs:
   TopicArn:
     Value: !Ref MyTopic
     Condition: MyCondition
-


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With the support to add the region ref in mappings inside the conditions for cloudformation in the PR:#11671 the test `tests.aws.services.cloudformation.engine.test_mappings.TestCloudFormationMappings.test_mapping_ref_map_key` was updated to use `AWS::Region`, but when the test runs against non-default region it would fail because of the missing mapping in the template with the following error: 

`localstack.services.cloudformation.engine.errors.TemplateError: Invalid reference: 'ap-southeast-2' could not be found in the 'MyMap' mapping: '['*********']'`

Related workflow: https://app.circleci.com/pipelines/github/localstack/localstack/28846/workflows/dc1a47d0-eaf1-46a7-8149-fc987e80351b/jobs/253009/parallel-runs/2

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This PR adds mappings for the non-default regions currently being used to run the MA/MR pipeline. 
(Alternatively added a static region in https://github.com/localstack/localstack/pull/11699/commits/680cc01ca948e18c9ba467c122e8cfa84aa05e72 but this would defeat the purpose of testing ref region in the mappings)

## Testing
Set the environment variable: `TEST_AWS_REGION=us-west-1`

<!-- Optional section: How to test these changes? -->
<!--
-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
