### PR TITLE
ExpectedBucketOwner for S3 bucket policy operations

### DIFF
--- a/localstack-core/localstack/aws/api/s3/__init__.py
+++ b/localstack-core/localstack/aws/api/s3/__init__.py
@@ -684,12 +684,6 @@ class InvalidBucketName(ServiceException):
     BucketName: Optional[BucketName]
 
 
-class InvalidBucketOwnerAWSAccountID(ServiceException):
-    code: str = "InvalidBucketOwnerAWSAccountID"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
 class NoSuchVersion(ServiceException):
     code: str = "NoSuchVersion"
     sender_fault: bool = False

--- a/localstack-core/localstack/aws/api/s3/__init__.py
+++ b/localstack-core/localstack/aws/api/s3/__init__.py
@@ -684,6 +684,12 @@ class InvalidBucketName(ServiceException):
     BucketName: Optional[BucketName]
 
 
+class InvalidBucketOwnerAWSAccountID(ServiceException):
+    code: str = "InvalidBucketOwnerAWSAccountID"
+    sender_fault: bool = False
+    status_code: int = 400
+
+
 class NoSuchVersion(ServiceException):
     code: str = "NoSuchVersion"
     sender_fault: bool = False

--- a/localstack-core/localstack/services/s3/exceptions.py
+++ b/localstack-core/localstack/services/s3/exceptions.py
@@ -41,3 +41,8 @@ class NoSuchObjectLockConfiguration(CommonServiceException):
 class MalformedPolicy(CommonServiceException):
     def __init__(self, message=None):
         super().__init__("MalformedPolicy", status_code=400, message=message)
+
+
+class InvalidBucketOwnerAWSAccountID(CommonServiceException):
+    def __init__(self, message=None) -> None:
+        super().__init__("InvalidBucketOwnerAWSAccountID", status_code=400, message=message)

