### PR TITLE
fixed s3 deletion from stack in cdk

### DIFF
--- a/localstack-core/localstack/testing/scenario/provisioning.py
+++ b/localstack-core/localstack/testing/scenario/provisioning.py
@@ -243,9 +243,8 @@ class InfraProvisioner:
                 ]
 
                 for s3_bucket in s3_buckets:
-                    bucket_to_delete = s3_bucket  # Capture current value
                     self.custom_cleanup_steps.append(
-                        lambda bucket=bucket_to_delete: cleanup_s3_bucket(
+                        lambda bucket=s3_bucket: cleanup_s3_bucket(
                             self.aws_client.s3, bucket, delete_bucket=False
                         )
                     )

--- a/localstack-core/localstack/testing/scenario/provisioning.py
+++ b/localstack-core/localstack/testing/scenario/provisioning.py
@@ -243,9 +243,10 @@ class InfraProvisioner:
                 ]
 
                 for s3_bucket in s3_buckets:
+                    bucket_to_delete = s3_bucket  # Capture current value
                     self.custom_cleanup_steps.append(
-                        lambda: cleanup_s3_bucket(
-                            self.aws_client.s3, s3_bucket, delete_bucket=False
+                        lambda bucket=bucket_to_delete: cleanup_s3_bucket(
+                            self.aws_client.s3, bucket, delete_bucket=False
                         )
                     )
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR aims to fix the S3 bucket cleaning when a stack contains more than one buckets (with objects in it). According to my theory due to late binding in the lambda function, the `cleanup_s3_bucket` is not able to get the reference to the actual variable.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- updated the cleanup of s3 buckets in the cdc provisioner function.


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
