### PR TITLE
Add test for SSM GetParameter API by parameter name

### DIFF
--- a/tests/aws/services/ssm/test_ssm.py
+++ b/tests/aws/services/ssm/test_ssm.py
@@ -150,13 +150,22 @@ class TestSSM:
         assert found_param["Value"] == "value"
 
     @markers.aws.validated
-    def test_get_parameter_by_arn(self, create_parameter, aws_client, snapshot, cleanups):
+    def test_get_parameter_by_arn(self, create_parameter, aws_client, snapshot):
         param_name = f"param-{short_uid()}"
         create_parameter(Name=param_name, Value="test", Type="String")
         parameter_by_name = aws_client.ssm.get_parameter(Name=param_name)["Parameter"]
 
         parameter_by_arn = aws_client.ssm.get_parameter(Name=parameter_by_name["ARN"])["Parameter"]
         snapshot.match("Parameter", parameter_by_arn)
+        snapshot.add_transformer(snapshot.transform.key_value("Name"))
+
+    @markers.aws.validated
+    def test_get_parameter_by_name(self, create_parameter, aws_client, snapshot):
+        param_name = f"param-{short_uid()}"
+        create_parameter(Name=param_name, Value="test", Type="String")
+        parameter_by_name = aws_client.ssm.get_parameter(Name=param_name)["Parameter"]
+
+        snapshot.match("Parameter", parameter_by_name)
         snapshot.add_transformer(snapshot.transform.key_value("Name"))
 
     @markers.aws.validated

--- a/tests/aws/services/ssm/test_ssm.snapshot.json
+++ b/tests/aws/services/ssm/test_ssm.snapshot.json
@@ -1,6 +1,20 @@
 {
   "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_arn": {
-    "recorded-date": "16-07-2024, 17:17:40",
+    "recorded-date": "14-11-2024, 14:21:20",
+    "recorded-content": {
+      "Parameter": {
+        "ARN": "arn:<partition>:ssm:<region>:111111111111:parameter/<name:1>",
+        "DataType": "text",
+        "LastModifiedDate": "<datetime>",
+        "Name": "<name:1>",
+        "Type": "String",
+        "Value": "test",
+        "Version": 1
+      }
+    }
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_name": {
+    "recorded-date": "14-11-2024, 14:21:20",
     "recorded-content": {
       "Parameter": {
         "ARN": "arn:<partition>:ssm:<region>:111111111111:parameter/<name:1>",

--- a/tests/aws/services/ssm/test_ssm.validation.json
+++ b/tests/aws/services/ssm/test_ssm.validation.json
@@ -1,5 +1,8 @@
 {
   "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_arn": {
-    "last_validated_date": "2024-07-16T17:17:40+00:00"
+    "last_validated_date": "2024-11-14T14:21:20+00:00"
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_name": {
+    "last_validated_date": "2024-11-14T14:21:20+00:00"
   }
 }


### PR DESCRIPTION
Hi😀

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When I was reading the test cases for the SSM Parameter Store, I found a test for the GetParameter API that `Name` parameter is specified by an **ARN** as `test_get_parameter_by_arn()`.
- https://github.com/localstack/localstack/blob/master/tests/aws/services/ssm/test_ssm.py#L152-L160

According to the boto3 documentation, the following is explains:

>**The name or Amazon Resource Name (ARN) of the parameter that you want to query.** For parameters shared with you from another account, you must use the full ARN.
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm/client/get_parameter.html

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
In this Pull Request, I’ve added a test for the SSM GetParameter API that `Name` parameter is specified by a **Name**.

<!-- Optional section: How to test these changes? -->

## Testing
The tests passed in my local environment.

```sh
$ make test TEST_PATH=tests/aws/services/ssm
(snip)
tests/aws/services/ssm/test_ssm.py::TestSSM::test_describe_parameters PASSED                                                                                                                                   [  7%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_put_parameters PASSED                                                                                                                                        [ 14%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_hierarchical_parameter[/<param>//b//c] PASSED                                                                                                                [ 21%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_hierarchical_parameter[<param>/b/c] PASSED                                                                                                                   [ 28%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_secret_parameter PASSED                                                                                                                                  [ 35%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_inexistent_secret PASSED                                                                                                                                 [ 42%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameters_and_secrets PASSED                                                                                                                            [ 50%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameters_by_path_and_filter_by_labels PASSED                                                                                                           [ 57%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_arn PASSED                                                                                                                                  [ 64%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_name PASSED                                                                                                                                 [ 71%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_inexistent_maintenance_window PASSED                                                                                                                     [ 78%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_trigger_event_on_systems_manager_change[standard] PASSED                                                                                                     [ 85%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_trigger_event_on_systems_manager_change[domain] PASSED                                                                                                       [ 92%]
tests/aws/services/ssm/test_ssm.py::TestSSM::test_trigger_event_on_systems_manager_change[path] PASSED                                                                                                         [100%]
```

Could you please review? Thanks a lot 👍

In relation to this, I am also submitting a pull request to add tests for the SSM GetParameterHistory API. I would appreciate it if you could take a look at that as well.
- https://github.com/localstack/localstack/pull/11841

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
