### PR TITLE
Add workflow to dispatch the update of the OpenAPI spec

### DIFF
--- a/.github/workflows/update_openapi_spec.yml
+++ b/.github/workflows/update_openapi_spec.yml
@@ -1,0 +1,23 @@
+name: Update OpenAPI Spec
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**/*openapi.yaml'
+      - '**/*openapi.yml'
+  workflow_dispatch:
+
+jobs:
+  update-openapi-spec:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Dispatch update spec workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PRO_ACCESS_TOKEN }}
+          repository: localstack/openapi
+          event-type: openapi-update
+          client-payload: '{"ref": "${{ github.ref }}", "repo": "${{ github.repository }}"}'

--- a/.github/workflows/update_openapi_spec.yml
+++ b/.github/workflows/update_openapi_spec.yml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # This step dispatches a workflow in the OpenAPI repo, updating the spec and opening a PR.
       - name: Dispatch update spec workflow
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PRO_ACCESS_TOKEN }}
           repository: localstack/openapi
           event-type: openapi-update
+          # A git reference is needed when we want to dispatch the worflow from another branch.
           client-payload: '{"ref": "${{ github.ref }}", "repo": "${{ github.repository }}"}'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,4 @@ repos:
     hooks:
       - id: openapi-spec-validator
         files: .*openapi.*\.(json|yaml|yml)
+        exclude: ^(tests/|.github/workflows/)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We are building a separate repo to store LocalStack's OpenAPI specs.
This workflow is triggered when the spec changes and it dispatches a workflow on the destination repo that generates a new `latest` spec.

See https://github.com/localstack/localstack-ext/pull/3554 for more context.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
