### PR TITLE
fix vtl resolver patch

### DIFF
--- a/localstack-core/localstack/services/apigateway/legacy/templates.py
+++ b/localstack-core/localstack/services/apigateway/legacy/templates.py
@@ -12,7 +12,7 @@ from localstack import config
 from localstack.constants import APPLICATION_JSON, APPLICATION_XML
 from localstack.services.apigateway.legacy.context import ApiInvocationContext
 from localstack.services.apigateway.legacy.helpers import select_integration_response
-from localstack.utils.aws.templating import VelocityUtil, VtlTemplate
+from localstack.utils.aws.templating import APIGW_SOURCE, VelocityUtil, VtlTemplate
 from localstack.utils.json import extract_jsonpath, json_safe, try_json
 from localstack.utils.strings import to_str
 
@@ -184,8 +184,8 @@ class VelocityInput:
 class ApiGatewayVtlTemplate(VtlTemplate):
     """Util class for rendering VTL templates with API Gateway specific extensions"""
 
-    def prepare_namespace(self, variables) -> Dict[str, Any]:
-        namespace = super().prepare_namespace(variables)
+    def prepare_namespace(self, variables, source: str = APIGW_SOURCE) -> Dict[str, Any]:
+        namespace = super().prepare_namespace(variables, source)
         if stage_var := variables.get("stage_variables") or {}:
             namespace["stageVariables"] = stage_var
         input_var = variables.get("input") or {}

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -27,7 +27,7 @@ from localstack.services.apigateway.next_gen.execute_api.variables import (
     ContextVarsRequestOverride,
     ContextVarsResponseOverride,
 )
-from localstack.utils.aws.templating import VelocityUtil, VtlTemplate
+from localstack.utils.aws.templating import APIGW_SOURCE, VelocityUtil, VtlTemplate
 from localstack.utils.json import extract_jsonpath, json_safe
 
 LOG = logging.getLogger(__name__)
@@ -173,8 +173,8 @@ class VelocityInput:
 class ApiGatewayVtlTemplate(VtlTemplate):
     """Util class for rendering VTL templates with API Gateway specific extensions"""
 
