### PR TITLE
fix APIGW AWS_PROXY lambda response validation

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1665,5 +1665,135 @@
         "status_code": 200
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_lambda.py::test_aws_proxy_response_payload_format_validation": {
+    "recorded-date": "15-11-2024, 17:48:06",
+    "recorded-content": {
+      "invoke-api-no-body": {
+        "content": ""
+      },
+      "invoke-api-with-headers": {
+        "content": "",
+        "headers": {
+          "Connection": "keep-alive",
+          "Content-Length": "0",
+          "Content-Type": "application/json",
+          "Date": "<date>",
+          "Via": "<via:1>",
+          "X-Amz-Cf-Id": "<x--amz--cf--id:1>",
+          "X-Amz-Cf-Pop": "<x--amz--cf--pop:1>",
+          "X-Amzn-Trace-Id": "<x--amzn--trace--id:1>",
+          "X-Cache": "<x--cache:1>",
+          "header-bool": "true",
+          "test-header": "value",
+          "x-amz-apigw-id": "<x-amz-apigw-id:1>",
+          "x-amzn-RequestId": "<uuid:1>"
+        }
+      },
+      "invoke-api-with-headers-null": {
+        "content": "",
+        "headers": {
+          "Connection": "keep-alive",
+          "Content-Length": "0",
+          "Content-Type": "application/json",
+          "Date": "<date>",
+          "Via": "<via:2>",
+          "X-Amz-Cf-Id": "<x--amz--cf--id:2>",
+          "X-Amz-Cf-Pop": "<x--amz--cf--pop:1>",
+          "X-Amzn-Trace-Id": "<x--amzn--trace--id:2>",
+          "X-Cache": "<x--cache:1>",
+          "x-amz-apigw-id": "<x-amz-apigw-id:2>",
+          "x-amzn-RequestId": "<uuid:2>"
+        }
+      },
+      "invoke-api-wrong-format": {
+        "content": {
+          "message": "Internal server error"
+        }
+      },
+      "invoke-api-empty-response": {
+        "content": {
+          "message": "Internal server error"
+        }
+      },
+      "invoke-api-b64-encoded-true": {
+        "content": "dGVzdC1kYXRh"
+      },
+      "invoke-api-b64-encoded-false": {
+        "content": "dGVzdC1kYXRh"
+      },
+      "invoke-api-multi-headers-valid": {
+        "content": "",
+        "headers": {
+          "Connection": "keep-alive",
+          "Content-Length": "0",
+          "Content-Type": "application/json",
+          "Date": "<date>",
+          "Via": "<via:3>",
+          "X-Amz-Cf-Id": "<x--amz--cf--id:3>",
+          "X-Amz-Cf-Pop": "<x--amz--cf--pop:1>",
+          "X-Amzn-Trace-Id": "<x--amzn--trace--id:3>",
+          "X-Cache": "<x--cache:1>",
+          "test-multi": "value1, value2",
+          "x-amz-apigw-id": "<x-amz-apigw-id:3>",
+          "x-amzn-RequestId": "<uuid:3>"
+        }
+      },
+      "invoke-api-multi-headers-overwrite": {
+        "content": "",
+        "headers": {
+          "Connection": "keep-alive",
+          "Content-Length": "0",
+          "Content-Type": "application/json",
+          "Date": "<date>",
+          "Via": "<via:4>",
+          "X-Amz-Cf-Id": "<x--amz--cf--id:4>",
+          "X-Amz-Cf-Pop": "<x--amz--cf--pop:1>",
+          "X-Amzn-Trace-Id": "<x--amzn--trace--id:4>",
+          "X-Cache": "<x--cache:1>",
+          "test-multi": "value-multi, value-solo",
+          "x-amz-apigw-id": "<x-amz-apigw-id:4>",
+          "x-amzn-RequestId": "<uuid:4>"
+        }
+      },
+      "invoke-api-multi-headers-overwrite-casing": {
+        "content": "",
+        "headers": {
+          "Connection": "keep-alive",
+          "Content-Length": "0",
+          "Content-Type": "application/json",
+          "Date": "<date>",
+          "Via": "<via:5>",
+          "X-Amz-Cf-Id": "<x--amz--cf--id:5>",
+          "X-Amz-Cf-Pop": "<x--amz--cf--pop:1>",
+          "X-Amzn-Trace-Id": "<x--amzn--trace--id:5>",
+          "X-Cache": "<x--cache:1>",
+          "tesT-Multi": "value-multi, value-solo",
+          "x-amz-apigw-id": "<x-amz-apigw-id:5>",
+          "x-amzn-RequestId": "<uuid:5>"
+        }
+      },
+      "invoke-api-multi-headers-invalid": {
+        "content": {
+          "message": "Internal server error"
+        }
+      },
+      "invoke-api-invalid-status-code": {
+        "content": {
+          "message": "Internal server error"
+        }
+      },
+      "invoke-api-status-code-str": {
+        "content": ""
+      },
+      "invoke-api-just-string": {
+        "content": {
+          "message": "Internal server error"
+        }
+      },
+      "invoke-api-only-headers": {
+        "content": ""
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/apigateway/test_apigateway_lambda.py::test_aws_proxy_response_payload_format_validation": {
+    "last_validated_date": "2024-11-15T17:48:06+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_integration": {
     "last_validated_date": "2023-05-31T21:11:42+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We got a report in our Community Slack regarding too strict lambda payload response validation for the `AWS_PROXY` integration:
```python
2024-11-15T05:30:24.755  WARN --- [et.reactor-1] l.s.a.n.e.integrations.aws : Lambda output should follow the next JSON format: { "isBase64Encoded": true|false, "statusCode": httpStatusCode, "headers": { "headerName": "headerValue", ... },"body": "..."} but was: b'{"statusCode":200,"headers":null,"multiValueHeaders":{"Content-Type":["application/json"],"X-Request-Id":["fcc51e39-0a54-45c6-88f7-c1d81b5f7075"]},"body":"''
2024-11-15T05:30:24.755 DEBUG --- [et.reactor-1] l.s.a.n.e.integrations.aws : Execution failed due to configuration error: Malformed Lambda proxy response
```

It seems we were too strict, and didn't have this validated by tests. I've added a quite complete tests inspired by some of our other work. 

I've also spotted an issue in our multi value headers handling which I've sneaked a fix for. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix raising an exception when the `headers` was set to `null`
- fix multi headers handling
- add a test for all of this

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
