### PR TITLE
Added tests and fixed the issue of the multiple targets

### DIFF
--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -2027,7 +2027,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             event_pattern = rule.event_pattern
             event_str = to_json_str(event_formatted)
 
-            if not matches_rule(event_str, event_pattern):
+            if not matches_event(event_pattern, event_str):
                 continue
 
             if not rule.targets:

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -1983,7 +1983,12 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         self._proxy_capture_input_event(event_formatted)
 
         has_processing_error = self._process_rules_for_event(
-            event_bus.rules.values(), region, account_id, event_formatted, failed_entry_count
+            event_bus_name,
+            event_bus.rules.values(),
+            region,
+            account_id,
+            event_formatted,
+            failed_entry_count,
         )
 
         if has_processing_error:
@@ -1997,6 +2002,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
 
     def _process_rules_for_event(
         self,
+        event_bus_name: str,
         rules: list[Rule],
         region: str,
         account_id: str,
@@ -2011,7 +2017,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                 json.dumps(
                     {
                         "InfoCode": "InternalInfoEvents at process_rules",
-                        "InfoMessage": "No rules configured for event bus",
+                        "InfoMessage": f"No rules attached to event_bus: {event_bus_name}",
                     }
                 )
             )
@@ -2044,7 +2050,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                     LOG.info(
                         json.dumps(
                             {
-                                "ErrorCode": "InternalException at process_target",
+                                "ErrorCode": "InternalException at process_entries",
                                 "ErrorMessage": str(error),
                             }
                         )


### PR DESCRIPTION
## Motivation
Fixes EventBridge PutEvents response so it correctly returns event IDs only once per event, regardless of how many rules or targets match. Currently, the response includes duplicate EventIds for each matching target, which doesn't match AWS behavior and can cause issues when clients try to track events by their IDs.

Related issue: https://github.com/localstack/localstack/issues/11597

## Changes
- Modified `_process_entries` and related methods in events provider to track and return event IDs only once
- Added new helper method `_process_target` to handle target processing without duplicating event IDs
- Refactored event processing logic to maintain a single event result per input event
- Added comprehensive test case to verify the fix and prevent regressions

## Testing
1. Create an EventBridge rule with multiple targets
2. Send an event that matches the rule
3. Verify that:
   - PutEvents response contains each EventId only once
   - All targets still receive the event correctly
   - Event IDs are consistent between response and delivered messages

