### PR TITLE
Add note recommending pyenv in dev environment docs

### DIFF
--- a/docs/development-environment-setup/README.md
+++ b/docs/development-environment-setup/README.md
@@ -8,7 +8,9 @@ Once LocalStack runs in your Docker environment and you’ve played around with 
 
 You will need the following tools for the local development of LocalStack.
 
-* [Python 3.11+](https://www.python.org/downloads/) and `pip`
+* [Python](https://www.python.org/downloads/) and `pip`
+    * We recommend to use a Python version management tool like [`pyenv`](https://github.com/pyenv/pyenv/).
+    This way you will always use the correct Python version as defined in `.python-version`.
 * [Node.js & npm](https://nodejs.org/en/download/)
 * [Docker](https://docs.docker.com/desktop/)
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Contributors might get confused by our current documentation stating Python 3.11+ is needed as Python 3.12 does not have full support at this time. 
For dev environments we already have a checked in `.python-version` file in the top level, which would get picked up by any python version manager (e.g., pyenv).
This can already serve as the single source of truth for this.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Remove direct reference to a Python version and instead point to use pyenv
- If contributors don't want to use pyenv they can also now just quickly have a look at the `.python-version` and handle the version themselves.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
