### PR TITLE
Cloudwatch: add basic composite alarm support

### DIFF
--- a/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
@@ -81,6 +81,9 @@ class AlarmScheduler:
 
         self.scheduled_alarms[alarm_arn] = task
 
+    def schedule_composite_alarm(self, alarm_arn: str) -> None:
+        pass
+
     def delete_scheduler_for_alarm(self, alarm_arn: str) -> None:
         """
         Deletes the recurring scheduler for an alarm

--- a/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
@@ -81,9 +81,6 @@ class AlarmScheduler:
 
         self.scheduled_alarms[alarm_arn] = task
 
-    def schedule_composite_alarm(self, alarm_arn: str) -> None:
-        pass
-
     def delete_scheduler_for_alarm(self, alarm_arn: str) -> None:
         """
         Deletes the recurring scheduler for an alarm

--- a/localstack-core/localstack/services/cloudwatch/models.py
+++ b/localstack-core/localstack/services/cloudwatch/models.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timezone
 from typing import Dict, List
 
 from localstack.aws.api.cloudwatch import CompositeAlarm, DashboardBody, MetricAlarm, StateValue
@@ -24,7 +25,7 @@ class LocalStackMetricAlarm:
         self.set_default_attributes()
 
     def set_default_attributes(self):
-        current_time = datetime.datetime.utcnow()
+        current_time = datetime.datetime.now(timezone.utc)
         self.alarm["AlarmArn"] = arns.cloudwatch_alarm_arn(
             self.alarm["AlarmName"], account_id=self.account_id, region_name=self.region
         )
@@ -52,7 +53,7 @@ class LocalStackCompositeAlarm:
         self.set_default_attributes()
 
     def set_default_attributes(self):
-        current_time = datetime.datetime.utcnow()
+        current_time = datetime.datetime.now(timezone.utc)
         self.alarm["AlarmArn"] = arns.cloudwatch_alarm_arn(
             self.alarm["AlarmName"], account_id=self.account_id, region_name=self.region
         )

--- a/localstack-core/localstack/services/cloudwatch/models.py
+++ b/localstack-core/localstack/services/cloudwatch/models.py
@@ -52,8 +52,20 @@ class LocalStackCompositeAlarm:
         self.set_default_attributes()
 
     def set_default_attributes(self):
-        # TODO
-        pass
+        current_time = datetime.datetime.utcnow()
+        self.alarm["AlarmArn"] = arns.cloudwatch_alarm_arn(
+            self.alarm["AlarmName"], account_id=self.account_id, region_name=self.region
+        )
+        self.alarm["AlarmConfigurationUpdatedTimestamp"] = current_time
+        self.alarm.setdefault("ActionsEnabled", True)
+        self.alarm.setdefault("OKActions", [])
+        self.alarm.setdefault("AlarmActions", [])
+        self.alarm.setdefault("InsufficientDataActions", [])
+        self.alarm["StateValue"] = StateValue.INSUFFICIENT_DATA
+        self.alarm["StateReason"] = "Unchecked: Initial alarm creation"
+        self.alarm["StateUpdatedTimestamp"] = current_time
+        self.alarm["StateTransitionedTimestamp"] = current_time
+
 
 
 class LocalStackDashboard:

--- a/localstack-core/localstack/services/cloudwatch/models.py
+++ b/localstack-core/localstack/services/cloudwatch/models.py
@@ -84,8 +84,11 @@ class CloudWatchStore(BaseStore):
     # maps resource ARN to tags
     TAGS: TaggingService = CrossRegionAttribute(default=TaggingService)
 
-    # maps resource ARN to alarms
+    # maps resource ARN to metric alarms
     alarms: Dict[str, LocalStackAlarm] = LocalAttribute(default=dict)
+
+    # maps resource ARN to composite alarms
+    composite_alarms: Dict[str, LocalStackAlarm] = LocalAttribute(default=dict)
 
     # Contains all the Alarm Histories. Per documentation, an alarm history is retained even if the alarm is deleted,
     # making it necessary to save this at store level

--- a/localstack-core/localstack/services/cloudwatch/models.py
+++ b/localstack-core/localstack/services/cloudwatch/models.py
@@ -68,7 +68,6 @@ class LocalStackCompositeAlarm:
         self.alarm["StateTransitionedTimestamp"] = current_time
 
 
-
 class LocalStackDashboard:
     region: str
     account_id: str

--- a/localstack-core/localstack/services/cloudwatch/models.py
+++ b/localstack-core/localstack/services/cloudwatch/models.py
@@ -84,11 +84,8 @@ class CloudWatchStore(BaseStore):
     # maps resource ARN to tags
     TAGS: TaggingService = CrossRegionAttribute(default=TaggingService)
 
-    # maps resource ARN to metric alarms
+    # maps resource ARN to alarms
     alarms: Dict[str, LocalStackAlarm] = LocalAttribute(default=dict)
-
-    # maps resource ARN to composite alarms
-    composite_alarms: Dict[str, LocalStackAlarm] = LocalAttribute(default=dict)
 
     # Contains all the Alarm Histories. Per documentation, an alarm history is retained even if the alarm is deleted,
     # making it necessary to save this at store level

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -892,9 +892,13 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             context, composite_alarm, new_state_value, state_reason, state_reason_data
         )
         if composite_alarm.alarm["ActionsEnabled"]:
-            self._run_composite_alarm_actions(context, composite_alarm, old_state_value, triggering_alarm)
+            self._run_composite_alarm_actions(
+                context, composite_alarm, old_state_value, triggering_alarm
+            )
 
-    def _run_composite_alarm_actions(self, context, composite_alarm, old_state_value, triggering_alarm):
+    def _run_composite_alarm_actions(
+        self, context, composite_alarm, old_state_value, triggering_alarm
+    ):
         new_state_value = composite_alarm.alarm["StateValue"]
         if new_state_value == StateValue.OK:
             actions = composite_alarm.alarm["OKActions"]

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -781,6 +781,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         old_state_reason = alarm.alarm["StateReason"]
         store = self.get_store(context.account_id, context.region)
         current_time = datetime.datetime.now()
