### PR TITLE
Feature/DynamoDBStreams: decompose process records

### DIFF
--- a/localstack-core/localstack/services/dynamodb/provider.py
+++ b/localstack-core/localstack/services/dynamodb/provider.py
@@ -208,14 +208,25 @@ class EventForwarder:
         self, account_id: str, region_name: str, records_map: RecordsMap, background: bool = True
     ) -> None:
         if background:
-            self.executor.submit(
-                self._forward,
+            self._submit_records(
+                forwarder=self._forward,
                 account_id=account_id,
                 region_name=region_name,
                 records_map=records_map,
             )
         else:
             self._forward(account_id, region_name, records_map)
+
+    def _submit_records(
+        self, forwarder, account_id: str, region_name: str, records_map: RecordsMap
+    ):
+        "Required for patching submit with local thread context for EventStudio"
+        self.executor.submit(
+            forwarder,
+            account_id,
+            region_name,
+            records_map,
+        )
 
     def _forward(self, account_id: str, region_name: str, records_map: RecordsMap) -> None:
         try:

--- a/localstack-core/localstack/services/dynamodb/provider.py
+++ b/localstack-core/localstack/services/dynamodb/provider.py
@@ -220,7 +220,7 @@ class EventForwarder:
     def _submit_records(
         self, forwarder, account_id: str, region_name: str, records_map: RecordsMap
     ):
-        "Required for patching submit with local thread context for EventStudio"
+        """Required for patching submit with local thread context for EventStudio"""
         self.executor.submit(
             forwarder,
             account_id,

--- a/localstack-core/localstack/services/dynamodb/provider.py
+++ b/localstack-core/localstack/services/dynamodb/provider.py
@@ -209,7 +209,6 @@ class EventForwarder:
     ) -> None:
         if background:
             self._submit_records(
-                forwarder=self._forward,
                 account_id=account_id,
                 region_name=region_name,
                 records_map=records_map,
@@ -217,12 +216,10 @@ class EventForwarder:
         else:
             self._forward(account_id, region_name, records_map)
 
-    def _submit_records(
-        self, forwarder, account_id: str, region_name: str, records_map: RecordsMap
-    ):
+    def _submit_records(self, account_id: str, region_name: str, records_map: RecordsMap):
         """Required for patching submit with local thread context for EventStudio"""
         self.executor.submit(
-            forwarder,
+            self._forward,
             account_id,
             region_name,
             records_map,

--- a/localstack-core/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack-core/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -89,7 +89,7 @@ def get_stream_for_table(account_id: str, region_name: str, table_arn: str) -> d
 
 def _process_forwarded_records(
     account_id: str, region_name: str, table_name: TableName, table_records: dict, kinesis
-):
+) -> None:
     records = table_records["records"]
     stream_type = table_records["table_stream_type"]
     # if the table does not have a DynamoDB Streams enabled, skip publishing anything

--- a/localstack-core/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack-core/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -87,63 +87,66 @@ def get_stream_for_table(account_id: str, region_name: str, table_arn: str) -> d
     return store.ddb_streams.get(table_name)
 
 
+def _process_forwarded_records(
+    account_id: str, region_name: str, table_name: TableName, table_records: dict, kinesis
+):
+    records = table_records["records"]
+    stream_type = table_records["table_stream_type"]
+    # if the table does not have a DynamoDB Streams enabled, skip publishing anything
+    if not stream_type.stream_view_type:
+        return
+
+    # in this case, Kinesis forces the record to have both OldImage and NewImage, so we need to filter it
+    # as the settings are different for DDB Streams and Kinesis
+    if stream_type.is_kinesis and stream_type.stream_view_type != StreamViewType.NEW_AND_OLD_IMAGES:
+        kinesis_records = []
+
+        # StreamViewType determines what information is written to the stream for the table
+        # When an item in the table is inserted, updated or deleted
+        image_filter = set()
+        if stream_type.stream_view_type == StreamViewType.KEYS_ONLY:
+            image_filter = {"OldImage", "NewImage"}
+        elif stream_type.stream_view_type == StreamViewType.OLD_IMAGE:
+            image_filter = {"NewImage"}
+        elif stream_type.stream_view_type == StreamViewType.NEW_IMAGE:
+            image_filter = {"OldImage"}
+
+        for record in records:
+            record["dynamodb"] = {
+                k: v for k, v in record["dynamodb"].items() if k not in image_filter
+            }
+
+            if "SequenceNumber" not in record["dynamodb"]:
+                record["dynamodb"]["SequenceNumber"] = str(
+                    get_and_increment_sequence_number_counter()
+                )
+
+            kinesis_records.append({"Data": dumps(record), "PartitionKey": "TODO"})
+
+    else:
+        kinesis_records = []
+        for record in records:
+            if "SequenceNumber" not in record["dynamodb"]:
+                # we can mutate the record for SequenceNumber, the Kinesis forwarding takes care of filtering it
+                record["dynamodb"]["SequenceNumber"] = str(
+                    get_and_increment_sequence_number_counter()
+                )
+
+            # simply pass along the records, they already have the right format
+            kinesis_records.append({"Data": dumps(record), "PartitionKey": "TODO"})
+
+    stream_name = get_kinesis_stream_name(table_name)
+    kinesis.put_records(
+        StreamName=stream_name,
+        Records=kinesis_records,
+    )
+
+
 def forward_events(account_id: str, region_name: str, records_map: dict[TableName, dict]) -> None:
     kinesis = get_kinesis_client(account_id, region_name)
 
     for table_name, table_records in records_map.items():
-        records = table_records["records"]
-        stream_type = table_records["table_stream_type"]
-        # if the table does not have a DynamoDB Streams enabled, skip publishing anything
-        if not stream_type.stream_view_type:
-            continue
-
-        # in this case, Kinesis forces the record to have both OldImage and NewImage, so we need to filter it
-        # as the settings are different for DDB Streams and Kinesis
-        if (
-            stream_type.is_kinesis
-            and stream_type.stream_view_type != StreamViewType.NEW_AND_OLD_IMAGES
-        ):
-            kinesis_records = []
-
-            # StreamViewType determines what information is written to the stream for the table
-            # When an item in the table is inserted, updated or deleted
-            image_filter = set()
-            if stream_type.stream_view_type == StreamViewType.KEYS_ONLY:
-                image_filter = {"OldImage", "NewImage"}
-            elif stream_type.stream_view_type == StreamViewType.OLD_IMAGE:
-                image_filter = {"NewImage"}
-            elif stream_type.stream_view_type == StreamViewType.NEW_IMAGE:
-                image_filter = {"OldImage"}
-
-            for record in records:
-                record["dynamodb"] = {
-                    k: v for k, v in record["dynamodb"].items() if k not in image_filter
-                }
-
-                if "SequenceNumber" not in record["dynamodb"]:
-                    record["dynamodb"]["SequenceNumber"] = str(
-                        get_and_increment_sequence_number_counter()
-                    )
-
-                kinesis_records.append({"Data": dumps(record), "PartitionKey": "TODO"})
-
-        else:
-            kinesis_records = []
-            for record in records:
-                if "SequenceNumber" not in record["dynamodb"]:
-                    # we can mutate the record for SequenceNumber, the Kinesis forwarding takes care of filtering it
-                    record["dynamodb"]["SequenceNumber"] = str(
-                        get_and_increment_sequence_number_counter()
-                    )
-
-                # simply pass along the records, they already have the right format
-                kinesis_records.append({"Data": dumps(record), "PartitionKey": "TODO"})
-
-        stream_name = get_kinesis_stream_name(table_name)
-        kinesis.put_records(
-            StreamName=stream_name,
-            Records=kinesis_records,
-        )
+        _process_forwarded_records(account_id, region_name, table_name, table_records, kinesis)
 
 
 def delete_streams(account_id: str, region_name: str, table_arn: str) -> None:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Decompose function that processes dynamodb records so each individual record can be collected as an event by EventStudio before they are sent to the kinesis stream
Decompose function that submits process records to background process to be able to patch it in EventStudio and submit it with the parent thread context

