### PR TITLE
add analytics to APIGW NextGen REST API handler chain

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway.py
@@ -41,6 +41,7 @@ class RestApiGateway(Gateway):
             [
                 handlers.response_enricher,
                 handlers.cors_response_enricher,
+                handlers.usage_counter,
                 # add composite response handlers?
             ]
         )

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/__init__.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/__init__.py
@@ -1,5 +1,6 @@
 from rolo.gateway import CompositeHandler
 
+from .analytics import IntegrationUsageCounter
 from .api_key_validation import ApiKeyValidationHandler
 from .cors import CorsResponseEnricher
 from .gateway_exception import GatewayExceptionHandler
@@ -25,3 +26,4 @@ gateway_exception_handler = GatewayExceptionHandler()
 api_key_validation_handler = ApiKeyValidationHandler()
 response_enricher = InvocationResponseEnricher()
 cors_response_enricher = CorsResponseEnricher()
+usage_counter = IntegrationUsageCounter()

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/analytics.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/analytics.py
@@ -1,0 +1,44 @@
+import logging
+
+from localstack.http import Response
+from localstack.utils.analytics.usage import UsageSetCounter
+
+from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
+from ..context import RestApiInvocationContext
+
+LOG = logging.getLogger(__name__)
+
+
+class IntegrationUsageCounter(RestApiGatewayHandler):
+    counter: UsageSetCounter
+
+    def __init__(self, counter: UsageSetCounter = None):
+        self.counter = counter or UsageSetCounter(namespace="apigateway:invokedrest")
+
+    def __call__(
+        self,
+        chain: RestApiGatewayHandlerChain,
+        context: RestApiInvocationContext,
+        response: Response,
+    ):
+        if context.integration:
+            invocation_type = context.integration["type"]
+            if invocation_type == "AWS":
+                service_name = self._get_aws_integration_service(context.integration.get("uri"))
+                invocation_type = f"{invocation_type}:{service_name}"
+        else:
+            # if the invocation does not have an integration attached, it probably failed before routing the request,
+            # hence we should count it as a NOT_FOUND invocation
+            invocation_type = "NOT_FOUND"
+
+        self.counter.record(invocation_type)
+
+    @staticmethod
+    def _get_aws_integration_service(integration_uri: str) -> str:
+        if not integration_uri:
+            return "null"
+
+        if len(split_arn := integration_uri.split(":", maxsplit=5)) < 4:
+            return "null"
+
+        return split_arn[4]


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As part of our effort to improve our analytics, this PR implements usage counters for API Gateway.

We can now properly have usage data on APIGW invocations, with the integration type (`AWS_PROXY`, `MOCK` etc), and in case of the `AWS` integration, the service the integration is targeting (`dynamodb`, `sqs` etc..)

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement APIGW NextGen handler for analytics

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
