### PR TITLE
Refactor EventBridge ArchiveServices to allow restoration without side effects

### DIFF
--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -1559,6 +1559,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             re_formatted_event_to_replay = replay_service.re_format_events_from_archive(
                 events_to_replay, replay_name
             )
+            # TODO should this really be run synchronously within the request?
             self._process_entries(context, re_formatted_event_to_replay)
         replay_service.finish()
 
@@ -1733,7 +1734,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         event_pattern: EventPattern,
         retention_days: RetentionDays,
     ) -> ArchiveService:
-        archive_service = ArchiveService(
+        archive_service = ArchiveService.create_archive_service(
             archive_name,
             region,
             account_id,
@@ -1742,6 +1743,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             event_pattern,
             retention_days,
         )
+        archive_service.register_archive_rule_and_targets()
         self._archive_service_store[archive_service.arn] = archive_service
         return archive_service
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, ArchiveServices have quite some side effects in its constructor.

This prevents us from avoiding those side effects when we want to restore those services from data in the store (for cloudpods or persistence).

With this PR, we split out the logic out of the constructor, to allow instantiation without side effects.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Remove boto calls from the ArchiveService constructor
* Refactor a bit to manually trigger rule/target registration

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