--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -104,7 +104,6 @@ from localstack.aws.api.s3 import (
     IntelligentTieringId,
     InvalidArgument,
     InvalidBucketName,
-    InvalidBucketOwnerAWSAccountID,
     InvalidDigest,
     InvalidLocationConstraint,
     InvalidObjectState,
@@ -225,6 +224,7 @@ from localstack.services.s3.constants import (
 )
 from localstack.services.s3.cors import S3CorsHandler, s3_cors_request_handler
 from localstack.services.s3.exceptions import (
+    InvalidBucketOwnerAWSAccountID,
     InvalidBucketState,
     InvalidRequest,
     MalformedPolicy,

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -1033,14 +1033,16 @@ class TestS3:
 
     @markers.aws.validated
     def test_put_bucket_policy_expected_bucket_owner(
-        self, s3_bucket, snapshot, aws_client, allow_bucket_acl, account_id
+        self, s3_bucket, snapshot, aws_client, allow_bucket_acl, account_id, secondary_account_id
     ):
         snapshot.add_transformer(snapshot.transform.key_value("Resource"))
         policy = _simple_bucket_policy(s3_bucket)
 
         with pytest.raises(ClientError) as e:
             aws_client.s3.put_bucket_policy(
-                Bucket=s3_bucket, Policy=json.dumps(policy), ExpectedBucketOwner="000000000002"
+                Bucket=s3_bucket,
+                Policy=json.dumps(policy),
+                ExpectedBucketOwner=secondary_account_id,
             )
         snapshot.match("put-bucket-policy-with-expected-bucket-owner-error", e.value.response)
 
@@ -1083,7 +1085,7 @@ class TestS3:
 
     @markers.aws.validated
     def test_delete_bucket_policy_expected_bucket_owner(
-        self, s3_bucket, snapshot, aws_client, allow_bucket_acl, account_id
+        self, s3_bucket, snapshot, aws_client, allow_bucket_acl, account_id, secondary_account_id
     ):
         snapshot.add_transformer(snapshot.transform.key_value("Resource"))
         snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
@@ -1092,7 +1094,9 @@ class TestS3:
         aws_client.s3.put_bucket_policy(Bucket=s3_bucket, Policy=json.dumps(policy))
 
         with pytest.raises(ClientError) as e:
-            aws_client.s3.delete_bucket_policy(Bucket=s3_bucket, ExpectedBucketOwner="000000000002")
+            aws_client.s3.delete_bucket_policy(
+                Bucket=s3_bucket, ExpectedBucketOwner=secondary_account_id
+            )
         snapshot.match("delete-bucket-policy-with-expected-bucket-owner-error", e.value.response)
 
         with pytest.raises(ClientError) as e:

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -13434,7 +13434,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_delete_bucket_policy_expected_bucket_owner": {
-    "recorded-date": "10-11-2024, 19:23:47",
+    "recorded-date": "14-11-2024, 21:43:07",
     "recorded-content": {
       "delete-bucket-policy-with-expected-bucket-owner-error": {
         "Error": {
@@ -13444,6 +13444,16 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 403
+        }
+      },
+      "delete-bucket-policy-invalid-bucket-owner": {
+        "Error": {
+          "Code": "InvalidBucketOwnerAWSAccountID",
+          "Message": "The value of the expected bucket owner parameter must be an AWS Account ID... [invalid]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       },
       "delete-bucket-policy-with-expected-bucket-owner": {
@@ -13471,6 +13481,126 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_policy_invalid_account_id[0000]": {
+    "recorded-date": "14-11-2024, 21:34:49",
+    "recorded-content": {
+      "get-bucket-policy-invalid-bucket-owner": {
+        "Error": {
+          "Code": "InvalidBucketOwnerAWSAccountID",
+          "Message": "The value of the expected bucket owner parameter must be an AWS Account ID... [0000]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_policy_invalid_account_id[0000000000020]": {
+    "recorded-date": "14-11-2024, 21:34:51",
+    "recorded-content": {
+      "get-bucket-policy-invalid-bucket-owner": {
+        "Error": {
+          "Code": "InvalidBucketOwnerAWSAccountID",
+          "Message": "The value of the expected bucket owner parameter must be an AWS Account ID... [0000000000020]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_policy_invalid_account_id[abcd]": {
+    "recorded-date": "14-11-2024, 21:34:53",
+    "recorded-content": {
+      "get-bucket-policy-invalid-bucket-owner": {
+        "Error": {
+          "Code": "InvalidBucketOwnerAWSAccountID",
+          "Message": "The value of the expected bucket owner parameter must be an AWS Account ID... [abcd]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_policy_invalid_account_id[aa000000000$]": {
+    "recorded-date": "14-11-2024, 21:34:56",
+    "recorded-content": {
+      "get-bucket-policy-invalid-bucket-owner": {
+        "Error": {
+          "Code": "InvalidBucketOwnerAWSAccountID",
+          "Message": "The value of the expected bucket owner parameter must be an AWS Account ID... [aa000000000$]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_invalid_account_id[0000]": {
+    "recorded-date": "14-11-2024, 21:38:42",
+    "recorded-content": {
+      "put-bucket-policy-invalid-bucket-owner": {
+        "Error": {
+          "Code": "InvalidBucketOwnerAWSAccountID",
+          "Message": "The value of the expected bucket owner parameter must be an AWS Account ID... [0000]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_invalid_account_id[0000000000020]": {
+    "recorded-date": "14-11-2024, 21:38:44",
+    "recorded-content": {
+      "put-bucket-policy-invalid-bucket-owner": {
+        "Error": {
+          "Code": "InvalidBucketOwnerAWSAccountID",
+          "Message": "The value of the expected bucket owner parameter must be an AWS Account ID... [0000000000020]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_invalid_account_id[abcd]": {
+    "recorded-date": "14-11-2024, 21:38:46",
+    "recorded-content": {
+      "put-bucket-policy-invalid-bucket-owner": {
+        "Error": {
+          "Code": "InvalidBucketOwnerAWSAccountID",
+          "Message": "The value of the expected bucket owner parameter must be an AWS Account ID... [abcd]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_invalid_account_id[aa000000000$]": {
+    "recorded-date": "14-11-2024, 21:38:49",
+    "recorded-content": {
+      "put-bucket-policy-invalid-bucket-owner": {
+        "Error": {
+          "Code": "InvalidBucketOwnerAWSAccountID",
+          "Message": "The value of the expected bucket owner parameter must be an AWS Account ID... [aa000000000$]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -365,36 +365,6 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_and_get_bucket_policy": {
-    "recorded-date": "04-08-2023, 23:56:00",
-    "recorded-content": {
-      "put-bucket-policy": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 204
-        }
-      },
-      "get-bucket-policy": {
-        "Policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "*"
-              },
-              "Action": "s3:GetObject",
-              "Resource": "<resource:1>"
-            }
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_tagging_empty_list": {
     "recorded-date": "03-08-2023, 04:14:24",
     "recorded-content": {
@@ -13356,27 +13326,6 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 403
-        }
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_with_expected_bucket_owner": {
-    "recorded-date": "10-11-2024, 19:06:26",
-    "recorded-content": {
-      "put-bucket-policy-with-expected-bucket-owner-error": {
-        "Error": {
-          "Code": "AccessDenied",
-          "Message": "Access Denied"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 403
-        }
-      },
-      "put-bucket-policy-with-expected-bucket-owner": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 204
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -13295,5 +13295,184 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_policy": {
+    "recorded-date": "10-11-2024, 19:20:17",
+    "recorded-content": {
+      "get-bucket-policy-no-such-bucket-policy": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucketPolicy",
+          "Message": "The bucket policy does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "get-bucket-policy": {
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Action": "s3:GetObject",
+              "Resource": "<resource:1>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-policy-with-expected-bucket-owner": {
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Action": "s3:GetObject",
+              "Resource": "<resource:1>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-policy-with-expected-bucket-owner-error": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_with_expected_bucket_owner": {
+    "recorded-date": "10-11-2024, 19:06:26",
+    "recorded-content": {
+      "put-bucket-policy-with-expected-bucket-owner-error": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "put-bucket-policy-with-expected-bucket-owner": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_delete_bucket_policy": {
+    "recorded-date": "10-11-2024, 19:21:53",
+    "recorded-content": {
+      "delete-bucket-policy": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-bucket-policy-no-such-bucket-policy": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucketPolicy",
+          "Message": "The bucket policy does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy": {
+    "recorded-date": "10-11-2024, 19:20:47",
+    "recorded-content": {
+      "put-bucket-policy": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-bucket-policy": {
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Action": "s3:GetObject",
+              "Resource": "<resource:1>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_delete_bucket_policy_expected_bucket_owner": {
+    "recorded-date": "10-11-2024, 19:23:47",
+    "recorded-content": {
+      "delete-bucket-policy-with-expected-bucket-owner-error": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "delete-bucket-policy-with-expected-bucket-owner": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_expected_bucket_owner": {
+    "recorded-date": "10-11-2024, 19:32:05",
+    "recorded-content": {
+      "put-bucket-policy-with-expected-bucket-owner-error": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "put-bucket-policy-with-expected-bucket-owner": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -44,6 +44,12 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_delete_bucket_no_such_bucket": {
     "last_validated_date": "2023-08-03T02:13:50+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_delete_bucket_policy": {
+    "last_validated_date": "2024-11-10T19:21:53+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_delete_bucket_policy_expected_bucket_owner": {
+    "last_validated_date": "2024-11-10T19:23:47+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_delete_bucket_with_content": {
     "last_validated_date": "2023-08-03T02:13:20+00:00"
   },
@@ -76,6 +82,9 @@
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_notification_configuration_no_such_bucket": {
     "last_validated_date": "2023-08-03T02:13:50+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_policy": {
+    "last_validated_date": "2024-11-10T19:20:17+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_versioning_order": {
     "last_validated_date": "2023-08-03T02:23:26+00:00"
@@ -160,6 +169,15 @@
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_inventory_config_order": {
     "last_validated_date": "2023-08-03T02:26:27+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy": {
+    "last_validated_date": "2024-11-10T19:20:47+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_expected_bucket_owner": {
+    "last_validated_date": "2024-11-10T19:32:05+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_with_expected_bucket_owner": {
+    "last_validated_date": "2024-11-10T19:06:26+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_get_object_special_character[a/%F0%9F%98%80/]": {
     "last_validated_date": "2023-12-12T12:46:44+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -167,9 +167,6 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_precondition_failed_error": {
     "last_validated_date": "2023-08-03T02:17:50+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_and_get_bucket_policy": {
-    "last_validated_date": "2023-08-04T21:56:00+00:00"
-  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_and_get_object_with_content_language_disposition": {
     "last_validated_date": "2023-08-03T02:13:24+00:00"
   },
@@ -199,9 +196,6 @@
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_invalid_account_id[abcd]": {
     "last_validated_date": "2024-11-14T21:38:46+00:00"
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_with_expected_bucket_owner": {
-    "last_validated_date": "2024-11-10T19:06:26+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_get_object_special_character[a/%F0%9F%98%80/]": {
     "last_validated_date": "2023-12-12T12:46:44+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -48,7 +48,7 @@
     "last_validated_date": "2024-11-10T19:21:53+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_delete_bucket_policy_expected_bucket_owner": {
-    "last_validated_date": "2024-11-10T19:23:47+00:00"
+    "last_validated_date": "2024-11-14T21:43:07+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_delete_bucket_with_content": {
     "last_validated_date": "2023-08-03T02:13:20+00:00"
@@ -85,6 +85,18 @@
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_policy": {
     "last_validated_date": "2024-11-10T19:20:17+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_policy_invalid_account_id[0000000000020]": {
+    "last_validated_date": "2024-11-14T21:34:51+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_policy_invalid_account_id[0000]": {
+    "last_validated_date": "2024-11-14T21:34:49+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_policy_invalid_account_id[aa000000000$]": {
+    "last_validated_date": "2024-11-14T21:34:56+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_policy_invalid_account_id[abcd]": {
+    "last_validated_date": "2024-11-14T21:34:53+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_get_bucket_versioning_order": {
     "last_validated_date": "2023-08-03T02:23:26+00:00"
@@ -175,6 +187,18 @@
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_expected_bucket_owner": {
     "last_validated_date": "2024-11-10T19:32:05+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_invalid_account_id[0000000000020]": {
+    "last_validated_date": "2024-11-14T21:38:44+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_invalid_account_id[0000]": {
+    "last_validated_date": "2024-11-14T21:38:42+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_invalid_account_id[aa000000000$]": {
+    "last_validated_date": "2024-11-14T21:38:49+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_invalid_account_id[abcd]": {
+    "last_validated_date": "2024-11-14T21:38:46+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_with_expected_bucket_owner": {
     "last_validated_date": "2024-11-10T19:06:26+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Closes #11826

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Implement the ExpectedBucketOwner parameter and its behavior in 3 S3 operations: 
- PutBucketPolicy
- GetBucketPolicy 
- DeleteBucketPolicy. 

This parameter is currently ignored in LocalStack S3.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
