### PR TITLE
add: TaggingService functionality to Lambda Provider

### DIFF
--- a/localstack-core/localstack/services/lambda_/api_utils.py
+++ b/localstack-core/localstack/services/lambda_/api_utils.py
@@ -108,6 +108,7 @@ ARCHITECTURES = [Architecture.arm64, Architecture.x86_64]
 # pattern therefore we can sub this value in when appropriate.
 ARN_NAME_PATTERN_VALIDATION_TEMPLATE = "(arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{{2}}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{{1}}:)?(\\d{{12}}:)?(function:)?([a-zA-Z0-9-_{0}]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
 
+# AWS response when invalid ARNs are used in Tag operations.
 TAGGABLE_RESOURCE_ARN_PATTERN = "arn:(aws[a-zA-Z-]*):lambda:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:(function:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?|layer:([a-zA-Z0-9-_]+)|code-signing-config:csc-[a-z0-9]{17}|event-source-mapping:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
 
 

--- a/localstack-core/localstack/services/lambda_/api_utils.py
+++ b/localstack-core/localstack/services/lambda_/api_utils.py
@@ -108,6 +108,8 @@ ARCHITECTURES = [Architecture.arm64, Architecture.x86_64]
 # pattern therefore we can sub this value in when appropriate.
 ARN_NAME_PATTERN_VALIDATION_TEMPLATE = "(arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{{2}}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{{1}}:)?(\\d{{12}}:)?(function:)?([a-zA-Z0-9-_{0}]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
 
+TAGGABLE_RESOURCE_ARN_PATTERN = "arn:(aws[a-zA-Z-]*):lambda:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:(function:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?|layer:([a-zA-Z0-9-_]+)|code-signing-config:csc-[a-z0-9]{17}|event-source-mapping:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+
 
 def validate_function_name(function_name_or_arn: str, operation_type: str):
     function_name, *_ = function_locators_from_arn(function_name_or_arn)

--- a/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
+++ b/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
@@ -595,7 +595,9 @@ class Function:
     provisioned_concurrency_configs: dict[str, ProvisionedConcurrencyConfiguration] = (
         dataclasses.field(default_factory=dict)
     )
-    tags: dict[str, str] | None = None
+    tags: dict[str, str] | None = (
+        None  # TODO: This should be removed in favour of the TaggingService
+    )
 
     lock: threading.RLock = dataclasses.field(default_factory=threading.RLock)
     next_version: int = 1

--- a/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
+++ b/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
@@ -595,9 +595,6 @@ class Function:
     provisioned_concurrency_configs: dict[str, ProvisionedConcurrencyConfiguration] = (
         dataclasses.field(default_factory=dict)
     )
-    tags: dict[str, str] | None = (
-        None  # TODO: This should be removed in favour of the TaggingService
-    )
 
     lock: threading.RLock = dataclasses.field(default_factory=threading.RLock)
     next_version: int = 1

--- a/localstack-core/localstack/services/lambda_/invocation/models.py
+++ b/localstack-core/localstack/services/lambda_/invocation/models.py
@@ -1,6 +1,7 @@
 from localstack.aws.api.lambda_ import EventSourceMappingConfiguration
 from localstack.services.lambda_.invocation.lambda_models import CodeSigningConfig, Function, Layer
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
+from localstack.utils.tagging import TaggingService
 
 
 class LambdaStore(BaseStore):
@@ -15,6 +16,9 @@ class LambdaStore(BaseStore):
 
     # maps layer names to Layers
     layers: dict[str, Layer] = LocalAttribute(default=dict)
