### PR TITLE
Use jpype-ext and set jpype interrupt=False

### DIFF
--- a/localstack-core/localstack/services/events/event_ruler.py
+++ b/localstack-core/localstack/services/events/event_ruler.py
@@ -29,7 +29,7 @@ def start_jvm() -> None:
         jvm_lib, event_ruler_libs_path = get_jpype_lib_paths()
         event_ruler_libs_pattern = Path(event_ruler_libs_path).joinpath("*")
 
-        jpype.startJVM(jvm_lib, classpath=[event_ruler_libs_pattern])
+        jpype.startJVM(jvm_lib, classpath=[event_ruler_libs_pattern], interrupt=False)
 
 
 @cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ runtime = [
     # TODO remove upper limit once https://github.com/getmoto/moto/pull/7876 is in our moto-ext version
     "cryptography>=41.0.5,<43.0.0",
     # allow Python programs full access to Java class libraries. Used for opt-in event ruler.
-    "JPype1>=1.5.0",
+    "jpype1-ext>=0.0.1",
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -198,7 +198,7 @@ jmespath==1.0.1
     #   botocore
 joserfc==1.0.0
     # via moto-ext
-jpype1==1.5.1
+jpype1-ext==0.0.1
     # via localstack-core
 jsii==1.105.0
     # via
@@ -287,7 +287,7 @@ packaging==24.2
     # via
     #   apispec
     #   build
-    #   jpype1
+    #   jpype1-ext
     #   pytest
     #   pytest-rerunfailures
 pandoc==2.4

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -143,7 +143,7 @@ jmespath==1.0.1
     #   botocore
 joserfc==1.0.0
     # via moto-ext
-jpype1==1.5.1
+jpype1-ext==0.0.1
     # via localstack-core (pyproject.toml)
 json5==0.9.28
     # via localstack-core (pyproject.toml)
@@ -214,7 +214,7 @@ packaging==24.2
     # via
     #   apispec
     #   build
-    #   jpype1
+    #   jpype1-ext
 parse==1.20.2
     # via openapi-core
 pathable==0.4.3

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -182,7 +182,7 @@ jmespath==1.0.1
     #   botocore
 joserfc==1.0.0
     # via moto-ext
-jpype1==1.5.1
+jpype1-ext==0.0.1
     # via localstack-core
 jsii==1.105.0
     # via
@@ -266,7 +266,7 @@ packaging==24.2
     # via
     #   apispec
     #   build
-    #   jpype1
+    #   jpype1-ext
     #   pytest
     #   pytest-rerunfailures
 parse==1.20.2

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -202,7 +202,7 @@ jmespath==1.0.1
     #   botocore
 joserfc==1.0.0
     # via moto-ext
-jpype1==1.5.1
+jpype1-ext==0.0.1
     # via localstack-core
 jsii==1.105.0
     # via
@@ -485,7 +485,7 @@ packaging==24.2
     # via
     #   apispec
     #   build
-    #   jpype1
+    #   jpype1-ext
     #   pytest
     #   pytest-rerunfailures
 pandoc==2.4


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, jpype1 only installs SIGINT signal handlers if `interrupt=False`. With https://github.com/localstack/jpype/pull/1, we (very crudely) added support for SIGTERM as well.

We should aim to upstream this changes ASAP, but for the 4.0 release, this should suffice to get proper shutdown handling in LocalStack even if a library is loaded using jpype.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Use jpype-ext, published with the changes here: https://github.com/localstack/jpype/pull/1
* Set `interrupt=False` when starting jpype

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
