### PR TITLE
add error replacement for DynamoDBStreams v2

### DIFF
--- a/localstack-core/localstack/services/dynamodbstreams/provider.py
+++ b/localstack-core/localstack/services/dynamodbstreams/provider.py
@@ -92,7 +92,9 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
                 stream_description = select_from_typed_dict(StreamDescription, stream)
                 return DescribeStreamOutput(StreamDescription=stream_description)
 
-        raise ResourceNotFoundException(f"Stream {stream_arn} was not found.")
+        raise ResourceNotFoundException(
+            f"Requested resource not found: Stream: {stream_arn} not found"
+        )
 
     @handler("GetRecords", expand=False)
     def get_records(self, context: RequestContext, payload: GetRecordsInput) -> GetRecordsOutput:

--- a/localstack-core/localstack/services/dynamodbstreams/v2/provider.py
+++ b/localstack-core/localstack/services/dynamodbstreams/v2/provider.py
@@ -30,6 +30,9 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
         # add response processor specific to ddblocal
         handlers.modify_service_response.append(self.service, modify_ddblocal_arns)
 
+    def on_before_start(self):
+        self.server.start_dynamodb()
+
     def forward_request(
         self, context: RequestContext, service_request: ServiceRequest = None
     ) -> ServiceResponse:

--- a/tests/aws/services/dynamodbstreams/test_dynamodb_streams.snapshot.json
+++ b/tests/aws/services/dynamodbstreams/test_dynamodb_streams.snapshot.json
@@ -81,5 +81,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/dynamodbstreams/test_dynamodb_streams.py::TestDynamoDBStreams::test_non_existent_stream": {
+    "recorded-date": "20-11-2024, 11:02:24",
+    "recorded-content": {
+      "non-existent-stream": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Requested resource not found: Stream: arn:<partition>:dynamodb:<region>:111111111111:table/<table-name>/stream/2024-11-18T14:36:44.149 not found"
+        },
+        "message": "Requested resource not found: Stream: arn:<partition>:dynamodb:<region>:111111111111:table/<table-name>/stream/2024-11-18T14:36:44.149 not found",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/dynamodbstreams/test_dynamodb_streams.validation.json
+++ b/tests/aws/services/dynamodbstreams/test_dynamodb_streams.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/dynamodbstreams/test_dynamodb_streams.py::TestDynamoDBStreams::test_enable_kinesis_streaming_destination": {
     "last_validated_date": "2024-01-30T20:27:32+00:00"
   },
+  "tests/aws/services/dynamodbstreams/test_dynamodb_streams.py::TestDynamoDBStreams::test_non_existent_stream": {
+    "last_validated_date": "2024-11-20T11:02:24+00:00"
+  },
   "tests/aws/services/dynamodbstreams/test_dynamodb_streams.py::TestDynamoDBStreams::test_table_v2_stream": {
     "last_validated_date": "2024-06-12T21:57:48+00:00"
   }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by a user, we had a red herring regarding some raised DynamoDB Streams error when used with ESM:

```python
2024-11-19T14:51:15.731 ERROR --- [functhread29] l.s.l.e.esm_worker     : Error while polling messages for event source arn:aws:dynamodb:us-west-2: 000000000001:table/<table-name>/stream/2024-11-18T14:36:43.932: An error occurred (ResourceNotFoundException) when calling the DescribeStream operation: Requested resource not found: Stream: arn:aws:dynamodb:ddblocal:000000000000:table/<table-name>/stream/2024-11-18T14:36:43.932 not found
```

Which made it look like we were not properly formatting the ARN or something related to DDB Local. 

The issue was that we were not replacing the ARN value in the exception as it was directly raised by DDB-local, but our headers were correct for the namespacing. 

Also, made a quick fix to start DDB-local in DynamoDB Streams v2 because if you targeted the `dynamodbstreams` service before doing a request to `dynamodb`, you would get a connection refused error as we'd try to send a request to it. I'm not adding all the hooks related to persistence because those services are very intertwined and this would only happen at startup with a fresh instance. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add more regex replacement on raised exception on DDB
- add a test for this specific issue, and do a quick format fix for v1

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
