### PR TITLE
Remove legacy StepFunctions CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,36 +431,6 @@ jobs:
   ######################
   ## Custom Test Jobs ##
   ######################
-  itest-sfn-legacy-provider:
-    executor: ubuntu-machine-amd64
-    working_directory: /tmp/workspace/repo
-    environment:
-      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
-    steps:
-      - prepare-acceptance-tests
-      - attach_workspace:
-          at: /tmp/workspace
-      - prepare-testselection
-      - prepare-pytest-tinybird
-      - prepare-account-region-randomization
-      - run:
-          name: Test SFN Legacy provider
-          environment:
-            PROVIDER_OVERRIDE_STEPFUNCTIONS: "legacy"
-            TEST_PATH: "tests/aws/services/stepfunctions/legacy/"
-            COVERAGE_ARGS: "-p"
-          command: |
-            COVERAGE_FILE="target/coverage/.coverage.sfnlegacy.${CIRCLE_NODE_INDEX}" \
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/sfn_legacy.xml -o junit_suite_name='sfn_legacy'" \
-            make test-coverage
-      - persist_to_workspace:
-          root:
-            /tmp/workspace
-          paths:
-            - repo/target/coverage/
-      - store_test_results:
-          path: target/reports/
-
   itest-cloudwatch-v1-provider:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -968,10 +938,6 @@ workflows:
       - test-selection:
           requires:
             - install
-      - itest-sfn-legacy-provider:
-          requires:
-            - preflight
-            - test-selection
       - itest-cloudwatch-v1-provider:
           requires:
             - preflight
@@ -1050,7 +1016,6 @@ workflows:
             - docker-build-amd64
       - report:
           requires:
-            - itest-sfn-legacy-provider
             - itest-cloudwatch-v1-provider
             - itest-events-v2-provider
             - itest-apigw-ng-provider
@@ -1067,7 +1032,6 @@ workflows:
             branches:
               only: master
           requires:
-            - itest-sfn-legacy-provider
             - itest-cloudwatch-v1-provider
             - itest-events-v2-provider
             - itest-apigw-ng-provider


### PR DESCRIPTION
## Motivation

We can remove the CI step earlier to minimize the changes in the PR removing the legacy StepFunctions provider (https://github.com/localstack/localstack/pull/11733) and mitigate merge conflicts.
Learned from the S3 example by @bentsku https://github.com/localstack/localstack/pull/11743

## Changes

* remove the legacy StepFunction CI job