### PR TITLE
drop support for Python 3.8 in the LocalStack CLI

### DIFF
--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -70,7 +70,7 @@ env:
   # report to tinybird if executed on master
   TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
 
-permissions: 
+permissions:
   contents: read # checkout the repository
 
 jobs:
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     timeout-minutes: 10
     env:
       # Set job-specific environment variables for pytest-tinybird
@@ -109,7 +109,7 @@ jobs:
     if: always() && github.ref == 'refs/heads/master' && github.repository == 'localstack/localstack'
     runs-on: ubuntu-latest
     needs: cli-tests
-    permissions: 
+    permissions:
       actions: read
     steps:
       - name: Push to Tinybird

--- a/localstack-core/localstack/services/s3/models.py
+++ b/localstack-core/localstack/services/s3/models.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from datetime import datetime
 from secrets import token_urlsafe
 from typing import Literal, NamedTuple, Optional, Union
-
 from zoneinfo import ZoneInfo
 
 from localstack.aws.api import CommonServiceException

--- a/localstack-core/localstack/services/s3/storage/ephemeral.py
+++ b/localstack-core/localstack/services/s3/storage/ephemeral.py
@@ -334,9 +334,10 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         :param range_data: the range data from which the S3Part will copy its data.
         :return: the EphemeralS3StoredObject representing the stored part
         """
-        with self._s3_store.open(
-            src_bucket, src_s3_object, mode="r"
-        ) as src_stored_object, self.open(s3_part, mode="w") as stored_part:
+        with (
+            self._s3_store.open(src_bucket, src_s3_object, mode="r") as src_stored_object,
+            self.open(s3_part, mode="w") as stored_part,
+        ):
             if not range_data:
                 stored_part.write(src_stored_object)
                 return

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -9,11 +9,11 @@ from enum import StrEnum
 from secrets import token_bytes
 from typing import IO, Any, Dict, Literal, NamedTuple, Optional, Protocol, Tuple, Union
 from urllib import parse as urlparser
+from zoneinfo import ZoneInfo
 
 import xmltodict
 from botocore.exceptions import ClientError
 from botocore.utils import InvalidArnException
-from zoneinfo import ZoneInfo
 
 from localstack import config, constants
 from localstack.aws.api import CommonServiceException, RequestContext

--- a/localstack-core/localstack/services/s3/validation.py
+++ b/localstack-core/localstack/services/s3/validation.py
@@ -1,9 +1,9 @@
 import base64
 import datetime
 import hashlib
+from zoneinfo import ZoneInfo
 
 from botocore.utils import InvalidArnException
-from zoneinfo import ZoneInfo
 
 from localstack.aws.api import CommonServiceException
 from localstack.aws.api.s3 import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
         { name = "LocalStack Contributors", email = "info@localstack.cloud" }
 ]
 description = "The core library and runtime of LocalStack"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "build",
     "click>=7.1",
@@ -175,8 +175,8 @@ exclude = ["tests*"]
 ]
 
 [tool.ruff]
-# Always generate Python 3.8-compatible code.
-target-version = "py38"
+# Always generate Python 3.9-compatible code.
+target-version = "py39"
 line-length = 100
 src = ["localstack-core", "tests"]
 exclude = [

--- a/tests/aws/services/events/test_events_patterns.py
+++ b/tests/aws/services/events/test_events_patterns.py
@@ -134,9 +134,10 @@ class TestEventPattern:
         https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-complex-example
         """
 
-        with open(COMPLEX_MULTI_KEY_EVENT, "r") as event_file, open(
-            COMPLEX_MULTI_KEY_EVENT_PATTERN, "r"
-        ) as event_pattern_file:
+        with (
+            open(COMPLEX_MULTI_KEY_EVENT, "r") as event_file,
+            open(COMPLEX_MULTI_KEY_EVENT_PATTERN, "r") as event_pattern_file,
+        ):
             event = event_file.read()
             event_pattern = event_pattern_file.read()
 

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -15,6 +15,7 @@ from io import BytesIO
 from operator import itemgetter
 from typing import TYPE_CHECKING
 from urllib.parse import SplitResult, parse_qs, quote, urlencode, urlparse, urlunsplit
+from zoneinfo import ZoneInfo
 
 import boto3 as boto3
 import pytest
