### PR TITLE
move parse_service_name after serve_edge_router_rules

### DIFF
--- a/localstack-core/localstack/aws/app.py
+++ b/localstack-core/localstack/aws/app.py
@@ -33,13 +33,13 @@ class LocalstackAwsGateway(Gateway):
                 metric_collector.create_metric_handler_item,
                 load_service_for_data_plane,
                 handlers.preprocess_request,
-                handlers.parse_service_name,  # enforce_cors and content_decoder depend on the service name
                 handlers.enforce_cors,
-                handlers.content_decoder,
+                handlers.content_decoder,  # depends on preprocess_request for the S3 service
                 handlers.validate_request_schema,  # validate request schema for public LS endpoints
                 handlers.serve_localstack_resources,  # try to serve endpoints in /_localstack
                 handlers.serve_edge_router_rules,
                 # start aws handler chain
+                handlers.parse_service_name,
                 handlers.parse_pre_signed_url_request,
                 handlers.inject_auth_header_if_missing,
                 handlers.add_region_from_header,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR moves our ServiceNameParser to be executed after our Edge Router.

Note: this will break upstream until #11801 and its companion are merged, so should be reviewed together. 

For historical reasons, we needed the service name for our security handling (we talk about CORS, but it is not about CORS, CORS is a "response" part, this is about our CRSF/firewall? security where we reject a request if not in our allowed hosts).

It however lead to some issues because every route would be considered as an S3 request, as our service name could not parse the request.

As S3 now properly manages its own CORS via a special handler executed very early in the request chain, we already know before the service name parser if an S3 request that needs to have its CORS managed is an S3 request or not via some heuristics. 

I believe the burden to find solutions for CORS is on the self-managed CORS services, and not for every edge route to have to find a way not to be an S3 request via the `localstack.aws.protocol.service_router.legacy_rules` or   `custom_path_addressing_rules`.

Currently we do have solutions for both S3 and API Gateway, so I think now is the time to finally jump the gun so we don't have CORS issues with any of external routes: they will all be managed by our default CORS/security handling. 

As a side effect, we also will see less issues where the stream of a route would have been consumed by our ServiceNameParser 😄 

Follow-up would be to clean the `service_router.legacy_rules` because most of them are there because of CORS/security issues. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- move the ServiceNameParser handler to be execute after our Edge Router
  - this changes means that we won't parse the request as an AWS request if an edge route was matched before


## Testing
run #/13565727990 (failing due to APIGW, fixed with #11801 and upstream PR)
