### PR TITLE
Fix validated events test for v2 provider 

### DIFF
--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -1986,6 +1986,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                     rule, region, account_id, event_formatted, processed_entries, failed_entry_count
                 )
         else:
+            processed_entries.append({"EventId": event_formatted["id"]})
             LOG.info(
                 json.dumps(
                     {

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -1800,7 +1800,9 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         if event_bus.last_modified_time:
             event_bus_api_type["LastModifiedTime"] = event_bus.last_modified_time
         if event_bus.policy:
-            event_bus_api_type["Policy"] = recursive_remove_none_values_from_dict(event_bus.policy)
+            event_bus_api_type["Policy"] = json.dumps(
+                recursive_remove_none_values_from_dict(event_bus.policy)
+            )
 
         return event_bus_api_type
 

--- a/localstack-core/localstack/services/lambda_/invocation/event_manager.py
+++ b/localstack-core/localstack/services/lambda_/invocation/event_manager.py
@@ -349,6 +349,8 @@ class Poller:
                 role=self.version_manager.function_version.config.role,
                 source_arn=self.version_manager.function_version.id.unqualified_arn(),
                 source_service="lambda",
+                events_source="lambda",
+                events_detail_type="Lambda Function Invocation Result - Success",
             )
         except Exception as e:
             LOG.warning("Error sending invocation result to %s: %s", target_arn, e)
@@ -401,6 +403,8 @@ class Poller:
                 role=self.version_manager.function_version.config.role,
                 source_arn=self.version_manager.function_version.id.unqualified_arn(),
                 source_service="lambda",
+                events_source="lambda",
+                events_detail_type="Lambda Function Invocation Result - Failure",
             )
         except Exception as e:
             LOG.warning("Error sending invocation result to %s: %s", target_arn, e)

--- a/localstack-core/localstack/utils/aws/message_forwarding.py
+++ b/localstack-core/localstack/utils/aws/message_forwarding.py
@@ -110,6 +110,7 @@ def send_event_to_target(
                     {
                         "EventBusName": eventbus_name,
                         "Source": event.get("source", source_service) or "",
+                        # TODO: detail type "" is invalid => figure out what is actually passed here on AWS
                         "DetailType": event.get("detail-type", ""),
                         "Detail": json.dumps(detail),
                         "Resources": resources,

--- a/localstack-core/localstack/utils/aws/message_forwarding.py
+++ b/localstack-core/localstack/utils/aws/message_forwarding.py
@@ -28,6 +28,7 @@ AUTH_API_KEY = "API_KEY"
 AUTH_OAUTH = "OAUTH_CLIENT_CREDENTIALS"
 
 
+# TODO: refactor/split this. too much here is service specific
 def send_event_to_target(
     target_arn: str,
     event: Dict,
@@ -112,7 +113,6 @@ def send_event_to_target(
                     {
                         "EventBusName": eventbus_name,
                         "Source": events_source or event.get("source", source_service) or "",
-                        # TODO: detail type "" is invalid => figure out what is actually passed here on AWS
                         "DetailType": events_detail_type or event.get("detail-type", ""),
                         "Detail": json.dumps(detail),
                         "Resources": resources,

--- a/localstack-core/localstack/utils/aws/message_forwarding.py
+++ b/localstack-core/localstack/utils/aws/message_forwarding.py
@@ -37,6 +37,8 @@ def send_event_to_target(
     role: str = None,
     source_arn: str = None,
     source_service: str = None,
+    events_source: str = None,  # optional data for publishing to EventBridge
+    events_detail_type: str = None,  # optional data for publishing to EventBridge
 ):
     region = extract_region_from_arn(target_arn)
     account_id = extract_account_id_from_arn(source_arn)
@@ -109,9 +111,9 @@ def send_event_to_target(
                 Entries=[
                     {
                         "EventBusName": eventbus_name,
-                        "Source": event.get("source", source_service) or "",
+                        "Source": events_source or event.get("source", source_service) or "",
                         # TODO: detail type "" is invalid => figure out what is actually passed here on AWS
-                        "DetailType": event.get("detail-type", ""),
+                        "DetailType": events_detail_type or event.get("detail-type", ""),
                         "Detail": json.dumps(detail),
                         "Resources": resources,
                     }

--- a/tests/aws/cdk_templates/LambdaDestinationEventbridge/EventbridgeStack.json
+++ b/tests/aws/cdk_templates/LambdaDestinationEventbridge/EventbridgeStack.json
@@ -1,86 +1,9 @@
 {
   "Resources": {
-    "MortgageQuotesEventBus988D4B69": {
+    "CustomEventBusEC0C3CB8": {
       "Type": "AWS::Events::EventBus",
       "Properties": {
-        "Name": "MortgageQuotesEventBus"
-      }
-    },
-    "TestQueue6F0069AA": {
-      "Type": "AWS::SQS::Queue",
-      "Properties": {
-        "MessageRetentionPeriod": 300
-      },
-      "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
-    },
-    "TestQueuePolicyA65327BC": {
-      "Type": "AWS::SQS::QueuePolicy",
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sqs:SendMessage",
-                "sqs:GetQueueAttributes",
-                "sqs:GetQueueUrl"
-              ],
-              "Condition": {
-                "ArnEquals": {
-                  "aws:SourceArn": {
-                    "Fn::GetAtt": [
-                      "EmptyFilterRule6627F20C",
-                      "Arn"
-                    ]
-                  }
-                }
-              },
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "events.amazonaws.com"
-              },
-              "Resource": {
-                "Fn::GetAtt": [
-                  "TestQueue6F0069AA",
-                  "Arn"
-                ]
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "Queues": [
-          {
-            "Ref": "TestQueue6F0069AA"
-          }
-        ]
-      }
-    },
-    "EmptyFilterRule6627F20C": {
-      "Type": "AWS::Events::Rule",
-      "Properties": {
-        "EventBusName": {
-          "Ref": "MortgageQuotesEventBus988D4B69"
-        },
-        "EventPattern": {
-          "version": [
-            "0"
-          ]
-        },
-        "Name": "CustomRule",
-        "State": "ENABLED",
-        "Targets": [
-          {
-            "Arn": {
-              "Fn::GetAtt": [
-                "TestQueue6F0069AA",
-                "Arn"
-              ]
-            },
-            "Id": "Target0",
-            "InputPath": "$.detail.responsePayload"
-          }
-        ]
+        "Name": "EventbridgeStackCustomEventBus7DA4065F"
       }
     },
     "InputLambdaServiceRole4E05AD7C": {
@@ -124,7 +47,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "MortgageQuotesEventBus988D4B69",
+                  "CustomEventBusEC0C3CB8",
                   "Arn"
                 ]
               }
@@ -144,9 +67,8 @@
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "ZipFile": "\ndef handler(event, context):\n    return {\n            \"hello\": \"world\",\n            \"test\": \"abc\",\n            \"val\": 5,\n            \"success\": True\n        }\n"
+          "ZipFile": "\ndef handler(event, context):\n    if event.get(\"mode\") == \"failure\":\n        raise Exception(\"intentional failure!\")\n    else:\n        return {\n            \"hello\": \"world\",\n            \"test\": \"abc\",\n            \"val\": 5,\n            \"success\": True\n        }\n"
         },
-        "FunctionName": "input-fn-20c5ef1d",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -154,7 +76,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.10"
+        "Runtime": "python3.12"
       },
       "DependsOn": [
         "InputLambdaServiceRoleDefaultPolicy9708E6F3",
@@ -165,10 +87,18 @@
       "Type": "AWS::Lambda::EventInvokeConfig",
       "Properties": {
         "DestinationConfig": {
+          "OnFailure": {
+            "Destination": {
+              "Fn::GetAtt": [
+                "CustomEventBusEC0C3CB8",
+                "Arn"
+              ]
+            }
+          },
           "OnSuccess": {
             "Destination": {
               "Fn::GetAtt": [
-                "MortgageQuotesEventBus988D4B69",
+                "CustomEventBusEC0C3CB8",
                 "Arn"
               ]
             }
@@ -177,6 +107,7 @@
         "FunctionName": {
           "Ref": "InputLambda695C9911"
         },
+        "MaximumRetryAttempts": 0,
         "Qualifier": "$LATEST"
       }
     },
@@ -211,45 +142,12 @@
         ]
       }
     },
-    "TriggeredLambdaServiceRoleDefaultPolicy85263E12": {
-      "Type": "AWS::IAM::Policy",
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sqs:ReceiveMessage",
-                "sqs:ChangeMessageVisibility",
-                "sqs:GetQueueUrl",
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes"
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "TestQueue6F0069AA",
-                  "Arn"
-                ]
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "PolicyName": "TriggeredLambdaServiceRoleDefaultPolicy85263E12",
-        "Roles": [
-          {
-            "Ref": "TriggeredLambdaServiceRoleBB080110"
-          }
-        ]
-      }
-    },
     "TriggeredLambdaBE2D8BDA": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "ZipFile": "\nimport json\n\ndef handler(event, context):\n    print(json.dumps(event))\n    return {\"invocation\": True}\n"
         },
-        "FunctionName": "triggered-fn-aa3e69ac",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -257,25 +155,54 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.10"
+        "Runtime": "python3.12"
       },
       "DependsOn": [
-        "TriggeredLambdaServiceRoleDefaultPolicy85263E12",
         "TriggeredLambdaServiceRoleBB080110"
       ]
     },
