### PR TITLE
Prevent usage of java rule engine in tests

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -744,14 +744,14 @@ class TestCfnLambdaIntegrations:
 
     # TODO: consider moving into the dedicated DynamoDB => Lambda tests
     #  tests.aws.services.lambda_.test_lambda_integration_dynamodbstreams.TestDynamoDBEventSourceMapping.test_dynamodb_event_filter
+    @pytest.mark.skipif(
+        config.EVENT_RULE_ENGINE != "java",
+        reason="Filtering is broken with the Python rule engine for this specific case (exists:false) in ESM v2",
+    )
     @markers.aws.validated
     def test_lambda_dynamodb_event_filter(
         self, dynamodb_wait_for_table_active, deploy_cfn_template, aws_client, monkeypatch
     ):
-        # TODO: Filtering is broken with the Python rule engine for this specific case (exists:false) in ESM v2
-        #  -> using java engine as workaround for now.
-        monkeypatch.setattr(config, "EVENT_RULE_ENGINE", "java")
-
         function_name = f"test-fn-{short_uid()}"
         table_name = f"ddb-tbl-{short_uid()}"
 

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py
@@ -1110,9 +1110,11 @@ class TestSQSEventSourceMapping:
         aws_client,
         monkeypatch,
     ):
-        if item_not_matching == "this is a test string":
-            # String comparison is broken in the Python rule engine for this specific case in ESM v2, using java engine.
-            monkeypatch.setattr(config, "EVENT_RULE_ENGINE", "java")
+        if item_not_matching == "this is a test string" and config.EVENT_RULE_ENGINE != "java":
+            pytest.skip(
+                "String comparison is broken in the Python rule engine for this specific case in ESM v2"
+            )
+
         function_name = f"lambda_func-{short_uid()}"
         queue_name_1 = f"queue-{short_uid()}-1"
         mapping_uuid = None

--- a/tests/unit/utils/test_event_matcher.py
+++ b/tests/unit/utils/test_event_matcher.py
@@ -28,12 +28,14 @@ def event_rule_engine(monkeypatch):
     return _set_engine
 
 
+@pytest.mark.skip(reason="jpype conflict")
 def test_matches_event_with_java_engine_strings(event_rule_engine):
     """Test Java engine with string inputs (EventBridge case)"""
     event_rule_engine("java")
     assert matches_event(EVENT_PATTERN_STR, EVENT_STR)
 
 
+@pytest.mark.skip(reason="jpype conflict")
 def test_matches_event_with_java_engine_dicts(event_rule_engine):
     """Test Java engine with dict inputs (ESM/Pipes case)"""
     event_rule_engine("java")
@@ -52,6 +54,7 @@ def test_matches_event_with_python_engine_dicts(event_rule_engine):
     assert matches_event(EVENT_PATTERN_DICT, EVENT_STR)
 
 
+@pytest.mark.skip(reason="jpype conflict")
 def test_matches_event_mixed_inputs(event_rule_engine):
     """Test with mixed string/dict inputs"""
     event_rule_engine("java")


### PR DESCRIPTION
## Motivation

We can't start both the JPype-based java rule engine as well as other JPype-based features in the same run, so we can't parametrize on this. If really necessary it would need to be added as a separate pipeline/test run.

## Changes

- Skip unit tests that would use the java rule engine
- Conditionally skip tests instead of monkeypatching java rule engine in integration tests