-    def prepare_namespace(self, variables) -> dict[str, Any]:
-        namespace = super().prepare_namespace(variables)
+    def prepare_namespace(self, variables, source: str = APIGW_SOURCE) -> dict[str, Any]:
+        namespace = super().prepare_namespace(variables, source)
         input_var = variables.get("input") or {}
         variables = {
             "input": VelocityInput(input_var.get("body"), input_var.get("params")),

--- a/tests/aws/services/apigateway/test_apigateway_kinesis.py
+++ b/tests/aws/services/apigateway/test_apigateway_kinesis.py
@@ -1,4 +1,4 @@
-import json
+import pytest
 
 from localstack.testing.pytest import markers
 from localstack.utils.http import safe_requests as requests
@@ -7,9 +7,35 @@ from localstack.utils.sync import retry
 from tests.aws.services.apigateway.apigateway_fixtures import api_invoke_url
 from tests.aws.services.apigateway.conftest import DEFAULT_STAGE_NAME
 
+KINESIS_PUT_RECORDS_INTEGRATION = """{
+    "StreamName": "%s",
+    "Records": [
+        #set( $numRecords = $input.path('$.records').size() )
+        #if($numRecords > 0)
+            #set( $maxIndex = $numRecords - 1 )
+            #foreach( $idx in [0..$maxIndex] )
+                #set( $elem = $input.path("$.records[${idx}]") )
+                #set( $elemJsonB64 = $util.base64Encode($elem.data) )
+                {
+                    "Data": "$elemJsonB64",
+                    "PartitionKey": #if( $foo.bar.stuff != '')"$elem.partitionKey"#else"$elemJsonB64.length()"#end
+                }#if($foreach.hasNext),#end
+            #end
+        #end
+    ]
+}"""
+
+KINESIS_PUT_RECORD_INTEGRATION = """
+{
+    "StreamName": "%s",
+    "Data": "$util.base64Encode($input.body)",
+    "PartitionKey": "test"
+}"""
+
 
 # PutRecord does not return EncryptionType, but it's documented as such.
 # xxx requires further investigation
+@pytest.mark.parametrize("action", ("PutRecord", "PutRecords"))
 @markers.snapshot.skip_snapshot_verify(paths=["$..EncryptionType", "$..ChildShards"])
 @markers.aws.validated
 def test_apigateway_to_kinesis(
@@ -19,9 +45,25 @@ def test_apigateway_to_kinesis(
     snapshot,
     region_name,
     aws_client,
+    action,
 ):
     snapshot.add_transformer(snapshot.transform.apigateway_api())
     snapshot.add_transformer(snapshot.transform.kinesis_api())
+
+    if action == "PutRecord":
+        template = KINESIS_PUT_RECORD_INTEGRATION
+        payload = {"kinesis": "snapshot"}
+        expected_key = "SequenceNumber"
+    else:
+        template = KINESIS_PUT_RECORDS_INTEGRATION
+        payload = {
+            "records": [
+                {"data": '{"foo": "bar1"}'},
+                {"data": '{"foo": "bar2"}'},
+                {"data": '{"foo": "bar3"}'},
+            ]
+        }
+        expected_key = "Records"
 
     # create stream
     stream_name = f"kinesis-stream-{short_uid()}"
@@ -35,16 +77,8 @@ def test_apigateway_to_kinesis(
     shard_id = first_stream_shard_data["ShardId"]
 
     # create REST API with Kinesis integration
-    integration_uri = f"arn:aws:apigateway:{region_name}:kinesis:action/PutRecord"
-    request_templates = {
-        "application/json": json.dumps(
-            {
-                "StreamName": stream_name,
-                "Data": "$util.base64Encode($input.body)",
-                "PartitionKey": "test",
-            }
-        )
-    }
+    integration_uri = f"arn:aws:apigateway:{region_name}:kinesis:action/{action}"
+    request_templates = {"application/json": template % stream_name}
     api_id = create_rest_api_with_integration(
         integration_uri=integration_uri,
         req_templates=request_templates,
@@ -53,10 +87,10 @@ def test_apigateway_to_kinesis(
 
     def _invoke_apigw_to_kinesis() -> dict:
         url = api_invoke_url(api_id, stage=DEFAULT_STAGE_NAME, path="/test")
-        _response = requests.post(url, json={"kinesis": "snapshot"})
+        _response = requests.post(url, json=payload)
         assert _response.ok
         json_resp = _response.json()
-        assert "SequenceNumber" in json_resp
+        assert expected_key in json_resp
         return json_resp
 
     # push events to Kinesis via API

--- a/tests/aws/services/apigateway/test_apigateway_kinesis.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_kinesis.snapshot.json
@@ -1,6 +1,6 @@
 {
-  "tests/aws/services/apigateway/test_apigateway_kinesis.py::test_apigateway_to_kinesis": {
-    "recorded-date": "12-07-2024, 20:32:13",
+  "tests/aws/services/apigateway/test_apigateway_kinesis.py::test_apigateway_to_kinesis[PutRecord]": {
+    "recorded-date": "20-11-2024, 05:29:53",
     "recorded-content": {
       "apigateway_response": {
         "SequenceNumber": "<sequence_number:1>",
@@ -15,6 +15,56 @@
             "Data": "b'{\"kinesis\": \"snapshot\"}'",
             "PartitionKey": "test",
             "SequenceNumber": "<sequence_number:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_kinesis.py::test_apigateway_to_kinesis[PutRecords]": {
+    "recorded-date": "20-11-2024, 06:33:51",
+    "recorded-content": {
+      "apigateway_response": {
+        "FailedRecordCount": 0,
+        "Records": [
+          {
+            "SequenceNumber": "<sequence_number:1>",
+            "ShardId": "<shard_id:1>"
+          },
+          {
+            "SequenceNumber": "<sequence_number:2>",
+            "ShardId": "<shard_id:1>"
+          },
+          {
+            "SequenceNumber": "<sequence_number:3>",
+            "ShardId": "<shard_id:1>"
+          }
+        ]
+      },
+      "kinesis_records": {
+        "MillisBehindLatest": 0,
+        "NextShardIterator": "<next_shard_iterator:1>",
+        "Records": [
+          {
+            "ApproximateArrivalTimestamp": "timestamp",
+            "Data": "b'{\"foo\": \"bar1\"}'",
+            "PartitionKey": "20",
+            "SequenceNumber": "<sequence_number:1>"
+          },
+          {
+            "ApproximateArrivalTimestamp": "timestamp",
+            "Data": "b'{\"foo\": \"bar2\"}'",
+            "PartitionKey": "20",
+            "SequenceNumber": "<sequence_number:2>"
+          },
+          {
+            "ApproximateArrivalTimestamp": "timestamp",
+            "Data": "b'{\"foo\": \"bar3\"}'",
+            "PartitionKey": "20",
+            "SequenceNumber": "<sequence_number:3>"
           }
         ],
         "ResponseMetadata": {

--- a/tests/aws/services/apigateway/test_apigateway_kinesis.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_kinesis.validation.json
@@ -1,5 +1,8 @@
 {
-  "tests/aws/services/apigateway/test_apigateway_kinesis.py::test_apigateway_to_kinesis": {
-    "last_validated_date": "2024-07-12T20:32:13+00:00"
+  "tests/aws/services/apigateway/test_apigateway_kinesis.py::test_apigateway_to_kinesis[PutRecord]": {
+    "last_validated_date": "2024-11-20T05:29:53+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_kinesis.py::test_apigateway_to_kinesis[PutRecords]": {
+    "last_validated_date": "2024-11-20T06:33:51+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While investigating the issue reported by #11843, I noticed that the default returned value of unfound variables differs between apigateway and appsync. We had this patch working for apigateway, but it would unfortunately fail some appsync functions that are expecting to receive a null value.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Augmented the signature of `prepare_namespace` to allow setting a `source`.
- Patch only if the source is apigateway
- Reimplemented the template used by the previous test reffered in the comment

_fixes #11843_
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
