### PR TITLE
deprecate env vars without prefix in CLI

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -431,8 +431,8 @@ VOLUME_DIR = os.environ.get("LOCALSTACK_VOLUME_DIR", "").strip() or TMP_FOLDER
 if TMP_FOLDER.startswith("/var/folders/") and os.path.exists("/private%s" % TMP_FOLDER):
     TMP_FOLDER = "/private%s" % TMP_FOLDER
 
-# whether to enable verbose debug logging
-LS_LOG = eval_log_type("LS_LOG")
+# whether to enable verbose debug logging ("LOG" is ued when using the CLI with LOCALSTACK_LOG instead of LS_LOG)
+LS_LOG = eval_log_type("LS_LOG") or eval_log_type("LOG")
 DEBUG = is_env_true("DEBUG") or LS_LOG in TRACE_LOG_LEVELS
 
 # PUBLIC PREVIEW: 0 (default), 1 (preview)

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -1210,6 +1210,9 @@ def start_infra_in_docker(console, cli_params: Dict[str, Any] = None):
     ensure_container_image(console, container)
 
     configure_container(container)
+
+    _warn_non_prefixed_env_vars(container.config.env_vars)
+
     container.configure(ContainerConfigurators.cli_params(cli_params or {}))
 
     status = console.status("Starting LocalStack container")
@@ -1293,6 +1296,9 @@ def start_infra_in_docker_detached(console, cli_params: Dict[str, Any] = None):
     container = Container(container_config)
     ensure_container_image(console, container)
     configure_container(container)
+
+    _warn_non_prefixed_env_vars(container.config.env_vars)
+
     container.configure(ContainerConfigurators.cli_params(cli_params or {}))
 
     container_config.detach = True
@@ -1303,6 +1309,22 @@ def start_infra_in_docker_detached(console, cli_params: Dict[str, Any] = None):
     server.start()
     server.wait_is_container_running()
     console.log("detaching")
+
+
+def _warn_non_prefixed_env_vars(env_vars: Dict[str, Any]) -> None:
+    """
+    Prints a warning log if the given env_vars contains a key which is not prefixed with "LOCALSTACK_".
+
+    :param env_vars: env var dict to check
+    :return: None
+    """
+    if not env_vars:
+        return
+    for env_key in env_vars.keys():
+        if not env_key.startswith("LOCALSTACK_"):
+            LOG.warning(
+                "%s is forwarded to the LocalStack container even though it is not prefixed."
+            )
 
 
 def wait_container_is_ready(timeout: Optional[float] = None):

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -516,9 +516,14 @@ class ContainerConfigurators:
         for env_var in config.CONFIG_ENV_VARS:
             value = os.environ.get(env_var, None)
             if value is not None:
-                if not env_var.startswith("LOCALSTACK_") and env_var not in profile_env:
+                if (
+                    env_var != "CI"
+                    and not env_var.startswith("LOCALSTACK_")
+                    and env_var not in profile_env
+                ):
                     # Show a warning here in case we are directly forwarding an environment variable from
                     # the system env to the container which has not been prefixed with LOCALSTACK_.
+                    # Suppress the warning for the "CI" env var.
                     # Suppress the warning if the env var was set from the profile.
                     LOG.warning(
                         "Non-prefixed environment variable %(env_var)s is forwarded to the LocalStack container! "

--- a/tests/bootstrap/test_container_configurators.py
+++ b/tests/bootstrap/test_container_configurators.py
@@ -191,6 +191,19 @@ def test_container_configurator_no_deprecation_warning_on_prefix(
     assert "LOCALSTACK_SERVICES" in container.config.env_vars
 
 
+def test_container_configurator_no_deprecation_warning_for_CI_env_var(
+    container_factory, monkeypatch, caplog
+):
+    # set the "CI" env var indicating that we are running in a CI environment
+    monkeypatch.setenv("CI", "1")
+
+    container: Container = container_factory()
+    configure_container(container)
+
+    assert "Non-prefixed environment variable" not in caplog.text
+    assert "CI" in container.config.env_vars
+
+
 def test_container_configurator_no_deprecation_warning_on_profile(
     container_factory, monkeypatch, caplog, tmp_path
 ):

--- a/tests/bootstrap/test_container_configurators.py
+++ b/tests/bootstrap/test_container_configurators.py
@@ -163,3 +163,58 @@ def test_default_localstack_container_configurator(
     ports = diagnose["docker-inspect"]["NetworkSettings"]["Ports"]
     for port in external_service_ports:
         assert ports[f"{port}/tcp"] == [{"HostIp": "127.0.0.1", "HostPort": f"{port}"}]
+
+
+def test_container_configurator_deprecation_warning(container_factory, monkeypatch, caplog):
+    # set non-prefixed well-known environment variable on the mocked OS env
+    monkeypatch.setenv("SERVICES", "1")
+
+    # config the container
+    container: Container = container_factory()
+    configure_container(container)
+
+    # assert the deprecation warning
+    assert "Non-prefixed environment variable" in caplog.text
+    assert "SERVICES" in container.config.env_vars
+
+
+def test_container_configurator_no_deprecation_warning_on_prefix(
+    container_factory, monkeypatch, caplog
+):
+    # set non-prefixed well-known environment variable on the mocked OS env
+    monkeypatch.setenv("LOCALSTACK_SERVICES", "1")
+
+    container: Container = container_factory()
+    configure_container(container)
+
+    assert "Non-prefixed environment variable" not in caplog.text
+    assert "LOCALSTACK_SERVICES" in container.config.env_vars
+
+
+def test_container_configurator_no_deprecation_warning_on_profile(
+    container_factory, monkeypatch, caplog, tmp_path
+):
+    from localstack import config
+
+    # create a test profile
+    tmp_config_dir = tmp_path
+    test_profile = tmp_config_dir / "testprofile.env"
+    test_profile.write_text(
+        textwrap.dedent(
+            """
+            SERVICES=1
+            """
+        ).strip()
+    )
+
+    # patch the profile config / env
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_config_dir)
+    monkeypatch.setattr(config, "LOADED_PROFILES", ["testprofile"])
+    monkeypatch.setenv("SERVICES", "1")
+
+    container: Container = container_factory()
+    configure_container(container)
+
+    # assert that profile env vars do not raise a deprecation warning
+    assert "Non-prefixed environment variable SERVICES" not in caplog.text
+    assert "SERVICES" in container.config.env_vars


### PR DESCRIPTION
## Motivation
As announced in https://github.com/localstack/localstack/issues/11803, with LocalStack 4.0 we are deprecating the usage of non-prefixed environment variables in the CLI:

> The LocalStack CLI is closely integrated with the runtime and needs to be able to determine which environment variables it should pass from the user's environment to the Docker container. This requirement restricts the CLI’s compatibility with new environment variables introduced in later LocalStack versions, often leading to issues that are challenging to debug. Using a well-known prefix (`LOCALSTACK_`) will enable forwards-compatibility for newer configuration options. To enhance flexibility, users are encouraged to use a variable prefix (`LOCALSTACK_`) for more straightforward management of environment variables across different versions.

This PR adds a deprecation warning to inform users about this change.

## Changes
- Add a warning if a non-prefixed environment variable is loaded to be forwarded to the runtime container.
- Loads the env var "LOG" if "LS_LOG" is not present to allow setting "LOCALSTACK_LOG" instead of "LOCALSTACK_LS_LOG" in Docker mode.


## TODO
- [x] Add prefix for environment variables defined in a profile.
- [x] Check where the best place to show the warning is.
  - Unfortunately, the place for the warning right now isn't the best, but we can properly separate this in upcoming iterations.