### PR TITLE
improve tests selection

### DIFF
--- a/localstack-core/localstack/testing/testselection/matching.py
+++ b/localstack-core/localstack/testing/testselection/matching.py
@@ -94,6 +94,10 @@ class Matcher:
         return lambda t: [t] if self.matching_func(t) else []
 
     def directory(self, paths: list[str] = None):
+        """Enables executing tests on a full directory if the file is matched.
+        By default, it will return the directory of the modified file.
+        If the argument `paths` is provided, it will instead return the provided list.
+        """
         return lambda t: (paths or [get_directory(t)]) if self.matching_func(t) else []
 
 

--- a/localstack-core/localstack/testing/testselection/matching.py
+++ b/localstack-core/localstack/testing/testselection/matching.py
@@ -93,8 +93,8 @@ class Matcher:
     def passthrough(self):
         return lambda t: [t] if self.matching_func(t) else []
 
-    def directory(self):
-        return lambda t: [get_directory(t)] if self.matching_func(t) else []
+    def directory(self, paths: list[str] = None):
+        return lambda t: (paths or [get_directory(t)]) if self.matching_func(t) else []
 
 
 class Matchers:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR aims to expand on the functionality of the `Matcher` for tests selection. The changes included will allow us to use the `directory` method to add an argument for which directory should be executed.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

We can now enter the following rule to explicitly target test folders when files in `my_feature` modules are changed.

```
Matchers.glob("localstack/my_feature/**").directory(
    paths=["tests/integration/my_feature"]
)
```


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
