### PR TITLE
Add test for SSM GetParameterHistory API

### DIFF
--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -1665,7 +1665,10 @@ def create_parameter(aws_client):
     yield _create_parameter
 
     for param in params:
-        aws_client.ssm.delete_parameter(Name=param)
+        try:
+            aws_client.ssm.delete_parameter(Name=param)
+        except Exception as e:
+            LOG.debug("error cleaning up parameter %s: %s", param, e)
 
 
 @pytest.fixture

--- a/tests/aws/services/ssm/test_ssm.snapshot.json
+++ b/tests/aws/services/ssm/test_ssm.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_arn": {
-    "recorded-date": "16-07-2024, 17:17:40",
+    "recorded-date": "28-01-2025, 12:43:53",
     "recorded-content": {
       "Parameter": {
         "ARN": "arn:<partition>:ssm:<region>:111111111111:parameter/<name:1>",
@@ -14,7 +14,7 @@
     }
   },
   "tests/aws/services/ssm/test_ssm.py::TestSSM::test_parameters_with_path": {
-    "recorded-date": "08-01-2025, 17:04:53",
+    "recorded-date": "28-01-2025, 12:43:55",
     "recorded-content": {
       "put-parameter-response": {
         "Tier": "Standard",
@@ -83,6 +83,55 @@
             "Type": "String",
             "Value": "123",
             "Version": 1
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_history": {
+    "recorded-date": "28-01-2025, 12:43:53",
+    "recorded-content": {
+      "get-parameter-history-response": {
+        "Parameters": [
+          {
+            "DataType": "text",
+            "Labels": [],
+            "LastModifiedDate": "<datetime>",
+            "LastModifiedUser": "<last-modified-user:1>",
+            "Name": "<name:1>",
+            "Policies": [],
+            "Tier": "Standard",
+            "Type": "String",
+            "Value": "test",
+            "Version": 1
+          },
+          {
+            "DataType": "text",
+            "Labels": [],
+            "LastModifiedDate": "<datetime>",
+            "LastModifiedUser": "<last-modified-user:1>",
+            "Name": "<name:1>",
+            "Policies": [],
+            "Tier": "Standard",
+            "Type": "String",
+            "Value": "test2",
+            "Version": 2
+          },
+          {
+            "DataType": "text",
+            "Labels": [],
+            "LastModifiedDate": "<datetime>",
+            "LastModifiedUser": "<last-modified-user:1>",
+            "Name": "<name:1>",
+            "Policies": [],
+            "Tier": "Standard",
+            "Type": "String",
+            "Value": "test3",
+            "Version": 3
           }
         ],
         "ResponseMetadata": {

--- a/tests/aws/services/ssm/test_ssm.validation.json
+++ b/tests/aws/services/ssm/test_ssm.validation.json
@@ -1,8 +1,38 @@
 {
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_describe_parameters": {
+    "last_validated_date": "2025-01-28T12:43:49+00:00"
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_inexistent_maintenance_window": {
+    "last_validated_date": "2025-01-28T12:43:53+00:00"
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_inexistent_secret": {
+    "last_validated_date": "2025-01-28T12:43:51+00:00"
+  },
   "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_arn": {
-    "last_validated_date": "2024-07-16T17:17:40+00:00"
+    "last_validated_date": "2025-01-28T12:43:53+00:00"
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_history": {
+    "last_validated_date": "2025-01-28T12:43:53+00:00"
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameters_and_secrets": {
+    "last_validated_date": "2025-01-28T12:43:51+00:00"
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameters_by_path_and_filter_by_labels": {
+    "last_validated_date": "2025-01-28T12:43:52+00:00"
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_secret_parameter": {
+    "last_validated_date": "2025-01-28T12:43:51+00:00"
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_hierarchical_parameter[/<param>//b//c]": {
+    "last_validated_date": "2025-01-28T12:43:50+00:00"
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_hierarchical_parameter[<param>/b/c]": {
+    "last_validated_date": "2025-01-28T12:43:50+00:00"
   },
   "tests/aws/services/ssm/test_ssm.py::TestSSM::test_parameters_with_path": {
-    "last_validated_date": "2025-01-08T17:04:53+00:00"
+    "last_validated_date": "2025-01-28T12:43:55+00:00"
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_put_parameters": {
+    "last_validated_date": "2025-01-28T12:43:50+00:00"
   }
 }


### PR DESCRIPTION
Hi! I regularly use LocalStack, and thank you for such an awesome product😀

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Recently, while using LocalStack’s SSM Parameter Store, I checked the API coverage and found that some APIs were not marked in the "Internal Test Suite". So I wanted to contribute by adding tests.
- https://docs.localstack.cloud/references/coverage/coverage_ssm/

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
In this Pull Request, I’ve added a test for the SSM `GetParameterHistory` API to improve coverage.

<!-- Optional section: How to test these changes? -->
## Testing
The tests passed in my local environment.

```sh
$ make test TEST_PATH=tests/aws/services/ssm
(snip)
tests/aws/services/ssm/test_ssm.py::TestSSM::test_describe_parameters PASSED                                                                                                                                                                                                                                                                                                                   [  7%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_put_parameters PASSED                                                                                                                                                                                                                                                                                                                        [ 14%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_hierarchical_parameter[/<param>//b//c] PASSED                                                                                                                                                                                                                                                                                                [ 21%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_hierarchical_parameter[<param>/b/c] PASSED                                                                                                                                                                                                                                                                                                   [ 28%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_secret_parameter PASSED                                                                                                                                                                                                                                                                                                                  [ 35%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_inexistent_secret PASSED                                                                                                                                                                                                                                                                                                                 [ 42%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameters_and_secrets PASSED                                                                                                                                                                                                                                                                                                            [ 50%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameters_by_path_and_filter_by_labels PASSED                                                                                                                                                                                                                                                                                           [ 57%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_arn PASSED                                                                                                                                                                                                                                                                                                                  [ 64%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_history PASSED                                                                                                                                                                                                                                                                                                                 [ 71%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_inexistent_maintenance_window PASSED                                                                                                                                                                                                                                                                                                     [ 78%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_trigger_event_on_systems_manager_change[standard] PASSED                                                                                                                                                                                                                                                                                     [ 85%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_trigger_event_on_systems_manager_change[domain] PASSED                                                                                                                                                                                                                                                                                       [ 92%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_trigger_event_on_systems_manager_change[path] PASSED                                                                                                                                                                                                                                                                                         [100%]
```

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->

Could you please review? Thanks a lot 👍 