+        # version is not present in state reason data for composite alarm, hence the check
         if state_reason_data and isinstance(alarm, LocalStackMetricAlarm):
             state_reason_data["version"] = HISTORY_VERSION
         history_data = {

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -1002,7 +1002,7 @@ def create_message_response_update_state_lambda(
     return json.dumps(response, cls=JSONEncoder)
 
 
-def create_message_response_update_state_sns(alarm: LocalStackMetricAlarm, old_state):
+def create_message_response_update_state_sns(alarm: LocalStackMetricAlarm, old_state: StateValue):
     _alarm = alarm.alarm
     response = {
         "AWSAccountId": alarm.account_id,

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -469,11 +469,12 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
 
             alarm_rule = composite_alarm.alarm["AlarmRule"]
 
-            alarms_from_rule = [alarm.strip() for alarm in alarm_rule.split("OR")]
-            for alarm in alarms_from_rule:
-                if not alarm.startswith("ALARM"):
-                    raise ValidationError(
-                        f"Error in alarm rule condition '{alarm}': Only ALARM expression is supported"
+            alarms_conditions = [alarm.strip() for alarm in alarm_rule.split("OR")]
+            for alarm_condition in alarms_conditions:
+                if not alarm_condition.startswith("ALARM"):
+                    LOG.warning(
+                        "Unsupported expression in alarm rule condition %s: Only ALARM expression is supported by Localstack as of now",
+                        alarm_condition,
                     )
 
             missing_alarms = []

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -864,6 +864,8 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         return DescribeAlarmHistoryOutput(AlarmHistoryItems=history)
 
     def _evaluate_composite_alarms(self, context: RequestContext, triggering_alarm):
+        # TODO either pass store as a parameter or acquire RLock (with _STORE_LOCK:)
+        # everything works ok now but better ensure protection of critical section in front of future changes
         store = self.get_store(context.account_id, context.region)
         alarms = list(store.alarms.values())
         composite_alarms = [a for a in alarms if isinstance(a, LocalStackCompositeAlarm)]

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -905,7 +905,6 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                     service = connect_to(
                         region_name=data["region"], aws_access_key_id=data["account"]
                     ).sns
-                    # TODO verify message for composite alarm
                     subject = f"""{new_state_value}: "{composite_alarm.alarm["AlarmName"]}" in {context.region}"""
                     message = create_message_response_update_composite_alarm_state_sns(
                         composite_alarm, triggering_alarm, old_state_value

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -462,7 +462,6 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             composite_alarm = LocalStackCompositeAlarm(context.account_id, context.region, {**request})
             alarm_arn = composite_alarm.alarm["AlarmArn"]
             store.alarms[alarm_arn] = composite_alarm
-            self.alarm_scheduler.schedule_composite_alarm(alarm_arn)
 
     def describe_alarms(
         self,

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -80,9 +80,9 @@ from localstack.services.cloudwatch.cloudwatch_database_helper import Cloudwatch
 from localstack.services.cloudwatch.models import (
     CloudWatchStore,
     LocalStackAlarm,
+    LocalStackCompositeAlarm,
     LocalStackDashboard,
     LocalStackMetricAlarm,
-    LocalStackCompositeAlarm,
     cloudwatch_stores,
 )
 from localstack.services.edge import ROUTER
@@ -460,7 +460,9 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
     def put_composite_alarm(self, context: RequestContext, request: PutCompositeAlarmInput) -> None:
         with _STORE_LOCK:
             store = self.get_store(context.account_id, context.region)
-            composite_alarm = LocalStackCompositeAlarm(context.account_id, context.region, {**request})
+            composite_alarm = LocalStackCompositeAlarm(
+                context.account_id, context.region, {**request}
+            )
             alarm_arn = composite_alarm.alarm["AlarmArn"]
             store.alarms[alarm_arn] = composite_alarm
 
@@ -846,7 +848,9 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             new_state_value = StateValue.OK
             alarm_rule = composite_alarm.alarm["AlarmRule"]
             # assuming that a rule consists only of ALARM evaluations of metric alarms, with OR logic applied
-            metric_alarm_arns = re.findall(r'\("([^"]*)"\)', alarm_rule) # regexp for everything within (" ")
+            metric_alarm_arns = re.findall(
+                r'\("([^"]*)"\)', alarm_rule
+            )  # regexp for everything within (" ")
             for metric_alarm_arn in metric_alarm_arns:
                 metric_alarm = store.alarms.get(metric_alarm_arn)
                 if metric_alarm.alarm["StateValue"] == StateValue.ALARM:
@@ -861,12 +865,17 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
 
             triggering_alarm_arn = triggering_alarm.alarm.get("AlarmArn")
             triggering_alarm_state = triggering_alarm.alarm.get("StateValue")
-            triggering_alarm_state_change_timestamp = triggering_alarm.alarm.get("StateTransitionedTimestamp")
+            triggering_alarm_state_change_timestamp = triggering_alarm.alarm.get(
+                "StateTransitionedTimestamp"
+            )
             state_reason_formatted_timestamp = triggering_alarm_state_change_timestamp.strftime(
-                "%A %d %B, %Y %H:%M:%S %Z")
-            state_reason = (f"{triggering_alarm_arn} "
-                            f"transitioned to {triggering_alarm_state} "
-                            f"at {state_reason_formatted_timestamp}")
+                "%A %d %B, %Y %H:%M:%S %Z"
+            )
+            state_reason = (
+                f"{triggering_alarm_arn} "
+                f"transitioned to {triggering_alarm_state} "
+                f"at {state_reason_formatted_timestamp}"
+            )
             state_reason_data = {
                 "triggeringAlarms": [
                     {
@@ -874,11 +883,13 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                         "state": {
                             "value": triggering_alarm_state,
                             "timestamp": timestamp_millis(triggering_alarm_state_change_timestamp),
-                        }
+                        },
                     }
                 ]
             }
-            self._update_state(context,composite_alarm, new_state_value, state_reason, state_reason_data)
+            self._update_state(
+                context, composite_alarm, new_state_value, state_reason, state_reason_data
+            )
 
             if not composite_alarm.alarm["ActionsEnabled"]:
                 return
@@ -896,7 +907,9 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                     ).sns
                     # TODO verify message for composite alarm
                     subject = f"""{new_state_value}: "{composite_alarm.alarm["AlarmName"]}" in {context.region}"""
-                    message = create_message_response_update_composite_alarm_state_sns(composite_alarm, triggering_alarm, old_state_value)
+                    message = create_message_response_update_composite_alarm_state_sns(
+                        composite_alarm, triggering_alarm, old_state_value
+                    )
                     service.publish(TopicArn=action, Subject=subject, Message=message)
                 else:
                     # TODO: support other actions
@@ -1015,10 +1028,11 @@ def create_message_response_update_state_sns(alarm: LocalStackMetricAlarm, old_s
 
     return json.dumps(response, cls=JSONEncoder)
 
+
 def create_message_response_update_composite_alarm_state_sns(
-        composite_alarm: LocalStackCompositeAlarm,
-        triggering_alarm: LocalStackMetricAlarm,
-        old_state,
+    composite_alarm: LocalStackCompositeAlarm,
+    triggering_alarm: LocalStackMetricAlarm,
+    old_state,
 ):
     _alarm = composite_alarm.alarm
     response = {
@@ -1039,13 +1053,15 @@ def create_message_response_update_composite_alarm_state_sns(
         "InsufficientDataActions": _alarm.get("InsufficientDataActions", []),
     }
 
-    triggering_children = [{
-        "Arn": triggering_alarm.alarm.get("AlarmArn"),
-        "State": {
-            "Value": triggering_alarm.alarm["StateValue"],
-            "Timestamp": triggering_alarm.alarm["StateUpdatedTimestamp"],
+    triggering_children = [
+        {
+            "Arn": triggering_alarm.alarm.get("AlarmArn"),
+            "State": {
+                "Value": triggering_alarm.alarm["StateValue"],
+                "Timestamp": triggering_alarm.alarm["StateUpdatedTimestamp"],
+            },
         }
-    }]
+    ]
 
     response["TriggeringChildren"] = triggering_children
 

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -355,7 +355,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                 state_reason_data,
             )
 
-            self._evaluate_composite_alarms(context)
+            self._evaluate_composite_alarms(context, alarm)
 
             if not alarm.alarm["ActionsEnabled"]:
                 return
@@ -838,12 +838,11 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             history = [h for h in history if (date := _get_timestamp(h)) and date <= end_date]
         return DescribeAlarmHistoryOutput(AlarmHistoryItems=history)
 
-    def _evaluate_composite_alarms(self, context: RequestContext):
+    def _evaluate_composite_alarms(self, context: RequestContext, triggering_alarm):
         store = self.get_store(context.account_id, context.region)
         alarms = list(store.alarms.values())
         composite_alarms = [a for a in alarms if isinstance(a, LocalStackCompositeAlarm)]
         for composite_alarm in composite_alarms:
-            triggering_alarm = None
             new_state_value = StateValue.OK
             alarm_rule = composite_alarm.alarm["AlarmRule"]
             # assuming that a rule consists only of ALARM evaluations of metric alarms, with OR logic applied

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -1061,7 +1061,7 @@ def create_message_response_update_state_sns(alarm: LocalStackMetricAlarm, old_s
 def create_message_response_update_composite_alarm_state_sns(
     composite_alarm: LocalStackCompositeAlarm,
     triggering_alarm: LocalStackMetricAlarm,
-    old_state,
+    old_state: StateValue,
 ):
     _alarm = composite_alarm.alarm
     response = {

--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -147,7 +147,10 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
     Cloudwatch provider.
 
     LIMITATIONS:
-        - no alarm rule evaluation
+        - simplified composite alarm rule evaluation:
+            - only OR operator is supported
+            - only ALARM expression is supported
+            - only metric alarms can be included in the rule and they should be referenced by ARN only
     """
 
     def __init__(self):

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1220,7 +1220,29 @@ class TestCloudwatch:
             composite_alarm_in_alarm_when_alarm_2_in_alarm,
         )
 
+        # trigger OK for alarm 2 - composite one should also go back to OK
+        aws_client.cloudwatch.set_alarm_state(
+            AlarmName=alarm_2_name, StateValue="OK", StateReason="resetting alarm 2"
+        )
+
+        _check_composite_alarm_ok_message(
+            expected_triggering_child_arn=alarm_2_arn,
+            expected_triggering_child_state="OK",
+        )
+
+        composite_alarms_list = aws_client.cloudwatch.describe_alarms(
+            AlarmNames=[composite_alarm_name], AlarmTypes=["CompositeAlarm"]
+        )
+        composite_alarm_in_ok_when_alarm_2_back_to_ok = composite_alarms_list["CompositeAlarms"][0]
+        snapshot.match(
+            "composite-alarm-in-ok-when-alarm-2-is-back-to-ok",
+            composite_alarm_in_ok_when_alarm_2_back_to_ok,
+        )
+
         # trigger alarm 1 while alarm 2 is triggered - composite one shouldn't change
+        aws_client.cloudwatch.set_alarm_state(
+            AlarmName=alarm_2_name, StateValue="ALARM", StateReason="trigger alarm 2"
+        )
         aws_client.cloudwatch.set_alarm_state(
             AlarmName=alarm_1_name, StateValue="ALARM", StateReason="trigger alarm 1"
         )

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1072,7 +1072,7 @@ class TestCloudwatch:
             sqs_client=aws_client.sqs,
             expected_queue_url=queue_url_alarm,
             expected_topic_arn=topic_arn_alarm,
-            expected_new="ALARM"
+            expected_new="ALARM",
             expected_reason=state_reason, #TODO define state reason for composite alarm
             alarm_name=composite_alarm_name,
             alarm_description=composite_alarm_description,

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1083,9 +1083,9 @@ class TestCloudwatch:
         composite_alarms_list = aws_client.cloudwatch.describe_alarms(
             AlarmNames=[composite_alarm_name], AlarmTypes=["CompositeAlarm"]
         )
-        alarm = composite_alarms_list["CompositeAlarms"][0]
-        assert alarm["AlarmName"] == composite_alarm_name
-        assert alarm["AlarmRule"] == composite_alarm_rule
+        composite_alarm = composite_alarms_list["CompositeAlarms"][0]
+        assert composite_alarm["AlarmName"] == composite_alarm_name
+        assert composite_alarm["AlarmRule"] == composite_alarm_rule
 
         # trigger alarm 1 - composite one should also go into ALARM state
         aws_client.cloudwatch.set_alarm_state(
@@ -1105,6 +1105,12 @@ class TestCloudwatch:
             expected_triggering_child_arn=alarm_1_arn,
             expected_triggering_child_state="ALARM",
         )
+
+        composite_alarms_list = aws_client.cloudwatch.describe_alarms(
+            AlarmNames=[composite_alarm_name], AlarmTypes=["CompositeAlarm"]
+        )
+        composite_alarm_in_alarm_caused_by_alarm_1 = composite_alarms_list["CompositeAlarms"][0]
+        snapshot.match("composite-alarm-in-alarm-when-alarm-1-is-in-alarm", composite_alarm_in_alarm_caused_by_alarm_1)
 
         # # trigger OK for alarm 1 - composite one should also go back to OK
         # aws_client.cloudwatch.set_alarm_state(

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -994,8 +994,8 @@ class TestCloudwatch:
         snapshot.add_transformer(snapshot.transform.cloudwatch_api())
 
         # create topics for state 'ALARM' and 'OK' of the composite alarm
-        topic_name_alarm = f"topic-{short_uid()}"
-        topic_name_ok = f"topic-{short_uid()}"
+        topic_name_alarm = f"topic-alarm-{short_uid()}"
+        topic_name_ok = f"topic-ok-{short_uid()}"
 
         sns_topic_alarm = sns_create_topic(Name=topic_name_alarm)
         topic_arn_alarm = sns_topic_alarm["TopicArn"]
@@ -1005,9 +1005,8 @@ class TestCloudwatch:
         snapshot.add_transformer(snapshot.transform.regex(topic_arn_ok, "<topic_ok>"))
 
         # create queues for 'ALARM' and 'OK' of the composite alarm (will receive sns messages)
-        uid = short_uid()
-        queue_url_alarm = sqs_create_queue(QueueName=f"AlarmQueue-{uid}")
-        queue_url_ok = sqs_create_queue(QueueName=f"OKQueue-{uid}")
+        queue_url_alarm = sqs_create_queue(QueueName=f"AlarmQueue-{short_uid()}")
+        queue_url_ok = sqs_create_queue(QueueName=f"OKQueue-{short_uid()}")
 
         arn_queue_alarm = aws_client.sqs.get_queue_attributes(
             QueueUrl=queue_url_alarm, AttributeNames=["QueueArn"]

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1027,12 +1027,10 @@ class TestCloudwatch:
         snapshot.add_transformer(TransformerUtility.key_value("MetricName"))
 
         def _put_metric_alarm(alarm_name: str):
-            metric_name = "CPUUtilization"
-            namespace = "AWS/EC2"
             aws_client.cloudwatch.put_metric_alarm(
                 AlarmName=alarm_name,
-                MetricName=metric_name,
-                Namespace=namespace,
+                MetricName="CPUUtilization",
+                Namespace="AWS/EC2",
                 EvaluationPeriods=1,
                 Period=10,
                 Statistic="Sum",

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1071,7 +1071,7 @@ class TestCloudwatch:
         )
 
         # put metric alarms that would be parts of a composite one
-        #TODO extract put metric alarm and associated cleanups into a fixture
+        # TODO extract put metric alarm and associated cleanups into a fixture
         def _put_metric_alarm(alarm_name: str):
             aws_client.cloudwatch.put_metric_alarm(
                 AlarmName=alarm_name,

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1035,6 +1035,7 @@ class TestCloudwatch:
         sns_topic_ok = sns_create_topic(Name=topic_name_ok)
         topic_arn_ok = sns_topic_ok["TopicArn"]
 
+        # TODO extract SNS-to-SQS into a fixture
         # create queues for 'ALARM' and 'OK' of the composite alarm (will receive sns messages)
         queue_url_alarm = sqs_create_queue(QueueName=f"AlarmQueue-{short_uid()}")
         queue_url_ok = sqs_create_queue(QueueName=f"OKQueue-{short_uid()}")
@@ -1070,6 +1071,7 @@ class TestCloudwatch:
         )
 
         # put metric alarms that would be parts of a composite one
+        #TODO extract put metric alarm and associated cleanups into a fixture
         def _put_metric_alarm(alarm_name: str):
             aws_client.cloudwatch.put_metric_alarm(
                 AlarmName=alarm_name,

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -601,19 +601,6 @@ class TestCloudwatch:
     @markers.aws.validated
     @pytest.mark.skipif(is_old_provider(), reason="not supported by the old provider")
     def test_put_composite_alarm_validation(self, aws_client):
-        # each logical expression operand should start with ALARM()
-        with pytest.raises(Exception) as ex:
-            aws_client.cloudwatch.put_composite_alarm(
-                AlarmName="alarm_name",
-                AlarmRule='ALARM("metric-alarm-arn-1") OR OK("metric-alarm-arn-2")',
-            )
-        err = ex.value.response["Error"]
-        assert err["Code"] == "ValidationError"
-        assert (
-            err["Message"]
-            == "Error in alarm rule condition 'OK(\"metric-alarm-arn-2\")': Only ALARM expression is supported"
-        )
-
         with pytest.raises(Exception) as ex:
             aws_client.cloudwatch.put_composite_alarm(
                 AlarmName="alarm_name",

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1039,14 +1039,14 @@ class TestCloudwatch:
             )
             cleanups.append(lambda: aws_client.cloudwatch.delete_alarms(AlarmNames=[alarm_name]))
 
-        alarm_1_name = "simple-alarm-1"
-        alarm_2_name = "simple-alarm-2"
+        alarm_1_name = f"simple-alarm-1-{short_uid()}"
+        alarm_2_name = f"simple-alarm-2-{short_uid()}"
 
         _put_metric_alarm(alarm_1_name)
         _put_metric_alarm(alarm_2_name)
 
         # put composite alarm that is triggered when either of metric alarms is triggered.
-        composite_alarm_name="composite-alarm"
+        composite_alarm_name=f"composite-alarm-{short_uid()}"
         composite_alarm_description="composite alarm description"
 
         aws_client.cloudwatch.put_composite_alarm(

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1083,54 +1083,54 @@ class TestCloudwatch:
         describe_alarm = aws_client.cloudwatch.describe_alarms(AlarmNames=[composite_alarm_name])
         snapshot.match("triggered-alarm", describe_alarm)
 
-        # trigger OK for alarm 1 - composite one should also go back to OK
-        aws_client.cloudwatch.set_alarm_state(
-            AlarmName=alarm_1_name, StateValue="OK", StateReason="resetting alarm 1"
-        )
-
-        retry(
-            check_message,
-            retries=PUBLICATION_RETRIES,
-            sleep_before=1,
-            sqs_client=aws_client.sqs,
-            expected_queue_url=queue_url_ok,
-            expected_topic_arn=topic_arn_ok,
-            expected_new="OK",
-            expected_reason=state_reason, #TODO define state reason for composite alarm
-            alarm_name=composite_alarm_name,
-            alarm_description=composite_alarm_description,
-            expected_trigger=expected_trigger, #TODO define expected trigger for composite alarm
-        )
-        describe_alarm = aws_client.cloudwatch.describe_alarms(AlarmNames=[composite_alarm_name])
-        snapshot.match("reset-alarm", describe_alarm)
-
-        # trigger alarm 2 - composite one should go again into ALARM state
-        aws_client.cloudwatch.set_alarm_state(
-            AlarmName=alarm_2_name, StateValue="ALARM", StateReason="trigger alarm 2"
-        )
-
-        retry(
-            check_message,
-            retries=PUBLICATION_RETRIES,
-            sleep_before=1,
-            sqs_client=aws_client.sqs,
-            expected_queue_url=queue_url_alarm,
-            expected_topic_arn=topic_arn_alarm,
-            expected_new="ALARM"
-        expected_reason = state_reason,  # TODO define state reason for composite alarm
-        alarm_name = composite_alarm_name,
-        alarm_description = composite_alarm_description,
-        expected_trigger = expected_trigger,  # TODO define expected trigger for composite alarm
-        )
-        describe_alarm = aws_client.cloudwatch.describe_alarms(AlarmNames=[composite_alarm_name])
-        snapshot.match("triggered-alarm", describe_alarm)
-
-        # trigger alarm 1 while alarm 2 is triggered - composite one shouldn't change
-        aws_client.cloudwatch.set_alarm_state(
-            AlarmName=alarm_1_name, StateValue="ALARM", StateReason="trigger alarm 1"
-        )
-        # TODO check that alarm state hasn't changed, probably with describe_alarm_history
-        # take into account that composite alarm runs on schedule
+        # # trigger OK for alarm 1 - composite one should also go back to OK
+        # aws_client.cloudwatch.set_alarm_state(
+        #     AlarmName=alarm_1_name, StateValue="OK", StateReason="resetting alarm 1"
+        # )
+        #
+        # retry(
+        #     check_message,
+        #     retries=PUBLICATION_RETRIES,
+        #     sleep_before=1,
+        #     sqs_client=aws_client.sqs,
+        #     expected_queue_url=queue_url_ok,
+        #     expected_topic_arn=topic_arn_ok,
+        #     expected_new="OK",
+        #     expected_reason=state_reason, #TODO define state reason for composite alarm
+        #     alarm_name=composite_alarm_name,
+        #     alarm_description=composite_alarm_description,
+        #     expected_trigger=expected_trigger, #TODO define expected trigger for composite alarm
+        # )
+        # describe_alarm = aws_client.cloudwatch.describe_alarms(AlarmNames=[composite_alarm_name])
+        # snapshot.match("reset-alarm", describe_alarm)
+        #
+        # # trigger alarm 2 - composite one should go again into ALARM state
+        # aws_client.cloudwatch.set_alarm_state(
+        #     AlarmName=alarm_2_name, StateValue="ALARM", StateReason="trigger alarm 2"
+        # )
+        #
+        # retry(
+        #     check_message,
+        #     retries=PUBLICATION_RETRIES,
+        #     sleep_before=1,
+        #     sqs_client=aws_client.sqs,
+        #     expected_queue_url=queue_url_alarm,
+        #     expected_topic_arn=topic_arn_alarm,
+        #     expected_new="ALARM"
+        # expected_reason = state_reason,  # TODO define state reason for composite alarm
+        # alarm_name = composite_alarm_name,
+        # alarm_description = composite_alarm_description,
+        # expected_trigger = expected_trigger,  # TODO define expected trigger for composite alarm
+        # )
+        # describe_alarm = aws_client.cloudwatch.describe_alarms(AlarmNames=[composite_alarm_name])
+        # snapshot.match("triggered-alarm", describe_alarm)
+        #
+        # # trigger alarm 1 while alarm 2 is triggered - composite one shouldn't change
+        # aws_client.cloudwatch.set_alarm_state(
+        #     AlarmName=alarm_1_name, StateValue="ALARM", StateReason="trigger alarm 1"
+        # )
+        # # TODO check that alarm state hasn't changed, probably with describe_alarm_history
+        # # take into account that composite alarm runs on schedule
 
 
     @markers.aws.validated

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1082,6 +1082,19 @@ class TestCloudwatch:
         assert composite_alarm["AlarmName"] == composite_alarm_name
         assert composite_alarm["AlarmRule"] == composite_alarm_rule
 
+
+        # add necessary transformers for the snapshot
+
+        # StateReason is a text with formatted dates inside it. For now stubbing it out fully because
+        # composite alarm reason can be checked via StateReasonData property which is simpler to check
+        # as its properties reference ARN and state of individual alarms without putting them all into a piece of text.
+        snapshot.add_transformer(snapshot.transform.key_value("StateReason"))
+        snapshot.add_transformer(snapshot.transform.regex(composite_alarm_name, "<composite-alarm-name>"))
+        snapshot.add_transformer(snapshot.transform.regex(alarm_1_name, "<simple-alarm-1-name>"))
+        snapshot.add_transformer(snapshot.transform.regex(alarm_2_name, "<simple-alarm-2-name>"))
+        snapshot.add_transformer(snapshot.transform.regex(topic_name_alarm, "<alarm-topic-name>"))
+        snapshot.add_transformer(snapshot.transform.regex(topic_name_ok, "<ok-topic-name>"))
+
         # trigger alarm 1 - composite one should also go into ALARM state
         aws_client.cloudwatch.set_alarm_state(
             AlarmName=alarm_1_name, StateValue="ALARM", StateReason="trigger alarm 1"

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1022,6 +1022,22 @@ class TestCloudwatch:
             QueueUrl=queue_url_ok, Attributes={"Policy": get_sqs_policy(arn_queue_ok, topic_arn_ok)}
         )
 
+        # subscribe to SQS
+        subscription_alarm = aws_client.sns.subscribe(
+            TopicArn=topic_arn_alarm, Protocol="sqs", Endpoint=arn_queue_alarm
+        )
+        cleanups.append(
+            lambda: aws_client.sns.unsubscribe(
+                SubscriptionArn=subscription_alarm["SubscriptionArn"]
+            )
+        )
+        subscription_ok = aws_client.sns.subscribe(
+            TopicArn=topic_arn_ok, Protocol="sqs", Endpoint=arn_queue_ok
+        )
+        cleanups.append(
+            lambda: aws_client.sns.unsubscribe(SubscriptionArn=subscription_ok["SubscriptionArn"])
+        )
+
         # put metric alarms that would be parts of a composite one
         snapshot.add_transformer(TransformerUtility.key_value("MetricName"))
 

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1039,8 +1039,6 @@ class TestCloudwatch:
         )
 
         # put metric alarms that would be parts of a composite one
-        snapshot.add_transformer(TransformerUtility.key_value("MetricName"))
-
         def _put_metric_alarm(alarm_name: str):
             aws_client.cloudwatch.put_metric_alarm(
                 AlarmName=alarm_name,
@@ -1067,7 +1065,7 @@ class TestCloudwatch:
         composite_alarm_name = f"composite-alarm-{short_uid()}"
         composite_alarm_description = "composite alarm description"
 
-        composite_alarm_rule = f'ALARM("{alarm_1_name}") OR ALARM("{alarm_2_name}")'
+        composite_alarm_rule = f'ALARM("{alarm_1_arn}") OR ALARM("{alarm_2_arn}")'
 
         aws_client.cloudwatch.put_composite_alarm(
             AlarmName=composite_alarm_name,
@@ -1105,6 +1103,10 @@ class TestCloudwatch:
             expected_triggering_child_arn=alarm_1_arn,
             expected_triggering_child_state="ALARM",
         )
+
+        # state reason is a text with dates, for now stubbing it out because
+        # composite alarm reason can be checked via TriggeringChildren property
+        snapshot.add_transformer(snapshot.transform.key_value("StateReason"))
 
         composite_alarms_list = aws_client.cloudwatch.describe_alarms(
             AlarmNames=[composite_alarm_name], AlarmTypes=["CompositeAlarm"]

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -604,6 +604,7 @@ class TestCloudwatch:
         alarm_name = f"a-{short_uid()}"
         metric_name = "something"
         namespace = f"test-ns-{short_uid()}"
+        alarm_rule = f'ALARM("{alarm_name}")'
         aws_client.cloudwatch.put_metric_alarm(
             AlarmName=alarm_name,
             Namespace=namespace,
@@ -615,12 +616,6 @@ class TestCloudwatch:
             Threshold=30,
         )
         cleanups.append(lambda: aws_client.cloudwatch.delete_alarms(AlarmNames=[alarm_name]))
-
-        metric_alarm_arn = aws_client.cloudwatch.describe_alarms(AlarmNames=[alarm_name])[
-            "MetricAlarms"
-        ][0]["AlarmArn"]
-        alarm_rule = f'ALARM("{metric_alarm_arn}")'
-
         aws_client.cloudwatch.put_composite_alarm(
             AlarmName=composite_alarm_name,
             AlarmRule=alarm_rule,

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -2924,7 +2924,6 @@ def check_composite_alarm_message(
         expected_triggering_child_state,
 ):
     receive_result = sqs_client.receive_message(QueueUrl=queue_url)
-    LOG.info(f"receive SQS message: {receive_result}")
     message = None
     for msg in receive_result["Messages"]:
         body = json.loads(msg["Body"])

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1107,6 +1107,10 @@ class TestCloudwatch:
             AlarmNames=[composite_alarm_name], AlarmTypes=["CompositeAlarm"]
         )
         composite_alarm = composite_alarms_list["CompositeAlarms"][0]
+        # TODO snapshot.match("describe-composite-alarm", composite_alarm) instead of asserts
+        # right now the lack of parity for initial composite alarm evaluation prevents from checking snapshot.
+        # Namely, for initial evaluation after alarm creation all child alarms
+        # should be included as triggering alarms
         assert composite_alarm["AlarmName"] == composite_alarm_name
         assert composite_alarm["AlarmRule"] == composite_alarm_rule
 

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -632,7 +632,6 @@ class TestCloudwatch:
         alarm_name = f"a-{short_uid()}"
         metric_name = "something"
         namespace = f"test-ns-{short_uid()}"
-        alarm_rule = f'ALARM("{alarm_name}")'
         aws_client.cloudwatch.put_metric_alarm(
             AlarmName=alarm_name,
             Namespace=namespace,
@@ -644,6 +643,12 @@ class TestCloudwatch:
             Threshold=30,
         )
         cleanups.append(lambda: aws_client.cloudwatch.delete_alarms(AlarmNames=[alarm_name]))
+
+        metric_alarm_arn = aws_client.cloudwatch.describe_alarms(AlarmNames=[alarm_name])[
+            "MetricAlarms"
+        ][0]["AlarmArn"]
+        alarm_rule = f'ALARM("{metric_alarm_arn}")'
+
         aws_client.cloudwatch.put_composite_alarm(
             AlarmName=composite_alarm_name,
             AlarmRule=alarm_rule,

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -599,21 +599,6 @@ class TestCloudwatch:
         assert isinstance(alarm["StateUpdatedTimestamp"], datetime)
 
     @markers.aws.validated
-    @pytest.mark.skipif(is_old_provider(), reason="not supported by the old provider")
-    def test_put_composite_alarm_validation(self, aws_client):
-        with pytest.raises(Exception) as ex:
-            aws_client.cloudwatch.put_composite_alarm(
-                AlarmName="alarm_name",
-                AlarmRule='ALARM("metric-alarm-arn")',
-            )
-        err = ex.value.response["Error"]
-        assert err["Code"] == "ValidationError"
-        assert (
-            err["Message"]
-            == "Could not save the composite alarm as alarms [metric-alarm-arn] in the alarm rule do not exist"
-        )
-
-    @markers.aws.validated
     def test_put_composite_alarm_describe_alarms(self, aws_client, cleanups):
         composite_alarm_name = f"composite-a-{short_uid()}"
         alarm_name = f"a-{short_uid()}"

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1102,7 +1102,7 @@ class TestCloudwatch:
 
         composite_alarm_rule = f'ALARM("{alarm_1_arn}") OR ALARM("{alarm_2_arn}")'
 
-        aws_client.cloudwatch.put_composite_alarm(
+        put_composite_alarm_response = aws_client.cloudwatch.put_composite_alarm(
             AlarmName=composite_alarm_name,
             AlarmDescription=composite_alarm_description,
             AlarmRule=composite_alarm_rule,
@@ -1112,6 +1112,7 @@ class TestCloudwatch:
         cleanups.append(
             lambda: aws_client.cloudwatch.delete_alarms(AlarmNames=[composite_alarm_name])
         )
+        snapshot.match("put-composite-alarm", put_composite_alarm_response)
 
         composite_alarms_list = aws_client.cloudwatch.describe_alarms(
             AlarmNames=[composite_alarm_name], AlarmTypes=["CompositeAlarm"]

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -2105,27 +2105,27 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "recorded-date": "07-11-2024, 15:07:28",
+    "recorded-date": "08-11-2024, 15:18:19",
     "recorded-content": {
       "composite-alarm-in-alarm-when-alarm-1-is-in-alarm": {
         "ActionsEnabled": true,
         "AlarmActions": [
-          "arn:<partition>:sns:<region>:111111111111:<topic_alarm>"
+          "arn:<partition>:sns:<region>:111111111111:<alarm-topic-name>"
         ],
-        "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+        "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<composite-alarm-name>",
         "AlarmConfigurationUpdatedTimestamp": "timestamp",
         "AlarmDescription": "composite alarm description",
-        "AlarmName": "<alarm-name:1>",
-        "AlarmRule": "ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:<SubscriptionArn:2>\") OR ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:simple-alarm-2-cc82e41a\")",
+        "AlarmName": "<composite-alarm-name>",
+        "AlarmRule": "ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-1-name>\") OR ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-2-name>\")",
         "InsufficientDataActions": [],
         "OKActions": [
-          "<topic_ok>"
+          "arn:<partition>:sns:<region>:111111111111:<ok-topic-name>"
         ],
-        "StateReason": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<SubscriptionArn:2> transitioned to ALARM at Thursday 07 November, 2024 15:07:<SubscriptionArn:1>",
+        "StateReason": "<state-reason:1>",
         "StateReasonData": {
           "triggeringAlarms": [
             {
-              "arn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<SubscriptionArn:2>",
+              "arn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-1-name>",
               "state": {
                 "value": "ALARM",
                 "timestamp": "date"

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -2105,7 +2105,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "recorded-date": "14-11-2024, 13:59:36",
+    "recorded-date": "14-11-2024, 14:25:30",
     "recorded-content": {
       "put-composite-alarm": {
         "ResponseMetadata": {
@@ -2232,6 +2232,36 @@
         "StateTransitionedTimestamp": "timestamp",
         "StateUpdatedTimestamp": "timestamp",
         "StateValue": "OK"
+      },
+      "composite-alarm-is-triggered-by-alarm-1-and-then-unchanged-by-alarm-2": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          "arn:<partition>:sns:<region>:111111111111:<alarm-topic-name>"
+        ],
+        "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<composite-alarm-name>",
+        "AlarmConfigurationUpdatedTimestamp": "timestamp",
+        "AlarmDescription": "composite alarm description",
+        "AlarmName": "<composite-alarm-name>",
+        "AlarmRule": "ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-1-name>\") OR ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-2-name>\")",
+        "InsufficientDataActions": [],
+        "OKActions": [
+          "arn:<partition>:sns:<region>:111111111111:<ok-topic-name>"
+        ],
+        "StateReason": "<state-reason:5>",
+        "StateReasonData": {
+          "triggeringAlarms": [
+            {
+              "arn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-1-name>",
+              "state": {
+                "value": "ALARM",
+                "timestamp": "date"
+              }
+            }
+          ]
+        },
+        "StateTransitionedTimestamp": "timestamp",
+        "StateUpdatedTimestamp": "timestamp",
+        "StateValue": "ALARM"
       }
     }
   }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -2105,7 +2105,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "recorded-date": "08-11-2024, 15:18:19",
+    "recorded-date": "11-11-2024, 10:26:28",
     "recorded-content": {
       "composite-alarm-in-alarm-when-alarm-1-is-in-alarm": {
         "ActionsEnabled": true,
@@ -2136,6 +2136,36 @@
         "StateTransitionedTimestamp": "timestamp",
         "StateUpdatedTimestamp": "timestamp",
         "StateValue": "ALARM"
+      },
+      "composite-alarm-in-ok-when-alarm-1-is-back-to-ok": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          "arn:<partition>:sns:<region>:111111111111:<alarm-topic-name>"
+        ],
+        "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<composite-alarm-name>",
+        "AlarmConfigurationUpdatedTimestamp": "timestamp",
+        "AlarmDescription": "composite alarm description",
+        "AlarmName": "<composite-alarm-name>",
+        "AlarmRule": "ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-1-name>\") OR ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-2-name>\")",
+        "InsufficientDataActions": [],
+        "OKActions": [
+          "arn:<partition>:sns:<region>:111111111111:<ok-topic-name>"
+        ],
+        "StateReason": "<state-reason:2>",
+        "StateReasonData": {
+          "triggeringAlarms": [
+            {
+              "arn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-1-name>",
+              "state": {
+                "value": "OK",
+                "timestamp": "date"
+              }
+            }
+          ]
+        },
+        "StateTransitionedTimestamp": "timestamp",
+        "StateUpdatedTimestamp": "timestamp",
+        "StateValue": "OK"
       }
     }
   }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -2105,7 +2105,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "recorded-date": "11-11-2024, 10:26:28",
+    "recorded-date": "11-11-2024, 10:37:42",
     "recorded-content": {
       "composite-alarm-in-alarm-when-alarm-1-is-in-alarm": {
         "ActionsEnabled": true,
@@ -2166,6 +2166,36 @@
         "StateTransitionedTimestamp": "timestamp",
         "StateUpdatedTimestamp": "timestamp",
         "StateValue": "OK"
+      },
+      "composite-alarm-in-alarm-when-alarm-2-is-in-alarm": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          "arn:<partition>:sns:<region>:111111111111:<alarm-topic-name>"
+        ],
+        "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<composite-alarm-name>",
+        "AlarmConfigurationUpdatedTimestamp": "timestamp",
+        "AlarmDescription": "composite alarm description",
+        "AlarmName": "<composite-alarm-name>",
+        "AlarmRule": "ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-1-name>\") OR ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-2-name>\")",
+        "InsufficientDataActions": [],
+        "OKActions": [
+          "arn:<partition>:sns:<region>:111111111111:<ok-topic-name>"
+        ],
+        "StateReason": "<state-reason:3>",
+        "StateReasonData": {
+          "triggeringAlarms": [
+            {
+              "arn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-2-name>",
+              "state": {
+                "value": "ALARM",
+                "timestamp": "date"
+              }
+            }
+          ]
+        },
+        "StateTransitionedTimestamp": "timestamp",
+        "StateUpdatedTimestamp": "timestamp",
+        "StateValue": "ALARM"
       }
     }
   }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -2105,7 +2105,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "recorded-date": "13-11-2024, 13:20:25",
+    "recorded-date": "14-11-2024, 13:59:36",
     "recorded-content": {
       "put-composite-alarm": {
         "ResponseMetadata": {
@@ -2202,6 +2202,36 @@
         "StateTransitionedTimestamp": "timestamp",
         "StateUpdatedTimestamp": "timestamp",
         "StateValue": "ALARM"
+      },
+      "composite-alarm-in-ok-when-alarm-2-is-back-to-ok": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          "arn:<partition>:sns:<region>:111111111111:<alarm-topic-name>"
+        ],
+        "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<composite-alarm-name>",
+        "AlarmConfigurationUpdatedTimestamp": "timestamp",
+        "AlarmDescription": "composite alarm description",
+        "AlarmName": "<composite-alarm-name>",
+        "AlarmRule": "ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-1-name>\") OR ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-2-name>\")",
+        "InsufficientDataActions": [],
+        "OKActions": [
+          "arn:<partition>:sns:<region>:111111111111:<ok-topic-name>"
+        ],
+        "StateReason": "<state-reason:4>",
+        "StateReasonData": {
+          "triggeringAlarms": [
+            {
+              "arn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-2-name>",
+              "state": {
+                "value": "OK",
+                "timestamp": "date"
+              }
+            }
+          ]
+        },
+        "StateTransitionedTimestamp": "timestamp",
+        "StateUpdatedTimestamp": "timestamp",
+        "StateValue": "OK"
       }
     }
   }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -2105,8 +2105,14 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "recorded-date": "11-11-2024, 10:37:42",
+    "recorded-date": "13-11-2024, 13:20:25",
     "recorded-content": {
+      "put-composite-alarm": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "composite-alarm-in-alarm-when-alarm-1-is-in-alarm": {
         "ActionsEnabled": true,
         "AlarmActions": [

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -2105,7 +2105,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "recorded-date": "07-11-2024, 11:29:50",
+    "recorded-date": "07-11-2024, 15:07:28",
     "recorded-content": {
       "composite-alarm-in-alarm-when-alarm-1-is-in-alarm": {
         "ActionsEnabled": true,
@@ -2116,12 +2116,12 @@
         "AlarmConfigurationUpdatedTimestamp": "timestamp",
         "AlarmDescription": "composite alarm description",
         "AlarmName": "<alarm-name:1>",
-        "AlarmRule": "ALARM(\"<SubscriptionArn:2>\") OR ALARM(\"simple-alarm-2-7a20e452\")",
+        "AlarmRule": "ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:<SubscriptionArn:2>\") OR ALARM(\"arn:<partition>:cloudwatch:<region>:111111111111:alarm:simple-alarm-2-cc82e41a\")",
         "InsufficientDataActions": [],
         "OKActions": [
           "<topic_ok>"
         ],
-        "StateReason": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<SubscriptionArn:2> transitioned to ALARM at Thursday 07 November, 2024 11:29:<SubscriptionArn:1>",
+        "StateReason": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<SubscriptionArn:2> transitioned to ALARM at Thursday 07 November, 2024 15:07:<SubscriptionArn:1>",
         "StateReasonData": {
           "triggeringAlarms": [
             {

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -2103,5 +2103,40 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
+    "recorded-date": "07-11-2024, 11:29:50",
+    "recorded-content": {
+      "composite-alarm-in-alarm-when-alarm-1-is-in-alarm": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          "arn:<partition>:sns:<region>:111111111111:<topic_alarm>"
+        ],
+        "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+        "AlarmConfigurationUpdatedTimestamp": "timestamp",
+        "AlarmDescription": "composite alarm description",
+        "AlarmName": "<alarm-name:1>",
+        "AlarmRule": "ALARM(\"<SubscriptionArn:2>\") OR ALARM(\"simple-alarm-2-7a20e452\")",
+        "InsufficientDataActions": [],
+        "OKActions": [
+          "<topic_ok>"
+        ],
+        "StateReason": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<SubscriptionArn:2> transitioned to ALARM at Thursday 07 November, 2024 11:29:<SubscriptionArn:1>",
+        "StateReasonData": {
+          "triggeringAlarms": [
+            {
+              "arn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<SubscriptionArn:2>",
+              "state": {
+                "value": "ALARM",
+                "timestamp": "date"
+              }
+            }
+          ]
+        },
+        "StateTransitionedTimestamp": "timestamp",
+        "StateUpdatedTimestamp": "timestamp",
+        "StateValue": "ALARM"
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -69,6 +69,6 @@
     "last_validated_date": "2024-09-02T14:03:31+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "last_validated_date": "2024-11-08T15:18:19+00:00"
+    "last_validated_date": "2024-11-11T10:26:28+00:00"
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -69,6 +69,6 @@
     "last_validated_date": "2024-09-02T14:03:31+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "last_validated_date": "2024-11-14T13:45:48+00:00"
+    "last_validated_date": "2024-11-14T13:59:36+00:00"
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -69,6 +69,6 @@
     "last_validated_date": "2024-09-02T14:03:31+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "last_validated_date": "2024-11-11T10:26:28+00:00"
+    "last_validated_date": "2024-11-11T10:37:42+00:00"
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -67,5 +67,8 @@
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_store_tags": {
     "last_validated_date": "2024-09-02T14:03:31+00:00"
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
+    "last_validated_date": "2024-11-07T11:29:50+00:00"
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -69,6 +69,6 @@
     "last_validated_date": "2024-09-02T14:03:31+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "last_validated_date": "2024-11-13T13:20:25+00:00"
+    "last_validated_date": "2024-11-14T13:45:48+00:00"
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -69,6 +69,6 @@
     "last_validated_date": "2024-09-02T14:03:31+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "last_validated_date": "2024-11-14T13:59:36+00:00"
+    "last_validated_date": "2024-11-14T14:25:30+00:00"
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -69,6 +69,6 @@
     "last_validated_date": "2024-09-02T14:03:31+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "last_validated_date": "2024-11-11T10:37:42+00:00"
+    "last_validated_date": "2024-11-13T13:20:25+00:00"
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -69,6 +69,6 @@
     "last_validated_date": "2024-09-02T14:03:31+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "last_validated_date": "2024-11-07T15:07:28+00:00"
+    "last_validated_date": "2024-11-08T15:18:19+00:00"
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -69,6 +69,6 @@
     "last_validated_date": "2024-09-02T14:03:31+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_trigger_composite_alarm": {
-    "last_validated_date": "2024-11-07T11:29:50+00:00"
+    "last_validated_date": "2024-11-07T15:07:28+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Add basic support for [composite alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Composite_Alarm.html) evaluation in Cloudwatch. Currently composite alarms can be saved but there is no evaluation for them, therefore there is no way to get them triggered.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Composite alarm rules will be evaluated now whenever a metric alarm state is changed.

This PR adds limited support for alarm rules:
- Alarms can be referred to by ARNs only (no alarm names support yet)
- It is assumed that only OR logic is applied for all child alarms
- Suppression logic for child alarms is not implemented
- Composite alarm actions only support a message to an SNS topic
- Only metric alarms can be child alarms, nesting of a composite ones is not supported yet

Example of supported rule: `ALARM("arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-1-name>") OR ALARM("arn:<partition>:cloudwatch:<region>:111111111111:alarm:<simple-alarm-2-name>")`



<!-- Optional section: How to test these changes? -->
## Testing
Snapshot tests have been recorded for several test cases to verify that alarm rule logic applies correctly.

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
