### PR TITLE
APIGW NG: fix storing store attribute instead of full store

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -10,6 +10,7 @@ from localstack.deprecations import deprecated_endpoint
 from localstack.http import Response
 from localstack.services.apigateway.models import ApiGatewayStore, apigateway_stores
 from localstack.services.edge import ROUTER
+from localstack.services.stores import AccountRegionBundle
 
 from .context import RestApiInvocationContext
 from .gateway import RestApiGateway
@@ -38,12 +39,14 @@ class ApiGatewayEndpoint:
     Gateway to be processed by the handler chain.
     """
 
-    def __init__(self, rest_gateway: RestApiGateway = None, store: ApiGatewayStore = None):
+    def __init__(self, rest_gateway: RestApiGateway = None, store: AccountRegionBundle = None):
         self.rest_gateway = rest_gateway or RestApiGateway()
         # we only access CrossAccount attributes in the handler, so we use a global store in default account and region
-        self._global_store = (
-            store or apigateway_stores[DEFAULT_AWS_ACCOUNT_ID][AWS_REGION_US_EAST_1]
-        )
+        self._store = store or apigateway_stores
+
+    @property
+    def _global_store(self) -> ApiGatewayStore:
+        return self._store[DEFAULT_AWS_ACCOUNT_ID][AWS_REGION_US_EAST_1]
 
     def __call__(self, request: Request, **kwargs: Unpack[RouteHostPathParameters]) -> Response:
         """

--- a/localstack-core/localstack/services/apigateway/next_gen/provider.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/provider.py
@@ -18,7 +18,6 @@ from localstack.aws.api.apigateway import (
     TestInvokeMethodRequest,
     TestInvokeMethodResponse,
 )
-from localstack.constants import AWS_REGION_US_EAST_1, DEFAULT_AWS_ACCOUNT_ID
 from localstack.services.apigateway.helpers import (
     get_apigateway_store,
     get_moto_rest_api,
@@ -47,8 +46,7 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
         # we initialize the route handler with a global store with default account and region, because it only ever
         # access values with CrossAccount attributes
         if not router:
-            store = apigateway_stores[DEFAULT_AWS_ACCOUNT_ID][AWS_REGION_US_EAST_1]
-            route_handler = ApiGatewayEndpoint(store=store)
+            route_handler = ApiGatewayEndpoint(store=apigateway_stores)
             router = ApiGatewayRouter(ROUTER, handler=route_handler)
 
         super().__init__(router=router)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #11696, we've had an issue with APIGW NG persistence. We need to store the actual full store variable (container) instead of some of its dict attributes, as those could be overwritten (replacing a nested dict value with another dict, thus losing the "sync" and reference). 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- store the full account bundle instead of the store, and create a property to access the store itself

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
