### PR TITLE
Init hooks: Remove default AWS credentials

### DIFF
--- a/localstack-core/localstack/runtime/init.py
+++ b/localstack-core/localstack/runtime/init.py
@@ -155,6 +155,8 @@ class InitScriptManager:
             for script in scripts:
                 LOG.debug("Running %s script %s", script.stage, script.path)
 
+                env_original = os.environ.copy()
+
                 try:
                     script.state = State.RUNNING
                     runner = self.get_script_runner(script.path)
@@ -167,7 +169,20 @@ class InitScriptManager:
                         LOG.error("Error while running script %s: %s", script, e)
                 else:
                     script.state = State.SUCCESSFUL
-
+                finally:
+                    # Discard env variables overridden in startup script that may cause side-effects
+                    for env_var in (
+                        "AWS_ACCESS_KEY_ID",
+                        "AWS_SECRET_ACCESS_KEY",
+                        "AWS_SESSION_TOKEN",
+                        "AWS_DEFAULT_REGION",
+                        "AWS_PROFILE",
+                        "AWS_REGION",
+                    ):
+                        if env_var in env_original:
+                            os.environ[env_var] = env_original[env_var]
+                        else:
+                            os.environ.pop(env_var, None)
         finally:
             self.stage_completed[stage] = True
 

--- a/localstack-core/localstack/runtime/init.py
+++ b/localstack-core/localstack/runtime/init.py
@@ -11,7 +11,6 @@ from typing import Dict, List, Optional
 
 from plux import Plugin, PluginManager
 
-from localstack import constants
 from localstack.runtime import hooks
 from localstack.utils.objects import singleton_factory
 
@@ -156,13 +155,6 @@ class InitScriptManager:
             for script in scripts:
                 LOG.debug("Running %s script %s", script.stage, script.path)
 
-                # Deprecated: To be removed in v4.0 major release.
-                # Explicit AWS credentials and region will need to be set in the script.
-                env_original = os.environ.copy()
-                os.environ["AWS_ACCESS_KEY_ID"] = constants.DEFAULT_AWS_ACCOUNT_ID
-                os.environ["AWS_SECRET_ACCESS_KEY"] = constants.INTERNAL_AWS_SECRET_ACCESS_KEY
-                os.environ["AWS_REGION"] = constants.AWS_REGION_US_EAST_1
-
                 try:
                     script.state = State.RUNNING
                     runner = self.get_script_runner(script.path)
@@ -175,13 +167,6 @@ class InitScriptManager:
                         LOG.error("Error while running script %s: %s", script, e)
                 else:
                     script.state = State.SUCCESSFUL
-                finally:
-                    # Restore original state of Boto credentials.
-                    for env_var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"):
-                        if env_var in env_original:
-                            os.environ[env_var] = env_original[env_var]
-                        else:
-                            os.environ.pop(env_var, None)
 
         finally:
             self.stage_completed[stage] = True


### PR DESCRIPTION
> [!IMPORTANT]
> This is a breaking change designated for LocalStack v4.0.0

## Background

The old implementation of multi-accounts in LocalStack used environment variables that determined the account/region of the sandbox. This impacted various other features, most notably the init hooks where we used to inherit the same environment variables when running the startup script. The startup scripts could be written without the need for explicit AWS credentials.

Since then, LocalStack moved to a multi-accounts implementation based on the request context. It no longer requires a global env var setting of account/region. But to maintain backward compatibility with existing init hook startup scripts, we started setting default account/region values in its environment.

## Changes

With LocalStack v4, the default AWS credentials will no longer be set in the init hook execution environment.

Startup scripts will now be required to set explicit credentials.

## Related

Closes:

- https://github.com/localstack/localstack/issues/11387