-    "TriggeredLambdaSqsEventSourceEventbridgeStackTestQueue1FCC00804CE4CDF0": {
-      "Type": "AWS::Lambda::EventSourceMapping",
+    "EmptyFilterRule6627F20C": {
+      "Type": "AWS::Events::Rule",
       "Properties": {
-        "BatchSize": 10,
-        "EventSourceArn": {
+        "EventBusName": {
+          "Ref": "CustomEventBusEC0C3CB8"
+        },
+        "EventPattern": {
+          "version": [
+            "0"
+          ]
+        },
+        "Name": "CustomRule",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "TriggeredLambdaBE2D8BDA",
+                "Arn"
+              ]
+            },
+            "Id": "Target0"
+          }
+        ]
+      }
+    },
+    "EmptyFilterRuleAllowEventRuleEventbridgeStackTriggeredLambda3DD76C6517715217": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
           "Fn::GetAtt": [
-            "TestQueue6F0069AA",
+            "TriggeredLambdaBE2D8BDA",
             "Arn"
           ]
         },
-        "FunctionName": {
-          "Ref": "TriggeredLambdaBE2D8BDA"
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "EmptyFilterRule6627F20C",
+            "Arn"
+          ]
         }
       }
     }
@@ -291,12 +218,9 @@
         "Ref": "TriggeredLambdaBE2D8BDA"
       }
     },
