### PR TITLE
Feature: filtering for ListFirewallRules in Route53Resolver 

### DIFF
--- a/localstack-core/localstack/services/route53resolver/provider.py
+++ b/localstack-core/localstack/services/route53resolver/provider.py
@@ -121,10 +121,12 @@ class Route53ResolverProvider(Route53ResolverApi):
     ) -> CreateFirewallRuleGroupResponse:
         """Create a Firewall Rule Group."""
         store = self.get_store(context.account_id, context.region)
-        id = get_route53_resolver_firewall_rule_group_id()
-        arn = arns.route53_resolver_firewall_rule_group_arn(id, context.account_id, context.region)
+        fw_rg_id = get_route53_resolver_firewall_rule_group_id()
+        arn = arns.route53_resolver_firewall_rule_group_arn(
+            fw_rg_id, context.account_id, context.region
+        )
         firewall_rule_group = FirewallRuleGroup(
-            Id=id,
+            Id=fw_rg_id,
             Arn=arn,
             Name=name,
             RuleCount=0,
@@ -136,7 +138,8 @@ class Route53ResolverProvider(Route53ResolverApi):
             CreationTime=datetime.now(timezone.utc).isoformat(),
             ModificationTime=datetime.now(timezone.utc).isoformat(),
         )
-        store.firewall_rule_groups[id] = firewall_rule_group
+        store.firewall_rule_groups[fw_rg_id] = firewall_rule_group
+        store.firewall_rules[fw_rg_id] = {}
         route53resolver_backends[context.account_id][context.region].tagger.tag_resource(
             arn, tags or []
         )
@@ -342,11 +345,9 @@ class Route53ResolverProvider(Route53ResolverApi):
             FirewallDomainRedirectionAction=firewall_domain_redirection_action,
             Qtype=qtype,
         )
-        if store.firewall_rules.get(firewall_rule_group_id):
+        if firewall_rule_group_id in store.firewall_rules:
             store.firewall_rules[firewall_rule_group_id][firewall_domain_list_id] = firewall_rule
