### PR TITLE
Fix non-validated events test for v2 provider

### DIFF
--- a/tests/aws/services/events/helper_functions.py
+++ b/tests/aws/services/events/helper_functions.py
@@ -2,19 +2,11 @@ import json
 import os
 from datetime import datetime, timedelta, timezone
 
-from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.sync import retry
 
 
-def is_v2_provider():
-    return os.environ.get("PROVIDER_OVERRIDE_EVENTS") == "v2" and not is_aws_cloud()
-
-
 def is_old_provider():
-    return (
-        "PROVIDER_OVERRIDE_EVENTS" not in os.environ
-        or os.environ.get("PROVIDER_OVERRIDE_EVENTS") != "v2"
-    )
+    return os.environ.get("PROVIDER_OVERRIDE_EVENTS") == "v1"
 
 
 def events_time_string_to_timestamp(time_string: str) -> datetime:

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -387,15 +387,14 @@ class TestEvents:
                 assert oauth_request.headers["oauthheader"] == "value2"
                 assert oauth_request.args["oauthquery"] == "value3"
 
-    @markers.aws.only_localstack
-    # tests for legacy v1 provider delete once v1 provider is removed, v2 covered in separate tests
+    @markers.aws.validated
     @pytest.mark.skipif(
         not is_old_provider(), reason="V2 provider does not support this feature yet"
     )
-    def test_create_connection_validations(self, aws_client):
+    def test_create_connection_validations(self, aws_client, snapshot):
         connection_name = "This should fail with two errors 123467890123412341234123412341234"
 
-        with pytest.raises(ClientError) as ctx:
+        with pytest.raises(ClientError) as e:
             (
                 aws_client.events.create_connection(
                     Name=connection_name,
@@ -405,15 +404,7 @@ class TestEvents:
                     },
                 ),
             )
-
-        assert ctx.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
-        assert ctx.value.response["Error"]["Code"] == "ValidationException"
-
-        message = ctx.value.response["Error"]["Message"]
-        assert "3 validation errors" in message
-        assert "must satisfy regular expression pattern" in message
-        assert "must have length less than or equal to 64" in message
-        assert "must satisfy enum value set: [BASIC, OAUTH_CLIENT_CREDENTIALS, API_KEY]" in message
+        snapshot.match("create_connection_exc", e.value.response)
 
 
 class TestEventBus:

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1753,5 +1753,20 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_create_connection_validations": {
+    "recorded-date": "14-11-2024, 20:29:49",
+    "recorded-content": {
+      "create_connection_exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "3 validation errors detected: Value 'This should fail with two errors 123467890123412341234123412341234' at 'name' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\.\\-_A-Za-z0-9]+; Value 'This should fail with two errors 123467890123412341234123412341234' at 'name' failed to satisfy constraint: Member must have length less than or equal to 64; Value 'INVALID' at 'authorizationType' failed to satisfy constraint: Member must satisfy enum value set: [BASIC, OAUTH_CLIENT_CREDENTIALS, API_KEY]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -111,7 +111,7 @@
     "last_validated_date": "2024-06-19T10:42:49+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_create_connection_validations": {
-    "last_validated_date": "2024-06-19T10:41:01+00:00"
+    "last_validated_date": "2024-11-14T20:29:49+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_event_without_detail": {
     "last_validated_date": "2024-06-19T10:40:51+00:00"


### PR DESCRIPTION
## Motivation

The PR addresses a subset of tests that were failing when testing against the v2 provider.

The main reason here is that they shouldn't even have run. The provider detection in the tests wasn't adapted, so the skip didn't evaluate to true.

The changes here should probably just be integrated into the "make events v2 the default provider" PR?

## Changes

- Fix `is_old_provider` and remove `is_v2_provider`. Keep in mind this is only technically valid when the default in  `providers.py` is already  switched to v2!
- Delete `test_scheduled_expression_events` as there's already other tests covering the same functionality executed for both provider versions.
-  `test_api_destinations`. untouched. can be kept for the v1 provider as a regression test but should be reimplemented for v2 tests
- `test_create_connection_validations` reworked into a validated snapshot test. Can be addressed during the work on the connections, but should be fairly low priority.
