### PR TITLE
APIGW: fix MOCK integration with no URI and path parameters

### DIFF
--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -1928,6 +1928,10 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         response = call_moto_with_request(context, moto_request)
         remove_empty_attributes_from_integration(integration=response)
 
+        # TODO: should fix fundamentally once we move away from moto
+        if integration_type == "MOCK":
+            response.pop("uri", None)
+
         return response
 
     def update_integration(

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
@@ -58,7 +58,10 @@ def render_uri_with_stage_variables(
     return _stage_variable_pattern.sub(replace_match, uri)
 
 
-def render_uri_with_path_parameters(uri: str, path_parameters: dict[str, str]) -> str:
+def render_uri_with_path_parameters(uri: str | None, path_parameters: dict[str, str]) -> str | None:
+    if not uri:
+        return uri
+
     for key, value in path_parameters.items():
         uri = uri.replace(f"{{{key}}}", value)
 
@@ -66,7 +69,7 @@ def render_uri_with_path_parameters(uri: str, path_parameters: dict[str, str]) -
 
 
 def render_integration_uri(
-    uri: str, path_parameters: dict[str, str], stage_variables: dict[str, str]
+    uri: str | None, path_parameters: dict[str, str], stage_variables: dict[str, str]
 ) -> str:
     """
     A URI can contain different value to interpolate / render
@@ -83,6 +86,9 @@ def render_integration_uri(
     :param stage_variables: -
     :return: the rendered URI
     """
+    if not uri:
+        return ""
+
     uri_with_path = render_uri_with_path_parameters(uri, path_parameters)
     return render_uri_with_stage_variables(uri_with_path, stage_variables)
 

--- a/tests/aws/services/apigateway/test_apigateway_integrations.py
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.py
@@ -409,8 +409,6 @@ def test_put_integration_response_with_response_template(
     snapshot.match("get-integration-response", response)
 
 
-# TODO: Aws does not return the uri when creating a MOCK integration
-@markers.snapshot.skip_snapshot_verify(paths=["$..not-required-integration-method-MOCK.uri"])
 @markers.aws.validated
 def test_put_integration_validation(
     aws_client, account_id, region_name, create_rest_apigw, snapshot, partition
@@ -545,6 +543,75 @@ def test_put_integration_validation(
             integrationHttpMethod="POST",
         )
     snapshot.match("invalid-uri-invalid-arn", ex.value.response)
+
+
+@markers.aws.validated
+@pytest.mark.skipif(
+    condition=not is_next_gen_api(),
+    reason="Behavior is properly implemented in Legacy, it returns the MOCK response",
+)
+def test_integration_mock_with_path_param(create_rest_apigw, aws_client):
+    api_id, _, root = create_rest_apigw(
+        name=f"test-api-{short_uid()}",
+        description="this is my api",
+    )
+
+    rest_resource = aws_client.apigateway.create_resource(
+        restApiId=api_id,
+        parentId=root,
+        pathPart="{testPath}",
+    )
+    resource_id = rest_resource["id"]
+
+    aws_client.apigateway.put_method(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="GET",
+        authorizationType="none",
+        requestParameters={
+            "method.request.path.testPath": True,
+        },
+    )
+
+    aws_client.apigateway.put_method_response(
+        restApiId=api_id, resourceId=resource_id, httpMethod="GET", statusCode="200"
+    )
+
+    # you don't have to pass URI for Mock integration as it's not used anyway
+    # when exporting an API in AWS, apparently you can get integration path parameters even if not used
+    aws_client.apigateway.put_integration(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="GET",
+        integrationHttpMethod="POST",
+        type="MOCK",
+        requestParameters={
+            "integration.request.path.integrationPath": "method.request.path.testPath",
+        },
+        requestTemplates={"application/json": '{"statusCode": 200}'},
+    )
+
+    aws_client.apigateway.put_integration_response(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="GET",
+        statusCode="200",
+        selectionPattern="2\\d{2}",
+        responseTemplates={},
+    )
+    stage_name = "dev"
+    aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
+
+    invocation_url = api_invoke_url(api_id=api_id, stage=stage_name, path="/test-path")
+
+    def invoke_api(url) -> requests.Response:
+        _response = requests.get(url, verify=False)
+        assert _response.ok
+        return _response
+
+    response_data = retry(invoke_api, sleep=2, retries=10, url=invocation_url)
+    assert response_data.content == b""
+    assert response_data.status_code == 200
 
 
 @pytest.fixture

--- a/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
@@ -14,6 +14,9 @@
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_create_execute_api_vpc_endpoint": {
     "last_validated_date": "2024-04-15T23:07:07+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_path_param": {
+    "last_validated_date": "2024-11-05T12:55:51+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_put_integration_response_with_response_template": {
     "last_validated_date": "2024-05-30T16:15:58+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We got a report in our Slack Community channel about the legacy implementation. While switching to NextGen, another issue happened. This setup is from an exported OpenAPI spec from an AWS REST API. 

```python
2024-11-05T10:59:03.146  WARN --- [et.reactor-0] localstack.deprecations    : /restapis/<api_id>/<stage>/_user_request_ is deprecated (since 3.8.0) and will be removed in upcoming releases of LocalStack! Use /_aws/execute-api/<api_id>/<stage> instead.
2024-11-05T10:59:03.146935385Z 2024-11-05T10:59:03.146 DEBUG --- [et.reactor-0] l.s.a.n.execute_api.router : APIGW v1 Endpoint called
[...removed]
2024-11-05T10:59:03.165331385Z 2024-11-05T10:59:03.162  WARN --- [et.reactor-0] l.s.a.n.e.h.gateway_except : Non Gateway Exception raised: 'NoneType' object has no attribute 'replace'
2024-11-05T10:59:03.165356385Z Traceback (most recent call last):
2024-11-05T10:59:03.165381385Z   File "/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo/gateway/chain.py", line 166, in handle
2024-11-05T10:59:03.165403385Z     handler(self, self.context, response)
2024-11-05T10:59:03.165425385Z   File "/opt/code/localstack/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py", line 140, in __call__
2024-11-05T10:59:03.165447385Z     rendered_integration_uri = render_integration_uri(
2024-11-05T10:59:03.165468385Z                                ^^^^^^^^^^^^^^^^^^^^^^^
2024-11-05T10:59:03.165492385Z   File "/opt/code/localstack/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py", line 86, in render_integration_uri
2024-11-05T10:59:03.165512385Z     uri_with_path = render_uri_with_path_parameters(uri, path_parameters)
2024-11-05T10:59:03.165531385Z                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-05T10:59:03.165553385Z   File "/opt/code/localstack/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py", line 63, in render_uri_with_path_parameters
2024-11-05T10:59:03.165575385Z     uri = uri.replace(f"{{{key}}}", value)
2024-11-05T10:59:03.165596385Z           ^^^^^^^^^^^
2024-11-05T10:59:03.165618385Z AttributeError: 'NoneType' object has no attribute 'replace'
2024-11-05T10:59:03.166060385Z 2024-11-05T10:59:03.165  INFO --- [et.reactor-0] localstack.request.http    : POST /restapis/<api-id>/localstack/_user_request_/v1/journeys/<redacted>/applications => 500
```

Trying to understand what is happening, it seems this issue happens when a `MOCK` integration does not have a URI (normal behavior) and also has integration path parameters. 

The issue is fixed by skipping the logic and returning early. Those helper functions can be used alone or in combination, so the logic is in all of them. 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fixed the logic when the URI is `None`
- added a test to validate the fix and prevent regression

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
