### PR TITLE
[SFN] Fix access to selected items in Distributed Map state

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/distributed_iteration_component.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/distributed_iteration_component.py
@@ -119,7 +119,7 @@ class DistributedIterationComponent(InlineIterationComponent, abc.ABC):
                     self._workers.remove(worker)
 
     def _map_run(self, env: Environment) -> None:
-        input_items: list[json] = env.stack[-1]
+        input_items: list[json] = env.stack.pop()
 
         input_item_prog: Final[Program] = Program(
             start_at=self._start_at,

--- a/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
+++ b/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
@@ -61,6 +61,9 @@ class ScenariosTemplate(TemplateLoader):
     MAP_STATE_CONFIG_DISTRIBUTED_ITEM_SELECTOR: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/map_state_config_distributed_item_selector.json5"
     )
+    MAP_STATE_CONFIG_DISTRIBUTED_ITEM_SELECTOR_PARAMETERS: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/map_state_config_distributed_item_selector_parameters.json5"
+    )
     MAP_STATE_LEGACY_REENTRANT: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/map_state_legacy_reentrant.json5"
     )
@@ -105,6 +108,9 @@ class ScenariosTemplate(TemplateLoader):
     )
     MAP_STATE_ITEM_SELECTOR: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/map_state_item_selector.json5"
