### PR TITLE
fix node installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,12 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
     108F52B48DB57BB0CC439B2997B01419BD92F80A \
     A363A499291CBBC940DD62E41F10027AF002F8B0 \
+    CC68F5A3106FF448322E48ED27F5E38D5B0A215F \
   ; do \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
   done \
-  && curl -O https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt \
+  && curl -LO https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt \
   && LATEST_VERSION_FILENAME=$(cat SHASUMS256.txt | grep -o "node-v.*-linux-$ARCH" | sort | uniq) \
   && rm SHASUMS256.txt \
   && curl -fsSLO --compressed "https://nodejs.org/dist/latest-v18.x/$LATEST_VERSION_FILENAME.tar.xz" \


### PR DESCRIPTION
## Motivation
Recently the NodeJS installation failed when building the Docker image with the following error:
```
#8 6.843 + cat+ uniq
#8 6.844  SHASUMS256.txt
#8 6.845 + sort
#8 6.846 + grep -o node-v.*-linux-x64
#8 6.847 + LATEST_VERSION_FILENAME=
#8 6.847 + rm SHASUMS256.txt
#8 6.848 + curl -fsSLO --compressed https://nodejs.org/dist/latest-v18.x/.tar.xz
#8 6.985 curl: (22) The requested URL returned error: 404
```

Here are some examples of failing pipelines:
- https://app.circleci.com/pipelines/github/localstack/localstack/29286/workflows/5000bdc4-af1d-4692-9180-100563d38e56
- https://app.circleci.com/pipelines/github/localstack/localstack/29286/workflows/2172c4b8-a5da-4123-96d9-7984fb97c0b6
- https://app.circleci.com/pipelines/github/localstack/localstack/29292/workflows/3c1bd969-bbf4-45ec-b01c-3b34b03e24c2
- https://app.circleci.com/pipelines/github/localstack/localstack/29295/workflows/991a7bb2-91b0-48ac-98a5-411a81fa49a7
- https://app.circleci.com/pipelines/github/localstack/localstack/29298/workflows/fca483bf-aa35-4531-a658-22e63741bdf4

This is due to an issue with how the NodeJS servers are configured.
https://nodejs.org/dist/latest-v18.x/ does not directly respond anymore, but redirects to the respective folder:
```
$ curl -v https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt
...
< location: https://nodejs.org/dist/v18.20.4/SHASUMS256.txt
...
```

## Changes
- Fix the node installation by adding the latest GPG key and follow redirects when downloading the `SHASUM256.txt`