### PR TITLE
Add Python 3.13 Lambda runtime

### DIFF
--- a/localstack-core/localstack/services/lambda_/api_utils.py
+++ b/localstack-core/localstack/services/lambda_/api_utils.py
@@ -50,6 +50,7 @@ FULL_FN_ARN_PATTERN = re.compile(
 )
 
 # Pattern for a full (both with and without qualifier) lambda layer ARN
+# TODO: It looks like they added `|(arn:[a-zA-Z0-9-]+:lambda:::awslayer:[a-zA-Z0-9-_]+` in 2024-11
 LAYER_VERSION_ARN_PATTERN = re.compile(
     rf"{ARN_PARTITION_REGEX}:lambda:(?P<region_name>[^:]+):(?P<account_id>\d{{12}}):layer:(?P<layer_name>[^:]+)(:(?P<layer_version>\d+))?$"
 )

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1048,8 +1048,13 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         latest_runtime = DEPRECATED_RUNTIMES_UPGRADES.get(deprecated_runtime)
 
         if latest_runtime is not None:
+            LOG.debug(
+                "The Lambda runtime %s is deprecated. Please upgrade to a supported Lambda runtime such as %s.",
+                deprecated_runtime,
+                latest_runtime,
+            )
             raise InvalidParameterValueException(
-                f"The runtime parameter of {deprecated_runtime} is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime ({latest_runtime}) while creating or updating functions.",
+                f"The runtime parameter of {deprecated_runtime} is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions.",
                 Type="User",
             )
 
@@ -3558,7 +3563,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         if not layer_version:
             raise ValidationException(
                 f"1 validation error detected: Value '{arn}' at 'arn' failed to satisfy constraint: Member must satisfy regular expression pattern: "
-                + "arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+"
+                + "(arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+)|(arn:[a-zA-Z0-9-]+:lambda:::awslayer:[a-zA-Z0-9-_]+)"
             )
 
         store = lambda_stores[account_id][region_name]