-        else:
-            store.firewall_rules[firewall_rule_group_id] = {}
-            store.firewall_rules[firewall_rule_group_id][firewall_domain_list_id] = firewall_rule
+        # TODO: handle missing firewall-rule-group-id
         return CreateFirewallRuleResponse(FirewallRule=firewall_rule)
 
     def delete_firewall_rule(

--- a/tests/aws/services/route53resolver/test_route53resolver.py
+++ b/tests/aws/services/route53resolver/test_route53resolver.py
@@ -4,6 +4,7 @@ import re
 import pytest
 
 from localstack.aws.api.route53resolver import (
+    Action,
     ListResolverEndpointsResponse,
     ListResolverQueryLogConfigsResponse,
     ListResolverRuleAssociationsResponse,
@@ -746,3 +747,174 @@ class TestRoute53Resolver:
             snapshot.add_transformer(snapshot.transform.regex(trace_id, "<trace-id>"))
 
         snapshot.match("missing-firewall-rule-group-id", resource_not_found.value.response)
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..ManagedOwnerName"])
+    @markers.snapshot.skip_snapshot_verify(paths=["$..FirewallDomainRedirectionAction"])
+    def test_list_firewall_rules(self, cleanups, snapshot, aws_client):
+        """Test listing firewall rules.
+
+        Setup of this testcase consists in creating:
+         - 1 firewall-rule-group
+         - 4 firewall-domain-lists
+         - 4 firewall-rules
+
+         We test listing:
+         - all rules in the rule-group
+         - rules filtered by priority
+         - rules filtered by action
+         - rules filtered by priority and action
+        """
+        firewall_rule_group_name = f"fw-rule-group-{short_uid()}"
+
+        snapshot.add_transformer(snapshot.transform.route53resolver_api())
+        snapshot.add_transformer(snapshot.transform.key_value("Name"))
+        snapshot.add_transformer(
+            snapshot.transform.key_value("FirewallDomainListId", "fw-domain-list")
+        )
+
+        rule_group_response = aws_client.route53resolver.create_firewall_rule_group(
+            Name=firewall_rule_group_name
+        )
+        snapshot.match("create-firewall-rule-group", rule_group_response)
+        cleanups.append(
+            lambda: aws_client.route53resolver.delete_firewall_rule_group(
+                FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"]
+            )
+        )
+
+        # Add 4 domain lists
+        domain_list_response_1 = aws_client.route53resolver.create_firewall_domain_list(
+            Name=f"fw-domain-list-{short_uid()}"
+        )
+        snapshot.match("create-firewall-domain-list-1", domain_list_response_1)
+        cleanups.append(
+            lambda: aws_client.route53resolver.delete_firewall_domain_list(
+                FirewallDomainListId=domain_list_response_1["FirewallDomainList"]["Id"]
+            )
+        )
+
+        domain_list_response_2 = aws_client.route53resolver.create_firewall_domain_list(
+            Name=f"fw-domain-list-{short_uid()}"
+        )
+        snapshot.match("create-firewall-domain-list-2", domain_list_response_2)
+        cleanups.append(
+            lambda: aws_client.route53resolver.delete_firewall_domain_list(
+                FirewallDomainListId=domain_list_response_2["FirewallDomainList"]["Id"]
+            )
+        )
+        domain_list_response_3 = aws_client.route53resolver.create_firewall_domain_list(
+            Name=f"fw-domain-list-{short_uid()}"
+        )
+        snapshot.match("create-firewall-domain-list-3", domain_list_response_3)
+        cleanups.append(
+            lambda: aws_client.route53resolver.delete_firewall_domain_list(
+                FirewallDomainListId=domain_list_response_3["FirewallDomainList"]["Id"]
+            )
+        )
+        domain_list_response_4 = aws_client.route53resolver.create_firewall_domain_list(
+            Name=f"fw-domain-list-{short_uid()}"
+        )
+        snapshot.match("create-firewall-domain-list-4", domain_list_response_4)
+        cleanups.append(
+            lambda: aws_client.route53resolver.delete_firewall_domain_list(
+                FirewallDomainListId=domain_list_response_4["FirewallDomainList"]["Id"]
+            )
+        )
+
+        # Add 4 FW rules
+        rule_response_1 = aws_client.route53resolver.create_firewall_rule(
+            FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"],
+            FirewallDomainListId=domain_list_response_1["FirewallDomainList"]["Id"],
+            Priority=1,
+            Action=Action.ALLOW,
+            Name=f"rule-name-{short_uid()}",
+        )
+        snapshot.match("create-firewall-rule-1", rule_response_1)
+        cleanups.append(
+            lambda: aws_client.route53resolver.delete_firewall_rule(
+                FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"],
+                FirewallDomainListId=domain_list_response_1["FirewallDomainList"]["Id"],
+            )
+        )
+
+        rule_response_2 = aws_client.route53resolver.create_firewall_rule(
+            FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"],
+            FirewallDomainListId=domain_list_response_2["FirewallDomainList"]["Id"],
+            Priority=2,
+            Action=Action.ALERT,
+            Name=f"rule-name-{short_uid()}",
+        )
+        snapshot.match("create-firewall-rule-2", rule_response_2)
+        cleanups.append(
+            lambda: aws_client.route53resolver.delete_firewall_rule(
+                FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"],
+                FirewallDomainListId=domain_list_response_2["FirewallDomainList"]["Id"],
+            )
+        )
+
+        rule_response_3 = aws_client.route53resolver.create_firewall_rule(
+            FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"],
+            FirewallDomainListId=domain_list_response_3["FirewallDomainList"]["Id"],
+            Priority=3,
+            Action=Action.ALERT,
+            Name=f"rule-name-{short_uid()}",
+        )
+        snapshot.match("create-firewall-rule-3", rule_response_3)
+        cleanups.append(
+            lambda: aws_client.route53resolver.delete_firewall_rule(
+                FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"],
+                FirewallDomainListId=domain_list_response_3["FirewallDomainList"]["Id"],
+            )
+        )
+
+        rule_response_4 = aws_client.route53resolver.create_firewall_rule(
+            FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"],
+            FirewallDomainListId=domain_list_response_4["FirewallDomainList"]["Id"],
+            Priority=4,
+            Action=Action.ALLOW,
+            Name=f"rule-name-{short_uid()}",
+        )
+        snapshot.match("create-firewall-rule-4", rule_response_4)
+        cleanups.append(
+            lambda: aws_client.route53resolver.delete_firewall_rule(
+                FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"],
+                FirewallDomainListId=domain_list_response_4["FirewallDomainList"]["Id"],
+            )
+        )
+
+        # Check list filtering
+        list_all_response = aws_client.route53resolver.list_firewall_rules(
+            FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"]
+        )
+
+        assert len(list_all_response["FirewallRules"]) == 4, "Expecting 4 firewall rules"
+        snapshot.match("firewall-rules-list-all", list_all_response)
+
+        filter_by_priority_response = aws_client.route53resolver.list_firewall_rules(
+            FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"], Priority=1
+        )
+        assert len(filter_by_priority_response["FirewallRules"]) == 1, "Expecting 1 firewall rule"
+        snapshot.match("firewall-rules-list-by-priority", filter_by_priority_response)
+
+        filter_by_action_response = aws_client.route53resolver.list_firewall_rules(
+            FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"], Action=Action.ALLOW
+        )
+        assert len(filter_by_action_response["FirewallRules"]) == 2, "Expecting 2 firewall rule"
+        snapshot.match("firewall-rules-list-by-action", filter_by_action_response)
+
+        action_and_priority_response = aws_client.route53resolver.list_firewall_rules(
+            FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"],
+            Action=Action.ALLOW,
+            Priority=4,
+        )
+        assert len(action_and_priority_response["FirewallRules"]) == 1, "Expecting 1 firewall rule"
+        snapshot.match("firewall-rules-list-by-action-and-priority", action_and_priority_response)
+
+        filter_empty_response = aws_client.route53resolver.list_firewall_rules(
+            FirewallRuleGroupId=rule_group_response["FirewallRuleGroup"]["Id"],
+            Action=Action.ALLOW,
+            Priority=0,  # 0 catches cases when integers pose as booleans
+        )
+        assert len(filter_empty_response["FirewallRules"]) == 0, "Expecting 0 firewall rule"
+        snapshot.match("firewall-rules-list-no-match", filter_empty_response)

--- a/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
@@ -629,5 +629,292 @@
         }
       }
     }
