### PR TITLE
APIGW NG: add LocalStack-only CORS handling for REST API

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway.py
@@ -32,15 +32,16 @@ class RestApiGateway(Gateway):
                 handlers.method_response_handler,
             ]
         )
-        self.response_handlers.extend(
-            [
-                handlers.response_enricher
-                # add composite response handlers?
-            ]
-        )
         self.exception_handlers.extend(
             [
                 handlers.gateway_exception_handler,
+            ]
+        )
+        self.response_handlers.extend(
+            [
+                handlers.response_enricher,
+                handlers.cors_response_enricher,
+                # add composite response handlers?
             ]
         )
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/__init__.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/__init__.py
@@ -1,6 +1,7 @@
 from rolo.gateway import CompositeHandler
 
 from .api_key_validation import ApiKeyValidationHandler
+from .cors import CorsResponseEnricher
 from .gateway_exception import GatewayExceptionHandler
 from .integration import IntegrationHandler
 from .integration_request import IntegrationRequestHandler
@@ -23,3 +24,4 @@ method_response_handler = MethodResponseHandler()
 gateway_exception_handler = GatewayExceptionHandler()
 api_key_validation_handler = ApiKeyValidationHandler()
 response_enricher = InvocationResponseEnricher()
+cors_response_enricher = CorsResponseEnricher()

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/cors.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/cors.py
@@ -1,0 +1,49 @@
+import logging
+from http import HTTPMethod
+
+from localstack import config
+from localstack.aws.handlers.cors import CorsEnforcer
+from localstack.aws.handlers.cors import CorsResponseEnricher as GlobalCorsResponseEnricher
+from localstack.http import Response
+
+from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
+from ..context import RestApiInvocationContext
+from ..gateway_response import MissingAuthTokenError
+
+LOG = logging.getLogger(__name__)
+
+
+class CorsResponseEnricher(RestApiGatewayHandler):
+    def __call__(
+        self,
+        chain: RestApiGatewayHandlerChain,
+        context: RestApiInvocationContext,
+        response: Response,
+    ):
+        """
+        This is a LocalStack only handler, to allow users to override API Gateway CORS configuration and just use the
+        default LocalStack configuration instead, to ease the usage and reduce production code changes.
+        """
+        if not config.DISABLE_CUSTOM_CORS_APIGATEWAY:
+            return
+
+        if not context.invocation_request:
+            return
+
+        headers = context.invocation_request["headers"]
+
+        if "Origin" not in headers:
+            return
+
+        if context.request.method == HTTPMethod.OPTIONS:
+            # If the user did not configure an OPTIONS route, we still want LocalStack to properly respond to CORS
+            # requests
+            if context.invocation_exception:
+                if isinstance(context.invocation_exception, MissingAuthTokenError):
+                    response.data = b""
+                    response.status_code = 204
+                else:
+                    return
+
+        if CorsEnforcer.is_cors_origin_allowed(headers):
+            GlobalCorsResponseEnricher.add_cors_headers(headers, response.headers)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We currently have special logic in `localstack/aws/handlers/cors.py`, special for S3 and API Gateway who can self manage their CORS behavior.

In order to guess that we are going to target an edge route, we currently have custom logic in `should_enforce_self_managed_service`, which uses some heuristic to guess it and let the CORS handler do its thing. 

However, this does not catch every API Gateway routes, especially the ones related to custom domains. It would be good to move most of the CORS related logic for those "self-managed" services inside the service itself, like we have done for S3: meaning that if the config flag to disable it is enabled, we should let the service apply the global LocalStack CORS logic in its own way (as they most probably already have logic in place for it). 

We have the `DISABLE_CUSTOM_CORS_APIGATEWAY` flag to disable the CORS handling of API Gateway, and try to apply the default LocalStack CORS logic to API Gateway routes, allowing users to disregard and not modify their lambda for example for the `AWS_PROXY` (managing CORS for REST API can be quite a pain, see https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-cors.html). This specific handler will be executed only if the flag is on, and is meant to properly apply the CORS headers in all situations for the API Gateway edge routes. 

It also also allows us to have custom logic for the `OPTIONS` request, for example. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a custom CORS handler for APIGW NextGen
- we currently already have tests for the CORS handling when `config.DISABLE_CUSTOM_CORS_APIGATEWAY` is set, and the pipeline is green
- we also will have custom tests in the upstream repo

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
