### PR TITLE
fixed java lib path for macos

### DIFF
--- a/localstack-core/localstack/packages/java.py
+++ b/localstack-core/localstack/packages/java.py
@@ -45,7 +45,7 @@ class JavaInstallerMixin:
         """
         if java_home := self.get_java_home():
             if is_mac_os():
-                return os.path.join(java_home, "Contents", "Home", "lib", "jli", "libjli.dylib")
+                return os.path.join(java_home, "lib", "jli", "libjli.dylib")
             return os.path.join(java_home, "lib", "server", "libjvm.so")
 
     def get_java_env_vars(self, path: str = None, ld_library_path: str = None) -> dict[str, str]:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This is a follow up PR to https://github.com/localstack/localstack/pull/11888#issuecomment-2490739229. @maxhoheiser [reported a bug](https://github.com/localstack/localstack/pull/11888#issuecomment-2490739229) where java lib path was not properly generated.

Thanks @maxhoheiser for reporting.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Updated java lib path for macos to not include `/Contents/Home` since it's already included in the java home.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
