### PR TITLE
remove APIGW NextGen CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,36 +521,6 @@ jobs:
       - store_test_results:
           path: target/reports/
 
-  itest-apigw-ng-provider:
-    executor: ubuntu-machine-amd64
-    working_directory: /tmp/workspace/repo
-    environment:
-      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
-    steps:
-      - prepare-acceptance-tests
-      - attach_workspace:
-          at: /tmp/workspace
-      - prepare-testselection
-      - prepare-pytest-tinybird
-      - prepare-account-region-randomization
-      - run:
-          name: Test ApiGateway Next Gen provider
-          environment:
-            PROVIDER_OVERRIDE_APIGATEWAY: "next_gen"
-            TEST_PATH: "tests/aws/services/apigateway/"
-            COVERAGE_ARGS: "-p"
-          command: |
-            COVERAGE_FILE="target/coverage/.coverage.apigwNG.${CIRCLE_NODE_INDEX}" \
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/apigw_ng.xml -o junit_suite_name='apigw_ng'" \
-            make test-coverage
-      - persist_to_workspace:
-          root:
-            /tmp/workspace
-          paths:
-            - repo/target/coverage/
-      - store_test_results:
-          path: target/reports/
-
   # Regression testing for ESM v1 until scheduled removal for v4.0
   itest-lambda-event-source-mapping-v1-feature:
     executor: ubuntu-machine-amd64
@@ -980,10 +950,6 @@ workflows:
           requires:
             - preflight
             - test-selection
-      - itest-apigw-ng-provider:
-          requires:
-            - preflight
-            - test-selection
       - itest-lambda-event-source-mapping-v1-feature:
           requires:
             - preflight
@@ -1053,7 +1019,6 @@ workflows:
             - itest-sfn-legacy-provider
             - itest-cloudwatch-v1-provider
             - itest-events-v2-provider
-            - itest-apigw-ng-provider
             - itest-ddb-v2-provider
             - itest-lambda-event-source-mapping-v1-feature
             - acceptance-tests-amd64
@@ -1070,7 +1035,6 @@ workflows:
             - itest-sfn-legacy-provider
             - itest-cloudwatch-v1-provider
             - itest-events-v2-provider
-            - itest-apigw-ng-provider
             - itest-ddb-v2-provider
             - itest-lambda-event-source-mapping-v1-feature
             - acceptance-tests-amd64


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #11035, this PR removes the APIGW NG CI step now that it is default.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- remove the APIGW NG CI job

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
