### PR TITLE
Remove DNS_LOCAL_NAME_PATTERNS

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1172,7 +1172,6 @@ DNS_PORT = int(os.environ.get("DNS_PORT", "53"))
 DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM = (
     os.environ.get("DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM") or ""
 ).strip()
-DNS_LOCAL_NAME_PATTERNS = (os.environ.get("DNS_LOCAL_NAME_PATTERNS") or "").strip()  # deprecated
 
 # IP address that AWS endpoints should resolve to in our local DNS server. By default,
 # hostnames resolve to 127.0.0.1, which allows to use the LocalStack APIs transparently
@@ -1239,7 +1238,6 @@ CONFIG_ENV_VARS = [
     "DISTRIBUTED_MODE",
     "DNS_ADDRESS",
     "DNS_PORT",
-    "DNS_LOCAL_NAME_PATTERNS",
     "DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM",
     "DNS_RESOLVE_IP",
     "DNS_SERVER",

--- a/localstack-core/localstack/deprecations.py
+++ b/localstack-core/localstack/deprecations.py
@@ -270,12 +270,6 @@ DEPRECATIONS = [
         "This option has no effect anymore. Please use OPENSEARCH_ENDPOINT_STRATEGY instead.",
     ),
     EnvVarDeprecation(
-        "DNS_LOCAL_NAME_PATTERNS",
-        "3.0.0",
-        "This option was confusingly named. Please use DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM "
-        "instead.",
-    ),
-    EnvVarDeprecation(
         "LAMBDA_EVENTS_INTERNAL_SQS",
         "4.0.0",
         "This option is ignored because the LocalStack SQS dependency for event invokes has been removed since 4.0.0"

--- a/localstack-core/localstack/dns/server.py
+++ b/localstack-core/localstack/dns/server.py
@@ -884,15 +884,7 @@ def start_server(upstream_dns: str, host: str, port: int = config.DNS_PORT):
     if config.LOCALSTACK_HOST.host != LOCALHOST_HOSTNAME:
         dns_server.add_host_pointing_to_localstack(f".*{config.LOCALSTACK_HOST.host}")
 
-    # support both DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM and DNS_LOCAL_NAME_PATTERNS
-    # until the next major version change
-    # TODO(srw): remove the usage of DNS_LOCAL_NAME_PATTERNS
-    skip_local_resolution = " ".join(
-        [
-            config.DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM,
-            config.DNS_LOCAL_NAME_PATTERNS,
-        ]
-    ).strip()
+    skip_local_resolution = config.DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM.strip()
     if skip_local_resolution:
         for skip_pattern in re.split(r"[,;\s]+", skip_local_resolution):
             dns_server.add_skip(skip_pattern.strip(" \"'"))


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation


We deprecated `DNS_LOCAL_NAME_PATTERNS` in LocalStack v3.0 as its name was confusing. We should now remove this variable.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Remove `DNS_LOCAL_NAME_PATTERNS` and all references to it

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
