### PR TITLE
Idempotent start of the DynamoDB server

### DIFF
--- a/localstack-core/localstack/services/dynamodb/server.py
+++ b/localstack-core/localstack/services/dynamodb/server.py
@@ -79,6 +79,10 @@ class DynamodbServer(Server):
     def start_dynamodb(self) -> bool:
         """Start the DynamoDB server."""
 
+        # We want this method to be idempotent.
+        if self.is_running() and self.is_up():
+            return True
+
         # For the v2 provider, the DynamodbServer has been made a singleton. Yet, the Server abstraction is modelled
         # after threading.Thread, where Start -> Stop -> Start is not allowed. This flow happens during state resets.
         # The following is a workaround that permits this flow

--- a/localstack-core/localstack/services/dynamodb/server.py
+++ b/localstack-core/localstack/services/dynamodb/server.py
@@ -76,6 +76,7 @@ class DynamodbServer(Server):
     def get() -> "DynamodbServer":
         return DynamodbServer(config.DYNAMODB_LOCAL_PORT)
 
+    @synchronized(lock=RESTART_LOCK)
     def start_dynamodb(self) -> bool:
         """Start the DynamoDB server."""
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR is a follow-up of https://github.com/localstack/localstack/pull/11789.
@HarshCasper [noticed](https://localstack-cloud.slack.com/archives/C037N93TF16/p1731003971136279) a bunch of logs like the following when loading a DDB state in a container without an initialized DDB provider (i.e., start LS and immediately load):

```
2024-11-08T16:47:39.854 DEBUG --- [functhread27] l.services.dynamodb.server : Initializing DynamoDB Local with the following configuration:
2024-11-08T16:47:39.854 DEBUG --- [functhread27] l.services.dynamodb.server : Port:	37097
2024-11-08T16:47:39.854 DEBUG --- [functhread27] l.services.dynamodb.server : InMemory:	false
2024-11-08T16:47:39.854 DEBUG --- [functhread27] l.services.dynamodb.server : Version:	2.5.3
2024-11-08T16:47:39.854 DEBUG --- [functhread27] l.services.dynamodb.server : DbPath:	/tmp/localstack/state/dynamodb
2024-11-08T16:47:39.854 DEBUG --- [functhread27] l.services.dynamodb.server : SharedDb:	false
2024-11-08T16:47:39.854 DEBUG --- [functhread27] l.services.dynamodb.server : shouldDelayTransientStatuses:	false
2024-11-08T16:47:39.854 DEBUG --- [functhread27] l.services.dynamodb.server : CorsParams:	null
2024-11-08T16:47:39.855 DEBUG --- [functhread27] l.services.dynamodb.server : 
2024-11-08T16:47:40.456 DEBUG --- [functhread27] l.services.dynamodb.server : Exception in thread "main" java.io.IOException: Failed to bind to 0.0.0.0/0.0.0.0:37097
2024-11-08T16:47:40.458 DEBUG --- [functhread27] l.services.dynamodb.server : at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:349)
```

One can simply verify the behavior with:

```bash
export LOCALSTACK_AUTH_TOKEN="xxx"
localstack start
localstack pod load ddb-test # created this pod with some ddb state
```

This described scenario triggers these provider hooks in the following order:
- `on_after_state_load`, which starts the DDB server on a given port via `DynamodbServer::start_dynamodb`;
- `on_before_start`, which also calls `DynamodbServer::start_dynamodb` and tries to start DDB once again on the same port, causing the issue above.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- To tackle the issue, I added a check in `start_dynamoddb` that verifies if the thread is already running and healthy, making the function idempotent.

[ext pipeline](https://github.com/localstack/localstack-ext/actions/runs/11747690919/job/32730135079) to make sure persistence works correctly.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
