### PR TITLE
fix source distro installation by limiting setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # LocalStack project configuration
 [build-system]
-requires = ['setuptools>=64', 'wheel', 'plux>=1.10', "setuptools_scm>=8"]
+requires = ['setuptools>=64,<=75.1.0', 'wheel', 'plux>=1.10', "setuptools_scm>=8.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Motivation
With `setuptools==75.2.0` (more specifically with https://github.com/pypa/setuptools/pull/4647), `setuptools` is now explicitly removing the egg-info dir when building source distributions which is causing issues with `plux` (since it needs to add the entry points detected at build time).
This issue needs to be addressed in `plux`, until then we limit the version of `setuptools` in the `build-sytem.requires` to circumvent this issue for now.

## Changes
- Set an upper limit to the `setuptools` version used when building source distributions of `localstack-core` to avoid the incompatibility of the latest release of `plux` (`1.11.0`) with the latest release of `setuptools` (`75.2.0`)