+
+    # maps resource ARNs for EventSourceMappings and CodeSigningConfiguration to tags
+    TAGS = LocalAttribute(default=TaggingService)
 
 
 lambda_stores = AccountRegionBundle("lambda", LambdaStore)

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -41,7 +41,6 @@ from localstack.aws.api.lambda_ import (
     Description,
     DestinationConfig,
     EventSourceMappingConfiguration,
-    FunctionArn,
     FunctionCodeLocation,
     FunctionConfiguration,
     FunctionEventInvokeConfig,
@@ -127,6 +126,7 @@ from localstack.aws.api.lambda_ import (
     StatementId,
     StateReasonCode,
     String,
+    TaggableResource,
     TagKeyList,
     Tags,
     TracingMode,
@@ -221,8 +221,12 @@ from localstack.services.lambda_.urlrouter import FunctionUrlRouter
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.state import StateVisitor
 from localstack.utils.aws.arns import (
+    ArnData,
+    extract_resource_from_arn,
     extract_service_from_arn,
     get_partition,
+    lambda_event_source_mapping_arn,
+    parse_arn,
 )
 from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.collections import PaginatedList
@@ -393,6 +397,18 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 Type="User",
             )
         return function
+
+    @staticmethod
+    def _get_esm(uuid: str, account_id: str, region: str) -> EventSourceMappingConfiguration:
+        state = lambda_stores[account_id][region]
+        esm = state.event_source_mappings.get(uuid)
+        if not esm:
+            arn = lambda_event_source_mapping_arn(uuid, account_id, region)
+            raise ResourceNotFoundException(
+                f"Event source mapping not found: {arn}",
+                Type="User",
+            )
+        return esm
 
     @staticmethod
     def _validate_qualifier_expression(qualifier: str) -> None:
@@ -988,7 +1004,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             )
             fn.versions["$LATEST"] = version
             if request.get("Tags"):
-                self._store_tags(fn, request["Tags"])
+                self._store_tags(arn.unqualified_arn(), request["Tags"])
                 # TODO: should validation failures here "fail" the function creation like it is now?
             state.functions[function_name] = fn
         self.lambda_service.create_function_version(version)
@@ -1453,7 +1469,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             account_id=account_id,
             region=region,
         )
-        tags = self._get_tags(fn)
+        tags = self._get_tags(api_utils.unqualified_lambda_arn(function_name, account_id, region))
         additional_fields = {}
         if tags:
             additional_fields["Tags"] = tags
@@ -1873,6 +1889,8 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         esm_worker = EsmWorkerFactory(esm_config, function_role, enabled).get_esm_worker()
         self.esm_workers[esm_worker.uuid] = esm_worker
         # TODO: check StateTransitionReason, LastModified, LastProcessingResult (concurrent updates requires locking!)
+        if tags := request.get("Tags"):
+            self._store_tags(esm_config.get("EventSourceMappingArn"), tags)
         esm_worker.create()
         return esm_config
 
@@ -4118,87 +4136,129 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
     # =======================================
     # ===============  TAGS   ===============
     # =======================================
-    # only function ARNs are available for tagging
+    # only Function, Event Source Mapping, and Code Signing Config (not currently supported by LocalStack) ARNs an are available for tagging in AWS
 
-    def _get_tags(self, function: Function) -> dict[str, str]:
-        return function.tags or {}
+    def _get_tags(self, resource: TaggableResource) -> dict[str, str]:
+        state = self.fetch_lambda_store_for_tagging(resource)
+        lambda_adapted_tags = {
+            tag["Key"]: tag["Value"]
+            for tag in state.TAGS.list_tags_for_resource(resource).get("Tags")
+        }
+        return lambda_adapted_tags
 
-    def _store_tags(self, function: Function, tags: dict[str, str]):
-        if len(tags) > LAMBDA_TAG_LIMIT_PER_RESOURCE:
+    def _store_tags(self, resource: TaggableResource, tags: dict[str, str]):
+        state = self.fetch_lambda_store_for_tagging(resource)
+        if len(state.TAGS.tags.get(resource, {}) | tags) > LAMBDA_TAG_LIMIT_PER_RESOURCE:
             raise InvalidParameterValueException(
                 "Number of tags exceeds resource tag limit.", Type="User"
             )
