### PR TITLE
fix S3 enabling versioning with a ObjectLockEnabledForBucket bucket

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -2680,13 +2680,13 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 message="The Versioning element must be specified",
             )
 
-        if s3_bucket.object_lock_enabled:
+        if versioning_status not in ("Enabled", "Suspended"):
+            raise MalformedXML()
+
+        if s3_bucket.object_lock_enabled and versioning_status == "Suspended":
             raise InvalidBucketState(
                 "An Object Lock configuration is present on this bucket, so the versioning state cannot be changed."
             )
-
-        if versioning_status not in ("Enabled", "Suspended"):
-            raise MalformedXML()
 
         if not s3_bucket.versioning_status:
             s3_bucket.objects = VersionedKeyStore.from_key_store(s3_bucket.objects)

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -1572,15 +1572,23 @@ class TestS3ObjectLock:
         reason="Moto implementation does not raise exceptions",
     )
     def test_disable_versioning_on_locked_bucket(self, s3_create_bucket, aws_client, snapshot):
-        s3_bucket = s3_create_bucket(ObjectLockEnabledForBucket=True)
+        bucket_name = s3_create_bucket(ObjectLockEnabledForBucket=True)
         with pytest.raises(ClientError) as e:
             aws_client.s3.put_bucket_versioning(
-                Bucket=s3_bucket,
+                Bucket=bucket_name,
                 VersioningConfiguration={
                     "Status": "Suspended",
                 },
             )
         snapshot.match("disable-versioning-on-locked-bucket", e.value.response)
+
+        put_bucket_versioning_again = aws_client.s3.put_bucket_versioning(
+            Bucket=bucket_name,
+            VersioningConfiguration={
+                "Status": "Enabled",
+            },
+        )
+        snapshot.match("enable-versioning-again-on-locked-bucket", put_bucket_versioning_again)
 
     @markers.aws.validated
     def test_delete_object_with_no_locking(self, s3_bucket, aws_client, snapshot):

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -2407,7 +2407,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectLock::test_disable_versioning_on_locked_bucket": {
-    "recorded-date": "09-08-2023, 03:49:49",
+    "recorded-date": "31-10-2024, 12:29:03",
     "recorded-content": {
       "disable-versioning-on-locked-bucket": {
         "Error": {
@@ -2417,6 +2417,12 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 409
+        }
+      },
+      "enable-versioning-again-on-locked-bucket": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -105,7 +105,7 @@
     "last_validated_date": "2023-09-08T16:29:03+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectLock::test_disable_versioning_on_locked_bucket": {
-    "last_validated_date": "2023-08-09T01:49:49+00:00"
+    "last_validated_date": "2024-10-31T12:29:03+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectLock::test_get_object_lock_configuration_exc": {
     "last_validated_date": "2023-08-08T23:41:42+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Raised from a support issue with a Crossplane integration. 

We would raise `InvalidBucketState: An Object Lock configuration is present on this bucket, so the versioning state cannot be changed` when setting up a bucket with both versioning and ObjectLock enabled. I've adapted a test case to reproduce this case, where enabling versioning on a bucket that already has it enabled via`ObjectLockEnabledForBucket` set to `True`, does not trigger an exception because it's effectively a null operation.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- adapt a test to reproduce the exception
- modify the logic so that we only block changing the status to `Suspended`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
