### PR TITLE
fix java home for macos

### DIFF
--- a/localstack-core/localstack/packages/java.py
+++ b/localstack-core/localstack/packages/java.py
@@ -142,7 +142,10 @@ class JavaPackageInstaller(ArchiveDownloadAndExtractInstaller):
         """
         Get JAVA_HOME for this installation of Java.
         """
-        return self.get_installed_dir()
+        installed_dir = self.get_installed_dir()
+        if is_mac_os():
+            return os.path.join(installed_dir, "Contents", "Home")
+        return installed_dir
 
     @property
     def arch(self) -> str | None:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR resolves the issue with Java home retrieval on macOS. For the temurin Java distribution, the Java home directory on macOS resides in <install-dir>/Contents/Home. This discrepancy caused errors in big data services when running in host mode.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Updated the logic for Java home retrieval on macOS to accommodate the temurin distribution structure.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
