### PR TITLE
Add EventBridge rule target analytics

### DIFF
--- a/localstack-core/localstack/services/events/usage.py
+++ b/localstack-core/localstack/services/events/usage.py
@@ -1,0 +1,7 @@
+from localstack.utils.analytics.usage import UsageSetCounter
+
+# number of pipe invocations per source (e.g. aws:sqs, aws:kafka, SelfManagedKafka) and target (e.g., aws:lambda)
+rule_invocation = UsageSetCounter("events:rule:invocation")
+
+# number of pipe errors per source (e.g. aws:sqs, aws:kafka, SelfManagedKafka) and target (e.g., aws:lambda)
+rule_error = UsageSetCounter("events:rule:error")


### PR DESCRIPTION
## Motivation

EventBridge v2 misses analytics to learn more about which targets are matched how frequently and how often they fail.

## Changes

* Add usage analytics for invocations and errors of rule targets

## Discussion

The error case currently does not distinguish between expected errors (i.e., AWS parity) and unexpected errors (i.e., not accounted), but I don't know what the AWS behavior here. Currently, we just ignore errors.