### PR TITLE
Fix typo `str.rsplit`

### DIFF
--- a/localstack-core/localstack/services/kms/utils.py
+++ b/localstack-core/localstack/services/kms/utils.py
@@ -14,7 +14,7 @@ def get_hash_algorithm(signing_algorithm: str) -> str:
     Return the hashing algorithm for a given signing algorithm.
     eg. "RSASSA_PSS_SHA_512" -> "SHA_512"
     """
-    return "_".join(signing_algorithm.rsplit(sep="_", maxsplit=-2)[-2:])
+    return "_".join(signing_algorithm.rsplit(sep="_", maxsplit=2)[-2:])
 
 
 def parse_key_arn(key_arn: str) -> Tuple[str, str, str]:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Minor bug: `maxsplit` in `str.split` with negative numbers defaults to `maxsplit=0`, which is the default.
The author probably intended `maxsplit=2` as only the last two elements are required.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
