### PR TITLE
Remove virtualenv dependency from docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,10 +78,6 @@ RUN chmod 777 . && \
     chmod 755 /root && \
     chmod -R 777 /.npm
 
-# install basic (global) tools to final image
-RUN --mount=type=cache,target=/root/.cache \
-    pip install --no-cache-dir --upgrade virtualenv
-
 # install the entrypoint script
 ADD bin/docker-entrypoint.sh /usr/local/bin/
 # add the shipped hosts file to prevent performance degredation in windows container mode on windows
@@ -114,7 +110,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
 
 # upgrade python build tools
 RUN --mount=type=cache,target=/root/.cache \
-    (virtualenv .venv && . .venv/bin/activate && pip3 install --upgrade pip wheel setuptools)
+    (python -m venv .venv && . .venv/bin/activate && pip3 install --upgrade pip wheel setuptools)
 
 # add files necessary to install runtime dependencies
 ADD Makefile pyproject.toml requirements-runtime.txt ./


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We currently install `virtualenv` into its own layer for the only purpose to create a virtual environment.
However, we can do that just as easily with `python -m venv .venv`. Virtualenv is a nice tool, but its features do not seem to be needed in our docker build.

This change reduces the layers by 1, and should decrease the image size a tad, and we get one less unpinned dependency.

The change should not have any impact on our users, but users might depend on "virtualenv" being installed in init scripts (although unlikely), so I would like to release it with 4.0 as breaking change.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Remove virtualenv installation from docker build

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
