### PR TITLE
Fix: Cfn: non-string parameter values

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -440,13 +440,13 @@ def _resolve_refs_recursively(
                     val,
                 )
 
-                if not isinstance(resolved_val, str):
+                if isinstance(resolved_val, (list, dict, tuple)):
                     # We don't have access to the resource that's a dependency in this case,
                     # so do the best we can with the resource ids
                     raise DependencyNotYetSatisfied(
                         resource_ids=key, message=f"Could not resolve {val} to terminal value type"
                     )
-                result = result.replace("${%s}" % key, resolved_val)
+                result = result.replace("${%s}" % key, str(resolved_val))
 
             # resolve placeholders
             result = resolve_placeholders_in_string(

--- a/tests/aws/services/cloudformation/engine/test_references.py
+++ b/tests/aws/services/cloudformation/engine/test_references.py
@@ -57,6 +57,22 @@ class TestFnSub:
 
         snapshot.match("outputs", deployment.outputs)
 
+    @markers.aws.validated
+    def test_non_string_parameter_in_sub(self, deploy_cfn_template, aws_client, snapshot):
+        ssm_parameter_name = f"test-param-{short_uid()}"
+        snapshot.add_transformer(
+            snapshot.transform.regex(ssm_parameter_name, "<ssm-parameter-name>")
+        )
+        deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__), "../../../templates/cfn_number_in_sub.yml"
+            ),
+            parameters={"ParameterName": ssm_parameter_name},
+        )
+
+        get_param_res = aws_client.ssm.get_parameter(Name=ssm_parameter_name)["Parameter"]
+        snapshot.match("get-parameter-result", get_param_res)
+
 
 @markers.aws.validated
 def test_useful_error_when_invalid_ref(deploy_cfn_template, snapshot):

--- a/tests/aws/services/cloudformation/engine/test_references.snapshot.json
+++ b/tests/aws/services/cloudformation/engine/test_references.snapshot.json
@@ -66,5 +66,19 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/engine/test_references.py::TestFnSub::test_non_string_parameter_in_sub": {
+    "recorded-date": "17-10-2024, 22:49:56",
+    "recorded-content": {
+      "get-parameter-result": {
+        "ARN": "arn:<partition>:ssm:<region>:111111111111:parameter/<ssm-parameter-name>",
+        "DataType": "text",
+        "LastModifiedDate": "datetime",
+        "Name": "<ssm-parameter-name>",
+        "Type": "String",
+        "Value": "my number is 3",
+        "Version": 1
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/engine/test_references.validation.json
+++ b/tests/aws/services/cloudformation/engine/test_references.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/cloudformation/engine/test_references.py::TestFnSub::test_fn_sub_cases": {
     "last_validated_date": "2023-08-23T18:41:02+00:00"
   },
+  "tests/aws/services/cloudformation/engine/test_references.py::TestFnSub::test_non_string_parameter_in_sub": {
+    "last_validated_date": "2024-10-17T22:49:56+00:00"
+  },
   "tests/aws/services/cloudformation/engine/test_references.py::test_resolve_transitive_placeholders_in_strings": {
     "last_validated_date": "2024-06-18T19:55:48+00:00"
   },

--- a/tests/aws/templates/cfn_number_in_sub.yml
+++ b/tests/aws/templates/cfn_number_in_sub.yml
@@ -1,0 +1,20 @@
+Parameters:
+  ParameterName:
+    Type: String
+
+  MyNumber:
+    Type: Number
+    Default: 3
+
+Resources:
+  Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name:
+        Ref: ParameterName
+      Type: String
+      Value:
+        Fn::Sub:
+          - "my number is ${numberRef}"
+          - numberRef:
+              Ref: MyNumber


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A customer had an issue when they used a non-string `Parameter` value, e.g.:

```yaml
Parameters:
  MyValue:
    Type: Number
    Default: 5
```

When this parameter is used within a `Fn::Sub` expression:

```
  Value:
    Fn::Sub: "my value is ${MyValue}"
```

it causes an error: `Could not resolve {'Ref': 'MyValue'} to terminal value type`. This is because we raise an error if any `Ref` type that we resolve does not eventually resolve to a string. This is limited however, as the parameter value is a number, but really the error should be related to if the ref cannot be resolved beyond a structured type, e.g. `dict`, `list` or `tuple`.

> [!WARNING]  
> The _true_ fix probably involves casting all parameters to strings, but using the `Type` for _something_... Not quite sure yet at this stage. This PR however applies a bandage over the problem so at least this error does not continue to happen. In the future, we should look into proper parameter/ref handling.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Only raise the existing exception if we resolve a ref to a structured type.
* Add minimal test that asserts the value is propagaed through the parameter and `Fn::Sub` invocation.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