--- a/localstack-core/localstack/services/lambda_/runtimes.py
+++ b/localstack-core/localstack/services/lambda_/runtimes.py
@@ -42,7 +42,7 @@ IMAGE_MAPPING: dict[Runtime, str] = {
     Runtime.nodejs16_x: "nodejs:16",
     Runtime.nodejs14_x: "nodejs:14",  # deprecated Dec 4, 2023  => Jan 9, 2024  => Feb 8, 2024
     Runtime.nodejs12_x: "nodejs:12",  # deprecated Mar 31, 2023 => Mar 31, 2023 => Apr 30, 2023
-    # "python3.13": "python:3.13", expected November 2024
+    Runtime.python3_13: "python:3.13",
     Runtime.python3_12: "python:3.12",
     Runtime.python3_11: "python:3.11",
     Runtime.python3_10: "python:3.10",
@@ -72,6 +72,8 @@ IMAGE_MAPPING: dict[Runtime, str] = {
 # ideally ordered by deprecation date (following the AWS docs).
 # LocalStack can still provide best-effort support.
 
+# TODO: Consider removing these as AWS is not using them anymore and they likely get outdated.
+#  We currently use them in LocalStack logs as bonus recommendation (DevX).
 # When updating the recommendation,
 # please regenerate all tests with @markers.lambda_runtime_update
 DEPRECATED_RUNTIMES_UPGRADES: dict[Runtime, Optional[Runtime]] = {
@@ -114,6 +116,7 @@ RUNTIMES_AGGREGATED = {
         Runtime.nodejs16_x,
     ],
     "python": [
+        Runtime.python3_13,
         Runtime.python3_12,
         Runtime.python3_11,
         Runtime.python3_10,
@@ -150,6 +153,6 @@ TESTED_RUNTIMES: list[Runtime] = [
 SNAP_START_SUPPORTED_RUNTIMES = [Runtime.java11, Runtime.java17, Runtime.java21]
 
 # An ordered list of all Lambda runtimes considered valid by AWS. Matching snapshots in test_create_lambda_exceptions
-VALID_RUNTIMES: str = "[nodejs20.x, provided.al2023, python3.12, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]"
+VALID_RUNTIMES: str = "[nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]"
 # An ordered list of all Lambda runtimes for layers considered valid by AWS. Matching snapshots in test_layer_exceptions
-VALID_LAYER_RUNTIMES: str = "[ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java17, nodejs, nodejs4.3, java8.al2, go1.x, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, python3.10, java8, nodejs12.x, python3.11, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, python3.13, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby2.5, python3.6, python2.7]"
+VALID_LAYER_RUNTIMES: str = "[ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java17, nodejs, nodejs4.3, java8.al2, go1.x, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, nodejs22.x, python3.10, java8, nodejs12.x, python3.11, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, python3.13, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby2.5, python3.6, python2.7]"

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -7836,7 +7836,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "recorded-date": "12-09-2024, 11:30:07",
+    "recorded-date": "18-11-2024, 15:57:03",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7851,10 +7851,10 @@
       "invalid_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7863,10 +7863,10 @@
       "uppercase_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7908,7 +7908,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "recorded-date": "12-09-2024, 11:30:09",
+    "recorded-date": "18-11-2024, 15:57:06",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7923,10 +7923,10 @@
       "invalid_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7935,10 +7935,10 @@
       "uppercase_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -8248,7 +8248,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_exceptions": {
-    "recorded-date": "10-04-2024, 09:22:40",
+    "recorded-date": "18-11-2024, 15:57:22",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8275,7 +8275,7 @@
       "list_layers_exc_compatibleruntime_invalid": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'runtimedoesnotexist' at 'compatibleRuntime' failed to satisfy constraint: Member must satisfy enum value set: [ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java17, nodejs, nodejs4.3, java8.al2, go1.x, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, python3.10, java8, nodejs12.x, python3.11, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, python3.13, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby2.5, python3.6, python2.7]"
+          "Message": "1 validation error detected: Value 'runtimedoesnotexist' at 'compatibleRuntime' failed to satisfy constraint: Member must satisfy enum value set: [ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java17, nodejs, nodejs4.3, java8.al2, go1.x, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, nodejs22.x, python3.10, java8, nodejs12.x, python3.11, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, python3.13, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby2.5, python3.6, python2.7]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8350,7 +8350,7 @@
       "get_layer_version_by_arn_exc_invalidarn": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'arn:<partition>:lambda:<region>:111111111111:layer:<resource:1>' at 'arn' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+"
+          "Message": "1 validation error detected: Value 'arn:<partition>:lambda:<region>:111111111111:layer:<resource:1>' at 'arn' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+)|(arn:[a-zA-Z0-9-]+:lambda:::awslayer:[a-zA-Z0-9-_]+)"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8426,7 +8426,7 @@
       "publish_layer_version_exc_invalid_runtime_arch": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "2 validation errors detected: Value '[invalidruntime]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
+          "Message": "2 validation errors detected: Value '[invalidruntime]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8436,7 +8436,7 @@
       "publish_layer_version_exc_partially_invalid_values": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "2 validation errors detected: Value '[invalidruntime, invalidruntime2, nodejs20.x]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch, x86_64]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
+          "Message": "2 validation errors detected: Value '[invalidruntime, invalidruntime2, nodejs20.x]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch, x86_64]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -13759,7 +13759,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes0]": {
-    "recorded-date": "22-04-2024, 10:39:35",
+    "recorded-date": "18-11-2024, 15:57:09",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -13772,6 +13772,7 @@
           "nodejs16.x",
           "nodejs14.x",
           "nodejs12.x",
+          "python3.13",
           "python3.12",
           "python3.11",
           "python3.10",
@@ -13779,8 +13780,7 @@
           "python3.8",
           "python3.7",
           "java21",
-          "java17",
-          "java11"
+          "java17"
         ],
         "Content": {
           "CodeSha256": "<code-sha256:1>",
@@ -13800,7 +13800,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes1]": {
-    "recorded-date": "22-04-2024, 10:39:39",
+    "recorded-date": "18-11-2024, 15:57:14",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -13808,6 +13808,7 @@
           "x86_64"
         ],
         "CompatibleRuntimes": [
+          "java11",
           "java8.al2",
           "java8",
           "dotnet8",
@@ -16303,15 +16304,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[java8]": {
-    "recorded-date": "13-06-2024, 08:52:04",
+    "recorded-date": "18-11-2024, 15:57:00",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "The runtime parameter of java8 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (java21) while creating or updating functions."
+          "Message": "The runtime parameter of java8 is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions."
         },
         "Type": "User",
-        "message": "The runtime parameter of java8 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (java21) while creating or updating functions.",
+        "message": "The runtime parameter of java8 is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -16320,15 +16321,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[go1.x]": {
-    "recorded-date": "13-06-2024, 08:52:21",
+    "recorded-date": "18-11-2024, 15:57:00",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "The runtime parameter of go1.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (provided.al2023) while creating or updating functions."
+          "Message": "The runtime parameter of go1.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions."
         },
         "Type": "User",
-        "message": "The runtime parameter of go1.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (provided.al2023) while creating or updating functions.",
+        "message": "The runtime parameter of go1.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -16337,15 +16338,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[provided]": {
-    "recorded-date": "13-06-2024, 08:52:38",
+    "recorded-date": "18-11-2024, 15:57:01",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "The runtime parameter of provided is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (provided.al2023) while creating or updating functions."
+          "Message": "The runtime parameter of provided is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions."
         },
         "Type": "User",
-        "message": "The runtime parameter of provided is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (provided.al2023) while creating or updating functions.",
+        "message": "The runtime parameter of provided is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -16354,15 +16355,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[ruby2.7]": {
-    "recorded-date": "13-06-2024, 08:52:55",
+    "recorded-date": "18-11-2024, 15:57:01",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "The runtime parameter of ruby2.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (ruby3.2) while creating or updating functions."
+          "Message": "The runtime parameter of ruby2.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions."
         },
         "Type": "User",
-        "message": "The runtime parameter of ruby2.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (ruby3.2) while creating or updating functions.",
+        "message": "The runtime parameter of ruby2.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -16371,15 +16372,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs14.x]": {
-    "recorded-date": "13-06-2024, 08:53:12",
+    "recorded-date": "18-11-2024, 15:57:01",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "The runtime parameter of nodejs14.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs20.x) while creating or updating functions."
+          "Message": "The runtime parameter of nodejs14.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions."
         },
         "Type": "User",
-        "message": "The runtime parameter of nodejs14.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs20.x) while creating or updating functions.",
+        "message": "The runtime parameter of nodejs14.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -16388,15 +16389,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[python3.7]": {
-    "recorded-date": "13-06-2024, 08:53:29",
+    "recorded-date": "18-11-2024, 15:57:01",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions."
+          "Message": "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions."
         },
         "Type": "User",
-        "message": "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions.",
+        "message": "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -16405,15 +16406,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[dotnetcore3.1]": {
-    "recorded-date": "13-06-2024, 08:53:45",
+    "recorded-date": "18-11-2024, 15:57:02",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "The runtime parameter of dotnetcore3.1 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (dotnet6) while creating or updating functions."
+          "Message": "The runtime parameter of dotnetcore3.1 is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions."
         },
         "Type": "User",
-        "message": "The runtime parameter of dotnetcore3.1 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (dotnet6) while creating or updating functions.",
+        "message": "The runtime parameter of dotnetcore3.1 is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -16422,15 +16423,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs12.x]": {
-    "recorded-date": "13-06-2024, 08:54:02",
+    "recorded-date": "18-11-2024, 15:57:02",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "The runtime parameter of nodejs12.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs18.x) while creating or updating functions."
+          "Message": "The runtime parameter of nodejs12.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions."
         },
         "Type": "User",
-        "message": "The runtime parameter of nodejs12.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs18.x) while creating or updating functions.",
+        "message": "The runtime parameter of nodejs12.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use a supported runtime while creating or updating functions.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -51,7 +51,7 @@
     "last_validated_date": "2024-04-10T08:58:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "last_validated_date": "2024-09-12T11:30:07+00:00"
+    "last_validated_date": "2024-11-18T15:57:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_delete_on_nonexisting_version": {
     "last_validated_date": "2024-09-12T11:29:32+00:00"
@@ -405,7 +405,7 @@
     "last_validated_date": "2024-09-12T11:29:23+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "last_validated_date": "2024-09-12T11:30:09+00:00"
+    "last_validated_date": "2024-11-18T15:57:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_vpc_config": {
     "last_validated_date": "2024-09-12T11:34:40+00:00"
@@ -423,13 +423,13 @@
     "last_validated_date": "2024-04-10T09:10:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes0]": {
-    "last_validated_date": "2024-04-22T10:39:35+00:00"
+    "last_validated_date": "2024-11-18T15:57:09+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes1]": {
-    "last_validated_date": "2024-04-22T10:39:39+00:00"
+    "last_validated_date": "2024-11-18T15:57:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_exceptions": {
-    "last_validated_date": "2024-04-10T09:22:39+00:00"
+    "last_validated_date": "2024-11-18T15:57:22+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_function_exceptions": {
     "last_validated_date": "2024-04-10T09:23:18+00:00"
@@ -630,27 +630,27 @@
     "last_validated_date": "2024-06-12T14:19:11+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[dotnetcore3.1]": {
-    "last_validated_date": "2024-06-13T08:53:45+00:00"
+    "last_validated_date": "2024-11-18T15:57:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[go1.x]": {
-    "last_validated_date": "2024-06-13T08:52:21+00:00"
+    "last_validated_date": "2024-11-18T15:57:00+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[java8]": {
-    "last_validated_date": "2024-06-13T08:52:04+00:00"
+    "last_validated_date": "2024-11-18T15:57:00+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs12.x]": {
-    "last_validated_date": "2024-06-13T08:54:02+00:00"
+    "last_validated_date": "2024-11-18T15:57:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs14.x]": {
-    "last_validated_date": "2024-06-13T08:53:12+00:00"
+    "last_validated_date": "2024-11-18T15:57:01+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[provided]": {
-    "last_validated_date": "2024-06-13T08:52:38+00:00"
+    "last_validated_date": "2024-11-18T15:57:01+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[python3.7]": {
-    "last_validated_date": "2024-06-13T08:53:29+00:00"
+    "last_validated_date": "2024-11-18T15:57:01+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[ruby2.7]": {
-    "last_validated_date": "2024-06-13T08:52:55+00:00"
+    "last_validated_date": "2024-11-18T15:57:01+00:00"
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_common.py
+++ b/tests/aws/services/lambda_/test_lambda_common.py
@@ -142,6 +142,8 @@ class TestLambdaRuntimesCommon:
             "$..environment.DOTNET_NOLOGO",
             "$..environment.DOTNET_RUNNING_IN_CONTAINER",
             "$..environment.DOTNET_VERSION",
+            # Changed from 127.0.0.1:9001 to 169.254.100.1:9001 around 2024-11, which would require network changes
+            "$..environment.AWS_LAMBDA_RUNTIME_API",
         ]
     )
     @markers.aws.validated

--- a/tests/aws/services/lambda_/test_lambda_common.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_common.snapshot.json
@@ -1,70 +1,70 @@
 {
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.8]": {
-    "recorded-date": "20-03-2024, 21:05:26",
+    "recorded-date": "18-11-2024, 15:47:54",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java11]": {
-    "recorded-date": "20-03-2024, 21:05:45",
+    "recorded-date": "18-11-2024, 15:48:15",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2]": {
-    "recorded-date": "20-03-2024, 21:06:24",
+    "recorded-date": "18-11-2024, 15:48:57",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8.al2]": {
-    "recorded-date": "20-03-2024, 21:05:49",
+    "recorded-date": "18-11-2024, 15:48:20",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.2]": {
-    "recorded-date": "22-04-2024, 10:10:53",
+    "recorded-date": "18-11-2024, 15:48:25",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.11]": {
-    "recorded-date": "20-03-2024, 21:05:13",
+    "recorded-date": "18-11-2024, 15:47:38",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java17]": {
-    "recorded-date": "20-03-2024, 21:05:40",
+    "recorded-date": "18-11-2024, 15:48:04",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs18.x]": {
-    "recorded-date": "20-03-2024, 21:05:00",
+    "recorded-date": "18-11-2024, 15:47:18",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java21]": {
-    "recorded-date": "20-03-2024, 21:05:36",
+    "recorded-date": "18-11-2024, 15:47:59",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2023]": {
-    "recorded-date": "20-03-2024, 21:06:16",
+    "recorded-date": "18-11-2024, 15:48:48",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.9]": {
-    "recorded-date": "20-03-2024, 21:05:22",
+    "recorded-date": "18-11-2024, 15:47:48",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.10]": {
-    "recorded-date": "20-03-2024, 21:05:17",
+    "recorded-date": "18-11-2024, 15:47:43",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.12]": {
-    "recorded-date": "20-03-2024, 21:05:09",
+    "recorded-date": "18-11-2024, 15:47:33",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs20.x]": {
-    "recorded-date": "20-03-2024, 21:04:56",
+    "recorded-date": "18-11-2024, 15:47:12",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet6]": {
-    "recorded-date": "20-03-2024, 21:06:02",
+    "recorded-date": "18-11-2024, 15:48:36",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs16.x]": {
-    "recorded-date": "20-03-2024, 21:05:05",
+    "recorded-date": "18-11-2024, 15:47:23",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.8]": {
-    "recorded-date": "20-03-2024, 21:06:47",
+    "recorded-date": "18-11-2024, 15:49:26",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -205,7 +205,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java11]": {
-    "recorded-date": "20-03-2024, 21:07:02",
+    "recorded-date": "18-11-2024, 15:49:37",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -277,13 +277,13 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SECRET_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -291,7 +291,7 @@
           "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "echo.Handler",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
