### PR TITLE
Parity test for Eventbridge logs target

### DIFF
--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -181,20 +181,25 @@ class TargetSender(ABC):
             self._validate_input_transformer(input_transformer)
 
     def _initialize_client(self) -> BaseClient:
-        """Initializes internal boto client."""
+        """Initializes internal boto client.
+        If a role from a target is provided, the client will be initialized with the assumed role.
+        If no role is provided, the client will be initialized with the account ID and region.
+        In both cases event bridge is requested as service principal"""
         service_principal = ServicePrincipal.events
         role_arn = self.target.get("RoleArn")
-        if role_arn:
+        if role_arn:  # required for cross account
+            # assumed role sessions expire after 6 hours in AWS, currently no expiration in LocalStack
             client_factory = connect_to.with_assumed_role(
                 role_arn=role_arn,
                 service_principal=service_principal,
                 region_name=self.region,
             )
-            client = client_factory.get_client(self.service)
-            client.request_metadata(service_principal=service_principal, source_arn=self.rule_arn)
         else:
-            # Use connect_to to get the client
-            client = connect_to(region_name=self.region).get_client(self.service)
+            client_factory = connect_to(aws_access_key_id=self.account_id, region_name=self.region)
+        client = client_factory.get_client(self.service)
+        client = client.request_metadata(
+            service_principal=service_principal, source_arn=self.rule_arn
+        )
         return client
 
     def _validate_input_transformer(self, input_transformer: InputTransformer):
@@ -459,8 +464,7 @@ class LambdaTargetSender(TargetSender):
 class LogsTargetSender(TargetSender):
     def send_event(self, event):
         log_group_name = self.target["Arn"].split(":")[6]
-        log_stream_name = str(uuid.uuid4())
-
+        log_stream_name = str(uuid.uuid4())  # Unique log stream name
         self.client.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)
         self.client.put_log_events(
             logGroupName=log_group_name,

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -191,14 +191,11 @@ class TargetSender(ABC):
                 region_name=self.region,
             )
             client = client_factory.get_client(self.service)
-            client.request_metadata(
-                service_principal=service_principal, source_arn=self.rule_arn
-            )
+            client.request_metadata(service_principal=service_principal, source_arn=self.rule_arn)
         else:
             # Use connect_to to get the client
             client = connect_to(region_name=self.region).get_client(self.service)
         return client
-
 
     def _validate_input_transformer(self, input_transformer: InputTransformer):
         if "InputTemplate" not in input_transformer:
@@ -462,11 +459,7 @@ class LambdaTargetSender(TargetSender):
 class LogsTargetSender(TargetSender):
     def send_event(self, event):
         log_group_name = self.target["Arn"].split(":")[6]
-        log_stream_name = str(uuid.uuid4())  # Unique log stream name
-
-        LOG.warn(f"log_group_name: {log_group_name}")
-        LOG.warn(f"log_stream_name: {log_stream_name}")
-        LOG.warn(f"event: {event}")
+        log_stream_name = str(uuid.uuid4())
 
         self.client.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)
         self.client.put_log_events(

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -384,6 +384,56 @@ def put_events_with_filter_to_sqs(
 
 
 @pytest.fixture
+def events_log_group(aws_client, account_id, region_name):
+    log_groups = []
+    policy_names = []
+
+    def _create_log_group():
+        log_group_name = f"/aws/events/test-log-group-{short_uid()}"
+        aws_client.logs.create_log_group(logGroupName=log_group_name)
+        log_group_arn = f"arn:aws:logs:{region_name}:{account_id}:log-group:{log_group_name}"
+        log_groups.append(log_group_name)
+
+        resource_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "EventBridgePutLogEvents",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "events.amazonaws.com"},
+                    "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+                    "Resource": f"{log_group_arn}:*",
+                }
+            ],
+        }
+        policy_name = f"EventBridgePolicy-{short_uid()}"
+        aws_client.logs.put_resource_policy(
+            policyName=policy_name, policyDocument=json.dumps(resource_policy)
+        )
+        policy_names.append(policy_name)
+
+        return {
+            "log_group_name": log_group_name,
+            "log_group_arn": log_group_arn,
+            "policy_name": policy_name,
+        }
+
+    yield _create_log_group
+
+    for log_group in log_groups:
+        try:
+            aws_client.logs.delete_log_group(logGroupName=log_group)
+        except Exception:
+            pass
+
+    for policy_name in policy_names:
+        try:
+            aws_client.logs.delete_resource_policy(policyName=policy_name)
+        except Exception:
+            pass
+
+
+@pytest.fixture
 def logs_create_log_group(aws_client):
     log_group_names = []
 

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -423,14 +423,14 @@ def events_log_group(aws_client, account_id, region_name):
     for log_group in log_groups:
         try:
             aws_client.logs.delete_log_group(logGroupName=log_group)
