### PR TITLE
fix transformation for matching operations in aws::events::rule

### DIFF
--- a/localstack-core/localstack/services/events/resource_providers/aws_events_rule.py
+++ b/localstack-core/localstack/services/events/resource_providers/aws_events_rule.py
@@ -233,6 +233,7 @@ class EventsRuleProvider(ResourceProvider[EventsRuleProperties]):
                         "prefix",
                         "cidr",
                         "exists",
+                        "suffix",
                     ]:
                         o[k] = [v]
             return o

--- a/localstack-core/localstack/services/events/resource_providers/aws_events_rule.py
+++ b/localstack-core/localstack/services/events/resource_providers/aws_events_rule.py
@@ -167,6 +167,17 @@ class Target(TypedDict):
 
 REPEATED_INVOCATION = "repeated_invocation"
 
+MATCHING_OPERATIONS = [
+    "prefix",
+    "cidr",
+    "exists",
+    "suffix",
+    "anything-but",
+    "numeric",
+    "equals-ignore-case",
+    "wildcard",
+]
+
 
 def extract_rule_name(rule_id: str) -> str:
     return rule_id.rsplit("|", maxsplit=1)[-1]
@@ -229,12 +240,7 @@ class EventsRuleProvider(ResourceProvider[EventsRuleProperties]):
         def wrap_in_lists(o, **kwargs):
             if isinstance(o, dict):
                 for k, v in o.items():
-                    if not isinstance(v, (dict, list)) and k not in [
-                        "prefix",
-                        "cidr",
-                        "exists",
-                        "suffix",
-                    ]:
+                    if not isinstance(v, (dict, list)) and k not in MATCHING_OPERATIONS:
                         o[k] = [v]
             return o
 

--- a/tests/aws/services/cloudformation/resources/test_events.py
+++ b/tests/aws/services/cloudformation/resources/test_events.py
@@ -2,6 +2,8 @@ import json
 import logging
 import os
 
+import aws_cdk as cdk
+
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import wait_until
@@ -211,3 +213,40 @@ def test_rule_properties(deploy_cfn_template, aws_client, snapshot):
     snapshot.add_transformer(snapshot.transform.regex(without_bus_id, "<without-bus-id>"))
 
     snapshot.match("outputs", stack.outputs)
+
+
+@markers.aws.validated
+def test_rule_pattern_transformation(aws_client, infrastructure_setup, snapshot):
+    """
+    The CFn provider for a rule applies a transformation to some properties. Extend this test as more properties or
+    situations arise.
+    """
+
+    infra = infrastructure_setup(namespace="RuleEventPattern")
+    stack_name = f"RuleStack{short_uid()}"
+    stack = cdk.Stack(infra.cdk_app, stack_name=stack_name)
+
+    log_group = cdk.aws_logs.LogGroup(stack, "TestLogGroup")
+
+    # Create an EventBridge rule
+    rule = cdk.aws_events.Rule(
+        stack,
+        "TestRule",
+        event_pattern={
+            "source": ["aws.s3"],
+            "detail-type": ["Object Created"],
+            "detail": {
+                "bucket": {"name": ["test-s3-bucket"]},
+                "object": {"key": [{"suffix": "/test.json"}]},
+            },
+        },
+        targets=[cdk.aws_events_targets.CloudWatchLogGroup(log_group)],
+    )
+
+    cdk.CfnOutput(stack, "RuleName", value=rule.rule_name)
+
+    with infra.provisioner() as prov:
+        outputs = prov.get_stack_outputs(stack_name=stack_name)
+        rule = aws_client.events.describe_rule(Name=outputs["RuleName"])
+        snapshot.match("rule", rule)
+        snapshot.add_transformer(snapshot.transform())

--- a/tests/aws/services/cloudformation/resources/test_events.py
+++ b/tests/aws/services/cloudformation/resources/test_events.py
@@ -2,8 +2,6 @@ import json
 import logging
 import os
 
-import aws_cdk as cdk
-
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import wait_until
@@ -216,37 +214,17 @@ def test_rule_properties(deploy_cfn_template, aws_client, snapshot):
 
 
 @markers.aws.validated
