### PR TITLE
fix APIGW oneOf and add APIGW test for Model $ref resolving

### DIFF
--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -261,6 +261,10 @@ class ModelResolver:
 
                 elif isinstance(value, dict):
                     _look_for_ref(value)
+                elif isinstance(value, list):
+                    for val in value:
+                        if isinstance(val, dict):
+                            _look_for_ref(val)
 
         if isinstance(resolved_model, dict):
             _look_for_ref(resolved_model)

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -1,5 +1,6 @@
 import json
 import time
+from operator import itemgetter
 
 import pytest
 import requests
@@ -332,6 +333,123 @@ class TestApiGatewayCommon:
         # GET request with an empty body
         response_get = requests.get(url)
         assert response_get.ok
+
+    @markers.aws.validated
+    def test_api_gateway_request_validator_with_ref_models(
+        self, create_rest_apigw, apigw_redeploy_api, snapshot, aws_client
+    ):
+        api_id, _, root = create_rest_apigw(name="test ref models")
+
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("id"),
+                snapshot.transform.regex(api_id, "<api-id>"),
+            ]
+        )
+
+        resource_id = aws_client.apigateway.create_resource(
+            restApiId=api_id, parentId=root, pathPart="path"
+        )["id"]
+
+        validator_id = aws_client.apigateway.create_request_validator(
+            restApiId=api_id,
+            name="test-validator",
+            validateRequestParameters=True,
+            validateRequestBody=True,
+        )["id"]
+
+        # create nested Model schema to validate body
+        aws_client.apigateway.create_model(
+            restApiId=api_id,
+            name="testSchema",
+            contentType="application/json",
+            schema=json.dumps(
+                {
+                    "$schema": "http://json-schema.org/draft-04/schema#",
+                    "title": "testSchema",
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "number"},
+                        "b": {"type": "number"},
+                    },
+                    "required": ["a", "b"],
+                }
+            ),
+        )
+
+        aws_client.apigateway.create_model(
+            restApiId=api_id,
+            name="testSchemaList",
+            contentType="application/json",
+            schema=json.dumps(
+                {
+                    "type": "array",
+                    "items": {
+                        # hardcoded URL to AWS
+                        "$ref": f"https://apigateway.amazonaws.com/restapis/{api_id}/models/testSchema"
+                    },
+                }
+            ),
+        )
+
+        get_models = aws_client.apigateway.get_models(restApiId=api_id)
+        get_models["items"] = sorted(get_models["items"], key=itemgetter("name"))
+        snapshot.match("get-models-with-ref", get_models)
+
+        aws_client.apigateway.put_method(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            authorizationType="NONE",
+            requestValidatorId=validator_id,
+            requestModels={"application/json": "testSchemaList"},
+        )
+
+        aws_client.apigateway.put_method_response(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            statusCode="200",
+        )
+
+        aws_client.apigateway.put_integration(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            type="MOCK",
+            requestTemplates={"application/json": '{"statusCode": 200}'},
+        )
+
+        aws_client.apigateway.put_integration_response(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            statusCode="200",
+            selectionPattern="",
+            responseTemplates={"application/json": json.dumps({"data": "ok"})},
+        )
+
+        stage_name = "local"
+        aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
+
+        url = api_invoke_url(api_id, stage=stage_name, path="/path")
+
+        def invoke_api(_data: dict) -> dict:
+            _response = requests.post(url, verify=False, json=_data)
+            assert _response.ok
+            content = _response.json()
+            return content
+
+        # test that with every request parameters and a valid body, it passes
+        response = retry(
+            invoke_api, retries=10 if is_aws_cloud() else 3, sleep=1, _data=[{"a": 1, "b": 2}]
+        )
+        snapshot.match("successful", response)
+
+        # GET request with no body
+        response_post_no_body = requests.post(url)
+        assert response_post_no_body.status_code == 400
+        snapshot.match("failed-validation", response_post_no_body.json())
 
     @markers.aws.validated
     def test_integration_request_parameters_mapping(

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -1281,5 +1281,100 @@
         "message": "Invalid request body"
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator_with_ref_one_ofmodels": {
+    "recorded-date": "28-10-2024, 23:12:21",
+    "recorded-content": {
+      "get-models-with-ref": {
+        "items": [
+          {
+            "contentType": "application/json",
+            "description": "This is a default empty schema model",
+            "id": "<id:1>",
+            "name": "Empty",
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "title": "Empty Schema",
+              "type": "object"
+            }
+          },
+          {
+            "contentType": "application/json",
+            "description": "This is a default error schema model",
+            "id": "<id:2>",
+            "name": "Error",
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "title": "Error Schema",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          {
+            "contentType": "application/json",
+            "id": "<id:3>",
+            "name": "StatusModel",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "Status": {
+                  "type": "string"
+                },
+                "Order": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "Status",
+                "Order"
+              ]
+            }
+          },
+          {
+            "contentType": "application/json",
+            "id": "<id:4>",
+            "name": "TestModel",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "https://apigateway.amazonaws.com/restapis/<api-id>/models/StatusModel"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "status"
+              ]
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "successful": {
+        "data": "ok"
+      },
+      "successful-with-data": {
+        "data": "ok"
+      },
+      "failed-validation-no-data": {
+        "message": "Invalid request body"
+      },
+      "failed-validation-bad-data": {
+        "message": "Invalid request body"
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -1202,5 +1202,84 @@
         "x-cache": "Miss from cloudfront"
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator_with_ref_models": {
+    "recorded-date": "28-10-2024, 17:37:06",
+    "recorded-content": {
+      "get-models-with-ref": {
+        "items": [
+          {
+            "contentType": "application/json",
+            "description": "This is a default empty schema model",
+            "id": "<id:1>",
+            "name": "Empty",
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "title": "Empty Schema",
+              "type": "object"
+            }
+          },
+          {
+            "contentType": "application/json",
+            "description": "This is a default error schema model",
+            "id": "<id:2>",
+            "name": "Error",
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "title": "Error Schema",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          {
+            "contentType": "application/json",
+            "id": "<id:3>",
+            "name": "testSchema",
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "title": "testSchema",
+              "type": "object",
+              "properties": {
+                "a": {
+                  "type": "number"
+                },
+                "b": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "a",
+                "b"
+              ]
+            }
+          },
+          {
+            "contentType": "application/json",
+            "id": "<id:4>",
+            "name": "testSchemaList",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "https://apigateway.amazonaws.com/restapis/<api-id>/models/testSchema"
+              }
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "successful": {
+        "data": "ok"
+      },
+      "failed-validation": {
+        "message": "Invalid request body"
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator": {
     "last_validated_date": "2024-01-10T00:06:10+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator_with_ref_models": {
+    "last_validated_date": "2024-10-28T17:37:06+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_integration_request_parameters_mapping": {
     "last_validated_date": "2024-02-05T19:37:03+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator_with_ref_models": {
     "last_validated_date": "2024-10-28T17:37:06+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator_with_ref_one_ofmodels": {
+    "last_validated_date": "2024-10-28T23:12:21+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_integration_request_parameters_mapping": {
     "last_validated_date": "2024-02-05T19:37:03+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The same issue as  #9631 was reported in #11755. I've implemented 2 tests to validate the behavior, and the main issue is that we were not properly replacing the `$ref` in lists, leading to the `jsonschema` library directly trying to reach the link. We could probably also remove the custom model resolving, and do a regex sub on the `https://apigateway.amazonaws.com` string and replace by the LocalStack edge, but still not sure it would work, as the first reported issue still had problems resolving it.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix the logic to also resolve `$ref` inside JSON arrays
- add 2 tests related to `$ref` resolving, one regular and one with `oneOf` property

_fixes #11755 and fixes #9631_

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
