### PR TITLE
Split analytics UsageCounter and TimingStats

### DIFF
--- a/localstack-core/localstack/services/lambda_/usage.py
+++ b/localstack-core/localstack/services/lambda_/usage.py
@@ -5,7 +5,7 @@ Usage reporting for Lambda service
 from localstack.utils.analytics.usage import UsageCounter, UsageSetCounter
 
 # usage of lambda hot-reload feature
-hotreload = UsageCounter("lambda:hotreload", aggregations=["sum"])
+hotreload = UsageCounter("lambda:hotreload")
 
 # number of function invocations per Lambda runtime (e.g. python3.7 invoked 10x times, nodejs14.x invoked 3x times, ...)
 runtime = UsageSetCounter("lambda:invokedruntime")

--- a/localstack-core/localstack/utils/analytics/usage.py
+++ b/localstack-core/localstack/utils/analytics/usage.py
@@ -50,15 +50,47 @@ class UsageSetCounter:
 
 class UsageCounter:
     """
-    Use this counter to count numeric values and perform aggregations
-
-    Available aggregations: min, max, sum, mean, median
+    Use this counter to count numeric values
 
     Example:
-        my_feature_counter = UsageCounter("lambda:somefeature", aggregations=["min", "max", "sum"])
-        my_feature_counter.increment()  # equivalent to my_feature_counter.record_value(1)
-        my_feature_counter.record_value(3)
-        my_feature_counter.aggregate()  # returns {"min": 1, "max": 3, "sum": 4}
+        my__counter = UsageCounter("lambda:somefeature")
+        my_counter.increment()
+        my_counter.increment()
+        my_counter.aggregate()  # returns {"count": 2}
+    """
+
+    state: int
+    namespace: str
+
+    def __init__(self, namespace: str):
+        self.enabled = not config.DISABLE_EVENTS
+        self.state = 0
+        self._counter = count()
+        self.namespace = namespace
+        collector_registry[namespace] = self
+
+    def increment(self):
+        # TODO: we should instead have different underlying datastructures to store the state, and have no-op operations
+        #  when config.DISABLE_EVENTS is set
+        if self.enabled:
+            self.state = next(self._counter)
+
+    def aggregate(self) -> dict:
+        # TODO: should we just keep `count`? "sum" might need to be kept for historical data?
+        return {"count": self.state, "sum": self.state}
+
+
+class TimingStats:
+    """
+    Use this counter to measure numeric values and perform aggregations
+
+    Available aggregations: min, max, sum, mean, median, count
+
+    Example:
+        my_feature_counter = TimingStats("lambda:somefeature", aggregations=["min", "max", "sum", "count"])
+        my_feature_counter.record_value(512)
+        my_feature_counter.record_value(256)
+        my_feature_counter.aggregate()  # returns {"min": 256, "max": 512, "sum": 768, "count": 2}
     """
 
     state: list[int | float]
@@ -71,12 +103,6 @@ class UsageCounter:
         self.namespace = namespace
         self.aggregations = aggregations
         collector_registry[namespace] = self
-
-    def increment(self):
-        # TODO: we should instead have different underlying datastructures to store the state, and have no-op operations
-        #  when config.DISABLE_EVENTS is set
-        if self.enabled:
-            self.state.append(1)
 
     def record_value(self, value: int | float):
         if self.enabled:

--- a/localstack-core/localstack/utils/analytics/usage.py
+++ b/localstack-core/localstack/utils/analytics/usage.py
@@ -65,7 +65,7 @@ class UsageCounter:
     def __init__(self, namespace: str):
         self.enabled = not config.DISABLE_EVENTS
         self.state = 0
-        self._counter = count()
+        self._counter = count(1)
         self.namespace = namespace
         collector_registry[namespace] = self
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #11848, with more changes to our counters.

This PR implements a simpler `UsageCounter` which does not need aggregation, as it only counts. 

To keep the current already implemented logic, which is more resembling the `timing` metric types of `statsd`, I've renamed it to `TimingStats` (naming TBD, it could also be NumericStats or anything?). 

The new `UsageCounter` is very memory efficient, and it relies on `itertools.count` which is thread safe in CPython, removing the need for an external locking mechanism. 

Statsd metrics types:
https://github.com/statsd/statsd/blob/master/docs/metric_types.md

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- refactor our counters to have a very simpler counter and more complex one with aggregations for more complex use cases
- modify the usage in lambda so that it uses the simple counter


\cc thanks again to @cloutierMat for the pairing 🙏 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
