### PR TITLE
Add lambda ESM analytics

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/senders/lambda_sender.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/senders/lambda_sender.py
@@ -34,6 +34,9 @@ class LambdaSender(Sender):
         self.payload_dict = payload_dict
         self.report_batch_item_failures = report_batch_item_failures
 
+    def event_target(self) -> str:
+        return "aws:lambda"
+
     def send_events(self, events: list[dict] | dict) -> dict:
         if self.payload_dict:
             events = {"Records": events}

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/senders/sender.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/senders/sender.py
@@ -42,3 +42,9 @@ class Sender:
         Returns an optional payload with a list of "batchItemFailures" if only part of the batch succeeds.
         """
         pass
+
+    @abstractmethod
+    def event_target(self) -> str:
+        """Return the event target metadata (e.g., aws:sqs)
+        Format analogous to event_source of pollers"""
+        pass

--- a/localstack-core/localstack/services/lambda_/usage.py
+++ b/localstack-core/localstack/services/lambda_/usage.py
@@ -9,3 +9,9 @@ hotreload = UsageCounter("lambda:hotreload")
 
 # number of function invocations per Lambda runtime (e.g. python3.7 invoked 10x times, nodejs14.x invoked 3x times, ...)
 runtime = UsageSetCounter("lambda:invokedruntime")
+
+# number of event source mapping invocations per source (e.g. aws:sqs, aws:kafka, SelfManagedKafka)
+esm_invocation = UsageSetCounter("lambda:esm:invocation")
+
+# number of event source mapping errors per source (e.g. aws:sqs, aws:kafka, SelfManagedKafka)
+esm_error = UsageSetCounter("lambda:esm:error")

--- a/localstack-core/localstack/utils/analytics/usage.py
+++ b/localstack-core/localstack/utils/analytics/usage.py
@@ -1,6 +1,5 @@
 import datetime
 import math
-import threading
 from collections import defaultdict
 from itertools import count
 from typing import Any
@@ -48,66 +47,6 @@ class UsageSetCounter:
 
     def aggregate(self) -> dict:
         return self.state
-
-
-class UsageMultiSetCounter:
-    """
-    Use this counter to count occurrences of unique values for multiple dimensions.
-    This dynamically creates UsageSetCounters and should be used with care (i.e., with limited keys).
-
-    Example:
-
-    my_feature_counter = UsageMultiSetCounter("pipes:invocation")
-    my_feature_counter.record("aws:sqs", "aws:lambda")
-    my_feature_counter.record("aws:sqs", "aws:lambda")
-    my_feature_counter.record("aws:sqs", "aws:stepfunctions")
-    my_feature_counter.record("aws:kinesis", "aws:lambda")
-    aggregate is implemented for each counter individually
-
-    my_feature_counter.aggregate() is available for testing purposes:
-    {
-       "aws:sqs": {
-         "aws:lambda": 2,
-         "aws:stepfunctions": 1,
-       },
-       "aws:kinesis": {
-         "aws:lambda": 1
-       }
-    }
-    """
-
-    namespace: str
-    _counters: dict[str, UsageSetCounter]
-    lock = threading.Lock()
-
-    def __init__(self, namespace: str):
-        self._counters = {}
-        self.namespace = namespace
-
-    def record(self, key: str, value: str):
-        namespace = f"{self.namespace}:{key}"
-        if namespace in self._counters:
-            set_counter = self._counters[namespace]
-        else:
-            with self.lock:
-                if namespace in self._counters:
-                    set_counter = self._counters[namespace]
-                else:
-                    # We cannot use setdefault here because Python always instantiates a new UsageSetCounter,
-                    # which overwrites the collector_registry
-                    set_counter = UsageSetCounter(namespace)
-                    self._counters[namespace] = set_counter
-
-        self._counters[namespace] = set_counter
-        set_counter.record(value)
-
-    def aggregate(self) -> dict:
-        """aggregate is invoked on a per UsageSetCounter level because each counter is registered individually.
-        This utility is only for testing!"""
-        merged_dict = {}
-        for namespace, counter in self._counters.items():
-            merged_dict[namespace] = counter.aggregate()
-        return merged_dict
 
 
 class UsageCounter:

--- a/localstack-core/localstack/utils/analytics/usage.py
+++ b/localstack-core/localstack/utils/analytics/usage.py
@@ -87,12 +87,12 @@ class UsageMultiSetCounter:
     def record(self, key: str, value: str):
         namespace = f"{self.namespace}:{key}"
 
-        with self.lock:
-            # We cannot use setdefault here because Python always instantiates a new UsageSetCounter,
-            # which overwrites the collector_registry
-            if namespace in self._counters:
-                set_counter = self._counters[namespace]
-            else:
+        if namespace in self._counters:
+            set_counter = self._counters[namespace]
+        else:
+            with self.lock:
+                # We cannot use setdefault here because Python always instantiates a new UsageSetCounter,
+                # which overwrites the collector_registry
                 set_counter = UsageSetCounter(namespace)
                 self._counters[namespace] = set_counter
         set_counter.record(value)

--- a/localstack-core/localstack/utils/analytics/usage.py
+++ b/localstack-core/localstack/utils/analytics/usage.py
@@ -86,15 +86,19 @@ class UsageMultiSetCounter:
 
     def record(self, key: str, value: str):
         namespace = f"{self.namespace}:{key}"
-
         if namespace in self._counters:
             set_counter = self._counters[namespace]
         else:
             with self.lock:
-                # We cannot use setdefault here because Python always instantiates a new UsageSetCounter,
-                # which overwrites the collector_registry
-                set_counter = UsageSetCounter(namespace)
-                self._counters[namespace] = set_counter
+                if namespace in self._counters:
+                    set_counter = self._counters[namespace]
+                else:
+                    # We cannot use setdefault here because Python always instantiates a new UsageSetCounter,
+                    # which overwrites the collector_registry
+                    set_counter = UsageSetCounter(namespace)
+                    self._counters[namespace] = set_counter
+
+        self._counters[namespace] = set_counter
         set_counter.record(value)
 
     def aggregate(self) -> dict:

--- a/tests/unit/utils/analytics/test_usage.py
+++ b/tests/unit/utils/analytics/test_usage.py
@@ -1,4 +1,4 @@
-from localstack.utils.analytics.usage import UsageMultiSetCounter, UsageSetCounter
+from localstack.utils.analytics.usage import UsageSetCounter
 
 
 def test_set_counter():
@@ -7,23 +7,3 @@ def test_set_counter():
     my_feature_counter.record("nodejs16.x")
     my_feature_counter.record("nodejs16.x")
     assert my_feature_counter.aggregate() == {"python3.7": 1, "nodejs16.x": 2}
-
-
-def test_multi_set_counter():
-    my_feature_counter = UsageMultiSetCounter("pipes:invocation")
-    my_feature_counter.record("aws:sqs", "aws:lambda")
-    my_feature_counter.record("aws:sqs", "aws:lambda")
-    my_feature_counter.record("aws:sqs", "aws:stepfunctions")
-    my_feature_counter.record("aws:kinesis", "aws:lambda")
-    assert my_feature_counter.aggregate() == {
-        "pipes:invocation:aws:sqs": {
-            "aws:lambda": 2,
-            "aws:stepfunctions": 1,
-        },
-        "pipes:invocation:aws:kinesis": {"aws:lambda": 1},
-    }
-    assert my_feature_counter._counters["pipes:invocation:aws:sqs"].state == {
-        "aws:lambda": 2,
-        "aws:stepfunctions": 1,
-    }
-    assert my_feature_counter._counters["pipes:invocation:aws:kinesis"].state == {"aws:lambda": 1}

--- a/tests/unit/utils/analytics/test_usage.py
+++ b/tests/unit/utils/analytics/test_usage.py
@@ -1,0 +1,29 @@
+from localstack.utils.analytics.usage import UsageMultiSetCounter, UsageSetCounter
+
+
+def test_set_counter():
+    my_feature_counter = UsageSetCounter("lambda:runtime")
+    my_feature_counter.record("python3.7")
+    my_feature_counter.record("nodejs16.x")
+    my_feature_counter.record("nodejs16.x")
+    assert my_feature_counter.aggregate() == {"python3.7": 1, "nodejs16.x": 2}
+
+
+def test_multi_set_counter():
+    my_feature_counter = UsageMultiSetCounter("pipes:invocation")
+    my_feature_counter.record("aws:sqs", "aws:lambda")
+    my_feature_counter.record("aws:sqs", "aws:lambda")
+    my_feature_counter.record("aws:sqs", "aws:stepfunctions")
+    my_feature_counter.record("aws:kinesis", "aws:lambda")
+    assert my_feature_counter.aggregate() == {
+        "pipes:invocation:aws:sqs": {
+            "aws:lambda": 2,
+            "aws:stepfunctions": 1,
+        },
+        "pipes:invocation:aws:kinesis": {"aws:lambda": 1},
+    }
+    assert my_feature_counter._counters["pipes:invocation:aws:sqs"].state == {
+        "aws:lambda": 2,
+        "aws:stepfunctions": 1,
+    }
+    assert my_feature_counter._counters["pipes:invocation:aws:kinesis"].state == {"aws:lambda": 1}


### PR DESCRIPTION
## Motivation

Add usage analytics for Lambda ESM to learn more about potential errors we should tackle and usage of different event sources.

## Changes

* Add usage analytics for `invocation` (successful ones) and `error` (unexpected error; i.e., LS bug)
* Add unit test for existing set counter (also serves to exemplify usage)