### PR TITLE
Add context manager to id generator

### DIFF
--- a/localstack-core/localstack/utils/id_generator.py
+++ b/localstack-core/localstack/utils/id_generator.py
@@ -19,9 +19,10 @@ class LocalstackIdManager(MotoIdManager):
 
     @contextmanager
     def custom_id(self, resource_identifier: ResourceIdentifier, custom_id: str) -> None:
-        yield self.set_custom_id(resource_identifier, custom_id)
-
-        self.unset_custom_id(resource_identifier)
+        try:
+            yield self.set_custom_id(resource_identifier, custom_id)
+        finally:
+            self.unset_custom_id(resource_identifier)
 
 
 localstack_id_manager = LocalstackIdManager()

--- a/localstack-core/localstack/utils/id_generator.py
+++ b/localstack-core/localstack/utils/id_generator.py
@@ -1,8 +1,9 @@
 import random
 import string
+from contextlib import contextmanager
 
 from moto.utilities import id_generator as moto_id_generator
-from moto.utilities.id_generator import MotoIdManager, moto_id
+from moto.utilities.id_generator import MotoIdManager, ResourceIdentifier, moto_id
 from moto.utilities.id_generator import ResourceIdentifier as MotoResourceIdentifier
 
 from localstack.utils.strings import long_uid, short_uid
@@ -15,6 +16,12 @@ class LocalstackIdManager(MotoIdManager):
     def set_custom_id_by_unique_identifier(self, unique_identifier: str, custom_id: str):
         with self._lock:
             self._custom_ids[unique_identifier] = custom_id
+
+    @contextmanager
+    def custom_id(self, resource_identifier: ResourceIdentifier, custom_id: str) -> None:
+        yield self.set_custom_id(resource_identifier, custom_id)
+
+        self.unset_custom_id(resource_identifier)
 
 
 localstack_id_manager = LocalstackIdManager()

--- a/tests/unit/utils/test_id_generator.py
+++ b/tests/unit/utils/test_id_generator.py
@@ -119,3 +119,13 @@ def test_generate_from_unique_identifier_string(
 
     generated = generate_str_id(default_resource_identifier)
     assert generated == custom_id
+
+
+def test_custom_id_context_manager(default_resource_identifier):
+    custom_id = "set_id"
+    with localstack_id_manager.custom_id(default_resource_identifier, custom_id):
+        # Within context, the custom id is used
+        assert default_resource_identifier.generate() == custom_id
+
+    # Outside the context the id is no longer present and a random id is generated
+    assert default_resource_identifier.generate() != custom_id

--- a/tests/unit/utils/test_id_generator.py
+++ b/tests/unit/utils/test_id_generator.py
@@ -129,3 +129,14 @@ def test_custom_id_context_manager(default_resource_identifier):
 
     # Outside the context the id is no longer present and a random id is generated
     assert default_resource_identifier.generate() != custom_id
+
+
+def test_custom_id_context_manager_exception_handling(default_resource_identifier):
+    custom_id = "set_id"
+
+    with pytest.raises(Exception):
+        with localstack_id_manager.custom_id(default_resource_identifier, custom_id):
+            assert default_resource_identifier.generate() == custom_id
+            raise Exception()
+
+    assert default_resource_identifier.generate() != custom_id


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Adding a context manager to allow for a streamlined usage of the id manager where a resource unsets after use.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
