### PR TITLE
add analytics for SNS internal routes

### DIFF
--- a/localstack-core/localstack/services/sns/usage.py
+++ b/localstack-core/localstack/services/sns/usage.py
@@ -1,0 +1,9 @@
+"""
+Usage reporting for SNS internal endpoints
+"""
+
+from localstack.utils.analytics.usage import UsageSetCounter
+
+# number of times SNS internal endpoint per resource types
+# (e.g. PlatformMessage:get invoked 10x times, SMSMessage:get invoked 3x times, SubscriptionToken...)
+internalapi = UsageSetCounter("sns:internalapi")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As part of our effort to improve our analytics, this PR implements usage counters for SNS internal routes.

We can now properly have usage data on SNS internal routes invocations, to understand their usage better. 

Usage is separated on what the internal route is targeting, be it Platform Endpoint messages, SMS messages or Subscription Tokens (useful for example for email subscriptions). 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement analytics for SNS internal routes via a base class + decorator on routes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
