### PR TITLE
fix usage aggregation to not send empty payloads

### DIFF
--- a/localstack-core/localstack/utils/analytics/usage.py
+++ b/localstack-core/localstack/utils/analytics/usage.py
@@ -109,7 +109,9 @@ class UsageCounter:
 def aggregate() -> dict:
     aggregated_payload = {}
     for ns, collector in collector_registry.items():
-        aggregated_payload[ns] = collector.aggregate()
+        agg = collector.aggregate()
+        if agg:
+            aggregated_payload[ns] = agg
     return aggregated_payload
 
 
@@ -128,7 +130,8 @@ def aggregate_and_send():
 
     aggregated_payload = aggregate()
 
-    publisher = AnalyticsClientPublisher()
-    publisher.publish(
-        [Event(name="ls:usage_analytics", metadata=metadata, payload=aggregated_payload)]
-    )
+    if aggregated_payload:
+        publisher = AnalyticsClientPublisher()
+        publisher.publish(
+            [Event(name="ls:usage_analytics", metadata=metadata, payload=aggregated_payload)]
+        )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When we create usage trackers, empty payloads are always generated, they'd look like this: `{'cognito:endpoints': {}}`. Sending empty data payloads is not helpful and causes unnecessary data usage, so this PR removes those.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* empty payloads are now removed when calling `aggregate` on usage set statistics

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
