### PR TITLE
Remove legacy ESM CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,37 +551,6 @@ jobs:
       - store_test_results:
           path: target/reports/
 
-  # Regression testing for ESM v1 until scheduled removal for v4.0
-  itest-lambda-event-source-mapping-v1-feature:
-    executor: ubuntu-machine-amd64
-    working_directory: /tmp/workspace/repo
-    environment:
-      PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
-    steps:
-      - prepare-acceptance-tests
-      - attach_workspace:
-          at: /tmp/workspace
-      - prepare-testselection
-      - prepare-pytest-tinybird
-      - prepare-account-region-randomization
-      - run:
-          name: Test Lambda Event Source Mapping v1 feature
-          environment:
-            LAMBDA_EVENT_SOURCE_MAPPING: "v1"
-            TEST_PATH: "tests/aws/services/lambda_/event_source_mapping"
-            COVERAGE_ARGS: "-p"
-          command: |
-            COVERAGE_FILE="target/coverage/.coverage.lambda_event_source_mappingV2.${CIRCLE_NODE_INDEX}" \
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/lambda_event_source_mapping_v2.xml -o junit_suite_name='lambda_event_source_mapping_v2'" \
-            make test-coverage
-      - persist_to_workspace:
-          root:
-            /tmp/workspace
-          paths:
-            - repo/target/coverage/
-      - store_test_results:
-          path: target/reports/
-
   itest-ddb-v2-provider:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -984,10 +953,6 @@ workflows:
           requires:
             - preflight
             - test-selection
-      - itest-lambda-event-source-mapping-v1-feature:
-          requires:
-            - preflight
-            - test-selection
       - itest-ddb-v2-provider:
           requires:
             - preflight
@@ -1055,7 +1020,6 @@ workflows:
             - itest-events-v2-provider
             - itest-apigw-ng-provider
             - itest-ddb-v2-provider
-            - itest-lambda-event-source-mapping-v1-feature
             - acceptance-tests-amd64
             - acceptance-tests-arm64
             - integration-tests-amd64
@@ -1072,7 +1036,6 @@ workflows:
             - itest-events-v2-provider
             - itest-apigw-ng-provider
             - itest-ddb-v2-provider
-            - itest-lambda-event-source-mapping-v1-feature
             - acceptance-tests-amd64
             - acceptance-tests-arm64
             - integration-tests-amd64


### PR DESCRIPTION
## Motivation

We can remove the CI step earlier to minimize the changes in the PR removing the legacy ESM feature (https://github.com/localstack/localstack/pull/11733) and mitigate merge conflicts.
Learned from the S3 example by @bentsku https://github.com/localstack/localstack/pull/11743

## Changes

* remove the legacy ESM CI job