### PR TITLE
Convert SQS test util into re-usable fixture sqs_collect_messages

### DIFF
--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -33,8 +33,6 @@ from localstack.utils.urls import localstack_host
 from tests.aws.services.lambda_.functions import lambda_integration
 from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON
 
-from .utils import sqs_collect_messages
-
 if TYPE_CHECKING:
     from mypy_boto3_sqs import SQSClient
 
@@ -2936,6 +2934,7 @@ class TestSqsProvider:
         sqs_create_queue,
         sqs_get_queue_arn,
         snapshot,
+        sqs_collect_messages,
     ):
         sqs = aws_client.sqs
 
@@ -2990,7 +2989,6 @@ class TestSqsProvider:
         snapshot.match("rec-pre-dlq", messages)
 
         messages = sqs_collect_messages(
-            sqs,
             dl_queue_url,
             expected=2,
             timeout=10,

--- a/tests/aws/services/sqs/utils.py
+++ b/tests/aws/services/sqs/utils.py
@@ -4,45 +4,6 @@ from localstack.utils.sync import poll_condition
 
 if TYPE_CHECKING:
     from mypy_boto3_sqs import SQSClient
-    from mypy_boto3_sqs.type_defs import MessageTypeDef
-
-
-def sqs_collect_messages(
-    sqs_client: "SQSClient",
-    queue_url: str,
-    expected: int,
-    timeout: int,
-    delete: bool = True,
-    attribute_names: list[str] = None,
-    message_attribute_names: list[str] = None,
-) -> list["MessageTypeDef"]:
-    collected = []
-
-    def _receive():
-        response = sqs_client.receive_message(
-            QueueUrl=queue_url,
-            # try not to wait too long, but also not poll too often
-            WaitTimeSeconds=min(max(1, timeout), 5),
-            MaxNumberOfMessages=1,
-            AttributeNames=attribute_names or [],
-            MessageAttributeNames=message_attribute_names or [],
-        )
-
-        if messages := response.get("Messages"):
-            collected.extend(messages)
-
-            if delete:
-                for m in messages:
-                    sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=m["ReceiptHandle"])
-
-        return len(collected) >= expected
-
-    if not poll_condition(_receive, timeout=timeout):
-        raise TimeoutError(
-            f"gave up waiting for messages (expected={expected}, actual={len(collected)}"
-        )
-
-    return collected
 
 
 def get_approx_number_of_messages(


### PR DESCRIPTION
## Motivation

Collecting SQS messages is a common task in LocalStack testing and we don't have a re-usable fixture (across LS and LS-ext) yet. The fixture is used in a LS-ext PR for testing Pipes persistence.

## Changes

* Convert SQS helper util into re-usable fixture `sqs_collect_messages`

## Discussion

When should we use fixtures and when util/helper methods (passing in an aws_client)?
