### PR TITLE
Fix: CFn: support tags with ESMs

### DIFF
--- a/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_eventsourcemapping.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_eventsourcemapping.py
@@ -136,7 +136,6 @@ class LambdaEventSourceMappingProvider(ResourceProvider[LambdaEventSourceMapping
 
         response = lambda_client.create_event_source_mapping(**params)
         model["Id"] = response["UUID"]
-        model["EventSourceArn"] = response["EventSourceArn"]
         model["EventSourceMappingArn"] = response["EventSourceMappingArn"]
 
         return ProgressEvent(

--- a/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_eventsourcemapping.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_eventsourcemapping.py
@@ -136,7 +136,8 @@ class LambdaEventSourceMappingProvider(ResourceProvider[LambdaEventSourceMapping
 
         response = lambda_client.create_event_source_mapping(**params)
         model["Id"] = response["UUID"]
-        model["EventSourceArn"] = model["EventSourceMappingArn"] = response["EventSourceMappingArn"]
+        model["EventSourceArn"] = response["EventSourceArn"]
+        model["EventSourceMappingArn"] = response["EventSourceMappingArn"]
 
         return ProgressEvent(
             status=OperationStatus.SUCCESS,

--- a/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_eventsourcemapping.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_eventsourcemapping.py
@@ -1,6 +1,7 @@
 # LocalStack Resource Provider Scaffolding v2
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 from typing import Optional, TypedDict
 
@@ -126,8 +127,16 @@ class LambdaEventSourceMappingProvider(ResourceProvider[LambdaEventSourceMapping
         model = request.desired_state
         lambda_client = request.aws_client_factory.lambda_
 
-        response = lambda_client.create_event_source_mapping(**model)
+        params = copy.deepcopy(model)
+        if tags := params.get("Tags"):
+            transformed_tags = {}
+            for tag_definition in tags:
+                transformed_tags[tag_definition["Key"]] = tag_definition["Value"]
+            params["Tags"] = transformed_tags
+
+        response = lambda_client.create_event_source_mapping(**params)
         model["Id"] = response["UUID"]
+        model["EventSourceArn"] = model["EventSourceMappingArn"] = response["EventSourceMappingArn"]
 
         return ProgressEvent(
             status=OperationStatus.SUCCESS,

--- a/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py
@@ -25,6 +25,8 @@ def test_adding_tags(deploy_cfn_template, aws_client, snapshot):
         template_path=template_path,
         parameters={"OutputKey": output_key},
     )
+    snapshot.add_transformer(snapshot.transform.regex(stack.stack_id, "<stack-id>"))
+    snapshot.add_transformer(snapshot.transform.regex(stack.stack_name, "<stack-name>"))
 
     event_source_mapping_arn = stack.outputs["EventSourceMappingArn"]
     tags_response = aws_client.lambda_.list_tags(Resource=event_source_mapping_arn)

--- a/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py
@@ -1,0 +1,47 @@
+import json
+import os
+
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
+
+
+@markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        "$..Tags.'aws:cloudformation:logical-id'",
+        "$..Tags.'aws:cloudformation:stack-id'",
+        "$..Tags.'aws:cloudformation:stack-name'",
+    ]
+)
+@pytest.mark.skip(reason="WIP")
+def test_adding_tags(deploy_cfn_template, aws_client, snapshot):
+    template_path = os.path.join(
+        os.path.join(os.path.dirname(__file__), "../../../templates/event_source_mapping_tags.yml")
+    )
+    assert os.path.isfile(template_path)
+
+    output_key = f"key-{short_uid()}"
+    stack = deploy_cfn_template(
+        template_path=template_path,
+        parameters={"OutputKey": output_key},
+    )
+
+    event_source_mapping_arn = stack.outputs["EventSourceMappingArn"]
+    tags_response = aws_client.lambda_.list_tags(Resource=event_source_mapping_arn)
+    snapshot.match("event-source-mapping-tags", tags_response)
+
+    # check the mapping works
+    queue_url = stack.outputs["QueueUrl"]
+    aws_client.sqs.send_message(
+        QueueUrl=queue_url,
+        MessageBody=json.dumps({"body": "something"}),
+    )
+
+    retry(
+        lambda: aws_client.s3.head_object(Bucket=stack.outputs["OutputBucketName"], Key=output_key),
+        retries=10,
+        sleep=5.0,
+    )

--- a/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py
@@ -1,12 +1,16 @@
 import json
 import os
 
+import pytest
+
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
+from tests.aws.services.lambda_.event_source_mapping.utils import is_old_esm
 
 
 @markers.aws.validated
+@pytest.mark.skipif(condition=is_old_esm(), reason="Not implemented in v1 provider")
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         "$..Tags.'aws:cloudformation:logical-id'",

--- a/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py
@@ -1,8 +1,6 @@
 import json
 import os
 
-import pytest
-
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
@@ -16,7 +14,6 @@ from localstack.utils.sync import retry
         "$..Tags.'aws:cloudformation:stack-name'",
     ]
 )
-@pytest.mark.skip(reason="WIP")
 def test_adding_tags(deploy_cfn_template, aws_client, snapshot):
     template_path = os.path.join(
         os.path.join(os.path.dirname(__file__), "../../../templates/event_source_mapping_tags.yml")

--- a/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.snapshot.json
@@ -1,0 +1,19 @@
+{
+  "tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py::test_adding_tags": {
+    "recorded-date": "05-11-2024, 19:51:08",
+    "recorded-content": {
+      "event-source-mapping-tags": {
+        "Tags": {
+          "aws:cloudformation:logical-id": "FunctionSqsEventSourceHubspot17769792702StackQueue12392946EE93DB22",
+          "aws:cloudformation:stack-id": "arn:<partition>:cloudformation:<region>:111111111111:stack/stack-6974af6d/28039440-9baf-11ef-af1a-02c60716e235",
+          "aws:cloudformation:stack-name": "stack-6974af6d",
+          "my": "tag"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py::test_adding_tags": {
-    "recorded-date": "05-11-2024, 21:35:12",
+    "recorded-date": "06-11-2024, 11:55:29",
     "recorded-content": {
       "event-source-mapping-tags": {
         "Tags": {

--- a/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.snapshot.json
@@ -1,12 +1,12 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py::test_adding_tags": {
-    "recorded-date": "05-11-2024, 19:51:08",
+    "recorded-date": "05-11-2024, 21:35:12",
     "recorded-content": {
       "event-source-mapping-tags": {
         "Tags": {
-          "aws:cloudformation:logical-id": "FunctionSqsEventSourceHubspot17769792702StackQueue12392946EE93DB22",
-          "aws:cloudformation:stack-id": "arn:<partition>:cloudformation:<region>:111111111111:stack/stack-6974af6d/28039440-9baf-11ef-af1a-02c60716e235",
-          "aws:cloudformation:stack-name": "stack-6974af6d",
+          "aws:cloudformation:logical-id": "EventSourceMapping",
+          "aws:cloudformation:stack-id": "<stack-id>",
+          "aws:cloudformation:stack-name": "<stack-name>",
           "my": "tag"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.validation.json
@@ -1,5 +1,5 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py::test_adding_tags": {
-    "last_validated_date": "2024-11-05T19:51:08+00:00"
+    "last_validated_date": "2024-11-05T21:35:12+00:00"
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.validation.json
@@ -1,5 +1,5 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py::test_adding_tags": {
-    "last_validated_date": "2024-11-05T21:35:12+00:00"
+    "last_validated_date": "2024-11-06T11:55:29+00:00"
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/lambda_/event_source_mapping/test_cfn_resource.py::test_adding_tags": {
+    "last_validated_date": "2024-11-05T19:51:08+00:00"
+  }
+}

--- a/tests/aws/templates/event_source_mapping_tags.yml
+++ b/tests/aws/templates/event_source_mapping_tags.yml
@@ -1,0 +1,120 @@
+Parameters:
+  OutputKey:
+    Type: String
+
+Resources:
+  Queue:
+    Type: AWS::SQS::Queue
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+
+  FunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ''
+            - - 'arn:'
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Tags:
+        - Key: my
+          Value: tag
+
+  FunctionRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - sqs:ChangeMessageVisibility
+              - sqs:DeleteMessage
+              - sqs:GetQueueAttributes
+              - sqs:GetQueueUrl
+              - sqs:ReceiveMessage
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - Queue
+                - Arn
+          - Action:
+              - s3:PutObject
+            Effect: Allow
+            Resource:
+              Fn::Sub:
+                - "${bucketArn}/${key}"
+                - bucketArn: !GetAtt OutputBucket.Arn
+                  key: !Ref OutputKey
+        Version: '2012-10-17'
+      PolicyName: FunctionRolePolicy
+      Roles:
+        - Ref: FunctionRole
+
+  OutputBucket:
+    Type: AWS::S3::Bucket
+
+  Function:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          import os
+          import boto3
+          
+          BUCKET = os.environ["BUCKET"]
+          KEY = os.environ["KEY"]
+          
+          def handler(event, context):
+              client = boto3.client("s3")
+              client.put_object(Bucket=BUCKET, Key=KEY, Body=b"ok")
+              return "ok"
+      Handler: index.handler
+      Environment:
+        Variables:
+          BUCKET: !Ref OutputBucket
+          KEY: !Ref OutputKey
+
+      Role:
+        Fn::GetAtt:
+          - FunctionRole
+          - Arn
+      Runtime: python3.11
+      Tags:
+        - Key: my
+          Value: tag
+    DependsOn:
+      - FunctionRolePolicy
+      - FunctionRole
+
+  EventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      EventSourceArn:
+        Fn::GetAtt:
+          - Queue
+          - Arn
+      FunctionName:
+        Ref: Function
+      Tags:
+        - Key: my
+          Value: tag
+
+Outputs:
+  QueueUrl:
+    Value: !Ref Queue
+
+  EventSourceMappingArn:
+    Value: !GetAtt EventSourceMapping.EventSourceMappingArn
+
+  FunctionName:
+    Value: !Ref Function
+
+  OutputBucketName:
+    Value: !Ref OutputBucket


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Event Source Mappings are supported via CloudFormation, however two things are currently broken:

1. When assigning tags, the following error is received:

```
Invalid type for parameter Tags, value: [{'Key': 'component', 'Value': 'value'}], type: <class 'list'>, valid types: <class 'dict'>
```

This means that the tag format supported by CloudFormation is not directly compatible with the tag format used by `boto3`.

2. When performing `!GetAtt <ESM>.EventSourceMappingArn` the value returned is `None`


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Translate tags from one format to another
* Set the `EventSourceMappingArn` property to handle the `GetAtt` case


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
