### PR TITLE
APIGW: fix importing API with Cognito Authorizer

### DIFF
--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -537,7 +537,7 @@ def import_api_from_openapi_spec(
                 name=security_scheme_name,
                 type=authorizer_type,
                 authorizerResultTtlInSeconds=aws_apigateway_authorizer.get(
-                    "authorizerResultTtlInSeconds", 300
+                    "authorizerResultTtlInSeconds", None
                 ),
             )
             if provider_arns := aws_apigateway_authorizer.get("providerARNs"):
@@ -548,7 +548,7 @@ def import_api_from_openapi_spec(
                 authorizer["authorizerUri"] = authorizer_uri
             if authorizer_credentials := aws_apigateway_authorizer.get("authorizerCredentials"):
                 authorizer["authorizerCredentials"] = authorizer_credentials
-            if authorizer_type == "TOKEN":
+            if authorizer_type in ("TOKEN", "COGNITO_USER_POOLS"):
                 header_name = security_config.get("name")
                 authorizer["identitySource"] = f"method.request.header.{header_name}"
             elif identity_source := aws_apigateway_authorizer.get("identitySource"):

--- a/tests/aws/files/openapi.cognito-auth.json
+++ b/tests/aws/files/openapi.cognito-auth.json
@@ -1,0 +1,97 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Example Pet Store",
+    "description": "A Pet Store API.",
+    "version": "1.0"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "operationId": "GET HTTP",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pets"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "HTTP_PROXY",
+          "httpMethod": "GET",
+          "uri": "http://petstore.execute-api.us-west-1.amazonaws.com/petstore/pets",
+          "payloadFormatVersion": 1.0
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "cognito-test-identity-source": {
+        "type": "apiKey",
+        "name": "TestHeaderAuth",
+        "in": "header",
+        "x-amazon-apigateway-authtype": "cognito_user_pools",
+        "x-amazon-apigateway-authorizer": {
+          "type": "cognito_user_pools",
+          "providerARNs": [
+            "${cognito_pool_arn}"
+          ]
+        }
+      }
+    },
+    "schemas": {
+      "Pets": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Pet"
+        }
+      },
+      "Empty": {
+        "type": "object"
+      },
+      "Pet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -4808,5 +4808,47 @@
         "message": "Internal server error"
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_cognito_auth_identity_source": {
+    "recorded-date": "05-11-2024, 11:37:35",
+    "recorded-content": {
+      "import-swagger": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "A Pet Store API.",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<rest-id:1>",
+        "name": "Example Pet Store",
+        "rootResourceId": "<root-resource-id:1>",
+        "version": "1.0",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-authorizers": {
+        "items": [
+          {
+            "authType": "cognito_user_pools",
+            "id": "<authorizer-id:1>",
+            "identitySource": "method.request.header.TestHeaderAuth",
+            "name": "cognito-test-identity-source",
+            "providerARNs": [
+              "arn:<partition>:cognito-idp:<region>:111111111111:userpool/<region>_ABC123"
+            ],
+            "type": "COGNITO_USER_POOLS"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -35,6 +35,9 @@
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_circular_models_and_request_validation": {
     "last_validated_date": "2024-04-15T21:37:44+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_cognito_auth_identity_source": {
+    "last_validated_date": "2024-11-05T11:37:34+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_global_api_key_authorizer": {
     "last_validated_date": "2024-04-15T21:36:29+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We got a report that import an API with the following configuration would fail with a cryptic error:
```python
localstack-test  | 2024-11-04T16:17:31.927  WARN --- [et.reactor-0] l.s.a.n.e.h.gateway_except : Non Gateway Exception raised: 'NoneType' object has no attribute 'startswith'
```

When the OpenAPI spec had the following:
```yaml
components:
  securitySchemes:
    EndpointAuthorizer:
      type: apiKey
      name: Authorization
      in: header
      x-amazon-apigateway-authtype: cognito_user_pools
      x-amazon-apigateway-authorizer:
        type: cognito_user_pools
        providerARNs:
          - arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${CognitoUserPool}
```

This was because we did not populate the `identitySource` of the Authorizer when the authorizer type was `cognito_user_pools`. 

As a note: we greatly improve the CRUD validation of the provider, but the `ImportApi` logic is not very well validated, and will probably lead to issue down the invocation road. We should dedicate some time to properly rework the import logic. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix the logic to properly get the `identitySource` if the auth type is `cognito_user_pools`
- add a test to verify that the CRUD layer works properly

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