-        except Exception:
-            pass
+        except Exception as e:
+            LOG.debug("error cleaning up log group %s: %s", log_group, e)
 
     for policy_name in policy_names:
         try:
             aws_client.logs.delete_resource_policy(policyName=policy_name)
-        except Exception:
-            pass
+        except Exception as e:
+            LOG.debug("error cleaning up resource policy %s: %s", policy_name, e)
 
 
 @pytest.fixture

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -28,9 +28,6 @@ from tests.aws.services.lambda_.test_lambda import (
 
 
 # TODO:
-#  Add tests for the following services:
-#   - API Gateway (community)
-#   - CloudWatch Logs (community)
 #  These tests should go into LocalStack Pro:
 #   - AppSync (pro)
 #   - Batch (pro)
@@ -81,10 +78,9 @@ class TestEventsTargetCloudWatchLogs:
             policyName=policy_name, policyDocument=json.dumps(resource_policy)
         )
 
-        cleanups.append(lambda: aws_client.logs.delete_log_group(logGroupName=log_group_name))
-        cleanups.append(lambda: aws_client.logs.delete_resource_policy(policyName=policy_name))
-
         if is_aws_cloud():
+            # Wait for IAM role propagation in AWS cloud environment before proceeding
+            # This delay is necessary as IAM changes can take several seconds to propagate globally
             time.sleep(10)
 
         rule_name = f"test-rule-{short_uid()}"

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -90,11 +90,10 @@ class TestEventsTargetCloudWatchLogs:
 
         # Step 4: Create a rule on the event bus
         rule_name = f"test-rule-{short_uid()}"
-        event_pattern = {"source": ["test.source"], "detail-type": ["test.detail.type"]}
         rule_response = events_put_rule(
             Name=rule_name,
             EventBusName=event_bus_name,
-            EventPattern=json.dumps(event_pattern),
+            EventPattern=json.dumps(TEST_EVENT_PATTERN),
         )
         snapshot.match("rule_response", rule_response)
 
@@ -116,9 +115,9 @@ class TestEventsTargetCloudWatchLogs:
         # Step 6: Send an event to the event bus
         event_entry = {
             "EventBusName": event_bus_name,
-            "Source": "test.source",
-            "DetailType": "test.detail.type",
-            "Detail": json.dumps({"message": "Hello from EventBridge"}),
+            "Source": TEST_EVENT_PATTERN["source"][0],
+            "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
+            "Detail": json.dumps(EVENT_DETAIL),
         }
         put_events_response = aws_client.events.put_events(Entries=[event_entry])
         snapshot.match("put_events_response", put_events_response)

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -43,10 +43,10 @@ class TestEventsTargetCloudWatchLogs:
         self,
         events_create_event_bus,
         events_put_rule,
+        events_log_group,
         aws_client,
         snapshot,
-        account_id,
-        region_name,
+        cleanups,
     ):
         snapshot.add_transformers_list(
             [
@@ -56,17 +56,14 @@ class TestEventsTargetCloudWatchLogs:
             ]
         )
 
-        # Step 1: Create an EventBridge event bus
         event_bus_name = f"test-bus-{short_uid()}"
         event_bus_response = events_create_event_bus(Name=event_bus_name)
         snapshot.match("event_bus_response", event_bus_response)
 
-        # Step 2: Create a CloudWatch Logs log group
-        log_group_name = f"/aws/events/test-log-group-{short_uid()}"
-        aws_client.logs.create_log_group(logGroupName=log_group_name)
-        log_group_arn = f"arn:aws:logs:{region_name}:{account_id}:log-group:{log_group_name}"
+        log_group = events_log_group()
+        log_group_name = log_group["log_group_name"]
+        log_group_arn = log_group["log_group_arn"]
 
