### PR TITLE
Bump airspeed-ext to 0.6.7

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=dev --output-file=requirements-dev.txt --strip-extras --unsafe-package=distribute --unsafe-package=localstack-core --unsafe-package=pip --unsafe-package=setuptools pyproject.toml
 #
-airspeed-ext==0.6.6
+airspeed-ext==0.6.7
     # via localstack-core
 amazon-kclpy==2.1.5
     # via localstack-core

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=runtime --output-file=requirements-runtime.txt --strip-extras --unsafe-package=distribute --unsafe-package=localstack-core --unsafe-package=pip --unsafe-package=setuptools pyproject.toml
 #
-airspeed-ext==0.6.6
+airspeed-ext==0.6.7
     # via localstack-core (pyproject.toml)
 amazon-kclpy==2.1.5
     # via localstack-core (pyproject.toml)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=test --output-file=requirements-test.txt --strip-extras --unsafe-package=distribute --unsafe-package=localstack-core --unsafe-package=pip --unsafe-package=setuptools pyproject.toml
 #
-airspeed-ext==0.6.6
+airspeed-ext==0.6.7
     # via localstack-core
 amazon-kclpy==2.1.5
     # via localstack-core

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=typehint --output-file=requirements-typehint.txt --strip-extras --unsafe-package=distribute --unsafe-package=localstack-core --unsafe-package=pip --unsafe-package=setuptools pyproject.toml
 #
-airspeed-ext==0.6.6
+airspeed-ext==0.6.7
     # via localstack-core
 amazon-kclpy==2.1.5
     # via localstack-core


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Bumping airspeed version to 0.6.7

https://github.com/localstack/airspeed/pull/20
- Fixing issue with matching `double` type.
- Adding mechanism to bypass silent behavior of `$util` functions.
