### PR TITLE
migrate to LOCALSTACK_AUTH_TOKEN

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -309,7 +309,7 @@ jobs:
         env:
           DEBUG: 1
           DNS_ADDRESS: 0
-          LOCALSTACK_API_KEY: "test"
+          LOCALSTACK_AUTH_TOKEN: "test"
         working-directory: localstack-ext
         run: |
           source .venv/bin/activate
@@ -338,7 +338,7 @@ jobs:
           DISABLE_BOTO_RETRIES: 1
           DNS_ADDRESS: 0
           LAMBDA_EXECUTOR: "local"
-          LOCALSTACK_API_KEY: "test"
+          LOCALSTACK_AUTH_TOKEN: "test"
           AWS_SECRET_ACCESS_KEY: "test"
           AWS_ACCESS_KEY_ID: "test"
           AWS_DEFAULT_REGION: "us-east-1"

--- a/localstack-core/localstack/dev/kubernetes/__main__.py
+++ b/localstack-core/localstack/dev/kubernetes/__main__.py
@@ -122,7 +122,7 @@ def generate_k8s_cluster_overrides(
     if pro:
         extra_env_vars.append(
             {
-                "name": "LOCALSTACK_API_KEY",
+                "name": "LOCALSTACK_AUTH_TOKEN",
                 "value": "test",
             }
         )

--- a/localstack-core/localstack/dev/run/__main__.py
+++ b/localstack-core/localstack/dev/run/__main__.py
@@ -139,7 +139,7 @@ def run(
 
     \b
         python -m localstack.dev.run
-        python -m localstack.dev.run -e DEBUG=1 -e LOCALSTACK_API_KEY=test
+        python -m localstack.dev.run -e DEBUG=1 -e LOCALSTACK_AUTH_TOKEN=test
         python -m localstack.dev.run -- bash -c 'echo "hello"'
 
     Explanations and more examples:
@@ -151,7 +151,7 @@ def run(
 
     If you start localstack-pro, you might also want to add the API KEY as environment variable::
 
-        python -m localstack.dev.run -e DEBUG=1 -e LOCALSTACK_API_KEY=test
+        python -m localstack.dev.run -e DEBUG=1 -e LOCALSTACK_AUTH_TOKEN=test
 
     If your local changes are making modifications to plux plugins (e.g., adding new providers or hooks),
     then you also want to mount the newly generated entry_point.txt files into the container::

--- a/localstack-core/localstack/testing/pytest/container.py
+++ b/localstack-core/localstack/testing/pytest/container.py
@@ -61,8 +61,8 @@ class ContainerFactory:
         # handle the convenience options
         if pro:
             container_configuration.env_vars["GATEWAY_LISTEN"] = "0.0.0.0:4566,0.0.0.0:443"
-            container_configuration.env_vars["LOCALSTACK_API_KEY"] = os.environ.get(
-                "LOCALSTACK_API_KEY", "test"
+            container_configuration.env_vars["LOCALSTACK_AUTH_TOKEN"] = os.environ.get(
+                "LOCALSTACK_AUTH_TOKEN", "test"
             )
 
         # override values from kwargs

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -455,7 +455,7 @@ def get_docker_image_to_start():
     image_name = os.environ.get("IMAGE_NAME")
     if not image_name:
         image_name = constants.DOCKER_IMAGE_NAME
-        if is_api_key_configured():
+        if is_auth_token_configured():
             image_name = constants.DOCKER_IMAGE_NAME_PRO
     return image_name
 
@@ -1358,10 +1358,11 @@ def in_ci():
     return False
 
 
-def is_api_key_configured() -> bool:
+def is_auth_token_configured() -> bool:
     """Whether an API key is set in the environment."""
     return (
         True
-        if os.environ.get("LOCALSTACK_API_KEY") and os.environ.get("LOCALSTACK_API_KEY").strip()
+        if os.environ.get("LOCALSTACK_AUTH_TOKEN")
+        and os.environ.get("LOCALSTACK_AUTH_TOKEN").strip()
         else False
     )

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -1362,7 +1362,7 @@ def is_auth_token_configured() -> bool:
     """Whether an API key is set in the environment."""
     return (
         True
-        if os.environ.get("LOCALSTACK_AUTH_TOKEN")
-        and os.environ.get("LOCALSTACK_AUTH_TOKEN").strip()
+        if os.environ.get("LOCALSTACK_AUTH_TOKEN", "").strip()
+        or os.environ.get("LOCALSTACK_API_KEY", "").strip()
         else False
     )

--- a/tests/bootstrap/test_container_configurators.py
+++ b/tests/bootstrap/test_container_configurators.py
@@ -116,6 +116,7 @@ def test_default_localstack_container_configurator(
     from localstack import config
 
     monkeypatch.setenv("DEBUG", "1")
+    monkeypatch.setenv("LOCALSTACK_AUTH_TOKEN", "")
     monkeypatch.setenv("LOCALSTACK_API_KEY", "")
     monkeypatch.setenv("ACTIVATE_PRO", "0")
     monkeypatch.setattr(config, "DEBUG", True)

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -168,7 +168,7 @@ services:
       - SERVICES=${SERVICES- }
       - DEBUG=${DEBUG- }
       - DATA_DIR=${DATA_DIR- }
-      - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY- }
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN- }
       - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:


### PR DESCRIPTION
## Motivation
With the upcoming release of LocalStack v4, we will push the deprecation of `LOCALSTACK_API_KEY` in favor of `LOCALSTACK_AUTH_TOKEN`.
This PR prepares this deprecation by migrating all usages of the API key in favor of the auth token.
This change does _not_ introduce any deprecation message yet. 

## Changes
- Use `LOCALSTACK_AUTH_TOKEN` instead of `LOCALSTACK_API_KEY` wherever possible.
- Avoid directing users to set a `LOCALSTACK_API_KEY` in case no credentials are set.

/cc @Pive01 @SimonWallner 