### PR TITLE
fix(11576): fixing bug in standardqueue put message

### DIFF
--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -750,7 +750,7 @@ class StandardQueue(SqsQueue):
             )
         if isinstance(message_group_id, str):
             raise InvalidParameterValueException(
-                f"Value {message_group_id} for parameter MessageGroupId is invalid. Reason: The request includes a "
+                f"Value {message_group_id} for parameter MessageGroupId is invalid. Reason: The request include "
                 f"parameter that is not valid for this queue type."
             )
 

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -748,7 +748,7 @@ class StandardQueue(SqsQueue):
                 f"Value {message_deduplication_id} for parameter MessageDeduplicationId is invalid. Reason: The "
                 f"request includes a parameter that is not valid for this queue type."
             )
-        if message_group_id:
+        if if isinstance(message_group_id, str):
             raise InvalidParameterValueException(
                 f"Value {message_group_id} for parameter MessageGroupId is invalid. Reason: The request includes a "
                 f"parameter that is not valid for this queue type."

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -748,7 +748,7 @@ class StandardQueue(SqsQueue):
                 f"Value {message_deduplication_id} for parameter MessageDeduplicationId is invalid. Reason: The "
                 f"request includes a parameter that is not valid for this queue type."
             )
-        if if isinstance(message_group_id, str):
+        if isinstance(message_group_id, str):
             raise InvalidParameterValueException(
                 f"Value {message_group_id} for parameter MessageGroupId is invalid. Reason: The request includes a "
                 f"parameter that is not valid for this queue type."

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -436,7 +436,8 @@ class TestSqsProvider:
 
         snapshot.match("send_oversized_message_batch", response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
     def test_send_message_to_standard_queue_with_empty_message_group_id(
         self, sqs_create_queue, aws_client, snapshot
     ):
@@ -444,8 +445,7 @@ class TestSqsProvider:
 
         with pytest.raises(ClientError) as e:
             aws_client.sqs.send_message(QueueUrl=queue, MessageBody="message", MessageGroupId="")
-
-        snapshot.match("error", e.value.response)
+        snapshot.match("error-response", e.value.response)
 
     @markers.aws.validated
     def test_tag_untag_queue(self, sqs_create_queue, aws_sqs_client, snapshot):

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -436,6 +436,15 @@ class TestSqsProvider:
 
         snapshot.match("send_oversized_message_batch", response)
 
+    @markers.aws.unknown
+    def test_send_message_to_standard_queue_with_empty_message_group_id(self, sqs_create_queue, aws_client, snapshot):
+        queue = sqs_create_queue()
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sqs.send_message(QueueUrl=queue, MessageBody="message", MessageGroupId="")
+
+        snapshot.match("error", e.value.response)
+
     @markers.aws.validated
     def test_tag_untag_queue(self, sqs_create_queue, aws_sqs_client, snapshot):
         queue_url = sqs_create_queue()

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -437,7 +437,6 @@ class TestSqsProvider:
         snapshot.match("send_oversized_message_batch", response)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
     def test_send_message_to_standard_queue_with_empty_message_group_id(
         self, sqs_create_queue, aws_client, snapshot
     ):

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -437,7 +437,9 @@ class TestSqsProvider:
         snapshot.match("send_oversized_message_batch", response)
 
     @markers.aws.unknown
-    def test_send_message_to_standard_queue_with_empty_message_group_id(self, sqs_create_queue, aws_client, snapshot):
+    def test_send_message_to_standard_queue_with_empty_message_group_id(
+        self, sqs_create_queue, aws_client, snapshot
+    ):
         queue = sqs_create_queue()
 
         with pytest.raises(ClientError) as e:

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -975,7 +975,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_to_standard_queue_with_empty_message_group_id": {
-    "recorded-date": "30-04-2024, 13:33:44",
+    "recorded-date": "08-11-2024, 12:04:39",
     "recorded-content": {
       "error-response": {
         "Error": {

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -974,6 +974,23 @@
       }
     }
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_to_standard_queue_with_empty_message_group_id": {
+    "recorded-date": "30-04-2024, 13:33:44",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value  for parameter MessageGroupId is invalid. Reason: The request include parameter that is not valid for this queue type.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_batch_missing_message_group_id_for_fifo_queue[sqs_query]": {
     "recorded-date": "30-04-2024, 13:33:45",
     "recorded-content": {

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -269,6 +269,9 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents_with_updated_maximum_message_size[sqs_query]": {
     "last_validated_date": "2024-04-30T13:33:10+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_to_standard_queue_with_empty_message_group_id": {
+    "last_validated_date": "2024-11-08T12:08:17+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_binary_attributes[sqs]": {
     "last_validated_date": "2024-04-30T13:33:48+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Raising a fix for an open issue in SQS flow of Localstack.
Fixes #11576 



<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

There was a bug in Localstack SQS put message in Standard SQS flow. Principally, standard SQS put calls do not support messagegroupid parameter to be passed. Current implementation of localstack allows "" ie empty string to be passed as messagegroupid while publishing to localstack, whereas same api request to actual AWS sqs throws an exception. Added an additional check in code which checks messagegroupid should not be any string ( having values or empty ) in case of standard sqs put message. If the parameter is an instance of the string, throw exception

<!-- Optional section: How to test these changes? -->
<!--
## Testing

Setup localstack locally, ran make start. Created a dummy queue, published a message, tested the behaviour to be in-sync with the request on an actual sqs in my aws account

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
