### PR TITLE
add /_extension to well-known path prefixes to avoid s3 fallback handling

### DIFF
--- a/localstack-core/localstack/aws/protocol/service_router.py
+++ b/localstack-core/localstack/aws/protocol/service_router.py
@@ -171,6 +171,14 @@ def custom_path_addressing_rules(path: str) -> Optional[ServiceModelIdentifier]:
         return ServiceModelIdentifier("lambda")
 
 
+well_known_path_prefixes = (
+    "/_aws",
+    "/_localstack",
+    "/_pods",
+    "/_extension",
+)
+
+
 def legacy_rules(request: Request) -> Optional[ServiceModelIdentifier]:
     """
     *Legacy* rules which migrate routing logic which will become obsolete with the ASF Gateway.
@@ -192,8 +200,9 @@ def legacy_rules(request: Request) -> Optional[ServiceModelIdentifier]:
 
     # TODO Remove once fallback to S3 is disabled (after S3 ASF and Cors rework)
     # necessary for correct handling of cors for internal endpoints
-    if path.startswith("/_localstack") or path.startswith("/_pods") or path.startswith("/_aws"):
-        return None
+    for prefix in well_known_path_prefixes:
+        if path.startswith(prefix):
+            return None
 
     # TODO The remaining rules here are special S3 rules - needs to be discussed how these should be handled.
     #      Some are similar to other rules and not that greedy, others are nearly general fallbacks.


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Over time we've made `/_extension` a well-known path prefix, similar to `/_aws` or `/_localstack`, which still suffers from S3 xml errors when calling URLs within the `/_extension` submount that don't exist. This is a band aid fix for that.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* calls to `/_extension/<path>` are now no longer handled by the s3 fallback handler 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
