### PR TITLE
Put events fix for multiple targets

### DIFF
--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2453,5 +2453,22 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_target_delivery_failure": {
+    "recorded-date": "20-11-2024, 17:19:19",
+    "recorded-content": {
+      "put-events-response": {
+        "Entries": [
+          {
+            "EventId": "<event-id:1>"
+          }
+        ],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2381,5 +2381,64 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_response_entries_order": {
+    "recorded-date": "20-11-2024, 08:37:56",
+    "recorded-content": {
+      "put-events-response": {
+        "Entries": [
+          {
+            "EventId": "event-id"
+          }
+        ],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sqs-messages": {
+        "queue1_messages": [
+          {
+            "Body": {
+              "version": "0",
+              "id": "<uuid:1>",
+              "detail-type": "test.detail.type",
+              "source": "test.source",
+              "account": "111111111111",
+              "time": "date",
+              "region": "<region>",
+              "resources": [],
+              "detail": {
+                "message": "test message"
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "queue2_messages": [
+          {
+            "Body": {
+              "version": "0",
+              "id": "<uuid:1>",
+              "detail-type": "test.detail.type",
+              "source": "test.source",
+              "account": "111111111111",
+              "time": "date",
+              "region": "<region>",
+              "resources": [],
+              "detail": {
+                "message": "test message"
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:3>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2383,7 +2383,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_response_entries_order": {
-    "recorded-date": "20-11-2024, 08:37:56",
+    "recorded-date": "20-11-2024, 12:32:18",
     "recorded-content": {
       "put-events-response": {
         "Entries": [
@@ -2403,15 +2403,13 @@
             "Body": {
               "version": "0",
               "id": "<uuid:1>",
-              "detail-type": "test.detail.type",
-              "source": "test.source",
+              "detail-type": "core.update-account-command",
+              "source": "core.update-account-command",
               "account": "111111111111",
               "time": "date",
               "region": "<region>",
               "resources": [],
-              "detail": {
-                "message": "test message"
-              }
+              "detail": "detail"
             },
             "MD5OfBody": "<md5-hash>",
             "MessageId": "<uuid:2>",
@@ -2423,21 +2421,36 @@
             "Body": {
               "version": "0",
               "id": "<uuid:1>",
-              "detail-type": "test.detail.type",
-              "source": "test.source",
+              "detail-type": "core.update-account-command",
+              "source": "core.update-account-command",
               "account": "111111111111",
               "time": "date",
               "region": "<region>",
               "resources": [],
-              "detail": {
-                "message": "test message"
-              }
+              "detail": "detail"
             },
             "MD5OfBody": "<md5-hash>",
             "MessageId": "<uuid:3>",
             "ReceiptHandle": "<receipt-handle:2>"
           }
         ]
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_iam_permission_failure": {
+    "recorded-date": "20-11-2024, 12:32:10",
+    "recorded-content": {
+      "put-events-response": {
+        "Entries": [
+          {
+            "EventId": "<event-id:1>"
+          }
+        ],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -167,6 +167,9 @@
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_exceed_limit_ten_entries[default]": {
     "last_validated_date": "2024-06-19T10:40:55+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_response_entries_order": {
+    "last_validated_date": "2024-11-20T08:37:56+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_time": {
     "last_validated_date": "2024-08-27T10:02:33+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -176,6 +176,9 @@
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_iam_permission_failure": {
     "last_validated_date": "2024-11-20T12:32:10+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_target_delivery_failure": {
+    "last_validated_date": "2024-11-20T17:19:19+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_without_source": {
     "last_validated_date": "2024-06-19T10:40:50+00:00"
   }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -168,10 +168,13 @@
     "last_validated_date": "2024-06-19T10:40:55+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_response_entries_order": {
-    "last_validated_date": "2024-11-20T08:37:56+00:00"
+    "last_validated_date": "2024-11-20T12:32:18+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_time": {
     "last_validated_date": "2024-08-27T10:02:33+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_iam_permission_failure": {
+    "last_validated_date": "2024-11-20T12:32:10+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_without_source": {
     "last_validated_date": "2024-06-19T10:40:50+00:00"


### PR DESCRIPTION
## Motivation
Fixes EventBridge PutEvents response so it correctly returns event IDs only once per event, regardless of how many rules or targets match. Currently, the response includes duplicate EventIds for each matching target, which doesn't match AWS behavior and can cause issues when clients try to track events by their IDs.

Related issue: https://github.com/localstack/localstack/issues/11597

## Changes
- Modified `_process_entries` and related methods in events provider to track and return event IDs only once
- Refactored event processing logic to maintain a single event result per input event
- Added test case to verify the fix and prevent regressions

## Testing
1. Create an EventBridge rule with multiple targets
2. Send an event that matches the rule
3. Verify that:
   - PutEvents response contains each EventId only once
   - All targets still receive the event correctly
   - Event IDs are consistent between response and delivered messages

