### PR TITLE
Fix Java shared library path for darwin

### DIFF
--- a/localstack-core/localstack/packages/java.py
+++ b/localstack-core/localstack/packages/java.py
@@ -44,11 +44,9 @@ class JavaInstallerMixin:
         Returns the path to the Java shared library.
         """
         if java_home := self.get_java_home():
-            if is_linux():
-                return os.path.join(java_home, "lib", "server", "libjvm.so")
             if is_mac_os():
-                return os.path.join(java_home, "lib", "server", "libjvm.dylib")
-        return None
+                return os.path.join(java_home, "Contents", "Home", "lib", "jli", "libjli.dylib")
+            return os.path.join(java_home, "lib", "server", "libjvm.so")
 
     def get_java_env_vars(self, path: str = None, ld_library_path: str = None) -> dict[str, str]:
         """
@@ -85,6 +83,8 @@ class JavaPackageInstaller(ArchiveDownloadAndExtractInstaller):
         super().__init__("java", version, extract_single_directory=True)
 
     def _get_install_marker_path(self, install_dir: str) -> str:
+        if self.os_name == "mac":
+            return os.path.join(install_dir, "Contents", "Home", "bin", "java")
         return os.path.join(install_dir, "bin", "java")
 
     def _get_download_url(self) -> str:

--- a/localstack-core/localstack/packages/java.py
+++ b/localstack-core/localstack/packages/java.py
@@ -83,7 +83,7 @@ class JavaPackageInstaller(ArchiveDownloadAndExtractInstaller):
         super().__init__("java", version, extract_single_directory=True)
 
     def _get_install_marker_path(self, install_dir: str) -> str:
-        if self.os_name == "mac":
+        if is_mac_os():
             return os.path.join(install_dir, "Contents", "Home", "bin", "java")
         return os.path.join(install_dir, "bin", "java")
 

--- a/localstack-core/localstack/packages/java.py
+++ b/localstack-core/localstack/packages/java.py
@@ -39,6 +39,17 @@ class JavaInstallerMixin:
         """
         return java_package.get_installer().get_java_home()
 
+    def get_java_lib_path(self) -> str | None:
+        """
+        Returns the path to the Java shared library.
+        """
+        if java_home := self.get_java_home():
+            if is_linux():
+                return os.path.join(java_home, "lib", "server", "libjvm.so")
+            if is_mac_os():
+                return os.path.join(java_home, "lib", "server", "libjvm.dylib")
+        return None
+
     def get_java_env_vars(self, path: str = None, ld_library_path: str = None) -> dict[str, str]:
         """
         Returns environment variables pointing to the Java installation. This is useful to build the environment where

--- a/localstack-core/localstack/services/events/event_ruler.py
+++ b/localstack-core/localstack/services/events/event_ruler.py
@@ -36,7 +36,7 @@ def start_jvm() -> None:
 def get_jpype_lib_paths() -> Tuple[str, str]:
     """
     Downloads Event Ruler, its dependencies and returns a tuple of:
-    - Path to libjvm.{so/dylib} to be used by JPype as jvmpath. JPype requires this to start the JVM.
+    - Path to libjvm.so/libjli.dylib to be used by JPype as jvmpath. JPype requires this to start the JVM.
         See https://jpype.readthedocs.io/en/latest/userguide.html#path-to-the-jvm
     - Path to Event Ruler libraries to be used by JPype as classpath
     """

--- a/localstack-core/localstack/services/events/event_ruler.py
+++ b/localstack-core/localstack/services/events/event_ruler.py
@@ -36,17 +36,14 @@ def start_jvm() -> None:
 def get_jpype_lib_paths() -> Tuple[Path, Path]:
     """
     Downloads Event Ruler, its dependencies and returns a tuple of:
-    - Path to libjvm.so to be used by JPype as jvmpath. JPype requires this to start the JVM.
+    - Path to libjvm.{so/dylib} to be used by JPype as jvmpath. JPype requires this to start the JVM.
         See https://jpype.readthedocs.io/en/latest/userguide.html#path-to-the-jvm
     - Path to Event Ruler libraries to be used by JPype as classpath
     """
     installer = event_ruler_package.get_installer()
     installer.install()
 
-    java_home = installer.get_java_home()
-    jvm_lib = Path(java_home) / "lib" / "server" / "libjvm.so"
-
-    return jvm_lib, Path(installer.get_installed_dir())
+    return installer.get_java_lib_path(), Path(installer.get_installed_dir())
 
 
 def matches_rule(event: str, rule: str) -> bool:

--- a/localstack-core/localstack/services/events/event_ruler.py
+++ b/localstack-core/localstack/services/events/event_ruler.py
@@ -27,13 +27,13 @@ def start_jvm() -> None:
 
     if not jpype.isJVMStarted():
         jvm_lib, event_ruler_libs_path = get_jpype_lib_paths()
-        event_ruler_libs_pattern = event_ruler_libs_path.joinpath("*")
+        event_ruler_libs_pattern = Path(event_ruler_libs_path).joinpath("*")
 
-        jpype.startJVM(str(jvm_lib), classpath=[event_ruler_libs_pattern])
+        jpype.startJVM(jvm_lib, classpath=[event_ruler_libs_pattern])
 
 
 @cache
-def get_jpype_lib_paths() -> Tuple[Path, Path]:
+def get_jpype_lib_paths() -> Tuple[str, str]:
     """
     Downloads Event Ruler, its dependencies and returns a tuple of:
     - Path to libjvm.{so/dylib} to be used by JPype as jvmpath. JPype requires this to start the JVM.
@@ -43,7 +43,7 @@ def get_jpype_lib_paths() -> Tuple[Path, Path]:
     installer = event_ruler_package.get_installer()
     installer.install()
 
-    return installer.get_java_lib_path(), Path(installer.get_installed_dir())
+    return installer.get_java_lib_path(), installer.get_installed_dir()
 
 
 def matches_rule(event: str, rule: str) -> bool:


### PR DESCRIPTION
## Background

In https://github.com/localstack/localstack/pull/11139 we started using Temurin builds for Java. All Java applications were explicitly configured to use these JREs, not OS ones.

On Mac OS, it was discovered that Jpype was failing to start, and this was affecting LocalStack development on Mac OS.

## Changes

Mac builds of Temurin have a different directory structure. Furthermore the shared library usage is also different. On Linux, it is simply `libjvm.so`. On Darwin, there is a passthrough interface, the so-called [Java launcher interface](https://nachtimwald.com/2017/06/17/calling-java-from-c/) aka `libjli.dylib`, which invokes the JVM.

This PR ensures that the Java installer accounts for these differences.