### PR TITLE
add ephemeral cli commands to advanced features

### DIFF
--- a/localstack-core/localstack/cli/localstack.py
+++ b/localstack-core/localstack/cli/localstack.py
@@ -41,6 +41,7 @@ class LocalStackCliGroup(click.Group):
         "logout",
         "pod",
         "state",
+        "ephemeral",
     ]
 
     def invoke(self, ctx: click.Context):


### PR DESCRIPTION
## Motivation
This PR marks the new CLI command "ephemeral" (which will be introduced with 4.0) as "advanced".

## Changes
- Add `ephemeral` to advanced CLI features