### PR TITLE
Allow adaptation of the localstack run command in the supervisor

### DIFF
--- a/bin/localstack-supervisor
+++ b/bin/localstack-supervisor
@@ -9,6 +9,7 @@ The supervisor behaves as follows:
 
 The methods ``waitpid_reap_other_children`` and ``stop_child_process`` were adapted from baseimage-docker
 licensed under MIT: https://github.com/phusion/baseimage-docker/blob/rel-0.9.16/image/bin/my_init"""
+
 import errno
 import os
 import signal
@@ -16,9 +17,6 @@ import subprocess
 import sys
 import threading
 from typing import Optional
-
-LOCALSTACK_COMMAND = [sys.executable, "-m", "localstack.runtime.main"]
-"""This command is used to run the localstack process"""
 
 DEBUG = os.getenv("DEBUG", "").strip().lower() in ["1", "true"]
 
@@ -30,6 +28,19 @@ class AlarmException(Exception):
     """Special exception raise if SIGALRM is received."""
 
     pass
+
+
+def get_localstack_command() -> list[str]:
+    """
+    Allow modification of the command to start LocalStack
+    :return: Command to start LocalStack
+    """
+    import shlex
+
+    command = os.environ.get("LOCALSTACK_SUPERVISOR_COMMAND")
+    if not command:
+        return [sys.executable, "-m", "localstack.runtime.main"]
+    return shlex.split(command)
 
 
 def log(message: str):
@@ -159,7 +170,7 @@ def main():
 
             # start a new localstack process
             process = subprocess.Popen(
-                LOCALSTACK_COMMAND,
+                get_localstack_command(),
                 stdout=sys.stdout,
                 stderr=subprocess.STDOUT,
             )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
In order to start LocalStack from different main methods, we have to make the command the localstack supervisor starts configurable.

This will allow us to be more flexible in the way we start LocalStack.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Add `LOCALSTACK_SUPERVISOR_COMMAND` to change the command executed by the supervisor to start LocalStack (the main entrypoint).

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