-def test_rule_pattern_transformation(aws_client, infrastructure_setup, snapshot):
+def test_rule_pattern_transformation(aws_client, deploy_cfn_template, snapshot):
     """
     The CFn provider for a rule applies a transformation to some properties. Extend this test as more properties or
     situations arise.
     """
-
-    infra = infrastructure_setup(namespace="RuleEventPattern")
-    stack_name = f"RuleStack{short_uid()}"
-    stack = cdk.Stack(infra.cdk_app, stack_name=stack_name)
-
-    log_group = cdk.aws_logs.LogGroup(stack, "TestLogGroup")
-
-    # Create an EventBridge rule
-    rule = cdk.aws_events.Rule(
-        stack,
-        "TestRule",
-        event_pattern={
-            "source": ["aws.s3"],
-            "detail-type": ["Object Created"],
-            "detail": {
-                "bucket": {"name": ["test-s3-bucket"]},
-                "object": {"key": [{"suffix": "/test.json"}]},
-            },
-        },
-        targets=[cdk.aws_events_targets.CloudWatchLogGroup(log_group)],
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/events_rule_pattern.yml"
+        ),
     )
 
-    cdk.CfnOutput(stack, "RuleName", value=rule.rule_name)
-
-    with infra.provisioner() as prov:
-        outputs = prov.get_stack_outputs(stack_name=stack_name)
-        rule = aws_client.events.describe_rule(Name=outputs["RuleName"])
-        snapshot.match("rule", rule)
-        snapshot.add_transformer(snapshot.transform())
+    rule = aws_client.events.describe_rule(Name=stack.outputs["RuleName"])
+    snapshot.match("rule", rule)
+    snapshot.add_transformer(snapshot.transform.key_value("Name"))

--- a/tests/aws/services/cloudformation/resources/test_events.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_events.snapshot.json
@@ -11,5 +11,43 @@
         "RuleWithoutNameRef": "<event-bus-name>|<rule-id>"
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_events.py::test_rule_pattern_transformation": {
+    "recorded-date": "08-11-2024, 15:49:06",
+    "recorded-content": {
+      "rule": {
+        "Arn": "arn:<partition>:events:<region>:111111111111:rule/<name:1>",
+        "CreatedBy": "111111111111",
+        "EventBusName": "default",
+        "EventPattern": {
+          "detail-type": [
+            "Object Created"
+          ],
+          "source": [
+            "aws.s3"
+          ],
+          "detail": {
+            "bucket": {
+              "name": [
+                "test-s3-bucket"
+              ]
+            },
+            "object": {
+              "key": [
+                {
+                  "suffix": "/test.json"
+                }
+              ]
+            }
+          }
+        },
+        "Name": "<name:1>",
+        "State": "ENABLED",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_events.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_events.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/cloudformation/resources/test_events.py::test_eventbus_policy_statement": {
     "last_validated_date": "2024-11-14T21:46:23+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_events.py::test_rule_pattern_transformation": {
+    "last_validated_date": "2024-11-08T15:49:06+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_events.py::test_rule_properties": {
     "last_validated_date": "2023-12-01T14:03:52+00:00"
   }

--- a/tests/aws/templates/events_rule_pattern.yml
+++ b/tests/aws/templates/events_rule_pattern.yml
@@ -1,0 +1,29 @@
+Resources:
+  TestLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/events/test-log-group-${AWS::AccountId}"
+
+  TestRule:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+          - aws.s3
+        detail-type:
+          - Object Created
+        detail:
+          bucket:
+            name:
+              - test-s3-bucket
+          object:
+            key:
+              - suffix: /test.json
+      Targets:
+        - Id: "TestLogGroupTarget"
+          Arn: !GetAtt TestLogGroup.Arn
+
+Outputs:
+  RuleName:
+    Description: Name of the EventBridge Rule
+    Value: !Ref TestRule


### PR DESCRIPTION
## Motivation
Adresses #11537. This PR extends the list of attributes that need to be converted in a EventPattern inside the resource provider for AWS::Events::Rule
Operations added are found in this [AWS doc](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-pattern-operators.htm)

## Changes
- simple addition of operations to the list of atts to be converted

## Testing
- new aws validated test.