-    "TestQueueName": {
+    "EventBusName": {
       "Value": {
-        "Fn::GetAtt": [
-          "TestQueue6F0069AA",
-          "QueueName"
-        ]
+        "Ref": "CustomEventBusEC0C3CB8"
       }
     }
   }

--- a/tests/aws/services/apigateway/test_apigateway_eventbridge.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_eventbridge.validation.json
@@ -1,5 +1,5 @@
 {
   "tests/aws/services/apigateway/test_apigateway_eventbridge.py::test_apigateway_to_eventbridge": {
-    "last_validated_date": "2024-07-12T17:42:38+00:00"
+    "last_validated_date": "2024-11-14T22:12:09+00:00"
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_events.py
+++ b/tests/aws/services/cloudformation/resources/test_events.py
@@ -3,7 +3,6 @@ import logging
 import os
 
 from localstack.testing.pytest import markers
-from localstack.utils.aws import arns
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import wait_until
 
@@ -191,56 +190,6 @@ def test_cfn_event_bus_resource(deploy_cfn_template, aws_client):
     _assert(0)
 
 
-TEST_TEMPLATE_16 = """
-AWSTemplateFormatVersion: 2010-09-09
-Resources:
-  MyBucket:
-    Type: 'AWS::S3::Bucket'
-    Properties:
-      BucketName: %s
-  ScheduledRule:
-    Type: 'AWS::Events::Rule'
-    Properties:
-      Name: %s
-      ScheduleExpression: rate(10 minutes)
-      State: ENABLED
-      Targets:
-        - Id: TargetBucketV1
-          Arn: !GetAtt "MyBucket.Arn"
-"""
-
-TEST_TEMPLATE_18 = """
-AWSTemplateFormatVersion: 2010-09-09
-Resources:
-  TestStateMachine:
-    Type: "AWS::StepFunctions::StateMachine"
-    Properties:
-      RoleArn: %s
-      DefinitionString:
-        !Sub
-        - |-
-          {
-            "StartAt": "state1",
-            "States": {
-              "state1": {
-                "Type": "Pass",
-                "Result": "Hello World",
-                "End": true
-              }
-            }
-          }
-        - {}
-  ScheduledRule:
-    Type: AWS::Events::Rule
-    Properties:
-      ScheduleExpression: "cron(0/1 * * * ? *)"
-      State: ENABLED
-      Targets:
-        - Id: TestStateMachine
-          Arn: !Ref TestStateMachine
-"""
-
-
 @markers.aws.validated
 def test_rule_properties(deploy_cfn_template, aws_client, snapshot):
     event_bus_name = f"events-{short_uid()}"
@@ -262,53 +211,3 @@ def test_rule_properties(deploy_cfn_template, aws_client, snapshot):
     snapshot.add_transformer(snapshot.transform.regex(without_bus_id, "<without-bus-id>"))
 
     snapshot.match("outputs", stack.outputs)
-
-
-# {"LogicalResourceId": "ScheduledRule", "ResourceType": "AWS::Events::Rule", "ResourceStatus": "CREATE_FAILED", "ResourceStatusReason": "s3 is not a supported service for a target."}
-@markers.aws.needs_fixing
-def test_cfn_handle_events_rule(deploy_cfn_template, aws_client):
-    bucket_name = f"target-{short_uid()}"
-    rule_prefix = f"s3-rule-{short_uid()}"
-    rule_name = f"{rule_prefix}-{short_uid()}"
-
-    stack = deploy_cfn_template(
-        template=TEST_TEMPLATE_16 % (bucket_name, rule_name),
-    )
-
-    rs = aws_client.events.list_rules(NamePrefix=rule_prefix)
-    assert rule_name in [rule["Name"] for rule in rs["Rules"]]
-
-    target_arn = arns.s3_bucket_arn(bucket_name)  # TODO: !
-    rs = aws_client.events.list_targets_by_rule(Rule=rule_name)
-    assert target_arn in [target["Arn"] for target in rs["Targets"]]
-
-    # clean up
-    stack.destroy()
-    rs = aws_client.events.list_rules(NamePrefix=rule_prefix)
-    assert rule_name not in [rule["Name"] for rule in rs["Rules"]]
-
-
-# {"LogicalResourceId": "TestStateMachine", "ResourceType": "AWS::StepFunctions::StateMachine", "ResourceStatus": "CREATE_FAILED", "ResourceStatusReason": "Resource handler returned message: \"Cross-account pass role is not allowed."}
-@markers.aws.needs_fixing
-def test_cfn_handle_events_rule_without_name(
-    deploy_cfn_template, aws_client, account_id, region_name
-):
-    rs = aws_client.events.list_rules()
-    rule_names = [rule["Name"] for rule in rs["Rules"]]
-
-    stack = deploy_cfn_template(
-        template=TEST_TEMPLATE_18
-        % arns.iam_role_arn("sfn_role", account_id=account_id, region_name=region_name),
-    )
-
-    rs = aws_client.events.list_rules()
-    new_rules = [rule for rule in rs["Rules"] if rule["Name"] not in rule_names]
-    assert len(new_rules) == 1
-    rule = new_rules[0]
-
-    assert rule["ScheduleExpression"] == "cron(0/1 * * * ? *)"
-
-    stack.destroy()
-
-    rs = aws_client.events.list_rules()
-    assert rule["Name"] not in [r["Name"] for r in rs["Rules"]]

--- a/tests/aws/services/cloudformation/resources/test_events.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_events.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/cloudformation/resources/test_events.py::test_cfn_event_api_destination_resource": {
     "last_validated_date": "2024-04-16T06:36:56+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_events.py::test_eventbus_policy_statement": {
+    "last_validated_date": "2024-11-14T21:46:23+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_events.py::test_rule_properties": {
     "last_validated_date": "2023-12-01T14:03:52+00:00"
   }

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -118,6 +118,10 @@ class TestEvents:
         snapshot.match("put-events", response)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        is_old_provider(),
+        reason="V1 provider does not support this feature",
+    )
     def test_put_event_without_detail_type(self, snapshot, aws_client):
         entries = [
             {

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -118,6 +118,18 @@ class TestEvents:
         snapshot.match("put-events", response)
 
     @markers.aws.validated
+    def test_put_event_without_detail_type(self, snapshot, aws_client):
+        entries = [
+            {
+                "Source": "some.source",
+                "Detail": json.dumps(EVENT_DETAIL),
+                "DetailType": "",
+            },
+        ]
+        response = aws_client.events.put_events(Entries=entries)
+        snapshot.match("put-events", response)
+
+    @markers.aws.validated
     def test_put_events_time(self, put_events_with_filter_to_sqs, snapshot):
         entries1 = [
             {

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2348,5 +2348,23 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_event_without_detail_type": {
+    "recorded-date": "14-11-2024, 22:43:09",
+    "recorded-content": {
+      "put-events": {
+        "Entries": [
+          {
+            "ErrorCode": "InvalidArgument",
+            "ErrorMessage": "Parameter DetailType is not valid. Reason: DetailType is a required argument."
+          }
+        ],
+        "FailedEntryCount": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -158,6 +158,9 @@
   "tests/aws/services/events/test_events.py::TestEvents::test_put_event_without_detail": {
     "last_validated_date": "2024-06-19T10:40:51+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_event_without_detail_type": {
+    "last_validated_date": "2024-11-14T22:43:51+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_exceed_limit_ten_entries[custom]": {
     "last_validated_date": "2024-06-19T10:40:54+00:00"
   },

--- a/tests/aws/services/lambda_/test_lambda_destinations.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_destinations.snapshot.json
@@ -543,85 +543,83 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationEventbridge::test_invoke_lambda_eventbridge": {
-    "recorded-date": "18-11-2024, 19:59:36",
+    "recorded-date": "19-11-2024, 08:49:47",
     "recorded-content": {
-      "lambda_destination_event_bus": [
-        {
-          "version": "0",
-          "id": "<uuid:1>",
-          "detail-type": "Lambda Function Invocation Result - Success",
-          "source": "lambda",
-          "account": "111111111111",
-          "time": "date",
-          "region": "<region>",
-          "resources": [
-            "arn:<partition>:events:<region>:111111111111:event-bus/<event-bus-name>",
-            "arn:<partition>:lambda:<region>:111111111111:function:<input-fn-name>:$LATEST"
-          ],
-          "detail": {
-            "version": "1.0",
-            "timestamp": "date",
-            "requestContext": {
-              "requestId": "<uuid:2>",
-              "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<input-fn-name>:$LATEST",
-              "condition": "Success",
-              "approximateInvokeCount": 1
-            },
-            "requestPayload": {
-              "mode": "success"
-            },
-            "responseContext": {
-              "statusCode": 200,
-              "executedVersion": "$LATEST"
-            },
-            "responsePayload": {
-              "hello": "world",
-              "test": "abc",
-              "val": 5,
-              "success": true
-            }
-          }
+      "lambda_destination_event_bus_success": {
+        "account": "111111111111",
+        "detail": {
+          "requestContext": {
+            "approximateInvokeCount": 1,
+            "condition": "Success",
+            "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<input-fn-name>:$LATEST",
+            "requestId": "<uuid:1>"
+          },
+          "requestPayload": {
+            "mode": "success"
+          },
+          "responseContext": {
+            "executedVersion": "$LATEST",
+            "statusCode": 200
+          },
+          "responsePayload": {
+            "hello": "world",
+            "success": true,
+            "test": "abc",
+            "val": 5
+          },
+          "timestamp": "date",
+          "version": "1.0"
         },
-        {
-          "version": "0",
-          "id": "<uuid:3>",
-          "detail-type": "Lambda Function Invocation Result - Failure",
-          "source": "lambda",
-          "account": "111111111111",
-          "time": "date",
-          "region": "<region>",
-          "resources": [
-            "arn:<partition>:events:<region>:111111111111:event-bus/<event-bus-name>",
-            "arn:<partition>:lambda:<region>:111111111111:function:<input-fn-name>:$LATEST"
-          ],
-          "detail": {
-            "version": "1.0",
-            "timestamp": "date",
-            "requestContext": {
-              "requestId": "<uuid:4>",
-              "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<input-fn-name>:$LATEST",
-              "condition": "RetriesExhausted",
-              "approximateInvokeCount": 1
-            },
-            "requestPayload": {
-              "mode": "failure"
-            },
-            "responseContext": {
-              "statusCode": 200,
-              "executedVersion": "$LATEST",
-              "functionError": "Unhandled"
-            },
-            "responsePayload": {
-              "errorMessage": "intentional failure!",
-              "errorType": "Exception",
-              "requestId": "<uuid:4>",
-              "stackTrace": [
-                "  File \"/var/task/index.py\", line 4, in handler\n    raise Exception(\"intentional failure!\")\n"
-              ]
-            }
-          }
-        }
-      ]
+        "detail-type": "Lambda Function Invocation Result - Success",
+        "id": "<uuid:2>",
+        "region": "<region>",
+        "resources": [
+          "arn:<partition>:events:<region>:111111111111:event-bus/<event-bus-name>",
+          "arn:<partition>:lambda:<region>:111111111111:function:<input-fn-name>:$LATEST"
+        ],
+        "source": "lambda",
+        "time": "date",
+        "version": "0"
+      },
+      "lambda_destination_event_bus_failure": {
+        "account": "111111111111",
+        "detail": {
+          "requestContext": {
+            "approximateInvokeCount": 1,
+            "condition": "RetriesExhausted",
+            "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<input-fn-name>:$LATEST",
+            "requestId": "<uuid:3>"
+          },
+          "requestPayload": {
+            "mode": "failure"
+          },
+          "responseContext": {
+            "executedVersion": "$LATEST",
+            "functionError": "Unhandled",
+            "statusCode": 200
+          },
+          "responsePayload": {
+            "errorMessage": "intentional failure!",
+            "errorType": "Exception",
+            "requestId": "<uuid:3>",
+            "stackTrace": [
+              "  File \"/var/task/index.py\", line 4, in handler\n    raise Exception(\"intentional failure!\")\n"
+            ]
+          },
+          "timestamp": "date",
+          "version": "1.0"
+        },
+        "detail-type": "Lambda Function Invocation Result - Failure",
+        "id": "<uuid:4>",
+        "region": "<region>",
+        "resources": [
+          "arn:<partition>:events:<region>:111111111111:event-bus/<event-bus-name>",
+          "arn:<partition>:lambda:<region>:111111111111:function:<input-fn-name>:$LATEST"
+        ],
+        "source": "lambda",
+        "time": "date",
+        "version": "0"
+      }
     }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_destinations.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_destinations.snapshot.json
@@ -543,34 +543,85 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationEventbridge::test_invoke_lambda_eventbridge": {
-    "recorded-date": "02-10-2024, 14:21:46",
+    "recorded-date": "18-11-2024, 19:59:36",
     "recorded-content": {
-      "filtered_message_event_bus_sqs": {
-          "Records": [
-            {
-              "messageId": "<message-id:1>",
-              "receiptHandle": "<receipt-handle:1>",
-              "body": {
-                "hello": "world",
-                "test": "abc",
-                "val": 5,
-                "success": true
-              },
-              "attributes": {
-                "ApproximateReceiveCount": "1",
-                "AWSTraceHeader": "trace-header",
-                "SentTimestamp": "timestamp",
-                "SenderId": "<sender-id:1>",
-                "ApproximateFirstReceiveTimestamp": "timestamp"
-              },
-              "messageAttributes": {},
-              "md5OfBody": "md5-of-body",
-              "eventSource": "aws:sqs",
-              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
-              "awsRegion": "<region>"
+      "lambda_destination_event_bus": [
+        {
+          "version": "0",
+          "id": "<uuid:1>",
+          "detail-type": "Lambda Function Invocation Result - Success",
+          "source": "lambda",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [
+            "arn:<partition>:events:<region>:111111111111:event-bus/<event-bus-name>",
+            "arn:<partition>:lambda:<region>:111111111111:function:<input-fn-name>:$LATEST"
+          ],
+          "detail": {
+            "version": "1.0",
+            "timestamp": "date",
+            "requestContext": {
+              "requestId": "<uuid:2>",
+              "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<input-fn-name>:$LATEST",
+              "condition": "Success",
+              "approximateInvokeCount": 1
+            },
+            "requestPayload": {
+              "mode": "success"
+            },
+            "responseContext": {
+              "statusCode": 200,
+              "executedVersion": "$LATEST"
+            },
+            "responsePayload": {
+              "hello": "world",
+              "test": "abc",
+              "val": 5,
+              "success": true
             }
-          ]
+          }
+        },
+        {
+          "version": "0",
+          "id": "<uuid:3>",
+          "detail-type": "Lambda Function Invocation Result - Failure",
+          "source": "lambda",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [
+            "arn:<partition>:events:<region>:111111111111:event-bus/<event-bus-name>",
+            "arn:<partition>:lambda:<region>:111111111111:function:<input-fn-name>:$LATEST"
+          ],
+          "detail": {
+            "version": "1.0",
+            "timestamp": "date",
+            "requestContext": {
+              "requestId": "<uuid:4>",
+              "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<input-fn-name>:$LATEST",
+              "condition": "RetriesExhausted",
+              "approximateInvokeCount": 1
+            },
+            "requestPayload": {
+              "mode": "failure"
+            },
+            "responseContext": {
+              "statusCode": 200,
+              "executedVersion": "$LATEST",
+              "functionError": "Unhandled"
+            },
+            "responsePayload": {
+              "errorMessage": "intentional failure!",
+              "errorType": "Exception",
+              "requestId": "<uuid:4>",
+              "stackTrace": [
+                "  File \"/var/task/index.py\", line 4, in handler\n    raise Exception(\"intentional failure!\")\n"
+              ]
+            }
+          }
         }
+      ]
     }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_destinations.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_destinations.validation.json
@@ -3,7 +3,7 @@
     "last_validated_date": "2024-06-17T11:49:58+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationEventbridge::test_invoke_lambda_eventbridge": {
-    "last_validated_date": "2024-11-18T20:02:23+00:00"
+    "last_validated_date": "2024-11-19T08:54:21+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationSqs::test_assess_lambda_destination_invocation[payload0]": {
     "last_validated_date": "2024-03-21T12:26:43+00:00"

--- a/tests/aws/services/lambda_/test_lambda_destinations.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_destinations.validation.json
@@ -3,7 +3,7 @@
     "last_validated_date": "2024-06-17T11:49:58+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationEventbridge::test_invoke_lambda_eventbridge": {
-    "last_validated_date": "2024-10-02T14:21:46+00:00"
+    "last_validated_date": "2024-11-14T22:26:52+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationSqs::test_assess_lambda_destination_invocation[payload0]": {
     "last_validated_date": "2024-03-21T12:26:43+00:00"

--- a/tests/aws/services/lambda_/test_lambda_destinations.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_destinations.validation.json
@@ -3,7 +3,7 @@
     "last_validated_date": "2024-06-17T11:49:58+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationEventbridge::test_invoke_lambda_eventbridge": {
-    "last_validated_date": "2024-11-14T22:26:52+00:00"
+    "last_validated_date": "2024-11-18T20:02:23+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationSqs::test_assess_lambda_destination_invocation[payload0]": {
     "last_validated_date": "2024-03-21T12:26:43+00:00"


### PR DESCRIPTION
## Motivation

Addressing a few issues we observed with the new EventBridge v2 provider and the existing test suite.

## Changes

- `test_cfn_handle_events_rule` ... invalid legacy test => removed
- `test_cfn_handle_events_rule_without_name` ... invalid legacy test => removed
- `test_apigateway_to_eventbridge` ... fixed by not just ignoring the event if there's no rule configured
- validated test added for missing detail type => `test_put_event_without_detail_type`
- `test_eventbus_policy_statement` & `test_eventbus_policies` ... fixed via the `json.dumps` on the policy
- `test_invoke_lambda_eventbridge` ... fixed by using the proper `"detail-type"` for the event sent to EventBridge in Lambda EventBridge destinations. Adapted the behavior test to surface the raw event payload and remove the intermediate SQS queue