+  },
+  "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules": {
+    "recorded-date": "24-10-2024, 10:05:33",
+    "recorded-content": {
+      "create-firewall-rule-group": {
+        "FirewallRuleGroup": {
+          "Arn": "arn:<partition>:route53resolver:<region>:111111111111:firewall-rule-group/<id:1>",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:1>",
+          "Id": "<id:1>",
+          "ModificationTime": "date",
+          "Name": "<name:1>",
+          "OwnerId": "111111111111",
+          "RuleCount": 0,
+          "ShareStatus": "NOT_SHARED",
+          "Status": "COMPLETE",
+          "StatusMessage": "status-message"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-firewall-domain-list-1": {
+        "FirewallDomainList": {
+          "Arn": "arn:<partition>:route53resolver:<region>:111111111111:firewall-domain-list/<id:2>",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:2>",
+          "DomainCount": 0,
+          "Id": "<id:2>",
+          "ModificationTime": "date",
+          "Name": "<name:2>",
+          "Status": "COMPLETE",
+          "StatusMessage": "status-message"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-firewall-domain-list-2": {
+        "FirewallDomainList": {
+          "Arn": "arn:<partition>:route53resolver:<region>:111111111111:firewall-domain-list/<id:3>",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:3>",
+          "DomainCount": 0,
+          "Id": "<id:3>",
+          "ModificationTime": "date",
+          "Name": "<name:3>",
+          "Status": "COMPLETE",
+          "StatusMessage": "status-message"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-firewall-domain-list-3": {
+        "FirewallDomainList": {
+          "Arn": "arn:<partition>:route53resolver:<region>:111111111111:firewall-domain-list/<id:4>",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:4>",
+          "DomainCount": 0,
+          "Id": "<id:4>",
+          "ModificationTime": "date",
+          "Name": "<name:4>",
+          "Status": "COMPLETE",
+          "StatusMessage": "status-message"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-firewall-domain-list-4": {
+        "FirewallDomainList": {
+          "Arn": "arn:<partition>:route53resolver:<region>:111111111111:firewall-domain-list/<id:5>",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:5>",
+          "DomainCount": 0,
+          "Id": "<id:5>",
+          "ModificationTime": "date",
+          "Name": "<name:5>",
+          "Status": "COMPLETE",
+          "StatusMessage": "status-message"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-firewall-rule-1": {
+        "FirewallRule": {
+          "Action": "ALLOW",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:6>",
+          "FirewallDomainListId": "<id:2>",
+          "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+          "FirewallRuleGroupId": "<id:1>",
+          "ModificationTime": "date",
+          "Name": "<name:6>",
+          "Priority": 1
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-firewall-rule-2": {
+        "FirewallRule": {
+          "Action": "ALERT",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:7>",
+          "FirewallDomainListId": "<id:3>",
+          "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+          "FirewallRuleGroupId": "<id:1>",
+          "ModificationTime": "date",
+          "Name": "<name:7>",
+          "Priority": 2
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-firewall-rule-3": {
+        "FirewallRule": {
+          "Action": "ALERT",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:8>",
+          "FirewallDomainListId": "<id:4>",
+          "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+          "FirewallRuleGroupId": "<id:1>",
+          "ModificationTime": "date",
+          "Name": "<name:8>",
+          "Priority": 3
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-firewall-rule-4": {
+        "FirewallRule": {
+          "Action": "ALLOW",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:9>",
+          "FirewallDomainListId": "<id:5>",
+          "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+          "FirewallRuleGroupId": "<id:1>",
+          "ModificationTime": "date",
+          "Name": "<name:9>",
+          "Priority": 4
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "firewall-rules-list-all": {
+        "FirewallRules": [
+          {
+            "Action": "ALLOW",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:6>",
+            "FirewallDomainListId": "<id:2>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:6>",
+            "Priority": 1
+          },
+          {
+            "Action": "ALERT",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:7>",
+            "FirewallDomainListId": "<id:3>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:7>",
+            "Priority": 2
+          },
+          {
+            "Action": "ALERT",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:8>",
+            "FirewallDomainListId": "<id:4>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:8>",
+            "Priority": 3
+          },
+          {
+            "Action": "ALLOW",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:9>",
+            "FirewallDomainListId": "<id:5>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:9>",
+            "Priority": 4
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "firewall-rules-list-by-priority": {
+        "FirewallRules": [
+          {
+            "Action": "ALLOW",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:6>",
+            "FirewallDomainListId": "<id:2>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:6>",
+            "Priority": 1
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "firewall-rules-list-by-action": {
+        "FirewallRules": [
+          {
+            "Action": "ALLOW",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:6>",
+            "FirewallDomainListId": "<id:2>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:6>",
+            "Priority": 1
+          },
+          {
+            "Action": "ALLOW",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:9>",
+            "FirewallDomainListId": "<id:5>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:9>",
+            "Priority": 4
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "firewall-rules-list-by-action-and-priority": {
+        "FirewallRules": [
+          {
+            "Action": "ALLOW",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:9>",
+            "FirewallDomainListId": "<id:5>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:9>",
+            "Priority": 4
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "firewall-rules-list-no-match": {
+        "FirewallRules": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
@@ -916,5 +916,36 @@
         }
       }
     }
+  },
+  "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_empty_rule_group": {
+    "recorded-date": "24-10-2024, 10:48:51",
+    "recorded-content": {
+      "create-firewall-rule-group": {
+        "FirewallRuleGroup": {
+          "Arn": "arn:<partition>:route53resolver:<region>:111111111111:firewall-rule-group/<id:1>",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:1>",
+          "Id": "<id:1>",
+          "ModificationTime": "date",
+          "Name": "<name:1>",
+          "OwnerId": "111111111111",
+          "RuleCount": 0,
+          "ShareStatus": "NOT_SHARED",
+          "Status": "COMPLETE",
+          "StatusMessage": "status-message"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "empty-firewall-rule-group": {
+        "FirewallRules": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
@@ -615,14 +615,14 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_missing_rule_group": {
-    "recorded-date": "24-10-2024, 08:34:55",
+    "recorded-date": "28-10-2024, 07:21:26",
     "recorded-content": {
       "missing-firewall-rule-group-id": {
         "Error": {
           "Code": "ResourceNotFoundException",
-          "Message": "[RSLVR-02025] Can\u2019t find the resource with ID \"<firewall-rule-group-id>\". Trace Id: \"<trace-id>\""
+          "Message": "[RSLVR-02025] Can\u2019t find the resource with ID \"missing-id\". Trace Id: \"trace-id\""
         },
-        "Message": "[RSLVR-02025] Can\u2019t find the resource with ID \"<firewall-rule-group-id>\". Trace Id: \"<trace-id>\"",
+        "Message": "[RSLVR-02025] Can\u2019t find the resource with ID \"missing-id\". Trace Id: \"trace-id\"",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -630,295 +630,8 @@
       }
     }
   },
-  "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules": {
-    "recorded-date": "24-10-2024, 10:05:33",
-    "recorded-content": {
-      "create-firewall-rule-group": {
-        "FirewallRuleGroup": {
-          "Arn": "arn:<partition>:route53resolver:<region>:111111111111:firewall-rule-group/<id:1>",
-          "CreationTime": "date",
-          "CreatorRequestId": "<creator-request-id:1>",
-          "Id": "<id:1>",
-          "ModificationTime": "date",
-          "Name": "<name:1>",
-          "OwnerId": "111111111111",
-          "RuleCount": 0,
-          "ShareStatus": "NOT_SHARED",
-          "Status": "COMPLETE",
-          "StatusMessage": "status-message"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-firewall-domain-list-1": {
-        "FirewallDomainList": {
-          "Arn": "arn:<partition>:route53resolver:<region>:111111111111:firewall-domain-list/<id:2>",
-          "CreationTime": "date",
-          "CreatorRequestId": "<creator-request-id:2>",
-          "DomainCount": 0,
-          "Id": "<id:2>",
-          "ModificationTime": "date",
-          "Name": "<name:2>",
-          "Status": "COMPLETE",
-          "StatusMessage": "status-message"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-firewall-domain-list-2": {
-        "FirewallDomainList": {
-          "Arn": "arn:<partition>:route53resolver:<region>:111111111111:firewall-domain-list/<id:3>",
-          "CreationTime": "date",
-          "CreatorRequestId": "<creator-request-id:3>",
-          "DomainCount": 0,
-          "Id": "<id:3>",
-          "ModificationTime": "date",
-          "Name": "<name:3>",
-          "Status": "COMPLETE",
-          "StatusMessage": "status-message"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-firewall-domain-list-3": {
-        "FirewallDomainList": {
-          "Arn": "arn:<partition>:route53resolver:<region>:111111111111:firewall-domain-list/<id:4>",
-          "CreationTime": "date",
-          "CreatorRequestId": "<creator-request-id:4>",
-          "DomainCount": 0,
-          "Id": "<id:4>",
-          "ModificationTime": "date",
-          "Name": "<name:4>",
-          "Status": "COMPLETE",
-          "StatusMessage": "status-message"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-firewall-domain-list-4": {
-        "FirewallDomainList": {
-          "Arn": "arn:<partition>:route53resolver:<region>:111111111111:firewall-domain-list/<id:5>",
-          "CreationTime": "date",
-          "CreatorRequestId": "<creator-request-id:5>",
-          "DomainCount": 0,
-          "Id": "<id:5>",
-          "ModificationTime": "date",
-          "Name": "<name:5>",
-          "Status": "COMPLETE",
-          "StatusMessage": "status-message"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-firewall-rule-1": {
-        "FirewallRule": {
-          "Action": "ALLOW",
-          "CreationTime": "date",
-          "CreatorRequestId": "<creator-request-id:6>",
-          "FirewallDomainListId": "<id:2>",
-          "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
-          "FirewallRuleGroupId": "<id:1>",
-          "ModificationTime": "date",
-          "Name": "<name:6>",
-          "Priority": 1
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-firewall-rule-2": {
-        "FirewallRule": {
-          "Action": "ALERT",
-          "CreationTime": "date",
-          "CreatorRequestId": "<creator-request-id:7>",
-          "FirewallDomainListId": "<id:3>",
-          "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
-          "FirewallRuleGroupId": "<id:1>",
-          "ModificationTime": "date",
-          "Name": "<name:7>",
-          "Priority": 2
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-firewall-rule-3": {
-        "FirewallRule": {
-          "Action": "ALERT",
-          "CreationTime": "date",
-          "CreatorRequestId": "<creator-request-id:8>",
-          "FirewallDomainListId": "<id:4>",
-          "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
-          "FirewallRuleGroupId": "<id:1>",
-          "ModificationTime": "date",
-          "Name": "<name:8>",
-          "Priority": 3
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-firewall-rule-4": {
-        "FirewallRule": {
-          "Action": "ALLOW",
-          "CreationTime": "date",
-          "CreatorRequestId": "<creator-request-id:9>",
-          "FirewallDomainListId": "<id:5>",
-          "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
-          "FirewallRuleGroupId": "<id:1>",
-          "ModificationTime": "date",
-          "Name": "<name:9>",
-          "Priority": 4
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "firewall-rules-list-all": {
-        "FirewallRules": [
-          {
-            "Action": "ALLOW",
-            "CreationTime": "date",
-            "CreatorRequestId": "<creator-request-id:6>",
-            "FirewallDomainListId": "<id:2>",
-            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
-            "FirewallRuleGroupId": "<id:1>",
-            "ModificationTime": "date",
-            "Name": "<name:6>",
-            "Priority": 1
-          },
-          {
-            "Action": "ALERT",
-            "CreationTime": "date",
-            "CreatorRequestId": "<creator-request-id:7>",
-            "FirewallDomainListId": "<id:3>",
-            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
-            "FirewallRuleGroupId": "<id:1>",
-            "ModificationTime": "date",
-            "Name": "<name:7>",
-            "Priority": 2
-          },
-          {
-            "Action": "ALERT",
-            "CreationTime": "date",
-            "CreatorRequestId": "<creator-request-id:8>",
-            "FirewallDomainListId": "<id:4>",
-            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
-            "FirewallRuleGroupId": "<id:1>",
-            "ModificationTime": "date",
-            "Name": "<name:8>",
-            "Priority": 3
-          },
-          {
-            "Action": "ALLOW",
-            "CreationTime": "date",
-            "CreatorRequestId": "<creator-request-id:9>",
-            "FirewallDomainListId": "<id:5>",
-            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
-            "FirewallRuleGroupId": "<id:1>",
-            "ModificationTime": "date",
-            "Name": "<name:9>",
-            "Priority": 4
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "firewall-rules-list-by-priority": {
-        "FirewallRules": [
-          {
-            "Action": "ALLOW",
-            "CreationTime": "date",
-            "CreatorRequestId": "<creator-request-id:6>",
-            "FirewallDomainListId": "<id:2>",
-            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
-            "FirewallRuleGroupId": "<id:1>",
-            "ModificationTime": "date",
-            "Name": "<name:6>",
-            "Priority": 1
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "firewall-rules-list-by-action": {
-        "FirewallRules": [
-          {
-            "Action": "ALLOW",
-            "CreationTime": "date",
-            "CreatorRequestId": "<creator-request-id:6>",
-            "FirewallDomainListId": "<id:2>",
-            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
-            "FirewallRuleGroupId": "<id:1>",
-            "ModificationTime": "date",
-            "Name": "<name:6>",
-            "Priority": 1
-          },
-          {
-            "Action": "ALLOW",
-            "CreationTime": "date",
-            "CreatorRequestId": "<creator-request-id:9>",
-            "FirewallDomainListId": "<id:5>",
-            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
-            "FirewallRuleGroupId": "<id:1>",
-            "ModificationTime": "date",
-            "Name": "<name:9>",
-            "Priority": 4
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "firewall-rules-list-by-action-and-priority": {
-        "FirewallRules": [
-          {
-            "Action": "ALLOW",
-            "CreationTime": "date",
-            "CreatorRequestId": "<creator-request-id:9>",
-            "FirewallDomainListId": "<id:5>",
-            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
-            "FirewallRuleGroupId": "<id:1>",
-            "ModificationTime": "date",
-            "Name": "<name:9>",
-            "Priority": 4
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "firewall-rules-list-no-match": {
-        "FirewallRules": [],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_empty_rule_group": {
-    "recorded-date": "24-10-2024, 10:48:51",
+    "recorded-date": "28-10-2024, 07:23:07",
     "recorded-content": {
       "create-firewall-rule-group": {
         "FirewallRuleGroup": {
@@ -940,6 +653,138 @@
         }
       },
       "empty-firewall-rule-group": {
+        "FirewallRules": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules": {
+    "recorded-date": "28-10-2024, 07:26:28",
+    "recorded-content": {
+      "firewall-rules-list-all": {
+        "FirewallRules": [
+          {
+            "Action": "ALLOW",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:1>",
+            "FirewallDomainListId": "<firewall-domain-list-id:1>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<firewall-rule-group-id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:1>",
+            "Priority": 1
+          },
+          {
+            "Action": "ALERT",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:2>",
+            "FirewallDomainListId": "<firewall-domain-list-id:2>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<firewall-rule-group-id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:2>",
+            "Priority": 2
+          },
+          {
+            "Action": "ALERT",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:3>",
+            "FirewallDomainListId": "<firewall-domain-list-id:3>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<firewall-rule-group-id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:3>",
+            "Priority": 3
+          },
+          {
+            "Action": "ALLOW",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:4>",
+            "FirewallDomainListId": "<firewall-domain-list-id:4>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<firewall-rule-group-id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:4>",
+            "Priority": 4
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "firewall-rules-list-by-priority": {
+        "FirewallRules": [
+          {
+            "Action": "ALLOW",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:1>",
+            "FirewallDomainListId": "<firewall-domain-list-id:1>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<firewall-rule-group-id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:1>",
+            "Priority": 1
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "firewall-rules-list-by-action": {
+        "FirewallRules": [
+          {
+            "Action": "ALLOW",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:1>",
+            "FirewallDomainListId": "<firewall-domain-list-id:1>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<firewall-rule-group-id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:1>",
+            "Priority": 1
+          },
+          {
+            "Action": "ALLOW",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:4>",
+            "FirewallDomainListId": "<firewall-domain-list-id:4>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<firewall-rule-group-id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:4>",
+            "Priority": 4
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "firewall-rules-list-by-action-and-priority": {
+        "FirewallRules": [
+          {
+            "Action": "ALLOW",
+            "CreationTime": "date",
+            "CreatorRequestId": "<creator-request-id:4>",
+            "FirewallDomainListId": "<firewall-domain-list-id:4>",
+            "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN",
+            "FirewallRuleGroupId": "<firewall-rule-group-id:1>",
+            "ModificationTime": "date",
+            "Name": "<name:4>",
+            "Priority": 4
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "firewall-rules-list-no-match": {
         "FirewallRules": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
@@ -615,7 +615,7 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_missing_rule_group": {
-    "recorded-date": "28-10-2024, 07:21:26",
+    "recorded-date": "21-01-2025, 16:40:17",
     "recorded-content": {
       "missing-firewall-rule-group-id": {
         "Error": {
@@ -631,7 +631,7 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_empty_rule_group": {
-    "recorded-date": "28-10-2024, 07:23:07",
+    "recorded-date": "21-01-2025, 16:40:17",
     "recorded-content": {
       "create-firewall-rule-group": {
         "FirewallRuleGroup": {
@@ -662,7 +662,7 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules": {
-    "recorded-date": "28-10-2024, 07:26:28",
+    "recorded-date": "21-01-2025, 16:40:19",
     "recorded-content": {
       "firewall-rules-list-all": {
         "FirewallRules": [

--- a/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
@@ -613,5 +613,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_missing_rule_group": {
+    "recorded-date": "24-10-2024, 08:34:55",
+    "recorded-content": {
+      "missing-firewall-rule-group-id": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "[RSLVR-02025] Can\u2019t find the resource with ID \"<firewall-rule-group-id>\". Trace Id: \"<trace-id>\""
+        },
+        "Message": "[RSLVR-02025] Can\u2019t find the resource with ID \"<firewall-rule-group-id>\". Trace Id: \"<trace-id>\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/route53resolver/test_route53resolver.validation.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.validation.json
@@ -35,6 +35,9 @@
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_domain_lists": {
     "last_validated_date": "2023-09-01T08:05:46+00:00"
   },
+  "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_missing_rule_group": {
+    "last_validated_date": "2024-10-24T08:34:55+00:00"
+  },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_multipe_create_resolver_rule": {
     "last_validated_date": "2023-09-08T08:10:19+00:00"
   },

--- a/tests/aws/services/route53resolver/test_route53resolver.validation.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.validation.json
@@ -35,6 +35,9 @@
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_domain_lists": {
     "last_validated_date": "2023-09-01T08:05:46+00:00"
   },
+  "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules": {
+    "last_validated_date": "2024-10-24T10:06:40+00:00"
+  },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_missing_rule_group": {
     "last_validated_date": "2024-10-24T08:34:55+00:00"
   },

--- a/tests/aws/services/route53resolver/test_route53resolver.validation.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.validation.json
@@ -36,13 +36,13 @@
     "last_validated_date": "2023-09-01T08:05:46+00:00"
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules": {
-    "last_validated_date": "2024-10-24T10:06:40+00:00"
+    "last_validated_date": "2024-10-28T07:26:53+00:00"
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_empty_rule_group": {
-    "last_validated_date": "2024-10-24T12:01:41+00:00"
+    "last_validated_date": "2024-10-28T07:23:19+00:00"
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_missing_rule_group": {
-    "last_validated_date": "2024-10-24T08:34:55+00:00"
+    "last_validated_date": "2024-10-28T07:21:39+00:00"
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_multipe_create_resolver_rule": {
     "last_validated_date": "2023-09-08T08:10:19+00:00"

--- a/tests/aws/services/route53resolver/test_route53resolver.validation.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.validation.json
@@ -38,6 +38,9 @@
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules": {
     "last_validated_date": "2024-10-24T10:06:40+00:00"
   },
+  "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_empty_rule_group": {
+    "last_validated_date": "2024-10-24T12:01:41+00:00"
+  },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_missing_rule_group": {
     "last_validated_date": "2024-10-24T08:34:55+00:00"
   },

--- a/tests/aws/services/route53resolver/test_route53resolver.validation.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.validation.json
@@ -36,13 +36,13 @@
     "last_validated_date": "2023-09-01T08:05:46+00:00"
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules": {
-    "last_validated_date": "2024-10-28T07:26:53+00:00"
+    "last_validated_date": "2025-01-21T16:40:18+00:00"
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_empty_rule_group": {
-    "last_validated_date": "2024-10-28T07:23:19+00:00"
+    "last_validated_date": "2025-01-21T16:40:17+00:00"
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_rules_for_missing_rule_group": {
-    "last_validated_date": "2024-10-28T07:21:39+00:00"
+    "last_validated_date": "2025-01-21T16:40:17+00:00"
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_multipe_create_resolver_rule": {
     "last_validated_date": "2023-09-08T08:10:19+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Implement priority and action filtering for the `ListFirewallRules` operation in Route 53 Resolver

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Added functionality to filter by `action` and `priority` for the Route53Resolver operation ListFirewallRules.

Additionally fixed a bug during which: listing a firewall-rule-group for which no rules were created resulted in a ResourceNotFoundException. This was because the store object for firewall-rules was only created when the 1st rule was added.
This change lifts creating a store space for firewall-rules at the firewall-rule-group creation.

Parity tests were included for:
- test listing firewall rules for a non-existing rule-group.
- test listing firewall rules for empty rule-group
- test listing all rules in the rule-group
- test listing rules filtered by priority
- test listing rules filtered by action
- test listing rules filtered by priority and action

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