@@ -26,7 +27,6 @@ from botocore.auth import SigV4Auth
 from botocore.client import Config
 from botocore.exceptions import ClientError
 from localstack_snapshot.snapshots.transformer import RegexTransformer
-from zoneinfo import ZoneInfo
 
 import localstack.config
 from localstack import config

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -6,10 +6,10 @@ import threading
 import time
 import zipfile
 from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 import yaml
-from zoneinfo import ZoneInfo
 
 from localstack import config
 from localstack.utils import common

--- a/tests/unit/test_docker_utils.py
+++ b/tests/unit/test_docker_utils.py
@@ -6,9 +6,10 @@ from localstack.utils.docker_utils import get_host_path_for_path_in_docker
 
 class TestDockerUtils:
     def test_host_path_for_path_in_docker_windows(self):
-        with mock.patch(
-            "localstack.utils.docker_utils.get_default_volume_dir_mount"
-        ) as get_volume, mock.patch("localstack.config.is_in_docker", True):
+        with (
+            mock.patch("localstack.utils.docker_utils.get_default_volume_dir_mount") as get_volume,
+            mock.patch("localstack.config.is_in_docker", True),
+        ):
             get_volume.return_value = VolumeInfo(
                 type="bind",
                 source=r"C:\Users\localstack\volume\mount",
@@ -23,9 +24,10 @@ class TestDockerUtils:
             assert result == r"C:\Users\localstack\volume\mount/some/test/file"
 
     def test_host_path_for_path_in_docker_linux(self):
-        with mock.patch(
-            "localstack.utils.docker_utils.get_default_volume_dir_mount"
-        ) as get_volume, mock.patch("localstack.config.is_in_docker", True):
+        with (
+            mock.patch("localstack.utils.docker_utils.get_default_volume_dir_mount") as get_volume,
+            mock.patch("localstack.config.is_in_docker", True),
+        ):
             get_volume.return_value = VolumeInfo(
                 type="bind",
                 source="/home/some-user/.cache/localstack/volume",
@@ -39,9 +41,10 @@ class TestDockerUtils:
             assert result == "/home/some-user/.cache/localstack/volume/some/test/file"
 
     def test_host_path_for_path_in_docker_linux_volume_dir(self):
-        with mock.patch(
-            "localstack.utils.docker_utils.get_default_volume_dir_mount"
-        ) as get_volume, mock.patch("localstack.config.is_in_docker", True):
+        with (
+            mock.patch("localstack.utils.docker_utils.get_default_volume_dir_mount") as get_volume,
+            mock.patch("localstack.config.is_in_docker", True),
+        ):
             get_volume.return_value = VolumeInfo(
                 type="bind",
                 source="/home/some-user/.cache/localstack/volume",
@@ -55,9 +58,10 @@ class TestDockerUtils:
             assert result == "/home/some-user/.cache/localstack/volume"
 
     def test_host_path_for_path_in_docker_linux_wrong_path(self):
-        with mock.patch(
-            "localstack.utils.docker_utils.get_default_volume_dir_mount"
-        ) as get_volume, mock.patch("localstack.config.is_in_docker", True):
+        with (
+            mock.patch("localstack.utils.docker_utils.get_default_volume_dir_mount") as get_volume,
+            mock.patch("localstack.config.is_in_docker", True),
+        ):
             get_volume.return_value = VolumeInfo(
                 type="bind",
                 source="/home/some-user/.cache/localstack/volume",

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -1,11 +1,11 @@
 import datetime
 import os
 import re
+import zoneinfo
 from io import BytesIO
 from urllib.parse import urlparse
 
 import pytest
-import zoneinfo
 
 from localstack.aws.api import RequestContext
 from localstack.aws.api.s3 import InvalidArgument


### PR DESCRIPTION
## Motivation
With v4 we will be dropping the support for Python 3.8 in our LocalStack CLI.
It reached its [End Of Life on the 7th of October 2024](https://peps.python.org/pep-0569/#lifespan) and does not get _any_ updates anymore (not even security).

## Changes
Similar to https://github.com/localstack/localstack/pull/9148, this PR bumps the minimum version in the `pyproject.toml` (+ in the ruff config), and removes 3.8 from the CLI test build matrix and adds 3.13 instead.