### PR TITLE
Introduce CONTAINER_RUNTIME environment variable to control all container runtimes

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -870,6 +870,9 @@ EXTERNAL_SERVICE_PORTS_END = int(
     or (EXTERNAL_SERVICE_PORTS_START + 50)
 )
 
+# The default container runtime to use
+CONTAINER_RUNTIME = os.environ.get("CONTAINER_RUNTIME", "").strip() or "docker"
+
 # PUBLIC v1: -Xmx512M (example) Currently not supported in new provider but possible via custom entrypoint.
 # Allow passing custom JVM options to Java Lambdas executed in Docker.
 LAMBDA_JAVA_OPTS = os.environ.get("LAMBDA_JAVA_OPTS", "").strip()
@@ -979,7 +982,7 @@ LAMBDA_PREBUILD_IMAGES = is_env_true("LAMBDA_PREBUILD_IMAGES")
 
 # PUBLIC: docker (default), kubernetes (pro)
 # Where Lambdas will be executed.
-LAMBDA_RUNTIME_EXECUTOR = os.environ.get("LAMBDA_RUNTIME_EXECUTOR", "").strip()
+LAMBDA_RUNTIME_EXECUTOR = os.environ.get("LAMBDA_RUNTIME_EXECUTOR", CONTAINER_RUNTIME).strip()
 
 # PUBLIC: 20 (default)
 # How many seconds Lambda will wait for the runtime environment to start up.
@@ -1239,6 +1242,7 @@ CONFIG_ENV_VARS = [
     "CFN_STRING_REPLACEMENT_DENY_LIST",
     "CFN_VERBOSE_ERRORS",
     "CI",
+    "CONTAINER_RUNTIME",
     "CUSTOM_SSL_CERT_PATH",
     "DEBUG",
     "DEBUG_HANDLER_CHAIN",

--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -8,6 +8,7 @@ from localstack.utils.analytics import log
 LOG = logging.getLogger(__name__)
 
 TRACKED_ENV_VAR = [
+    "CONTAINER_RUNTIME",
     "DEBUG",
     "DEFAULT_REGION",  # Not functional; deprecated in 0.12.7, removed in 3.0.0
     "DISABLE_CORS_CHECK",
@@ -17,6 +18,7 @@ TRACKED_ENV_VAR = [
     "DNS_ADDRESS",
     "DYNAMODB_ERROR_PROBABILITY",
     "EAGER_SERVICE_LOADING",
+    "ECS_TASK_EXECUTOR",
     "EDGE_PORT",
     "ENFORCE_IAM",
     "IAM_SOFT_MODE",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, we only use the CONTAINER_RUNTIME environment variable in pro.
However, it makes sense to have this variable a global override, including for the lambda runtime executor.

For this, we need to move this variable to community.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Update tracked variables
* Introduce CONTAINER_RUNTIME as environment variable in the open source project and make `LAMBDA_RUNTIME_EXECUTOR` fall back on it.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