+    )
+    MAP_STATE_ITEM_SELECTOR_PARAMETERS: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/map_state_item_selector_parameters.json5"
     )
     MAP_STATE_PARAMETERS_LEGACY: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/map_state_parameters_legacy.json5"

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_config_distributed_item_selector_parameters.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_config_distributed_item_selector_parameters.json5
@@ -1,0 +1,45 @@
+{
+  "Comment": "MAP_STATE_CONFIG_DISTRIBUTED_ITEM_SELECTOR_PARAMETERS",
+  "StartAt": "Start",
+  "States": {
+    "Start": {
+      "Type": "Pass",
+      "Parameters": {
+        "bucket": "test-bucket",
+        "values": [
+          "1",
+          "2",
+          "3"
+        ]
+      },
+      "ResultPath": "$.content",
+      "Next": "MapState"
+    },
+    "MapState": {
+      "Type": "Map",
+      "MaxConcurrency": 1,
+      "ItemsPath": "$.content.values",
+      "ItemSelector": {
+        "bucketName.$": "$.content.bucket",
+        "value.$": "$$.Map.Item.Value"
+      },
+      "ItemProcessor": {
+        "StartAt": "IteratorInner",
+        "States": {
+          "IteratorInner": {
+            "Type": "Pass",
+            "End": true
+          }
+        },
+        "ProcessorConfig": {
+          "Mode": "DISTRIBUTED",
+          "ExecutionType": "STANDARD"
+        }
+      },
+      "Next": "Finish",
+    },
+    "Finish": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_item_selector_parameters.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_item_selector_parameters.json5
@@ -1,0 +1,45 @@
+{
+  "Comment": "MAP_STATE_ITEM_SELECTOR_PARAMETERS",
+  "StartAt": "Start",
+  "States": {
+    "Start": {
+      "Type": "Pass",
+      "Parameters": {
+        "bucket": "test-bucket",
+        "values": [
+          "1",
+          "2",
+          "3"
+        ]
+      },
+      "ResultPath": "$.content",
+      "Next": "MapState"
+    },
+    "MapState": {
+      "Type": "Map",
+      "MaxConcurrency": 1,
+      "ItemsPath": "$.content.values",
+      "ItemSelector": {
+        "bucketName.$": "$.content.bucket",
+        "value.$": "$$.Map.Item.Value"
+      },
+      "ItemProcessor": {
+        "StartAt": "EndState",
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "States": {
+          "EndState": {
+            "Type": "Pass",
+            "Parameters": {
+              "message": "Processing item completed"
+            },
+            "End": true
+          }
+        }
+      },
+      "ResultPath": null,
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
@@ -582,6 +582,34 @@ class TestBaseScenarios:
         )
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            # FIXME: AWS appears to have the state prior to MapStateExited as MapRunStarted.
+            # LocalStack currently has this previous state as MapRunSucceeded.
+            "$..events[8].previousEventId"
+        ]
+    )
+    def test_map_state_config_distributed_item_selector_parameters(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+    ):
+        template = ST.load_sfn_template(ST.MAP_STATE_CONFIG_DISTRIBUTED_ITEM_SELECTOR_PARAMETERS)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
     def test_map_state_legacy_reentrant(
         self,
         aws_client,
@@ -762,6 +790,27 @@ class TestBaseScenarios:
         sfn_snapshot,
     ):
         template = ST.load_sfn_template(ST.MAP_STATE_ITEM_SELECTOR)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
+    def test_map_state_item_selector_parameters(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+    ):
+        template = ST.load_sfn_template(ST.MAP_STATE_ITEM_SELECTOR_PARAMETERS)
         definition = json.dumps(template)
 
         exec_input = json.dumps({})

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
@@ -20177,5 +20177,463 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_config_distributed_item_selector_parameters": {
+    "recorded-date": "15-11-2024, 13:56:59",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Start",
+              "output": {
+                "content": {
+                  "bucket": "test-bucket",
+                  "values": [
+                    "1",
+                    "2",
+                    "3"
+                  ]
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "content": {
+                  "bucket": "test-bucket",
+                  "values": [
+                    "1",
+                    "2",
+                    "3"
+                  ]
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 5,
+            "mapStateStartedEventDetails": {
+              "length": 3
+            },
+            "previousEventId": 4,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "id": 6,
+            "mapRunStartedEventDetails": {
+              "mapRunArn": "arn:<partition>:states:<region>:111111111111:mapRun:<ArnPart_0idx>/<MapRunArnPart0_0idx>:<MapRunArnPart1_0idx>"
+            },
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "MapRunStarted"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "MapRunSucceeded"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "timestamp": "timestamp",
+            "type": "MapStateSucceeded"
+          },
+          {
+            "id": 9,
+            "previousEventId": 6,
+            "stateExitedEventDetails": {
+              "name": "MapState",
+              "output": "[{\"bucketName\":\"test-bucket\",\"value\":\"1\"},{\"bucketName\":\"test-bucket\",\"value\":\"2\"},{\"bucketName\":\"test-bucket\",\"value\":\"3\"}]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateExited"
+          },
+          {
+            "id": 10,
+            "previousEventId": 9,
+            "stateEnteredEventDetails": {
+              "input": "[{\"bucketName\":\"test-bucket\",\"value\":\"1\"},{\"bucketName\":\"test-bucket\",\"value\":\"2\"},{\"bucketName\":\"test-bucket\",\"value\":\"3\"}]",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Finish"
+            },
+            "timestamp": "timestamp",
+            "type": "SucceedStateEntered"
+          },
+          {
+            "id": 11,
+            "previousEventId": 10,
+            "stateExitedEventDetails": {
+              "name": "Finish",
+              "output": "[{\"bucketName\":\"test-bucket\",\"value\":\"1\"},{\"bucketName\":\"test-bucket\",\"value\":\"2\"},{\"bucketName\":\"test-bucket\",\"value\":\"3\"}]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "SucceedStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "[{\"bucketName\":\"test-bucket\",\"value\":\"1\"},{\"bucketName\":\"test-bucket\",\"value\":\"2\"},{\"bucketName\":\"test-bucket\",\"value\":\"3\"}]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 12,
+            "previousEventId": 11,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_item_selector_parameters": {
+    "recorded-date": "15-11-2024, 11:20:56",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Start",
+              "output": {
+                "content": {
+                  "bucket": "test-bucket",
+                  "values": [
+                    "1",
+                    "2",
+                    "3"
+                  ]
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "content": {
+                  "bucket": "test-bucket",
+                  "values": [
+                    "1",
+                    "2",
+                    "3"
+                  ]
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 5,
+            "mapStateStartedEventDetails": {
+              "length": 3
+            },
+            "previousEventId": 4,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "id": 6,
+            "mapIterationStartedEventDetails": {
+              "index": 0,
+              "name": "MapState"
+            },
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateEnteredEventDetails": {
+              "input": {
+                "bucketName": "test-bucket",
+                "value": "1"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "EndState"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateExitedEventDetails": {
+              "name": "EndState",
+              "output": {
+                "message": "Processing item completed"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 9,
+            "mapIterationSucceededEventDetails": {
+              "index": 0,
+              "name": "MapState"
+            },
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 10,
+            "mapIterationStartedEventDetails": {
+              "index": 1,
+              "name": "MapState"
+            },
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 11,
+            "previousEventId": 10,
+            "stateEnteredEventDetails": {
+              "input": {
+                "bucketName": "test-bucket",
+                "value": "2"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "EndState"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 12,
+            "previousEventId": 11,
+            "stateExitedEventDetails": {
+              "name": "EndState",
+              "output": {
+                "message": "Processing item completed"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 13,
+            "mapIterationSucceededEventDetails": {
+              "index": 1,
+              "name": "MapState"
+            },
+            "previousEventId": 12,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 14,
+            "mapIterationStartedEventDetails": {
+              "index": 2,
+              "name": "MapState"
+            },
+            "previousEventId": 12,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 15,
+            "previousEventId": 14,
+            "stateEnteredEventDetails": {
+              "input": {
+                "bucketName": "test-bucket",
+                "value": "3"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "EndState"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 16,
+            "previousEventId": 15,
+            "stateExitedEventDetails": {
+              "name": "EndState",
+              "output": {
+                "message": "Processing item completed"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 17,
+            "mapIterationSucceededEventDetails": {
+              "index": 2,
+              "name": "MapState"
+            },
+            "previousEventId": 16,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 18,
+            "previousEventId": 17,
+            "timestamp": "timestamp",
+            "type": "MapStateSucceeded"
+          },
+          {
+            "id": 19,
+            "previousEventId": 17,
+            "stateExitedEventDetails": {
+              "name": "MapState",
+              "output": {
+                "content": {
+                  "bucket": "test-bucket",
+                  "values": [
+                    "1",
+                    "2",
+                    "3"
+                  ]
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "content": {
+                  "bucket": "test-bucket",
+                  "values": [
+                    "1",
+                    "2",
+                    "3"
+                  ]
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 20,
+            "previousEventId": 19,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
@@ -116,6 +116,9 @@
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_config_distributed_item_selector": {
     "last_validated_date": "2024-02-08T21:44:04+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_config_distributed_item_selector_parameters": {
+    "last_validated_date": "2024-11-15T13:56:59+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_config_distributed_parameters": {
     "last_validated_date": "2024-02-08T21:44:45+00:00"
   },
@@ -133,6 +136,9 @@
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_item_selector": {
     "last_validated_date": "2023-07-19T11:47:54+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_item_selector_parameters": {
+    "last_validated_date": "2024-11-15T11:20:56+00:00"
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_item_selector_singleton": {
     "last_validated_date": "2023-07-19T12:11:14+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes input passed to an `ItemSelector` not being correctly propogated to each iteration of a distributed map run. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Instead of retrieving input data from the stack via a peek, items are instead popped off.
- Added `ItemSelector` tests for both a `DISTRIBUTED` and  `INLINE` map type.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
