### PR TITLE
fix usage analytics to properly register and not count if disabled

### DIFF
--- a/localstack-core/localstack/utils/analytics/usage.py
+++ b/localstack-core/localstack/utils/analytics/usage.py
@@ -112,11 +112,14 @@ def aggregate() -> dict:
     return aggregated_payload
 
 
-@hooks.on_infra_shutdown(should_load=lambda: not config.DISABLE_EVENTS)
+@hooks.on_infra_shutdown()
 def aggregate_and_send():
     """
     Aggregates data from all registered usage trackers and immediately sends the aggregated result to the analytics service.
     """
+    if not config.DISABLE_EVENTS:
+        return
+
     metadata = EventMetadata(
         session_id=get_session_id(),
         client_time=str(datetime.datetime.now()),

--- a/localstack-core/localstack/utils/analytics/usage.py
+++ b/localstack-core/localstack/utils/analytics/usage.py
@@ -37,7 +37,7 @@ class UsageSetCounter:
     def __init__(self, namespace: str):
         self.enabled = not config.DISABLE_EVENTS
         self.state = {}
-        self._counter = defaultdict(count)
+        self._counter = defaultdict(lambda: count(1))
         self.namespace = namespace
 
     def record(self, value: str):

--- a/localstack-core/localstack/utils/analytics/usage.py
+++ b/localstack-core/localstack/utils/analytics/usage.py
@@ -117,7 +117,7 @@ def aggregate_and_send():
     """
     Aggregates data from all registered usage trackers and immediately sends the aggregated result to the analytics service.
     """
-    if not config.DISABLE_EVENTS:
+    if config.DISABLE_EVENTS:
         return
 
     metadata = EventMetadata(

--- a/localstack-core/localstack/utils/analytics/usage.py
+++ b/localstack-core/localstack/utils/analytics/usage.py
@@ -1,7 +1,7 @@
 import datetime
 import math
-import threading
 from collections import defaultdict
+from itertools import count
 from typing import Any
 
 from localstack import config
@@ -31,19 +31,18 @@ class UsageSetCounter:
     """
 
     state: dict[str, int]
+    _counter: dict[str, count]
     namespace: str
-    _lock: threading.RLock
 
     def __init__(self, namespace: str):
-        self.enabled = True
-        self.state = defaultdict(int)
+        self.enabled = not config.DISABLE_EVENTS
+        self.state = {}
+        self._counter = defaultdict(count)
         self.namespace = namespace
-        self._lock = threading.RLock()
 
     def record(self, value: str):
         if self.enabled:
-            with self._lock:
-                self.state[value] += 1
+            self.state[value] = next(self._counter[value])
 
     def aggregate(self) -> dict:
         return self.state


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While looking to implement the usage analytics for the API Gateway service, I've noticed three things:
- we were not sending usage analytics anymore since #11202, as we removed the code to send it, but didn't register the hook back
- the usage counters were still counting even though analytics would be disabled, and would only skip sending the data over
- the usage counters are using lists that are growing unbounded, possibly using large amount of memory for very long lasting sessions (we're aware of 20+ hours sessions)

This PR mainly does 2 things:
- re-register the hook so that we send analytics over
- it does not count if analytics is disabled
- refactor the counter a bit to avoid growing a list, instead keeping the "set" entries and counting with `itertools.count` which is thread safe in CPython

I don't really like the boolean check for every call to `increment` and such, we could probably refactor our counters to be no-op classes if the analytics are disabled? But this at least prevents the memory leaks for users with `DISABLE_EVENTS=1` as a quick fix before v4, while re-enabling sending the analytics over. 

As a sanity check, I've run some small benchmarks with `timeit`:
Setting 1 000 000 values in the `state`:
Performance:
- 0.236s for the new counter
- 0.199s for the old counter with `append`

Memory:
- 384 bytes for the new counter
- 8448728 bytes for the old counter with `append`


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- register `aggregate_and_send ` with `@hooks.on_infra_shutdown(should_load=lambda: not config.DISABLE_EVENTS)`
- don't count if `DISABLE_EVENTS` is true
- small refactor of the `UsageSetCounter`
- small change: added the `count` aggregation method
- fix the `median` calculation, as it would have been incorrect without sorting the list first

## Follow-up

I'm following with #11854 which might contain more controversial changes, related to our counters. I believe the `UsageCounter` could be simplified into a really simple counter for less complex use case with no aggregation (like `lambda:hotreload`), and rename the current counter into a somewhat "timing" related counter with aggregation for more complex use cases. 

## Multithreading testing:

With this small test, we would always end up with the right amount of counting, just for sanity check. 
```python

iter_counter = UsageSetCounterIter("namespace")

def incr_iter(*args, **kwargs):
    iter_counter.record(random.choice(["test", "test2", "test3", "test4"]))

with ThreadPoolExecutor(max_workers=1000) as tp:
    p = tp.map(incr_iter, range(100000))

    for _ in p:
        pass

    print(sum(iter_counter.state.values()))
    > always prints out 100000
```

\cc @cloutierMat thanks for the help and pairing on this! 🙏 


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