@@ -320,13 +320,13 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SECRET_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -334,7 +334,7 @@
           "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "echo.Handler",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
@@ -344,7 +344,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2]": {
-    "recorded-date": "20-03-2024, 21:08:08",
+    "recorded-date": "18-11-2024, 15:50:08",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -477,7 +477,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8.al2]": {
-    "recorded-date": "20-03-2024, 21:07:05",
+    "recorded-date": "18-11-2024, 15:49:41",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -616,7 +616,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.2]": {
-    "recorded-date": "22-04-2024, 10:11:01",
+    "recorded-date": "18-11-2024, 15:49:44",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -761,7 +761,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.11]": {
-    "recorded-date": "20-03-2024, 21:06:39",
+    "recorded-date": "18-11-2024, 15:49:16",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -902,7 +902,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java17]": {
-    "recorded-date": "20-03-2024, 21:06:58",
+    "recorded-date": "18-11-2024, 15:49:33",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -973,12 +973,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -986,10 +986,10 @@
           "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "echo.Handler",
-          "_LAMBDA_TELEMETRY_LOG_FD": "3"
+          "_LAMBDA_TELEMETRY_LOG_FD": "62"
         },
         "packages": []
       },
@@ -1014,12 +1014,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -1027,17 +1027,17 @@
           "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "echo.Handler",
