### PR TITLE
Cfn/fix lambda update

### DIFF
--- a/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_function.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_function.py
@@ -463,7 +463,7 @@ class LambdaFunctionProvider(ResourceProvider[LambdaFunctionProperties]):
         # TODO: handle defaults properly
         old_name = request.previous_state["FunctionName"]
         new_name = request.desired_state.get("FunctionName")
-        if old_name != new_name:
+        if new_name and old_name != new_name:
             # replacement (!) => shouldn't be handled here but in the engine
             self.delete(request)
             return self.create(request)

--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -626,5 +626,48 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_apigateway.py::test_update_apigateway_stage": {
+    "recorded-date": "07-11-2024, 05:35:20",
+    "recorded-content": {
+      "created-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tags": {
+          "aws:cloudformation:logical-id": "Stage",
+          "aws:cloudformation:stack-id": "arn:<partition>:cloudformation:<region>:111111111111:stack/<aws:cloudformation:stack-name:1>/<resource:1>",
+          "aws:cloudformation:stack-name": "<aws:cloudformation:stack-name:1>"
+        },
+        "tracingEnabled": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tags": {
+          "aws:cloudformation:logical-id": "Stage",
+          "aws:cloudformation:stack-id": "arn:<partition>:cloudformation:<region>:111111111111:stack/<aws:cloudformation:stack-name:1>/<resource:1>",
+          "aws:cloudformation:stack-name": "<aws:cloudformation:stack-name:1>"
+        },
+        "tracingEnabled": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
@@ -23,6 +23,9 @@
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_rest_api_serverless_ref_resolving": {
     "last_validated_date": "2023-07-06T19:01:08+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_apigateway.py::test_update_apigateway_stage": {
+    "last_validated_date": "2024-11-07T05:35:20+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_update_usage_plan": {
     "last_validated_date": "2024-09-13T09:57:21+00:00"
   }

--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -101,9 +101,6 @@ def test_lambda_w_dynamodb_event_filter_update(deploy_cfn_template, snapshot, aw
     snapshot.match("updated_source_mappings", source_mappings)
 
 
-@pytest.mark.skip(
-    reason="fails/times out. Provider not able to update lambda function environment variables"
-)
 @markers.aws.validated
 def test_update_lambda_function(s3_create_bucket, deploy_cfn_template, aws_client):
     stack = deploy_cfn_template(

--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -103,14 +103,14 @@ def test_lambda_w_dynamodb_event_filter_update(deploy_cfn_template, snapshot, aw
 
 @markers.aws.validated
 def test_update_lambda_function(s3_create_bucket, deploy_cfn_template, aws_client):
+    function_name = f"lambda-{short_uid()}"
     stack = deploy_cfn_template(
         template_path=os.path.join(
             os.path.dirname(__file__), "../../../templates/lambda_function_update.yml"
         ),
-        parameters={"Environment": "ORIGINAL"},
+        parameters={"Environment": "ORIGINAL", "FunctionName": function_name},
     )
 
-    function_name = stack.outputs["LambdaName"]
     response = aws_client.lambda_.get_function(FunctionName=function_name)
     assert response["Configuration"]["Environment"]["Variables"]["TEST"] == "ORIGINAL"
 
@@ -120,11 +120,40 @@ def test_update_lambda_function(s3_create_bucket, deploy_cfn_template, aws_clien
         template_path=os.path.join(
             os.path.dirname(__file__), "../../../templates/lambda_function_update.yml"
         ),
-        parameters={"Environment": "UPDATED"},
+        parameters={"Environment": "UPDATED", "FunctionName": function_name},
     )
 
     response = aws_client.lambda_.get_function(FunctionName=function_name)
     assert response["Configuration"]["Environment"]["Variables"]["TEST"] == "UPDATED"
+
+
+@markers.aws.validated
+def test_update_lambda_function_name(s3_create_bucket, deploy_cfn_template, aws_client):
+    function_name_1 = f"lambda-{short_uid()}"
+    function_name_2 = f"lambda-{short_uid()}"
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/lambda_function_update.yml"
+        ),
+        parameters={"FunctionName": function_name_1},
+    )
+
+    function_name = stack.outputs["LambdaName"]
+    response = aws_client.lambda_.get_function(FunctionName=function_name_1)
+    assert response["Configuration"]["Environment"]["Variables"]["TEST"] == "ORIGINAL"
+
+    deploy_cfn_template(
+        stack_name=stack.stack_name,
+        is_update=True,
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/lambda_function_update.yml"
+        ),
+        parameters={"FunctionName": function_name_2},
+    )
+    with pytest.raises(aws_client.lambda_.exceptions.ResourceNotFoundException):
+        aws_client.lambda_.get_function(FunctionName=function_name)
+
+    aws_client.lambda_.get_function(FunctionName=function_name_2)
 
 
 @markers.snapshot.skip_snapshot_verify(

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -48,7 +48,10 @@
     "last_validated_date": "2024-04-09T07:38:32+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_update_lambda_function": {
-    "last_validated_date": "2024-06-20T15:49:50+00:00"
+    "last_validated_date": "2024-11-07T03:16:40+00:00"
+  },
+  "tests/aws/services/cloudformation/resources/test_lambda.py::test_update_lambda_function_name": {
+    "last_validated_date": "2024-11-07T03:10:48+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_update_lambda_permissions": {
     "last_validated_date": "2024-04-09T07:23:41+00:00"

--- a/tests/aws/templates/apigateway_update_stage.yml
+++ b/tests/aws/templates/apigateway_update_stage.yml
@@ -1,0 +1,46 @@
+Parameters:
+  Description:
+    Type: String
+    Default: "Original description"
+  Method:
+    Type: String
+    Default: GET
+  RestApiName:
+    Type: String
+
+Resources:
+  RestApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: !Ref RestApiName
+  Stage:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      RestApiId:
+        Ref: RestApi
+      DeploymentId:
+        Ref: ApiDeployment
+      StageName: dev
+  MockMethod:
+    Type: 'AWS::ApiGateway::Method'
+    Properties:
+      RestApiId: !Ref RestApi
+      ResourceId: !GetAtt
+        - RestApi
+        - RootResourceId
+      HttpMethod: !Ref Method
+      AuthorizationType: NONE
+      Integration:
+        Type: MOCK
+  ApiDeployment:
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      RestApiId:
+        Ref: RestApi
+      Description: !Ref Description
+    DependsOn:
+      - MockMethod
+
+Outputs:
+    RestApiId:
+        Value: !GetAtt RestApi.RestApiId

--- a/tests/aws/templates/lambda_function_update.yml
+++ b/tests/aws/templates/lambda_function_update.yml
@@ -6,6 +6,8 @@ Parameters:
     AllowedValues:
       - 'ORIGINAL'
       - 'UPDATED'
+  FunctionName:
+    Type: String
 
 Resources:
   PullMarketsRole:
@@ -47,6 +49,7 @@ Resources:
           - Arn
       Runtime: nodejs18.x
       Timeout: 6
+      FunctionName: !Ref FunctionName
       Environment:
         Variables:
           TEST: !Ref Environment


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

_fixes #11365_

Updating lambda code through cloud formation was triggering a creation/deletion of a lambda function. This was only happening when the lambda name was not provided in the template.

As such when updating the code of a lambda authorizer, the name was changing and was no longer reachable by apigw. On AWS the code on a lambda function can change without the need to create a new deployment of a rest api.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Prevent replacing the function when the `functionName` is not provided
- Added Cfn Lambda tests to validate the behavior
- Added small apigw update test to validate that changes to the methods it depends on do not trigger the deployment

Out Of Scope
This pr does not address updating apigw resources such as authorizer, deployment and stages. More digging will be required to get right and this small pr does enough to fix the user issue. It seems Cfn does never recreate the deployment while the CDK seems to trigger it through some configuration (but I believe it does it by changing it's logical id, which should trigger a create/delete from Cfn?). The apigw test was added as have a a safeguard when we start implementing redeployment.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
