### PR TITLE
Add Bedrock configuration values to analytics

### DIFF
--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -8,9 +8,11 @@ from localstack.utils.analytics import log
 LOG = logging.getLogger(__name__)
 
 TRACKED_ENV_VAR = [
+    "BEDROCK_PREWARM",
     "CONTAINER_RUNTIME",
     "DEBUG",
     "DEFAULT_REGION",  # Not functional; deprecated in 0.12.7, removed in 3.0.0
+    "DEFAULT_BEDROCK_MODEL",
     "DISABLE_CORS_CHECK",
     "DISABLE_CORS_HEADERS",
     "DMS_SERVERLESS_DEPROVISIONING_DELAY",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Bedrock is an upcoming new pro service which needs tracking in our analytics

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- add tracking for the pre-warming configuration to check how many people want to have their ollama container started on localstack startup
- add tracking for the default model used in ollama so that we know for which models to optimize our implementations

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
