### PR TITLE
Fix testing links and update aws client fixtures in contributing docs

### DIFF
--- a/docs/testing/integration-tests/README.md
+++ b/docs/testing/integration-tests/README.md
@@ -46,12 +46,12 @@ class TestMyThing:
 
 ### Fixtures
 
-We use the pytest fixture concept, and provide several fixtures you can use when writing AWS tests. For example, to inject a Boto client for SQS, you can specify the `sqs_client` in your test method:
+We use the pytest fixture concept, and provide several fixtures you can use when writing AWS tests. For example, to inject a boto client factory for all services, you can specify the `aws_client` fixture in your test method and access a client from it:
 
 ```python
 class TestMyThing:
-  def test_something(self, sqs_client):
-    assert len(sqs_client.list_queues()["QueueUrls"]) == 0
+  def test_something(self, aws_client):
+    assert len(aws_client.sqs.list_queues()["QueueUrls"]) == 0
 ```
 
 We also provide fixtures for certain disposable resources, like buckets:

--- a/docs/testing/parity-testing/README.md
+++ b/docs/testing/parity-testing/README.md
@@ -1,3 +1,5 @@
+from conftest import aws_client
+
 # Parity Testing
 
 Parity tests (also called snapshot tests) are a special form of integration tests that should verify and improve the correctness of LocalStack compared to AWS.
@@ -16,7 +18,7 @@ This guide assumes you are already familiar with writing [integration tests](../
 In a nutshell, the necessary steps include:
 
 1.  Make sure that the test works against AWS.
-    * Check out our [Integration Test Guide](integration-tests.md#running-integration-tests-against-aws) for tips on how run integration tests against AWS.
+    * Check out our [Integration Test Guide](../integration-tests/README.md#running-integration-tests-against-aws) for tips on how run integration tests against AWS.
 2.  Add the `snapshot` fixture to your test and identify which responses you want to collect and compare against LocalStack.
     * Use `snapshot.match(”identifier”, result)` to mark the result of interest. It will be recorded and stored in a file with the name `<testfile-name>.snapshot.json`
     *  The **identifier** can be freely selected, but ideally it gives a hint on what is recorded - so typically the name of the function. The **result** is expected to be a `dict`.
@@ -29,11 +31,11 @@ In a nutshell, the necessary steps include:
 Here is an example of a parity test:
 
 ```python
-def test_invocation(self, lambda_client, snapshot):
+def test_invocation(self, aws_client, snapshot):
     # add transformers to make the results comparable
-    snapshot.add_transformer(snapshot.transform.lambda_api()
+    snapshot.add_transformer(snapshot.transform.lambda_api())
 
-    result = lambda_client.invoke(
+    result = aws_client.lambda_.invoke(
             ....
     )
     # records the 'result' using the identifier 'invoke'
@@ -124,7 +126,7 @@ Consider the following example:
 
 ```python
 def test_basic_invoke(
-        self, lambda_client, create_lambda, snapshot
+        self, aws_client, create_lambda, snapshot
     ):
 
     # custom transformers
@@ -143,11 +145,11 @@ def test_basic_invoke(
     snapshot.match("lambda_create_fn_2", response)
 
     # get function 1
-    get_fn_result = lambda_client.get_function(FunctionName=fn_name)
+    get_fn_result = aws_client.lambda_.get_function(FunctionName=fn_name)
     snapshot.match("lambda_get_fn", get_fn_result)
 
     # get function 2
-    get_fn_result_2 = lambda_client.get_function(FunctionName=fn_name_2)
+    get_fn_result_2 = aws_client.lambda_.get_function(FunctionName=fn_name_2)
     snapshot.match("lambda_get_fn_2", get_fn_result_2)
 ```
 
@@ -223,13 +225,13 @@ Simply include a list of json-paths. Those paths will then be excluded from the 
 @pytest.mark.skip_snapshot_verify(
         paths=["$..LogResult", "$..Payload.context.memory_limit_in_mb"]
     )
-    def test_something_that_does_not_work_completly_yet(self, lambda_client, snapshot):
+    def test_something_that_does_not_work_completly_yet(self, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.lambda_api())
-        result = lambda_client....
+        result = aws_client.lambda_....
         snapshot.match("invoke-result", result)
 ```
 
-> [!NOTE]  
+> [!NOTE]
 > Generally, [transformers](#using-transformers) should be used wherever possible to make responses comparable.
 > If specific paths are skipped from the verification, it means LocalStack does not have parity yet.
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We had a dead link from the parity testing docs to the integration test docs, which is fixed now.

Also, we are still using the old version of boto client fixtures as examples. While the examples are only illustrative, we should still use the correct ones if possible.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Fix broken link
* Replace usage of `sqs_client` and `lambda_client` fixtures with the `aws_client` fixture

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
