### PR TITLE
Update cbor 2 requirement to 5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ base-runtime = [
     # pinned / updated by ASF update action
     "botocore==1.35.39",
     "awscrt>=0.13.14",
-    "cbor2>=5.2.0",
+    "cbor2>=5.5.0",
     "dnspython>=1.16.0",
     "docker>=6.1.1",
     "jsonpatch>=1.24",


### PR DESCRIPTION
Currently cbor is listed as required for >= 5.2
https://github.com/localstack/localstack/commit/b612563c223423fb808f7117ba4eb0043a49f7f1 relies on the existence of `cbor2._decoder` which appears first in cbor 5.5 https://github.com/agronholm/cbor2/tree/5.5.0/cbor2 notice its absence here
https://github.com/agronholm/cbor2/tree/5.4.6/cbor2

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
https://github.com/localstack/localstack/issues/11703

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
more accurately reflects requirements

<!-- Optional section: How to test these changes? -->
<!--
## Testing
no testing.  I'm hoping this PR will run some automated tests
-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
