### PR TITLE
Bump moto-ext to 5.0.20.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.18.post1",
+    "moto-ext[all]==5.0.20.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -256,7 +256,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.18.post1
+moto-ext==5.0.20.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -190,7 +190,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.18.post1
+moto-ext==5.0.20.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -240,7 +240,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.18.post1
+moto-ext==5.0.20.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -260,7 +260,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.18.post1
+moto-ext==5.0.20.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.0.20.post1

## To do

- [x] Ext compatibility ([Ext integration tests](https://github.com/localstack/localstack-ext/actions/runs/11907259939))
- [x] Multi-account/region compatibility ([Randomised credentials test run](https://app.circleci.com/pipelines/github/localstack/localstack/29421/workflows/f8a249a4-6291-46e7-a036-fd2338f4ef2d))