### PR TITLE
Bump moto-ext to 5.0.18.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.17.post2",
+    "moto-ext[all]==5.0.18.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -32,7 +32,7 @@ mdurl==0.1.2
     # via markdown-it-py
 packaging==24.1
     # via build
-plux==1.12.0
+plux==1.12.1
     # via localstack-core (pyproject.toml)
 psutil==6.1.0
     # via localstack-core (pyproject.toml)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -256,7 +256,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.17.post2
+moto-ext==5.0.18.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -190,7 +190,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.17.post2
+moto-ext==5.0.18.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -240,7 +240,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.17.post2
+moto-ext==5.0.18.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -260,7 +260,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.17.post2
+moto-ext==5.0.18.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.0.18.post1

Contains:

- https://github.com/getmoto/moto/pull/8260
- https://github.com/getmoto/moto/pull/8235
  closes https://github.com/localstack/localstack/issues/9337

## To do

- [x] Ext compatibility (Ext integration tests) **AWS / Ext Integration Tests # 1652**
- [x] Multi-account/region compatibility (Randomised credentials test run) https://app.circleci.com/pipelines/github/localstack/localstack/29108/workflows/264a19bb-c2b0-49e4-ac40-1958a85e9368