### PR TITLE
Update analytics tracked env vars

### DIFF
--- a/localstack-core/localstack/deprecations.py
+++ b/localstack-core/localstack/deprecations.py
@@ -298,6 +298,11 @@ DEPRECATIONS = [
         "This option is ignored because the legacy StepFunctions provider (v1) has been removed since 4.0.0."
         " Please remove PROVIDER_OVERRIDE_STEPFUNCTIONS.",
     ),
+    EnvVarDeprecation(
+        "PERSIST_ALL",
+        "2.3.2",
+        "LocalStack treats backends and assets the same with respect to persistence. Please remove PERSIST_ALL.",
+    ),
 ]
 
 

--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -19,15 +19,21 @@ TRACKED_ENV_VAR = [
     "DMS_SERVERLESS_STATUS_CHANGE_WAITING_TIME",
     "DNS_ADDRESS",
     "DYNAMODB_ERROR_PROBABILITY",
+    "DYNAMODB_IN_MEMORY",
+    "DYNAMODB_REMOVE_EXPIRED_ITEMS",
     "EAGER_SERVICE_LOADING",
+    "EC2_VM_MANAGER",
     "ECS_TASK_EXECUTOR",
     "EDGE_PORT",
     "ENABLE_REPLICATOR",
     "ENFORCE_IAM",
+    "ES_CUSTOM_BACKEND",  # deprecated in 0.14.0, removed in 3.0.0
+    "ES_MULTI_CLUSTER",  # deprecated in 0.14.0, removed in 3.0.0
+    "ES_ENDPOINT_STRATEGY",  # deprecated in 0.14.0, removed in 3.0.0
     "IAM_SOFT_MODE",
     "KINESIS_PROVIDER",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
     "KINESIS_ERROR_PROBABILITY",
-    "KMS_PROVIDER",
+    "KMS_PROVIDER",  # defunct since 1.4.0
     "LAMBDA_DEBUG_MODE",
     "LAMBDA_DEBUG_MODE_CONFIG_PATH",
     "LAMBDA_DOWNLOAD_AWS_LAYERS",
@@ -47,7 +53,7 @@ TRACKED_ENV_VAR = [
     "OPENSEARCH_ENDPOINT_STRATEGY",
     "PERSISTENCE",
     "PERSISTENCE_SINGLE_FILE",
-    "PERSIST_ALL",
+    "PERSIST_ALL",  # defunct since 3.0.0
     "PORT_WEB_UI",
     "RDS_MYSQL_DOCKER",
     "REQUIRE_PRO",
@@ -57,9 +63,6 @@ TRACKED_ENV_VAR = [
     "SQS_ENDPOINT_STRATEGY",
     "USE_SINGLE_REGION",  # Not functional; deprecated in 0.12.7, removed in 3.0.0
     "USE_SSL",
-    "ES_CUSTOM_BACKEND",  # deprecated in 0.14.0, removed in 3.0.0
-    "ES_MULTI_CLUSTER",  # deprecated in 0.14.0, removed in 3.0.0
-    "ES_ENDPOINT_STRATEGY",  # deprecated in 0.14.0, removed in 3.0.0
 ]
 
 PRESENCE_ENV_VAR = [

--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -53,7 +53,7 @@ TRACKED_ENV_VAR = [
     "OPENSEARCH_ENDPOINT_STRATEGY",
     "PERSISTENCE",
     "PERSISTENCE_SINGLE_FILE",
-    "PERSIST_ALL",  # defunct since 3.0.0
+    "PERSIST_ALL",  # defunct since 2.3.2
     "PORT_WEB_UI",
     "RDS_MYSQL_DOCKER",
     "REQUIRE_PRO",

--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -8,6 +8,7 @@ from localstack.utils.analytics import log
 LOG = logging.getLogger(__name__)
 
 TRACKED_ENV_VAR = [
+    "ALLOW_NONSTANDARD_REGIONS",
     "BEDROCK_PREWARM",
     "CONTAINER_RUNTIME",
     "DEBUG",
@@ -78,6 +79,8 @@ PRESENCE_ENV_VAR = [
     "LEGACY_INIT_DIR",  # Not functional; deprecated in 1.1.0, removed in 2.0.0
     "LOCALSTACK_HOST",
     "LOCALSTACK_HOSTNAME",
+    "OUTBOUND_HTTP_PROXY",
+    "OUTBOUND_HTTPS_PROXY",
     "S3_DIR",
     "TMPDIR",
 ]


### PR DESCRIPTION
## Changes

This PR adds the following environment config options to analytics collection:

- `EC2_VM_MANAGER`: To understand which VM managers are commonly used in EC2 (e.g. Docker, Libvirt, etc.)
- `DYNAMODB_IN_MEMORY`: To understand usage of in-memory mode for DDB
- `DYNAMODB_REMOVE_EXPIRED_ITEMS`: To track the usage of DDB TTL expired item removal
- `ALLOW_NONSTANDARD_REGIONS`: To increase our understanding of multi-region usage
- `OUTBOUND_HTTP_PROXY` and `OUTBOUND_HTTPS_PROXY`: To help improve proxy support

Also the following defunct config options are marked as such:
- `PERSIST_ALL`: see localstack/localstack-ext#2144