-          "_LAMBDA_TELEMETRY_LOG_FD": "3"
+          "_LAMBDA_TELEMETRY_LOG_FD": "62"
         },
         "packages": []
       }
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs18.x]": {
-    "recorded-date": "20-03-2024, 21:06:30",
+    "recorded-date": "18-11-2024, 15:49:03",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1178,7 +1178,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java21]": {
-    "recorded-date": "20-03-2024, 21:06:55",
+    "recorded-date": "18-11-2024, 15:49:29",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1249,12 +1249,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -1262,10 +1262,10 @@
           "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "echo.Handler",
-          "_LAMBDA_TELEMETRY_LOG_FD": "3"
+          "_LAMBDA_TELEMETRY_LOG_FD": "62"
         },
         "packages": []
       },
@@ -1290,12 +1290,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -1303,17 +1303,17 @@
           "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "echo.Handler",
-          "_LAMBDA_TELEMETRY_LOG_FD": "3"
+          "_LAMBDA_TELEMETRY_LOG_FD": "62"
         },
         "packages": []
       }
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2023]": {
-    "recorded-date": "20-03-2024, 21:08:05",
+    "recorded-date": "18-11-2024, 15:50:03",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1446,7 +1446,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.9]": {
-    "recorded-date": "20-03-2024, 21:06:44",
+    "recorded-date": "18-11-2024, 15:49:23",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1587,7 +1587,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.10]": {
-    "recorded-date": "20-03-2024, 21:06:41",
+    "recorded-date": "18-11-2024, 15:49:19",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1728,7 +1728,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.12]": {
-    "recorded-date": "20-03-2024, 21:06:36",
+    "recorded-date": "18-11-2024, 15:49:13",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1799,12 +1799,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -1816,7 +1816,7 @@
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "handler.handler",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
@@ -1844,12 +1844,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -1861,7 +1861,7 @@
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "handler.handler",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
@@ -1871,7 +1871,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs20.x]": {
-    "recorded-date": "20-03-2024, 21:06:27",
+    "recorded-date": "18-11-2024, 15:49:00",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1941,12 +1941,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -1957,7 +1957,7 @@
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "index.handler",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
@@ -1984,12 +1984,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -2000,7 +2000,7 @@
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "index.handler",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
@@ -2010,7 +2010,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet6]": {
-    "recorded-date": "20-03-2024, 21:07:15",
+    "recorded-date": "18-11-2024, 15:49:51",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2155,7 +2155,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs16.x]": {
-    "recorded-date": "20-03-2024, 21:06:33",
+    "recorded-date": "18-11-2024, 15:49:07",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2296,7 +2296,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.8]": {
-    "recorded-date": "20-03-2024, 21:08:29",
+    "recorded-date": "18-11-2024, 15:50:33",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2358,7 +2358,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java11]": {
-    "recorded-date": "20-03-2024, 21:08:44",
+    "recorded-date": "18-11-2024, 15:50:43",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2420,7 +2420,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2]": {
-    "recorded-date": "20-03-2024, 21:09:51",
+    "recorded-date": "18-11-2024, 15:51:07",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2481,7 +2481,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8.al2]": {
-    "recorded-date": "20-03-2024, 21:08:47",
+    "recorded-date": "18-11-2024, 15:50:47",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2543,7 +2543,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.2]": {
-    "recorded-date": "22-04-2024, 10:11:07",
+    "recorded-date": "18-11-2024, 15:50:50",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2605,7 +2605,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.11]": {
-    "recorded-date": "20-03-2024, 21:08:22",
+    "recorded-date": "18-11-2024, 15:50:25",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2668,7 +2668,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java17]": {
-    "recorded-date": "20-03-2024, 21:08:40",
+    "recorded-date": "18-11-2024, 15:50:40",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2730,7 +2730,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs18.x]": {
-    "recorded-date": "20-03-2024, 21:08:14",
+    "recorded-date": "18-11-2024, 15:50:13",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2792,7 +2792,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java21]": {
-    "recorded-date": "20-03-2024, 21:08:38",
+    "recorded-date": "18-11-2024, 15:50:37",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2854,7 +2854,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2023]": {
-    "recorded-date": "20-03-2024, 21:09:48",
+    "recorded-date": "18-11-2024, 15:51:03",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2915,7 +2915,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.9]": {
-    "recorded-date": "20-03-2024, 21:08:27",
+    "recorded-date": "18-11-2024, 15:50:30",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2978,7 +2978,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.10]": {
-    "recorded-date": "20-03-2024, 21:08:24",
+    "recorded-date": "18-11-2024, 15:50:27",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3041,7 +3041,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.12]": {
-    "recorded-date": "20-03-2024, 21:08:19",
+    "recorded-date": "18-11-2024, 15:50:22",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3104,7 +3104,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs20.x]": {
-    "recorded-date": "20-03-2024, 21:08:11",
+    "recorded-date": "18-11-2024, 15:50:11",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3166,7 +3166,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet6]": {
-    "recorded-date": "20-03-2024, 21:08:57",
+    "recorded-date": "18-11-2024, 15:50:56",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3228,7 +3228,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs16.x]": {
-    "recorded-date": "20-03-2024, 21:08:16",
+    "recorded-date": "18-11-2024, 15:50:16",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3290,7 +3290,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.8]": {
-    "recorded-date": "20-03-2024, 21:10:13",
+    "recorded-date": "18-11-2024, 15:51:20",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3343,7 +3343,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java11]": {
-    "recorded-date": "20-03-2024, 21:10:21",
+    "recorded-date": "18-11-2024, 15:51:17",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3396,7 +3396,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java8.al2]": {
-    "recorded-date": "20-03-2024, 21:10:24",
+    "recorded-date": "18-11-2024, 15:51:48",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3449,7 +3449,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.2]": {
-    "recorded-date": "22-04-2024, 10:11:12",
+    "recorded-date": "18-11-2024, 15:51:51",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3502,7 +3502,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.11]": {
-    "recorded-date": "20-03-2024, 21:10:30",
+    "recorded-date": "18-11-2024, 15:51:10",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3555,7 +3555,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java17]": {
-    "recorded-date": "20-03-2024, 21:09:54",
+    "recorded-date": "18-11-2024, 15:51:41",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3608,7 +3608,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs18.x]": {
-    "recorded-date": "20-03-2024, 21:10:16",
+    "recorded-date": "18-11-2024, 15:51:35",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3661,7 +3661,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java21]": {
-    "recorded-date": "20-03-2024, 21:10:05",
+    "recorded-date": "18-11-2024, 15:51:26",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3714,7 +3714,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.9]": {
-    "recorded-date": "20-03-2024, 21:10:11",
+    "recorded-date": "18-11-2024, 15:51:13",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3767,7 +3767,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.10]": {
-    "recorded-date": "20-03-2024, 21:10:18",
+    "recorded-date": "18-11-2024, 15:51:44",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3820,7 +3820,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.12]": {
-    "recorded-date": "20-03-2024, 21:10:08",
+    "recorded-date": "18-11-2024, 15:51:29",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3873,7 +3873,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs20.x]": {
-    "recorded-date": "20-03-2024, 21:09:57",
+    "recorded-date": "18-11-2024, 15:51:23",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3926,7 +3926,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet6]": {
-    "recorded-date": "20-03-2024, 21:10:27",
+    "recorded-date": "18-11-2024, 15:52:01",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3979,7 +3979,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs16.x]": {
-    "recorded-date": "20-03-2024, 21:09:59",
+    "recorded-date": "18-11-2024, 15:51:32",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4032,47 +4032,47 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs20.x]": {
-    "recorded-date": "20-03-2024, 21:10:55",
+    "recorded-date": "18-11-2024, 15:52:37",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs18.x]": {
-    "recorded-date": "20-03-2024, 21:11:28",
+    "recorded-date": "18-11-2024, 15:53:05",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs16.x]": {
-    "recorded-date": "20-03-2024, 21:10:58",
+    "recorded-date": "18-11-2024, 15:53:02",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.8]": {
-    "recorded-date": "20-03-2024, 21:11:25",
+    "recorded-date": "18-11-2024, 15:52:33",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.9]": {
-    "recorded-date": "20-03-2024, 21:11:22",
+    "recorded-date": "18-11-2024, 15:52:08",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.10]": {
-    "recorded-date": "20-03-2024, 21:11:31",
+    "recorded-date": "18-11-2024, 15:53:30",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.11]": {
-    "recorded-date": "20-03-2024, 21:12:29",
+    "recorded-date": "18-11-2024, 15:52:04",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.12]": {
-    "recorded-date": "20-03-2024, 21:11:19",
+    "recorded-date": "18-11-2024, 15:52:58",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.2]": {
-    "recorded-date": "22-04-2024, 10:11:19",
+    "recorded-date": "18-11-2024, 15:54:18",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet8]": {
-    "recorded-date": "20-03-2024, 21:06:10",
+    "recorded-date": "18-11-2024, 15:48:42",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet8]": {
-    "recorded-date": "20-03-2024, 21:07:22",
+    "recorded-date": "18-11-2024, 15:49:54",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4143,12 +4143,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "DOTNET_ROOT": "/var/lang/bin",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_RUNTIME_NAME": "dotnet8",
@@ -4161,10 +4161,10 @@
           "SSL_CERT_FILE": "/var/runtime/empty-certificates.crt",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "dotnet::Dotnet.Function::FunctionHandler",
