### PR TITLE
remove setuptools limit in build-system.requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # LocalStack project configuration
 [build-system]
-requires = ['setuptools>=64,<=75.1.0', 'wheel', 'plux>=1.10', "setuptools_scm>=8.1"]
+requires = ['setuptools>=64', 'wheel', 'plux>=1.10', "setuptools_scm>=8.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # LocalStack project configuration
 [build-system]
-requires = ['setuptools>=64', 'wheel', 'plux>=1.10', "setuptools_scm>=8.1"]
+requires = ['setuptools>=64', 'wheel', 'plux>=1.12', "setuptools_scm>=8.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/11715, we added a version limit for `setuptools` in `build-system.requres` in the `pyproject.toml` to mitigate an issue with `plux`.
This issue has been resolved with the latest release of `plux` (`1.12`), specifically with https://github.com/localstack/plux/pull/26.

## Changes
- Reverts the limit of `setuptools` in `build-system.requres` in the `pyproject.toml` introduced in https://github.com/localstack/localstack/pull/11715.
- Bumps the minimum version of `plux`.