### PR TITLE
DynamoDB: fix mkdir call with None when DYNAMODB_IN_MEMORY=1

### DIFF
--- a/localstack-core/localstack/services/dynamodb/server.py
+++ b/localstack-core/localstack/services/dynamodb/server.py
@@ -95,7 +95,9 @@ class DynamodbServer(Server):
         # - pod load with some assets already lying in the asset folder
         # - ...
         # The cleaning is now done via the reset endpoint
-        mkdir(self.db_path)
+        if self.db_path:
+            mkdir(self.db_path)
+
         started = self.start()
         self.wait_for_dynamodb()
         return started


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With #11789 fixing previous issues we've introduced with DynamoDB Streams v2 implementation, a call to `mkdir` was introduced.

However, when `DYNAMODB_IN_MEMORY=1` is set, we set `self.db_path` to `None` leading to this exception:
```python
2024-11-14T12:47:05.847 ERROR --- [et.reactor-3] localstack.utils.functions : error calling function on_before_start
Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/utils/functions.py", line 42, in call_safe
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/dynamodb/v2/provider.py", line 378, in on_before_start
    self.server.start_dynamodb()
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/utils/sync.py", line 99, in _wrapper
    return wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/dynamodb/server.py", line 98, in start_dynamodb
    mkdir(self.db_path)
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/utils/files.py", line 114, in mkdir
    if not os.path.exists(folder):
           ^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen genericpath>", line 19, in exists
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
2024-11-14T12:47:05.884 DEBUG --- [et.reactor-1] rolo.gateway.wsgi          : POST localhost:4566/
```

This PR sets a conditional so that it works. We should probably implements a bootstrap test starting DynamoDB Local in memory knowing some users depends on it, but this PR quickly fixes it for them. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- only conditionally call `mkdir` if `self.db_path` is truthy 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