-          "_LAMBDA_TELEMETRY_LOG_FD": "3",
+          "_LAMBDA_TELEMETRY_LOG_FD": "62",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
         },
         "packages": []
@@ -4190,12 +4190,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "DOTNET_ROOT": "/var/lang/bin",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_RUNTIME_NAME": "dotnet8",
@@ -4208,10 +4208,10 @@
           "SSL_CERT_FILE": "/var/runtime/empty-certificates.crt",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "dotnet::Dotnet.Function::FunctionHandler",
-          "_LAMBDA_TELEMETRY_LOG_FD": "3",
+          "_LAMBDA_TELEMETRY_LOG_FD": "62",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
         },
         "packages": []
@@ -4219,7 +4219,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet8]": {
-    "recorded-date": "20-03-2024, 21:09:04",
+    "recorded-date": "18-11-2024, 15:51:00",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4281,7 +4281,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet8]": {
-    "recorded-date": "20-03-2024, 21:10:33",
+    "recorded-date": "18-11-2024, 15:51:54",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4334,35 +4334,35 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java17]": {
-    "recorded-date": "20-03-2024, 21:10:52",
+    "recorded-date": "18-11-2024, 15:53:27",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java21]": {
-    "recorded-date": "20-03-2024, 21:11:15",
+    "recorded-date": "18-11-2024, 15:52:54",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java11]": {
-    "recorded-date": "20-03-2024, 21:11:48",
+    "recorded-date": "18-11-2024, 15:52:30",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java8.al2]": {
-    "recorded-date": "20-03-2024, 21:12:17",
+    "recorded-date": "18-11-2024, 15:54:14",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet6]": {
-    "recorded-date": "20-03-2024, 21:12:26",
+    "recorded-date": "18-11-2024, 15:54:43",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet8]": {
-    "recorded-date": "20-03-2024, 21:12:38",
+    "recorded-date": "18-11-2024, 15:54:29",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.3]": {
-    "recorded-date": "22-04-2024, 10:10:58",
+    "recorded-date": "18-11-2024, 15:48:31",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.3]": {
-    "recorded-date": "22-04-2024, 10:11:04",
+    "recorded-date": "18-11-2024, 15:49:47",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4433,12 +4433,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "GEM_HOME": "/var/runtime",
           "GEM_PATH": "/var/task/vendor/bundle/ruby/3.3.0:/opt/ruby/gems/3.3.0:/var/runtime:/var/runtime/ruby/3.3.0",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
@@ -4451,7 +4451,7 @@
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "function.handler",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
@@ -4479,12 +4479,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "GEM_HOME": "/var/runtime",
           "GEM_PATH": "/var/task/vendor/bundle/ruby/3.3.0:/opt/ruby/gems/3.3.0:/var/runtime:/var/runtime/ruby/3.3.0",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