-        with function.lock:
-            function.tags = tags
-            # dirty hack for changed revision id, should reevaluate model to prevent this:
-            latest_version = function.versions["$LATEST"]
-            function.versions["$LATEST"] = dataclasses.replace(
-                latest_version, config=dataclasses.replace(latest_version.config)
+
+        tag_svc_adapted_tags = [{"Key": key, "Value": value} for key, value in tags.items()]
+        state.TAGS.tag_resource(resource, tag_svc_adapted_tags)
+
+    def fetch_lambda_store_for_tagging(self, resource: TaggableResource) -> LambdaStore:
+        def _raise_validation_exception():
+            raise ValidationException(
+                f"1 validation error detected: Value '{resource}' at 'resource' failed to satisfy constraint: Member must satisfy regular expression pattern: {api_utils.TAGGABLE_RESOURCE_ARN_PATTERN}"
             )
 
-    def _update_tags(self, function: Function, tags: dict[str, str]):
-        with function.lock:
-            stored_tags = function.tags or {}
-            stored_tags |= tags
-            self._store_tags(function=function, tags=stored_tags)
+        # Check whether the ARN we have been passed is correctly formatted
+        parsed_resource_arn: ArnData = None
+        try:
+            parsed_resource_arn = parse_arn(resource)
+        except Exception:
+            _raise_validation_exception()
+
+        # TODO: Should we be checking whether this is a full ARN?
+        region, account_id, resource_type = map(
+            parsed_resource_arn.get, ("region", "account", "resource")
+        )
+
+        if not all((region, account_id, resource_type)):
+            _raise_validation_exception()
+
+        if not (parts := resource_type.split(":")):
+            _raise_validation_exception()
+
+        resource_type, resource_identifier, *qualifier = parts
+        if resource_type not in {"event-source-mapping", "code-signing-config", "function"}:
+            _raise_validation_exception()
+
+        if qualifier:
+            if resource_type == "function":
+                raise InvalidParameterValueException(
+                    "Tags on function aliases and versions are not supported. Please specify a function ARN.",
+                    Type="User",
+                )
+            _raise_validation_exception()
+
+        match resource_type:
+            case "event-source-mapping":
+                self._get_esm(resource_identifier, account_id, region)
+            case "code-signing-config":
+                raise NotImplementedError("Resource tagging on CSC not yet implemented.")
+            case "function":
+                self._get_function(
+                    function_name=resource_identifier, account_id=account_id, region=region
+                )
+
+        # If no exceptions are raised, assume ARN and referenced resource is valid for tag operations
+        return lambda_stores[account_id][region]
 
     def tag_resource(
-        self, context: RequestContext, resource: FunctionArn, tags: Tags, **kwargs
+        self, context: RequestContext, resource: TaggableResource, tags: Tags, **kwargs
     ) -> None:
         if not tags:
             raise InvalidParameterValueException(
                 "An error occurred and the request cannot be processed.", Type="User"
             )
+        self._store_tags(resource, tags)
 
-        # TODO: test layer (added in snapshot update 2023-11)
-        pattern_match = api_utils.FULL_FN_ARN_PATTERN.search(resource)
-        if not pattern_match:
-            raise ValidationException(
-                rf"1 validation error detected: Value '{resource}' at 'resource' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{{2}}((-gov)|(-iso(b?)))?-[a-z]+-\d{{1}}:\d{{12}}:(function:[a-zA-Z0-9-_]+(:(\$LATEST|[a-zA-Z0-9-_]+))?|layer:[a-zA-Z0-9-_]+)"
-            )
-
-        groups = pattern_match.groupdict()
-        fn_name = groups.get("function_name")
-
-        if groups.get("qualifier"):
-            raise InvalidParameterValueException(
-                "Tags on function aliases and versions are not supported. Please specify a function ARN.",
-                Type="User",
-            )
-
-        account_id, region = api_utils.get_account_and_region(resource, context)
-        fn = self._get_function(function_name=fn_name, account_id=account_id, region=region)
-
-        self._update_tags(fn, tags)
+        if (resource_id := extract_resource_from_arn(resource)) and resource_id.startswith(
+            "function"
+        ):
+            name, _, account, region = function_locators_from_arn(resource)
+            function = self._get_function(name, account, region)
+            with function.lock:
+                function.tags = tags
+                # dirty hack for changed revision id, should reevaluate model to prevent this:
+                latest_version = function.versions["$LATEST"]
+                function.versions["$LATEST"] = dataclasses.replace(
+                    latest_version, config=dataclasses.replace(latest_version.config)
+                )
 
     def list_tags(
-        self, context: RequestContext, resource: FunctionArn, **kwargs
+        self, context: RequestContext, resource: TaggableResource, **kwargs
     ) -> ListTagsResponse:
-        account_id, region = api_utils.get_account_and_region(resource, context)
-        function_name = api_utils.get_function_name(resource, context)
-        fn = self._get_function(function_name=function_name, account_id=account_id, region=region)
-
-        return ListTagsResponse(Tags=self._get_tags(fn))
+        tags = self._get_tags(resource)
+        return ListTagsResponse(Tags=tags)
 
     def untag_resource(
-        self, context: RequestContext, resource: FunctionArn, tag_keys: TagKeyList, **kwargs
+        self, context: RequestContext, resource: TaggableResource, tag_keys: TagKeyList, **kwargs
     ) -> None:
         if not tag_keys:
             raise ValidationException(
                 "1 validation error detected: Value null at 'tagKeys' failed to satisfy constraint: Member must not be null"
             )  # should probably be generalized a bit
 
-        account_id, region = api_utils.get_account_and_region(resource, context)
-        function_name = api_utils.get_function_name(resource, context)
-        fn = self._get_function(function_name=function_name, account_id=account_id, region=region)
+        state = self.fetch_lambda_store_for_tagging(resource)
+        state.TAGS.untag_resource(resource, tag_keys)
 
-        # copy first, then set explicitly in store tags
-        tags = dict(fn.tags or {})
-        if tags:
-            for key in tag_keys:
-                if key in tags:
-                    tags.pop(key)
-        self._store_tags(function=fn, tags=tags)
+        if (resource_id := extract_resource_from_arn(resource)) and resource_id.startswith(
+            "function"
+        ):
+            name, _, account, region = function_locators_from_arn(resource)
+            function = self._get_function(name, account, region)
+            with function.lock:
+                function.tags = {
+                    tag["Key"]: tag["Value"]
+                    for tag in state.TAGS.list_tags_for_resource(resource).get("Tags")
+                }
+                # dirty hack for changed revision id, should reevaluate model to prevent this:
+                latest_version = function.versions["$LATEST"]
+                function.versions["$LATEST"] = dataclasses.replace(
+                    latest_version, config=dataclasses.replace(latest_version.config)
+                )
 
     # =======================================
     # =======  LEGACY / DEPRECATED   ========

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -47,7 +47,11 @@ from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils import testutil
 from localstack.utils.aws import arns
-from localstack.utils.aws.arns import get_partition
+from localstack.utils.aws.arns import (
+    get_partition,
+    lambda_event_source_mapping_arn,
+    lambda_function_arn,
+)
 from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.files import load_file
 from localstack.utils.functions import call_safe
@@ -2587,7 +2591,7 @@ class TestLambdaRevisions:
 class TestLambdaTag:
     @pytest.fixture(scope="function")
     def fn_arn(self, create_lambda_function, aws_client):
-        """simple reusable setup to test tagging operations against"""
+        """simple reusable setup to test tagging operations against Lambda function resources"""
         function_name = f"fn-{short_uid()}"
         create_lambda_function(
             handler_file=TEST_LAMBDA_PYTHON_ECHO,
@@ -2598,6 +2602,22 @@ class TestLambdaTag:
         yield aws_client.lambda_.get_function(FunctionName=function_name)["Configuration"][
             "FunctionArn"
         ]
+
+    @pytest.fixture(scope="function")
+    def esm_arn(self, fn_arn, create_event_source_mapping, sqs_create_queue, sqs_get_queue_arn):
+        """simple reusable setup to test tagging operations against ESM resources"""
+
+        # Create an SQS queue and pass it as an event source for the mapping
+        queue_url = sqs_create_queue()
+        queue_arn = sqs_get_queue_arn(queue_url)
+
+        create_response = create_event_source_mapping(
+            EventSourceArn=queue_arn,
+            FunctionName=fn_arn,
+            BatchSize=1,
+        )
+
+        yield create_response["EventSourceMappingArn"]
 
     @markers.aws.validated
     def test_create_tag_on_fn_create(self, create_lambda_function, snapshot, aws_client):
@@ -2618,68 +2638,162 @@ class TestLambdaTag:
         snapshot.match("list_tags_result", list_tags_result)
 
     @markers.aws.validated
-    def test_tag_lifecycle(self, create_lambda_function, snapshot, fn_arn, aws_client):
+    def test_create_tag_on_esm_create(
+        self,
+        create_lambda_function,
+        create_event_source_mapping,
+        sqs_create_queue,
+        sqs_get_queue_arn,
+        snapshot,
+        aws_client,
+    ):
+        function_name = f"fn-{short_uid()}"
+        custom_tag = f"tag-{short_uid()}"
+        snapshot.add_transformer(snapshot.transform.regex(custom_tag, "<custom-tag>"))
+
+        queue_url = sqs_create_queue()
+        queue_arn = sqs_get_queue_arn(queue_url)
+
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name,
+            runtime=Runtime.python3_12,
+        )
+
+        create_response = create_event_source_mapping(
+            EventSourceArn=queue_arn,
+            FunctionName=function_name,
+            BatchSize=1,
+            Tags={"testtag": custom_tag},
+        )
+
+        uuid = create_response["UUID"]
+
+        # the stream might not be active immediately(!)
+        def check_esm_active():
+            return aws_client.lambda_.get_event_source_mapping(UUID=uuid)["State"] != "Creating"
+
+        get_response = wait_until(check_esm_active)
+        snapshot.match("get_event_source_mapping_with_tag", get_response)
+
+        esm_arn = create_response["EventSourceMappingArn"]
+        list_tags_result = aws_client.lambda_.list_tags(Resource=esm_arn)
+        snapshot.match("list_tags_result", list_tags_result)
+
+    @pytest.mark.parametrize(
+        "resource_arn_fixture",
+        ["fn_arn", "esm_arn"],
+        ids=["lambda_function", "event_source_mapping"],
+    )
+    @markers.aws.validated
+    def test_tag_lifecycle(self, snapshot, aws_client, resource_arn_fixture, request):
+        # Lazily get
+        resource_arn = request.getfixturevalue(resource_arn_fixture)
         # 1. add tag
-        tag_single_response = aws_client.lambda_.tag_resource(Resource=fn_arn, Tags={"A": "tag-a"})
+        tag_single_response = aws_client.lambda_.tag_resource(
+            Resource=resource_arn, Tags={"A": "tag-a"}
+        )
         snapshot.match("tag_single_response", tag_single_response)
         snapshot.match(
-            "tag_single_response_listtags", aws_client.lambda_.list_tags(Resource=fn_arn)
+            "tag_single_response_listtags", aws_client.lambda_.list_tags(Resource=resource_arn)
         )
 
         # 2. add multiple tags
         tag_multiple_response = aws_client.lambda_.tag_resource(
-            Resource=fn_arn, Tags={"B": "tag-b", "C": "tag-c"}
+            Resource=resource_arn, Tags={"B": "tag-b", "C": "tag-c"}
         )
         snapshot.match("tag_multiple_response", tag_multiple_response)
         snapshot.match(
-            "tag_multiple_response_listtags", aws_client.lambda_.list_tags(Resource=fn_arn)
+            "tag_multiple_response_listtags", aws_client.lambda_.list_tags(Resource=resource_arn)
         )
 
         # 3. add overlapping tags
         tag_overlap_response = aws_client.lambda_.tag_resource(
-            Resource=fn_arn, Tags={"C": "tag-c-newsuffix", "D": "tag-d"}
+            Resource=resource_arn, Tags={"C": "tag-c-newsuffix", "D": "tag-d"}
         )
         snapshot.match("tag_overlap_response", tag_overlap_response)
         snapshot.match(
-            "tag_overlap_response_listtags", aws_client.lambda_.list_tags(Resource=fn_arn)
+            "tag_overlap_response_listtags", aws_client.lambda_.list_tags(Resource=resource_arn)
         )
 
         # 3. remove tag
-        untag_single_response = aws_client.lambda_.untag_resource(Resource=fn_arn, TagKeys=["A"])
+        untag_single_response = aws_client.lambda_.untag_resource(
+            Resource=resource_arn, TagKeys=["A"]
+        )
         snapshot.match("untag_single_response", untag_single_response)
         snapshot.match(
-            "untag_single_response_listtags", aws_client.lambda_.list_tags(Resource=fn_arn)
+            "untag_single_response_listtags", aws_client.lambda_.list_tags(Resource=resource_arn)
         )
 
         # 4. remove multiple tags
         untag_multiple_response = aws_client.lambda_.untag_resource(
-            Resource=fn_arn, TagKeys=["B", "C"]
+            Resource=resource_arn, TagKeys=["B", "C"]
         )
         snapshot.match("untag_multiple_response", untag_multiple_response)
         snapshot.match(
-            "untag_multiple_response_listtags", aws_client.lambda_.list_tags(Resource=fn_arn)
+            "untag_multiple_response_listtags", aws_client.lambda_.list_tags(Resource=resource_arn)
         )
 
         # 5. try to remove only tags that don't exist
         untag_nonexisting_response = aws_client.lambda_.untag_resource(
-            Resource=fn_arn, TagKeys=["F"]
+            Resource=resource_arn, TagKeys=["F"]
         )
         snapshot.match("untag_nonexisting_response", untag_nonexisting_response)
         snapshot.match(
-            "untag_nonexisting_response_listtags", aws_client.lambda_.list_tags(Resource=fn_arn)
+            "untag_nonexisting_response_listtags",
+            aws_client.lambda_.list_tags(Resource=resource_arn),
         )
 
         # 6. remove a mix of tags that exist & don't exist
         untag_existing_and_nonexisting_response = aws_client.lambda_.untag_resource(
-            Resource=fn_arn, TagKeys=["D", "F"]
+            Resource=resource_arn, TagKeys=["D", "F"]
         )
         snapshot.match(
             "untag_existing_and_nonexisting_response", untag_existing_and_nonexisting_response
         )
         snapshot.match(
             "untag_existing_and_nonexisting_response_listtags",
-            aws_client.lambda_.list_tags(Resource=fn_arn),
+            aws_client.lambda_.list_tags(Resource=resource_arn),
         )
+
+    @pytest.mark.parametrize(
+        "create_resource_arn",
+        [lambda_function_arn, lambda_event_source_mapping_arn],
+        ids=["lambda_function", "event_source_mapping"],
+    )
+    @markers.aws.validated
+    def test_tag_exceptions(
+        self, snapshot, aws_client, create_resource_arn, region_name, account_id
+    ):
+        resource_name = long_uid()
+        snapshot.add_transformer(snapshot.transform.regex(resource_name, "<resource-name>"))
+
+        resource_arn = create_resource_arn(resource_name, account_id, region_name)
+
+        with pytest.raises(aws_client.lambda_.exceptions.ResourceNotFoundException) as e:
+            aws_client.lambda_.tag_resource(Resource=resource_arn, Tags={"A": "B"})
+        snapshot.match("not_found_exception_tag", e.value.response)
+
+        with pytest.raises(aws_client.lambda_.exceptions.ResourceNotFoundException) as e:
+            aws_client.lambda_.untag_resource(Resource=resource_arn, TagKeys=["A"])
+        snapshot.match("not_found_exception_untag", e.value.response)
+
+        with pytest.raises(aws_client.lambda_.exceptions.ResourceNotFoundException) as e:
+            aws_client.lambda_.list_tags(Resource=resource_arn)
+        snapshot.match("not_found_exception_list", e.value.response)
+
+        with pytest.raises(aws_client.lambda_.exceptions.ClientError) as e:
+            aws_client.lambda_.list_tags(Resource=f"{resource_arn}:alias")
+        snapshot.match("aliased_arn_exception", e.value.response)
+
+        # change the resource name to an invalid one
+        parts = resource_arn.rsplit(":", 2)
+        parts[1] = "foobar"
+        invalid_resource_arn = ":".join(parts)
+
+        with pytest.raises(aws_client.lambda_.exceptions.ClientError) as e:
+            aws_client.lambda_.list_tags(Resource=f"{invalid_resource_arn}")
+        snapshot.match("invalid_arn_exception", e.value.response)
 
     @markers.aws.validated
     def test_tag_nonexisting_resource(self, snapshot, fn_arn, aws_client):

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -6062,7 +6062,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTags::test_tag_limits": {
-    "recorded-date": "24-10-2024, 15:22:35",
+    "recorded-date": "28-10-2024, 14:16:38",
     "recorded-content": {
       "tag_lambda_too_many_tags": {
         "Error": {
@@ -6244,6 +6244,18 @@
         }
       },
       "tag_lambda_too_many_tags_additional": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Number of tags exceeds resource tag limit."
+        },
+        "Type": "User",
+        "message": "Number of tags exceeds resource tag limit.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create_function_invalid_tags": {
         "Error": {
           "Code": "InvalidParameterValueException",
           "Message": "Number of tags exceeds resource tag limit."

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -5988,12 +5988,12 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTags::test_tag_exceptions": {
-    "recorded-date": "10-04-2024, 09:22:07",
+    "recorded-date": "24-10-2024, 15:22:29",
     "recorded-content": {
       "tag_lambda_invalidarn": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'arn:<partition>:something' at 'resource' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:\\d{12}:(function:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?|layer:[a-zA-Z0-9-_]+)"
+          "Message": "1 validation error detected: Value 'arn:<partition>:something' at 'resource' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:(aws[a-zA-Z-]*):lambda:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:(function:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?|layer:([a-zA-Z0-9-_]+)|code-signing-config:csc-[a-z0-9]{17}|event-source-mapping:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -6062,7 +6062,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTags::test_tag_limits": {
-    "recorded-date": "10-04-2024, 09:22:11",
+    "recorded-date": "24-10-2024, 15:22:35",
     "recorded-content": {
       "tag_lambda_too_many_tags": {
         "Error": {
@@ -6258,7 +6258,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTags::test_tag_lifecycle": {
-    "recorded-date": "10-04-2024, 09:22:20",
+    "recorded-date": "24-10-2024, 15:22:49",
     "recorded-content": {
       "list_tags_response_postfncreate": {
         "Tags": {
@@ -7035,7 +7035,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTags::test_tag_versions": {
-    "recorded-date": "10-04-2024, 09:22:14",
+    "recorded-date": "24-10-2024, 15:22:40",
     "recorded-content": {
       "tag_resource_exception": {
         "Error": {
@@ -17511,6 +17511,375 @@
         "Error": {
           "Code": "ValidationException",
           "Message": "1 validation error detected: Value 'InvalidValue' at 'recursiveLoop' failed to satisfy constraint: Member must satisfy enum value set: [Terminate, Allow]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_tag_lifecycle[lambda_function]": {
+    "recorded-date": "23-10-2024, 10:51:15",
+    "recorded-content": {
+      "tag_single_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "tag_single_response_listtags": {
+        "Tags": {
+          "A": "tag-a"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "tag_multiple_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "tag_multiple_response_listtags": {
+        "Tags": {
+          "A": "tag-a",
+          "B": "tag-b",
+          "C": "tag-c"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "tag_overlap_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "tag_overlap_response_listtags": {
+        "Tags": {
+          "A": "tag-a",
+          "B": "tag-b",
+          "C": "tag-c-newsuffix",
+          "D": "tag-d"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_single_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "untag_single_response_listtags": {
+        "Tags": {
+          "B": "tag-b",
+          "C": "tag-c-newsuffix",
+          "D": "tag-d"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_multiple_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "untag_multiple_response_listtags": {
+        "Tags": {
+          "D": "tag-d"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_nonexisting_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "untag_nonexisting_response_listtags": {
+        "Tags": {
+          "D": "tag-d"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_existing_and_nonexisting_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "untag_existing_and_nonexisting_response_listtags": {
+        "Tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_tag_lifecycle[event_source_mapping]": {
+    "recorded-date": "23-10-2024, 10:51:27",
+    "recorded-content": {
+      "tag_single_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "tag_single_response_listtags": {
+        "Tags": {
+          "A": "tag-a"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "tag_multiple_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "tag_multiple_response_listtags": {
+        "Tags": {
+          "A": "tag-a",
+          "B": "tag-b",
+          "C": "tag-c"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "tag_overlap_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "tag_overlap_response_listtags": {
+        "Tags": {
+          "A": "tag-a",
+          "B": "tag-b",
+          "C": "tag-c-newsuffix",
+          "D": "tag-d"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_single_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "untag_single_response_listtags": {
+        "Tags": {
+          "B": "tag-b",
+          "C": "tag-c-newsuffix",
+          "D": "tag-d"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_multiple_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "untag_multiple_response_listtags": {
+        "Tags": {
+          "D": "tag-d"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_nonexisting_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "untag_nonexisting_response_listtags": {
+        "Tags": {
+          "D": "tag-d"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_existing_and_nonexisting_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "untag_existing_and_nonexisting_response_listtags": {
+        "Tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_create_tag_on_esm_create": {
+    "recorded-date": "24-10-2024, 14:16:07",
+    "recorded-content": {
+      "get_event_source_mapping_with_tag": true,
+      "list_tags_result": {
+        "Tags": {
+          "testtag": "<custom-tag>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_tag_exceptions[lambda_function]": {
+    "recorded-date": "24-10-2024, 12:42:56",
+    "recorded-content": {
+      "not_found_exception_tag": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:<resource-name>"
+        },
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:<resource-name>",
+        "Type": "User",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "not_found_exception_untag": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:<resource-name>"
+        },
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:<resource-name>",
+        "Type": "User",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "not_found_exception_list": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:<resource-name>"
+        },
+        "Message": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:<resource-name>",
+        "Type": "User",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "aliased_arn_exception": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Tags on function aliases and versions are not supported. Please specify a function ARN."
+        },
+        "Type": "User",
+        "message": "Tags on function aliases and versions are not supported. Please specify a function ARN.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid_arn_exception": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'arn:<partition>:lambda:<region>:111111111111:foobar:<resource-name>' at 'resource' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:(aws[a-zA-Z-]*):lambda:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:(function:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?|layer:([a-zA-Z0-9-_]+)|code-signing-config:csc-[a-z0-9]{17}|event-source-mapping:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_tag_exceptions[event_source_mapping]": {
+    "recorded-date": "24-10-2024, 12:42:57",
+    "recorded-content": {
+      "not_found_exception_tag": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event source mapping not found: arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource-name>"
+        },
+        "Message": "Event source mapping not found: arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource-name>",
+        "Type": "User",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "not_found_exception_untag": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event source mapping not found: arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource-name>"
+        },
+        "Message": "Event source mapping not found: arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource-name>",
+        "Type": "User",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "not_found_exception_list": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event source mapping not found: arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource-name>"
+        },
+        "Message": "Event source mapping not found: arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource-name>",
+        "Type": "User",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "aliased_arn_exception": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource-name>:alias' at 'resource' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:(aws[a-zA-Z-]*):lambda:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:(function:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?|layer:([a-zA-Z0-9-_]+)|code-signing-config:csc-[a-z0-9]{17}|event-source-mapping:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid_arn_exception": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'arn:<partition>:lambda:<region>:111111111111:foobar:<resource-name>' at 'resource' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:(aws[a-zA-Z-]*):lambda:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:(function:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?|layer:([a-zA-Z0-9-_]+)|code-signing-config:csc-[a-z0-9]{17}|event-source-mapping:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -542,26 +542,41 @@
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java21]": {
     "last_validated_date": "2024-04-10T09:30:28+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_create_tag_on_esm_create": {
+    "last_validated_date": "2024-10-24T14:16:05+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_create_tag_on_fn_create": {
     "last_validated_date": "2024-04-10T09:13:04+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_tag_exceptions[event_source_mapping]": {
+    "last_validated_date": "2024-10-24T12:42:57+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_tag_exceptions[lambda_function]": {
+    "last_validated_date": "2024-10-24T12:42:56+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_tag_lifecycle": {
     "last_validated_date": "2024-04-10T09:13:09+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_tag_lifecycle[event_source_mapping]": {
+    "last_validated_date": "2024-10-23T10:51:25+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_tag_lifecycle[lambda_function]": {
+    "last_validated_date": "2024-10-23T10:51:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_tag_nonexisting_resource": {
     "last_validated_date": "2024-04-10T09:13:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTags::test_tag_exceptions": {
-    "last_validated_date": "2024-04-10T09:22:06+00:00"
+    "last_validated_date": "2024-10-24T15:22:27+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTags::test_tag_lifecycle": {
-    "last_validated_date": "2024-04-10T09:22:19+00:00"
+    "last_validated_date": "2024-10-24T15:22:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTags::test_tag_limits": {
-    "last_validated_date": "2024-04-10T09:22:10+00:00"
+    "last_validated_date": "2024-10-24T15:22:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTags::test_tag_versions": {
-    "last_validated_date": "2024-04-10T09:22:13+00:00"
+    "last_validated_date": "2024-10-24T15:22:38+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaUrl::test_url_config_exceptions": {
     "last_validated_date": "2024-04-10T09:16:49+00:00"

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -573,7 +573,7 @@
     "last_validated_date": "2024-10-24T15:22:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTags::test_tag_limits": {
-    "last_validated_date": "2024-10-24T15:22:33+00:00"
+    "last_validated_date": "2024-10-28T14:16:36+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTags::test_tag_versions": {
     "last_validated_date": "2024-10-24T15:22:38+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
- This PR adds tagging functionality to the Lambda provider that leverages the TaggingService. In addition, we add tagging functionality for event source mapping. 
- Fixes https://github.com/localstack/localstack/issues/11739

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Extended `TestLambdaTag` suite to include tagging tests for Event Source Mappings
- Refactored/reworked the internal `tag_resource`, `list_tags`, and `untag_resource` Lambda provider functions to use a provider-wde TaggingService. This allows for tagging of Lambda Event Source Mapping or Lambda Function resources (with support for CSC but this is not yet implemented).


## Testing
- Manually verified event source mapping creation with Terraform, using the [terraform-aws-lambda/event-source-mapping](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/event-source-mapping) example.


<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