-        # Step 3: Attach a resource policy to the log group to allow EventBridge to write to it
         resource_policy = {
             "Version": "2012-10-17",
             "Statement": [
@@ -84,11 +81,12 @@ class TestEventsTargetCloudWatchLogs:
             policyName=policy_name, policyDocument=json.dumps(resource_policy)
         )
 
-        # Wait for the resource policy to take effect (only needed in AWS)
+        cleanups.append(lambda: aws_client.logs.delete_log_group(logGroupName=log_group_name))
+        cleanups.append(lambda: aws_client.logs.delete_resource_policy(policyName=policy_name))
+
         if is_aws_cloud():
             time.sleep(10)
 
-        # Step 4: Create a rule on the event bus
         rule_name = f"test-rule-{short_uid()}"
         rule_response = events_put_rule(
             Name=rule_name,
@@ -97,7 +95,6 @@ class TestEventsTargetCloudWatchLogs:
         )
         snapshot.match("rule_response", rule_response)
 
-        # Step 5: Add the CloudWatch Logs log group as a target
         target_id = f"target-{short_uid()}"
         put_targets_response = aws_client.events.put_targets(
             Rule=rule_name,
@@ -112,7 +109,6 @@ class TestEventsTargetCloudWatchLogs:
         snapshot.match("put_targets_response", put_targets_response)
         assert put_targets_response["FailedEntryCount"] == 0
 
-        # Step 6: Send an event to the event bus
         event_entry = {
             "EventBusName": event_bus_name,
             "Source": TEST_EVENT_PATTERN["source"][0],
@@ -123,28 +119,22 @@ class TestEventsTargetCloudWatchLogs:
         snapshot.match("put_events_response", put_events_response)
         assert put_events_response["FailedEntryCount"] == 0
 
-        # Step 7: Verify that the event was logged to the log group
         def get_log_events():
             response = aws_client.logs.describe_log_streams(logGroupName=log_group_name)
             log_streams = response.get("logStreams", [])
-            if not log_streams:
-                raise Exception("No log streams found")
+            assert log_streams, "No log streams found"
+
             log_stream_name = log_streams[0]["logStreamName"]
             events_response = aws_client.logs.get_log_events(
                 logGroupName=log_group_name,
                 logStreamName=log_stream_name,
             )
             events = events_response.get("events", [])
-            if not events:
-                raise Exception("No log events found")
+            assert events, "No log events found"
             return events
 
         events = retry(get_log_events, retries=5, sleep=5)
         snapshot.match("log_events", events)
-
-        # Cleanup: delete the log group
-        aws_client.logs.delete_log_group(logGroupName=log_group_name)
-        aws_client.logs.delete_resource_policy(policyName=policy_name)
 
 
 class TestEventsTargetApiGateway:

--- a/tests/aws/services/events/test_events_targets.snapshot.json
+++ b/tests/aws/services/events/test_events_targets.snapshot.json
@@ -837,5 +837,63 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events_targets.py::TestEventsTargetCloudWatchLogs::test_put_events_with_target_cloudwatch_logs": {
+    "recorded-date": "05-11-2024, 21:20:12",
+    "recorded-content": {
+      "event_bus_response": {
+        "EventBusArn": "arn:<partition>:events:<region>:111111111111:event-bus/test-bus-e47f5fd3",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "rule_response": {
+        "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/test-bus-e47f5fd3/test-rule-e533ccd4",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put_targets_response": {
+        "FailedEntries": [],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put_events_response": {
+        "Entries": [
+          {
+            "EventId": "<uuid:1>"
+          }
+        ],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "log_events": [
+        {
+          "timestamp": "timestamp",
+          "message": {
+            "version": "0",
+            "id": "<uuid:1>",
+            "detail-type": "test.detail.type",
+            "source": "test.source",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "message": "Hello from EventBridge"
+            }
+          },
+          "ingestionTime": "timestamp"
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events_targets.snapshot.json
+++ b/tests/aws/services/events/test_events_targets.snapshot.json
@@ -839,17 +839,17 @@
     }
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetCloudWatchLogs::test_put_events_with_target_cloudwatch_logs": {
-    "recorded-date": "05-11-2024, 21:20:12",
+    "recorded-date": "06-11-2024, 14:37:32",
     "recorded-content": {
       "event_bus_response": {
-        "EventBusArn": "arn:<partition>:events:<region>:111111111111:event-bus/test-bus-e47f5fd3",
+        "EventBusArn": "<event-bus-arn:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
       "rule_response": {
-        "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/test-bus-e47f5fd3/test-rule-e533ccd4",
+        "RuleArn": "<rule-arn:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -866,7 +866,7 @@
       "put_events_response": {
         "Entries": [
           {
-            "EventId": "<uuid:1>"
+            "EventId": "<event-id:1>"
           }
         ],
         "FailedEntryCount": 0,
@@ -880,7 +880,7 @@
           "timestamp": "timestamp",
           "message": {
             "version": "0",
-            "id": "<uuid:1>",
+            "id": "<event-id:1>",
             "detail-type": "test.detail.type",
             "source": "test.source",
             "account": "111111111111",

--- a/tests/aws/services/events/test_events_targets.snapshot.json
+++ b/tests/aws/services/events/test_events_targets.snapshot.json
@@ -839,7 +839,7 @@
     }
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetCloudWatchLogs::test_put_events_with_target_cloudwatch_logs": {
-    "recorded-date": "06-11-2024, 14:37:32",
+    "recorded-date": "07-11-2024, 14:26:16",
     "recorded-content": {
       "event_bus_response": {
         "EventBusArn": "<event-bus-arn:1>",
@@ -881,14 +881,18 @@
           "message": {
             "version": "0",
             "id": "<event-id:1>",
-            "detail-type": "test.detail.type",
-            "source": "test.source",
+            "detail-type": "core.update-account-command",
+            "source": "core.update-account-command",
             "account": "111111111111",
             "time": "date",
             "region": "<region>",
             "resources": [],
             "detail": {
-              "message": "Hello from EventBridge"
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
             }
           },
           "ingestionTime": "timestamp"

--- a/tests/aws/services/events/test_events_targets.validation.json
+++ b/tests/aws/services/events/test_events_targets.validation.json
@@ -3,7 +3,7 @@
     "last_validated_date": "2024-10-03T20:10:39+00:00"
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetCloudWatchLogs::test_put_events_with_target_cloudwatch_logs": {
-    "last_validated_date": "2024-11-05T21:20:12+00:00"
+    "last_validated_date": "2024-11-06T14:37:32+00:00"
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetEvents::test_put_events_with_target_events[bus_combination0]": {
     "last_validated_date": "2024-07-11T08:59:28+00:00"

--- a/tests/aws/services/events/test_events_targets.validation.json
+++ b/tests/aws/services/events/test_events_targets.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetApiGateway::test_put_events_with_target_api_gateway": {
     "last_validated_date": "2024-10-03T20:10:39+00:00"
   },
+  "tests/aws/services/events/test_events_targets.py::TestEventsTargetCloudWatchLogs::test_put_events_with_target_cloudwatch_logs": {
+    "last_validated_date": "2024-11-05T21:20:12+00:00"
+  },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetEvents::test_put_events_with_target_events[bus_combination0]": {
     "last_validated_date": "2024-07-11T08:59:28+00:00"
   },

--- a/tests/aws/services/events/test_events_targets.validation.json
+++ b/tests/aws/services/events/test_events_targets.validation.json
@@ -3,7 +3,7 @@
     "last_validated_date": "2024-10-03T20:10:39+00:00"
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetCloudWatchLogs::test_put_events_with_target_cloudwatch_logs": {
-    "last_validated_date": "2024-11-06T14:37:32+00:00"
+    "last_validated_date": "2024-11-07T14:26:16+00:00"
   },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetEvents::test_put_events_with_target_events[bus_combination0]": {
     "last_validated_date": "2024-07-11T08:59:28+00:00"


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds parity tests for eventbridge logs target. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
None in code. 

<!-- Optional section: How to test these changes? -->

## Testing
```
PROVIDER_OVERRIDE_EVENTS=v2 DEBUG=1 make test TEST_PATH=tests/aws/services/events/test_events_targets.py::TestEventsTargetCloudWatchLogs::test_put_events_with_target_cloudwatch_logs
```