@@ -4497,7 +4497,7 @@
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "function.handler",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
@@ -4507,7 +4507,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.3]": {
-    "recorded-date": "22-04-2024, 10:11:09",
+    "recorded-date": "18-11-2024, 15:50:53",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4569,7 +4569,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.3]": {
-    "recorded-date": "22-04-2024, 10:11:15",
+    "recorded-date": "18-11-2024, 15:51:57",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4622,7 +4622,274 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.3]": {
-    "recorded-date": "22-04-2024, 10:11:23",
+    "recorded-date": "18-11-2024, 15:54:34",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.13]": {
+    "recorded-date": "18-11-2024, 15:47:28",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.13]": {
+    "recorded-date": "18-11-2024, 15:49:10",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "TEST_KEY": "TEST_VAL"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.13",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "invocation_result_payload": {
+        "ctx": {
+          "aws_request_id": "<uuid:2>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "memory_limit_in_mb": "1024",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_python3.13",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LC_CTYPE": "C.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "PWD": "/var/task",
+          "PYTHONPATH": "/var/runtime",
+          "SHLVL": "0",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "handler.handler",
+          "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
+        },
+        "packages": []
+      },
+      "invocation_result_payload_qualified": {
+        "ctx": {
+          "aws_request_id": "<uuid:3>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:$LATEST",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "memory_limit_in_mb": "1024",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_python3.13",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LC_CTYPE": "C.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "PWD": "/var/task",
+          "PYTHONPATH": "/var/runtime",
+          "SHLVL": "0",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "handler.handler",
+          "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
+        },
+        "packages": []
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.13]": {
+    "recorded-date": "18-11-2024, 15:50:19",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.13",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "error_result": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorMessage": "Failed: some_error_msg",
+          "errorType": "Exception",
+          "requestId": "<uuid:2>",
+          "stackTrace": "<stack-trace>"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.13]": {
+    "recorded-date": "18-11-2024, 15:51:38",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "AWS_LAMBDA_EXEC_WRAPPER": "/var/task/environment_wrapper"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.13",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.13]": {
+    "recorded-date": "18-11-2024, 15:53:09",
     "recorded-content": {}
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_common.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_common.validation.json
@@ -1,260 +1,275 @@
 {
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet6]": {
-    "last_validated_date": "2024-03-20T21:26:11+00:00"
+    "last_validated_date": "2024-11-18T15:54:42+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet8]": {
-    "last_validated_date": "2024-03-20T21:26:19+00:00"
+    "last_validated_date": "2024-11-18T15:54:28+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java11]": {
-    "last_validated_date": "2024-03-20T21:26:39+00:00"
+    "last_validated_date": "2024-11-18T15:52:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java17]": {
-    "last_validated_date": "2024-03-20T21:25:58+00:00"
+    "last_validated_date": "2024-11-18T15:53:26+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java21]": {
-    "last_validated_date": "2024-03-20T21:26:57+00:00"
+    "last_validated_date": "2024-11-18T15:52:54+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java8.al2]": {
-    "last_validated_date": "2024-03-20T21:25:38+00:00"
+    "last_validated_date": "2024-11-18T15:54:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs16.x]": {
-    "last_validated_date": "2024-03-20T21:26:02+00:00"
+    "last_validated_date": "2024-11-18T15:53:01+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs18.x]": {
-    "last_validated_date": "2024-03-20T21:26:22+00:00"
+    "last_validated_date": "2024-11-18T15:53:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs20.x]": {
-    "last_validated_date": "2024-03-20T21:25:06+00:00"
+    "last_validated_date": "2024-11-18T15:52:36+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.10]": {
-    "last_validated_date": "2024-03-20T21:27:06+00:00"
+    "last_validated_date": "2024-11-18T15:53:30+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.11]": {
-    "last_validated_date": "2024-03-20T21:27:00+00:00"
+    "last_validated_date": "2024-11-18T15:52:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.12]": {
-    "last_validated_date": "2024-03-20T21:27:03+00:00"
+    "last_validated_date": "2024-11-18T15:52:57+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.13]": {
+    "last_validated_date": "2024-11-18T15:53:09+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.8]": {
-    "last_validated_date": "2024-03-20T21:25:09+00:00"
+    "last_validated_date": "2024-11-18T15:52:32+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.9]": {
-    "last_validated_date": "2024-03-20T21:26:46+00:00"
+    "last_validated_date": "2024-11-18T15:52:07+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.2]": {
-    "last_validated_date": "2024-04-22T10:11:18+00:00"
+    "last_validated_date": "2024-11-18T15:54:18+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.3]": {
-    "last_validated_date": "2024-04-22T10:11:22+00:00"
+    "last_validated_date": "2024-11-18T15:54:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet6]": {
-    "last_validated_date": "2024-03-20T21:20:34+00:00"
+    "last_validated_date": "2024-11-18T15:48:36+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet8]": {
-    "last_validated_date": "2024-03-20T21:20:42+00:00"
+    "last_validated_date": "2024-11-18T15:48:41+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java11]": {
-    "last_validated_date": "2024-03-20T21:20:17+00:00"
+    "last_validated_date": "2024-11-18T15:48:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java17]": {
-    "last_validated_date": "2024-03-20T21:20:12+00:00"
+    "last_validated_date": "2024-11-18T15:48:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java21]": {
-    "last_validated_date": "2024-03-20T21:20:08+00:00"
+    "last_validated_date": "2024-11-18T15:47:59+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8.al2]": {
-    "last_validated_date": "2024-03-20T21:20:21+00:00"
+    "last_validated_date": "2024-11-18T15:48:20+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs16.x]": {
-    "last_validated_date": "2024-03-20T21:19:33+00:00"
+    "last_validated_date": "2024-11-18T15:47:23+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs18.x]": {
-    "last_validated_date": "2024-03-20T21:19:28+00:00"
+    "last_validated_date": "2024-11-18T15:47:17+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs20.x]": {
-    "last_validated_date": "2024-03-20T21:19:24+00:00"
+    "last_validated_date": "2024-11-18T15:47:12+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2023]": {
-    "last_validated_date": "2024-03-20T21:20:48+00:00"
+    "last_validated_date": "2024-11-18T15:48:48+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2]": {
-    "last_validated_date": "2024-03-20T21:20:56+00:00"
+    "last_validated_date": "2024-11-18T15:48:57+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.10]": {
-    "last_validated_date": "2024-03-20T21:19:46+00:00"
+    "last_validated_date": "2024-11-18T15:47:43+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.11]": {
-    "last_validated_date": "2024-03-20T21:19:42+00:00"
+    "last_validated_date": "2024-11-18T15:47:38+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.12]": {
-    "last_validated_date": "2024-03-20T21:19:37+00:00"
+    "last_validated_date": "2024-11-18T15:47:33+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.13]": {
+    "last_validated_date": "2024-11-18T15:47:28+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.8]": {
-    "last_validated_date": "2024-03-20T21:19:55+00:00"
+    "last_validated_date": "2024-11-18T15:47:53+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.9]": {
-    "last_validated_date": "2024-03-20T21:19:50+00:00"
+    "last_validated_date": "2024-11-18T15:47:48+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.2]": {
-    "last_validated_date": "2024-04-22T10:10:53+00:00"
+    "last_validated_date": "2024-11-18T15:48:25+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.3]": {
-    "last_validated_date": "2024-04-22T10:10:58+00:00"
+    "last_validated_date": "2024-11-18T15:48:31+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet6]": {
-    "last_validated_date": "2024-03-20T21:21:47+00:00"
+    "last_validated_date": "2024-11-18T15:49:50+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet8]": {
-    "last_validated_date": "2024-03-20T21:21:54+00:00"
+    "last_validated_date": "2024-11-18T15:49:54+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java11]": {
-    "last_validated_date": "2024-03-20T21:21:33+00:00"
+    "last_validated_date": "2024-11-18T15:49:36+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java17]": {
-    "last_validated_date": "2024-03-20T21:21:30+00:00"
+    "last_validated_date": "2024-11-18T15:49:32+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java21]": {
-    "last_validated_date": "2024-03-20T21:21:27+00:00"
+    "last_validated_date": "2024-11-18T15:49:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8.al2]": {
-    "last_validated_date": "2024-03-20T21:21:37+00:00"
+    "last_validated_date": "2024-11-18T15:49:40+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs16.x]": {
-    "last_validated_date": "2024-03-20T21:21:05+00:00"
+    "last_validated_date": "2024-11-18T15:49:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs18.x]": {
-    "last_validated_date": "2024-03-20T21:21:02+00:00"
+    "last_validated_date": "2024-11-18T15:49:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs20.x]": {
-    "last_validated_date": "2024-03-20T21:20:59+00:00"
+    "last_validated_date": "2024-11-18T15:49:00+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2023]": {
-    "last_validated_date": "2024-03-20T21:22:38+00:00"
+    "last_validated_date": "2024-11-18T15:50:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2]": {
-    "last_validated_date": "2024-03-20T21:22:44+00:00"
+    "last_validated_date": "2024-11-18T15:50:07+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.10]": {
-    "last_validated_date": "2024-03-20T21:21:13+00:00"
+    "last_validated_date": "2024-11-18T15:49:19+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.11]": {
-    "last_validated_date": "2024-03-20T21:21:11+00:00"
+    "last_validated_date": "2024-11-18T15:49:16+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.12]": {
-    "last_validated_date": "2024-03-20T21:21:08+00:00"
+    "last_validated_date": "2024-11-18T15:49:13+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.13]": {
+    "last_validated_date": "2024-11-18T15:49:10+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.8]": {
-    "last_validated_date": "2024-03-20T21:21:19+00:00"
+    "last_validated_date": "2024-11-18T15:49:25+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.9]": {
-    "last_validated_date": "2024-03-20T21:21:16+00:00"
+    "last_validated_date": "2024-11-18T15:49:22+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.2]": {
-    "last_validated_date": "2024-04-22T10:11:01+00:00"
+    "last_validated_date": "2024-11-18T15:49:44+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.3]": {
-    "last_validated_date": "2024-04-22T10:11:04+00:00"
+    "last_validated_date": "2024-11-18T15:49:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet6]": {
-    "last_validated_date": "2024-03-20T21:24:38+00:00"
+    "last_validated_date": "2024-11-18T15:52:00+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet8]": {
-    "last_validated_date": "2024-03-20T21:24:41+00:00"
+    "last_validated_date": "2024-11-18T15:51:54+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java11]": {
-    "last_validated_date": "2024-03-20T21:24:47+00:00"
+    "last_validated_date": "2024-11-18T15:51:16+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java17]": {
-    "last_validated_date": "2024-03-20T21:24:33+00:00"
+    "last_validated_date": "2024-11-18T15:51:41+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java21]": {
-    "last_validated_date": "2024-03-20T21:24:55+00:00"
+    "last_validated_date": "2024-11-18T15:51:26+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java8.al2]": {
-    "last_validated_date": "2024-03-20T21:24:30+00:00"
+    "last_validated_date": "2024-11-18T15:51:48+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs16.x]": {
-    "last_validated_date": "2024-03-20T21:24:35+00:00"
+    "last_validated_date": "2024-11-18T15:51:32+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs18.x]": {
-    "last_validated_date": "2024-03-20T21:24:44+00:00"
+    "last_validated_date": "2024-11-18T15:51:35+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs20.x]": {
-    "last_validated_date": "2024-03-20T21:24:24+00:00"
+    "last_validated_date": "2024-11-18T15:51:22+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.10]": {
-    "last_validated_date": "2024-03-20T21:25:03+00:00"
+    "last_validated_date": "2024-11-18T15:51:44+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.11]": {
-    "last_validated_date": "2024-03-20T21:24:58+00:00"
+    "last_validated_date": "2024-11-18T15:51:10+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.12]": {
-    "last_validated_date": "2024-03-20T21:25:01+00:00"
+    "last_validated_date": "2024-11-18T15:51:29+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.13]": {
+    "last_validated_date": "2024-11-18T15:51:38+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.8]": {
-    "last_validated_date": "2024-03-20T21:24:27+00:00"
+    "last_validated_date": "2024-11-18T15:51:19+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.9]": {
-    "last_validated_date": "2024-03-20T21:24:52+00:00"
+    "last_validated_date": "2024-11-18T15:51:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.2]": {
-    "last_validated_date": "2024-04-22T10:11:12+00:00"
+    "last_validated_date": "2024-11-18T15:51:51+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.3]": {
-    "last_validated_date": "2024-04-22T10:11:14+00:00"
+    "last_validated_date": "2024-11-18T15:51:57+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet6]": {
-    "last_validated_date": "2024-03-20T21:23:28+00:00"
+    "last_validated_date": "2024-11-18T15:50:56+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet8]": {
-    "last_validated_date": "2024-03-20T21:23:35+00:00"
+    "last_validated_date": "2024-11-18T15:50:59+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java11]": {
-    "last_validated_date": "2024-03-20T21:23:16+00:00"
+    "last_validated_date": "2024-11-18T15:50:43+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java17]": {
-    "last_validated_date": "2024-03-20T21:23:13+00:00"
+    "last_validated_date": "2024-11-18T15:50:39+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java21]": {
-    "last_validated_date": "2024-03-20T21:23:10+00:00"
+    "last_validated_date": "2024-11-18T15:50:36+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8.al2]": {
-    "last_validated_date": "2024-03-20T21:23:19+00:00"
+    "last_validated_date": "2024-11-18T15:50:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs16.x]": {
-    "last_validated_date": "2024-03-20T21:22:51+00:00"
+    "last_validated_date": "2024-11-18T15:50:16+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs18.x]": {
-    "last_validated_date": "2024-03-20T21:22:48+00:00"
+    "last_validated_date": "2024-11-18T15:50:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs20.x]": {
-    "last_validated_date": "2024-03-20T21:22:46+00:00"
+    "last_validated_date": "2024-11-18T15:50:10+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2023]": {
-    "last_validated_date": "2024-03-20T21:24:18+00:00"
+    "last_validated_date": "2024-11-18T15:51:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2]": {
-    "last_validated_date": "2024-03-20T21:24:21+00:00"
+    "last_validated_date": "2024-11-18T15:51:07+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.10]": {
-    "last_validated_date": "2024-03-20T21:22:58+00:00"
+    "last_validated_date": "2024-11-18T15:50:27+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.11]": {
-    "last_validated_date": "2024-03-20T21:22:55+00:00"
+    "last_validated_date": "2024-11-18T15:50:24+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.12]": {
-    "last_validated_date": "2024-03-20T21:22:53+00:00"
+    "last_validated_date": "2024-11-18T15:50:22+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.13]": {
+    "last_validated_date": "2024-11-18T15:50:19+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.8]": {
-    "last_validated_date": "2024-03-20T21:23:02+00:00"
+    "last_validated_date": "2024-11-18T15:50:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.9]": {
-    "last_validated_date": "2024-03-20T21:23:00+00:00"
+    "last_validated_date": "2024-11-18T15:50:30+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.2]": {
-    "last_validated_date": "2024-04-22T10:11:06+00:00"
+    "last_validated_date": "2024-11-18T15:50:50+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.3]": {
-    "last_validated_date": "2024-04-22T10:11:09+00:00"
+    "last_validated_date": "2024-11-18T15:50:53+00:00"
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_runtimes.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_runtimes.snapshot.json
@@ -966,43 +966,43 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.12]": {
-    "recorded-date": "13-03-2024, 08:56:29",
+    "recorded-date": "18-11-2024, 16:39:19",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.11]": {
-    "recorded-date": "13-03-2024, 08:56:32",
+    "recorded-date": "18-11-2024, 16:39:22",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.10]": {
-    "recorded-date": "13-03-2024, 08:56:36",
+    "recorded-date": "18-11-2024, 16:39:26",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.9]": {
-    "recorded-date": "13-03-2024, 08:56:39",
+    "recorded-date": "18-11-2024, 16:39:30",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.8]": {
-    "recorded-date": "13-03-2024, 08:56:42",
+    "recorded-date": "18-11-2024, 16:39:34",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.12]": {
-    "recorded-date": "13-03-2024, 08:56:45",
+    "recorded-date": "18-11-2024, 16:39:41",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.11]": {
-    "recorded-date": "13-03-2024, 08:56:48",
+    "recorded-date": "18-11-2024, 16:39:45",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.10]": {
-    "recorded-date": "13-03-2024, 08:56:51",
+    "recorded-date": "18-11-2024, 16:39:48",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.9]": {
-    "recorded-date": "13-03-2024, 08:56:54",
+    "recorded-date": "18-11-2024, 16:39:52",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.8]": {
-    "recorded-date": "13-03-2024, 08:56:57",
+    "recorded-date": "18-11-2024, 16:39:55",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestGoProvidedRuntimes::test_uncaught_exception_invoke[provided.al2023]": {
@@ -1133,6 +1133,14 @@
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestGoProvidedRuntimes::test_manual_endpoint_injection[provided.al2]": {
     "recorded-date": "14-03-2024, 17:19:10",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.13]": {
+    "recorded-date": "18-11-2024, 16:39:15",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.13]": {
+    "recorded-date": "18-11-2024, 16:39:38",
     "recorded-content": {}
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_runtimes.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_runtimes.validation.json
@@ -60,33 +60,39 @@
     "last_validated_date": "2024-03-13T08:54:27+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.10]": {
-    "last_validated_date": "2024-03-13T08:56:35+00:00"
+    "last_validated_date": "2024-11-18T16:39:25+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.11]": {
-    "last_validated_date": "2024-03-13T08:56:32+00:00"
+    "last_validated_date": "2024-11-18T16:39:21+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.12]": {
-    "last_validated_date": "2024-03-13T08:56:29+00:00"
+    "last_validated_date": "2024-11-18T16:39:18+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.13]": {
+    "last_validated_date": "2024-11-18T16:39:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.8]": {
-    "last_validated_date": "2024-03-13T08:56:41+00:00"
+    "last_validated_date": "2024-11-18T16:39:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.9]": {
-    "last_validated_date": "2024-03-13T08:56:38+00:00"
+    "last_validated_date": "2024-11-18T16:39:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.10]": {
-    "last_validated_date": "2024-03-13T08:56:51+00:00"
+    "last_validated_date": "2024-11-18T16:39:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.11]": {
-    "last_validated_date": "2024-03-13T08:56:48+00:00"
+    "last_validated_date": "2024-11-18T16:39:44+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.12]": {
-    "last_validated_date": "2024-03-13T08:56:44+00:00"
+    "last_validated_date": "2024-11-18T16:39:40+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.13]": {
+    "last_validated_date": "2024-11-18T16:39:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.8]": {
-    "last_validated_date": "2024-03-13T08:56:56+00:00"
+    "last_validated_date": "2024-11-18T16:39:54+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.9]": {
-    "last_validated_date": "2024-03-13T08:56:54+00:00"
+    "last_validated_date": "2024-11-18T16:39:51+00:00"
   }
 }


### PR DESCRIPTION
## Motivation

AWS just announced support for the new Python 3.13 Lambda runtime on Nov 14th (4 days ago) and we want to support it quickly.
https://aws.amazon.com/blogs/compute/python-3-13-runtime-now-available-in-aws-lambda/

## Changes

* Add support for the new Lambda runtime Python 3.13
* Remove the dynamic Lambda runtime deprecation upgrade recommendation that AWS recently removed replacing it with a static message
* Add LocalStack debug message with the upgrade recommendation (we can also consider dropping it)
* Update snapshots