### PR TITLE
Enable EventBridge API destinations and connections

### DIFF
--- a/localstack-core/localstack/services/events/models.py
+++ b/localstack-core/localstack/services/events/models.py
@@ -9,6 +9,13 @@ from localstack.aws.api.events import (
     ArchiveName,
     ArchiveState,
     Arn,
+    ConnectionArn,
+    ConnectionAuthorizationType,
+    ConnectionDescription,
+    ConnectionName,
+    ConnectionState,
+    ConnectionStateReason,
+    CreateConnectionAuthRequestParameters,
     CreatedBy,
     EventBusName,
     EventPattern,
@@ -27,6 +34,7 @@ from localstack.aws.api.events import (
     RuleName,
     RuleState,
     ScheduleExpression,
+    SecretsManagerSecretArn,
     TagList,
     Target,
     TargetId,
@@ -223,6 +231,23 @@ class EventBus:
 EventBusDict = dict[EventBusName, EventBus]
 
 
+class Connection(TypedDict, total=False):
+    ConnectionArn: Optional[ConnectionArn]
+    Name: Optional[ConnectionName]
+    Description: Optional[ConnectionDescription]
+    ConnectionState: Optional[ConnectionState]
+    StateReason: Optional[ConnectionStateReason]
+    AuthorizationType: Optional[ConnectionAuthorizationType]
+    SecretArn: Optional[SecretsManagerSecretArn]
+    AuthParameters: Optional[CreateConnectionAuthRequestParameters]
+    CreationTime: Optional[Timestamp]
+    LastModifiedTime: Optional[Timestamp]
+    LastAuthorizedTime: Optional[Timestamp]
+
+
+ConnectionDict = dict[ConnectionName, Connection]
+
+
 class EventsStore(BaseStore):
     # Map of eventbus names to eventbus objects. The name MUST be unique per account and region (works with AccountRegionBundle)
     event_buses: EventBusDict = LocalAttribute(default=dict)
@@ -232,6 +257,9 @@ class EventsStore(BaseStore):
 
     # Map of replay names to replay objects. The name MUST be unique per account and region (works with AccountRegionBundle)
     replays: ReplayDict = LocalAttribute(default=dict)
+
+    # Map of connection names to connection objects.
+    connections: ConnectionDict = LocalAttribute(default=dict)
 
     # Maps resource ARN to tags
     TAGS: TaggingService = CrossRegionAttribute(default=TaggingService)

--- a/localstack-core/localstack/services/events/models.py
+++ b/localstack-core/localstack/services/events/models.py
@@ -5,18 +5,15 @@ from typing import Literal, Optional, TypeAlias, TypedDict
 
 from localstack.aws.api.core import ServiceException
 from localstack.aws.api.events import (
+    ApiDestinationName,
     ArchiveDescription,
     ArchiveName,
     ArchiveState,
     Arn,
-    ConnectionArn,
-    ConnectionAuthorizationType,
-    ConnectionDescription,
     ConnectionName,
-    ConnectionState,
-    ConnectionStateReason,
-    CreateConnectionAuthRequestParameters,
     CreatedBy,
+    DescribeApiDestinationResponse,
+    DescribeConnectionResponse,
     EventBusName,
     EventPattern,
     EventResourceList,
@@ -34,7 +31,6 @@ from localstack.aws.api.events import (
     RuleName,
     RuleState,
     ScheduleExpression,
-    SecretsManagerSecretArn,
     TagList,
     Target,
     TargetId,
@@ -231,21 +227,8 @@ class EventBus:
 EventBusDict = dict[EventBusName, EventBus]
 
 
-class Connection(TypedDict, total=False):
-    ConnectionArn: Optional[ConnectionArn]
-    Name: Optional[ConnectionName]
-    Description: Optional[ConnectionDescription]
-    ConnectionState: Optional[ConnectionState]
-    StateReason: Optional[ConnectionStateReason]
-    AuthorizationType: Optional[ConnectionAuthorizationType]
-    SecretArn: Optional[SecretsManagerSecretArn]
-    AuthParameters: Optional[CreateConnectionAuthRequestParameters]
-    CreationTime: Optional[Timestamp]
-    LastModifiedTime: Optional[Timestamp]
-    LastAuthorizedTime: Optional[Timestamp]
-
-
-ConnectionDict = dict[ConnectionName, Connection]
+ConnectionDict = dict[ConnectionName, DescribeConnectionResponse]
+ApiDestinationDict = dict[ApiDestinationName, DescribeApiDestinationResponse]
 
 
 class EventsStore(BaseStore):
@@ -260,6 +243,9 @@ class EventsStore(BaseStore):
 
     # Map of connection names to connection objects.
     connections: ConnectionDict = LocalAttribute(default=dict)
+
+    # Map of api destination names to api destination objects
+    api_destinations: ApiDestinationDict = LocalAttribute(default=dict)
 
     # Maps resource ARN to tags
     TAGS: TaggingService = CrossRegionAttribute(default=TaggingService)

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -386,7 +386,6 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         ).secretsmanager
         secret_value = self._get_secret_value(authorization_type, auth_parameters)
 
-        # TODO check if secret already exists / needs to be updated
         # create secret
         secret_name = f"events!connection/{name}/{str(uuid.uuid4())}"
         return secretsmanager_client.create_secret(

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -287,7 +287,12 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                 "AuthorizationEndpoint": oauth_params["AuthorizationEndpoint"],
                 "HttpMethod": oauth_params["HttpMethod"],
                 "ClientParameters": {"ClientID": oauth_params["ClientParameters"]["ClientID"]},
+                "OAuthHttpParameters": oauth_params.get("OAuthHttpParameters"),
             }
+            if "OAuthHttpParameters" in oauth_params:
+                public_params["OAuthParameters"]["OAuthHttpParameters"] = oauth_params.get(
+                    "OAuthHttpParameters"
+                )
 
         if "InvocationHttpParameters" in auth_parameters:
             public_params["InvocationHttpParameters"] = auth_parameters["InvocationHttpParameters"]
@@ -442,7 +447,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             "Name": name,
             "ConnectionState": connection_state or self._get_initial_state(authorization_type),
             "AuthorizationType": authorization_type,
-            "AuthParameters": auth_parameters,
+            "AuthParameters": self._get_public_parameters(authorization_type, auth_parameters),
             "SecretArn": secret_id,
             "CreationTime": current_time,
             "LastModifiedTime": current_time,
@@ -540,11 +545,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                     f"Failed to describe the connection(s). Connection '{name}' does not exist."
                 )
 
-            connection_response = DescribeConnectionResponse(**store.connections[name])
-            connection_response["AuthParameters"] = self._get_public_parameters(
-                connection_response["AuthorizationType"], connection_response["AuthParameters"]
-            )
-            return connection_response
+            return DescribeConnectionResponse(**store.connections[name])
 
         except ResourceNotFoundException as e:
             raise e

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -284,7 +284,6 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                 "AuthorizationEndpoint": oauth_params["AuthorizationEndpoint"],
                 "HttpMethod": oauth_params["HttpMethod"],
                 "ClientParameters": {"ClientID": oauth_params["ClientParameters"]["ClientID"]},
-                "OAuthHttpParameters": oauth_params.get("OAuthHttpParameters"),
             }
             if "OAuthHttpParameters" in oauth_params:
                 public_params["OAuthParameters"]["OAuthHttpParameters"] = oauth_params.get(

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -156,7 +156,7 @@ from localstack.services.events.utils import (
     to_json_str,
 )
 from localstack.services.plugins import ServiceLifecycleHook
-from localstack.utils.aws.arns import parse_arn
+from localstack.utils.aws.arns import get_partition, parse_arn
 from localstack.utils.common import truncate
 from localstack.utils.event_matcher import matches_event
 from localstack.utils.strings import long_uid, short_uid
@@ -316,7 +316,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
     ) -> ApiDestination:
         """Create a standardized API destination object."""
         now = datetime.utcnow()
-        api_destination_arn = f"arn:aws:events:{context.region}:{context.account_id}:api-destination/{name}/{short_uid()}"
+        api_destination_arn = f"arn:{get_partition(context.region)}:events:{context.region}:{context.account_id}:api-destination/{name}/{short_uid()}"
 
         api_destination: ApiDestination = {
             "ApiDestinationArn": api_destination_arn,
@@ -336,11 +336,11 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         self, context: RequestContext, name: str, connection_uuid: str
     ) -> str:
         """Create a standardized connection ARN."""
-        return f"arn:aws:events:{context.region}:{context.account_id}:connection/{name}/{connection_uuid}"
+        return f"arn:{get_partition(context.region)}:events:{context.region}:{context.account_id}:connection/{name}/{connection_uuid}"
 
     def _create_secret_arn(self, context: RequestContext, name: str) -> str:
         """Create a standardized secret ARN."""
-        return f"arn:aws:secretsmanager:{context.region}:{context.account_id}:secret:events!connection/{name}/{str(uuid.uuid4())}"
+        return f"arn:{get_partition(context.region)}:secretsmanager:{context.region}:{context.account_id}:secret:events!connection/{name}/{str(uuid.uuid4())}"
 
     def _create_connection_object(
         self,

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -262,7 +262,7 @@ class ApiGatewayTargetSender(TargetSender):
 
     def send_event(self, event):
         # Parse the ARN to extract api_id, stage_name, http_method, and resource path
-        # Example ARN: arn:aws:execute-api:{region}:{account_id}:{api_id}/{stage_name}/{method}/{resource_path}
+        # Example ARN: arn:{partition}:execute-api:{region}:{account_id}:{api_id}/{stage_name}/{method}/{resource_path}
         arn_parts = parse_arn(self.target["Arn"])
         api_gateway_info = arn_parts["resource"]  # e.g., 'myapi/dev/POST/pets/*/*'
         api_gateway_info_parts = api_gateway_info.split("/")

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -14,6 +14,7 @@ from localstack import config
 from localstack.aws.api.events import Arn, InputTransformer, RuleName, Target, TargetInputPath
 from localstack.aws.connect import connect_to
 from localstack.services.events.models import FormattedEvent, TransformedEvent, ValidationException
+from localstack.services.events.target_helper import send_event_to_api_destination
 from localstack.services.events.utils import (
     event_time_to_time_string,
     get_trace_header_encoded_region_account,
@@ -390,6 +391,10 @@ class EventsTargetSender(TargetSender):
     def send_event(self, event):
         # TODO add validation and tests for eventbridge to eventbridge requires Detail, DetailType, and Source
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/events/client/put_events.html
+        target_arn = self.target["Arn"]
+        if ":api-destination/" in target_arn or ":destination/" in target_arn:
+            send_event_to_api_destination(target_arn, event, self.target.get("HttpParameters"))
+            return
         source = self._get_source(event)
         detail_type = self._get_detail_type(event)
         detail = event.get("detail", event)

--- a/localstack-core/localstack/services/events/target_helper.py
+++ b/localstack-core/localstack/services/events/target_helper.py
@@ -1,0 +1,91 @@
+import json
+import logging
+import re
+from typing import Dict, Optional
+
+import requests
+
+from localstack.aws.connect import connect_to
+from localstack.services.events.models import events_stores
+from localstack.utils.aws.arns import extract_account_id_from_arn, extract_region_from_arn
+from localstack.utils.aws.message_forwarding import (
+    add_target_http_parameters,
+    auth_keys_from_connection,
+    list_of_parameters_to_object,
+)
+from localstack.utils.http import add_query_params_to_url
+
+LOG = logging.getLogger(__name__)
+
+
+def send_event_to_api_destination(target_arn, event, http_parameters: Optional[Dict] = None):
+    """Send an event to an EventBridge API destination
+    See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destinations.html"""
+
+    # ARN format: ...:api-destination/{name}/{uuid}
+    account_id = extract_account_id_from_arn(target_arn)
+    region = extract_region_from_arn(target_arn)
+
+    api_destination_name = target_arn.split(":")[-1].split("/")[1]
+    events_client = connect_to(aws_access_key_id=account_id, region_name=region).events
+    destination = events_client.describe_api_destination(Name=api_destination_name)
+
+    # get destination endpoint details
+    method = destination.get("HttpMethod", "GET")
+    endpoint = destination.get("InvocationEndpoint")
+    state = destination.get("ApiDestinationState") or "ACTIVE"
+
+    LOG.debug('Calling EventBridge API destination (state "%s"): %s %s', state, method, endpoint)
+    headers = {
+        # default headers AWS sends with every api destination call
+        "User-Agent": "Amazon/EventBridge/ApiDestinations",
+        "Content-Type": "application/json; charset=utf-8",
+        "Range": "bytes=0-1048575",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "close",
+    }
+
+    endpoint = add_api_destination_authorization(destination, headers, event)
+    if http_parameters:
+        endpoint = add_target_http_parameters(http_parameters, endpoint, headers, event)
+
+    result = requests.request(
+        method=method, url=endpoint, data=json.dumps(event or {}), headers=headers
+    )
+    if result.status_code >= 400:
+        LOG.debug("Received code %s forwarding events: %s %s", result.status_code, method, endpoint)
+        if result.status_code == 429 or 500 <= result.status_code <= 600:
+            pass  # TODO: retry logic (only retry on 429 and 5xx response status)
+
+
+def add_api_destination_authorization(destination, headers, event):
+    connection_arn = destination.get("ConnectionArn", "")
+    connection_name = re.search(r"connection\/([a-zA-Z0-9-_]+)\/", connection_arn).group(1)
+
+    account_id = extract_account_id_from_arn(connection_arn)
+    region = extract_region_from_arn(connection_arn)
+
+    store = events_stores[account_id][region]
+    connection = store.connections.get(connection_name)
+    headers.update(auth_keys_from_connection(connection))
+
+    auth_parameters = connection.get("AuthParameters", {})
+    invocation_parameters = auth_parameters.get("InvocationHttpParameters")
+
+    endpoint = destination.get("InvocationEndpoint")
+    if invocation_parameters:
+        header_parameters = list_of_parameters_to_object(
+            invocation_parameters.get("HeaderParameters", [])
+        )
+        headers.update(header_parameters)
+
+        body_parameters = list_of_parameters_to_object(
+            invocation_parameters.get("BodyParameters", [])
+        )
+        event.update(body_parameters)
+
+        query_parameters = invocation_parameters.get("QueryStringParameters", [])
+        query_object = list_of_parameters_to_object(query_parameters)
+        endpoint = add_query_params_to_url(endpoint, query_object)
+
+    return endpoint

--- a/localstack-core/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack-core/localstack/testing/snapshots/transformer_utility.py
@@ -767,12 +767,7 @@ class TransformerUtility:
             connection_name: The name of the connection to transform in the snapshot
         """
         snapshot.add_transformer(snapshot.transform.regex(connection_name, "<connection-name>"))
-        snapshot.add_transformer(
-            snapshot.transform.key_value("ConnectionArn", reference_replacement=False)
-        )
-        snapshot.add_transformer(
-            snapshot.transform.key_value("SecretArn", reference_replacement=False)
-        )
+        snapshot.add_transformer(TransformerUtility.resource_name())
         return snapshot
 
 

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -566,7 +566,12 @@ def create_connection(aws_client, connection_name):
                 AuthParameters=auth_parameters,
             )
 
-    return _create_connection
+    yield _create_connection
+
+    try:
+        aws_client.events.delete_connection(Name=connection_name)
+    except Exception as e:
+        LOG.debug("Error cleaning up connection: %s", e)
 
 
 @pytest.fixture

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -1928,7 +1928,10 @@ class TestEventBridgeConnections:
     @pytest.mark.parametrize(
         "auth_params", API_DESTINATION_AUTH_PARAMS, ids=["basic", "api-key", "oauth"]
     )
-    # @pytest.mark.skip(reason="Not implemented yet")
+    @pytest.mark.skipif(
+        is_old_provider(),
+        reason="V1 provider does not support this feature",
+    )
     def test_connection_secrets(
         self, aws_client, snapshot, create_connection, connection_name, auth_params
     ):

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -243,9 +243,7 @@ class TestEvents:
         assert [json.loads(event["Detail"]) for event in sorted_events] == event_details_to_publish
 
     @markers.aws.only_localstack
-    # tests for legacy v1 provider delete once v1 provider is removed, v2 covered in separate tests
     @pytest.mark.parametrize("auth", API_DESTINATION_AUTHS)
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_api_destinations(self, httpserver: HTTPServer, auth, aws_client, clean_up):
         token = short_uid()
         bearer = f"Bearer {token}"

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1948,13 +1948,51 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_update_connection": {
-    "recorded-date": "21-11-2024, 14:49:54",
+    "recorded-date": "21-11-2024, 15:39:32",
     "recorded-content": {
       "create-connection": {
         "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "AUTHORIZED",
         "CreationTime": "datetime",
         "LastModifiedTime": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-created-connection": {
+        "AuthParameters": {
+          "BasicAuthParameters": {
+            "Username": "user"
+          },
+          "InvocationHttpParameters": {}
+        },
+        "AuthorizationType": "BASIC",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
+        "ConnectionState": "AUTHORIZED",
+        "CreationTime": "datetime",
+        "LastAuthorizedTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<connection-name>",
+        "SecretArn": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<secret-uuid>-<secret-id-suffix>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "connection-secret-before-update": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<secret-uuid>-<secret-id-suffix>",
+        "CreatedDate": "datetime",
+        "Name": "events!connection/<connection-name>/<secret-uuid>",
+        "SecretString": {
+          "username": "user",
+          "password": "pass",
+          "invocation_http_parameters": {}
+        },
+        "VersionId": "<uuid:1>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1985,7 +2023,25 @@
         "LastAuthorizedTime": "datetime",
         "LastModifiedTime": "datetime",
         "Name": "<connection-name>",
-        "SecretArn": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<resource:2>",
+        "SecretArn": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<secret-uuid>-<secret-id-suffix>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "connection-secret-after-update": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<secret-uuid>-<secret-id-suffix>",
+        "CreatedDate": "datetime",
+        "Name": "events!connection/<connection-name>/<secret-uuid>",
+        "SecretString": {
+          "username": "new_user",
+          "password": "new_pass",
+          "invocation_http_parameters": {}
+        },
+        "VersionId": "<uuid:2>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2009,7 +2065,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_delete_connection": {
-    "recorded-date": "21-11-2024, 14:49:53",
+    "recorded-date": "21-11-2024, 15:47:45",
     "recorded-content": {
       "create-connection-response": {
         "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
@@ -2481,8 +2537,8 @@
       }
     }
   },
-  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[auth_params0]": {
-    "recorded-date": "21-11-2024, 14:49:54",
+  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[basic]": {
+    "recorded-date": "21-11-2024, 15:16:35",
     "recorded-content": {
       "create-connection-auth": {
         "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
@@ -2532,8 +2588,8 @@
       }
     }
   },
-  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[auth_params1]": {
-    "recorded-date": "21-11-2024, 14:49:55",
+  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[api-key]": {
+    "recorded-date": "21-11-2024, 15:16:35",
     "recorded-content": {
       "create-connection-auth": {
         "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
@@ -2583,8 +2639,8 @@
       }
     }
   },
-  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[auth_params2]": {
-    "recorded-date": "21-11-2024, 14:49:55",
+  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[oauth]": {
+    "recorded-date": "21-11-2024, 15:16:36",
     "recorded-content": {
       "create-connection-auth": {
         "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1754,7 +1754,7 @@
       ]
     }
   },
-    "tests/aws/services/events/test_events.py::TestEvents::test_create_connection_validations": {
+  "tests/aws/services/events/test_events.py::TestEvents::test_create_connection_validations": {
     "recorded-date": "14-11-2024, 20:29:49",
     "recorded-content": {
       "create_connection_exc": {
@@ -1770,10 +1770,10 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection": {
-    "recorded-date": "12-11-2024, 16:49:40",
+    "recorded-date": "21-11-2024, 14:00:54",
     "recorded-content": {
       "create-connection": {
-        "ConnectionArn": "connection-arn",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "AUTHORIZED",
         "CreationTime": "datetime",
         "LastModifiedTime": "datetime",
@@ -1790,13 +1790,13 @@
           "InvocationHttpParameters": {}
         },
         "AuthorizationType": "API_KEY",
-        "ConnectionArn": "connection-arn",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "AUTHORIZED",
         "CreationTime": "datetime",
         "LastAuthorizedTime": "datetime",
         "LastModifiedTime": "datetime",
         "Name": "<connection-name>",
-        "SecretArn": "secret-arn",
+        "SecretArn": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<resource:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1805,10 +1805,10 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_with_auth[auth_params0]": {
-    "recorded-date": "12-11-2024, 16:49:41",
+    "recorded-date": "21-11-2024, 14:00:54",
     "recorded-content": {
       "create-connection-auth": {
-        "ConnectionArn": "connection-arn",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "AUTHORIZED",
         "CreationTime": "datetime",
         "LastModifiedTime": "datetime",
@@ -1824,13 +1824,13 @@
           }
         },
         "AuthorizationType": "BASIC",
-        "ConnectionArn": "connection-arn",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "AUTHORIZED",
         "CreationTime": "datetime",
         "LastAuthorizedTime": "datetime",
         "LastModifiedTime": "datetime",
         "Name": "<connection-name>",
-        "SecretArn": "secret-arn",
+        "SecretArn": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<resource:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1839,10 +1839,10 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_with_auth[auth_params1]": {
-    "recorded-date": "12-11-2024, 16:49:41",
+    "recorded-date": "21-11-2024, 14:00:55",
     "recorded-content": {
       "create-connection-auth": {
-        "ConnectionArn": "connection-arn",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "AUTHORIZED",
         "CreationTime": "datetime",
         "LastModifiedTime": "datetime",
@@ -1858,13 +1858,13 @@
           }
         },
         "AuthorizationType": "API_KEY",
-        "ConnectionArn": "connection-arn",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "AUTHORIZED",
         "CreationTime": "datetime",
         "LastAuthorizedTime": "datetime",
         "LastModifiedTime": "datetime",
         "Name": "<connection-name>",
-        "SecretArn": "secret-arn",
+        "SecretArn": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<resource:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1873,10 +1873,10 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_with_auth[auth_params2]": {
-    "recorded-date": "12-11-2024, 16:49:42",
+    "recorded-date": "21-11-2024, 14:00:55",
     "recorded-content": {
       "create-connection-auth": {
-        "ConnectionArn": "connection-arn",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "AUTHORIZING",
         "CreationTime": "datetime",
         "LastModifiedTime": "datetime",
@@ -1896,13 +1896,13 @@
           }
         },
         "AuthorizationType": "OAUTH_CLIENT_CREDENTIALS",
-        "ConnectionArn": "connection-arn",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "AUTHORIZING",
         "CreationTime": "datetime",
         "LastAuthorizedTime": "datetime",
         "LastModifiedTime": "datetime",
         "Name": "<connection-name>",
-        "SecretArn": "secret-arn",
+        "SecretArn": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<resource:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1911,13 +1911,13 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_list_connections": {
-    "recorded-date": "12-11-2024, 16:49:42",
+    "recorded-date": "21-11-2024, 14:00:56",
     "recorded-content": {
       "list-connections": {
         "Connections": [
           {
             "AuthorizationType": "BASIC",
-            "ConnectionArn": "connection-arn",
+            "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
             "ConnectionState": "AUTHORIZED",
             "CreationTime": "datetime",
             "LastAuthorizedTime": "datetime",
@@ -1933,7 +1933,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_invalid_parameters": {
-    "recorded-date": "12-11-2024, 16:49:47",
+    "recorded-date": "21-11-2024, 14:00:58",
     "recorded-content": {
       "create-connection-invalid-auth-error": {
         "Error": {
@@ -1948,10 +1948,10 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_update_connection": {
-    "recorded-date": "12-11-2024, 16:49:48",
+    "recorded-date": "21-11-2024, 14:00:59",
     "recorded-content": {
       "create-connection": {
-        "ConnectionArn": "connection-arn",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "AUTHORIZED",
         "CreationTime": "datetime",
         "LastModifiedTime": "datetime",
@@ -1961,7 +1961,7 @@
         }
       },
       "update-connection": {
-        "ConnectionArn": "connection-arn",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "AUTHORIZED",
         "CreationTime": "datetime",
         "LastAuthorizedTime": "datetime",
@@ -1979,13 +1979,13 @@
           "InvocationHttpParameters": {}
         },
         "AuthorizationType": "BASIC",
-        "ConnectionArn": "connection-arn",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "AUTHORIZED",
         "CreationTime": "datetime",
         "LastAuthorizedTime": "datetime",
         "LastModifiedTime": "datetime",
         "Name": "<connection-name>",
-        "SecretArn": "secret-arn",
+        "SecretArn": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<resource:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1994,7 +1994,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_name_validation": {
-    "recorded-date": "12-11-2024, 16:49:49",
+    "recorded-date": "21-11-2024, 14:00:59",
     "recorded-content": {
       "create-connection-invalid-name-error": {
         "Error": {
@@ -2009,10 +2009,20 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_delete_connection": {
-    "recorded-date": "12-11-2024, 16:49:46",
+    "recorded-date": "21-11-2024, 14:00:58",
     "recorded-content": {
+      "create-connection-response": {
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
+        "ConnectionState": "AUTHORIZED",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "delete-connection": {
-        "ConnectionArn": "connection-arn",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
         "ConnectionState": "DELETING",
         "CreationTime": "datetime",
         "LastAuthorizedTime": "datetime",
@@ -2022,7 +2032,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "describe-deleted-connection-error": {
+      "describe-deleted-connection": {
         "Error": {
           "Code": "ResourceNotFoundException",
           "Message": "Failed to describe the connection(s). Connection '<connection-name>' does not exist."

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1770,7 +1770,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection": {
-    "recorded-date": "21-11-2024, 14:00:54",
+    "recorded-date": "21-11-2024, 14:49:50",
     "recorded-content": {
       "create-connection": {
         "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
@@ -1805,7 +1805,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_with_auth[auth_params0]": {
-    "recorded-date": "21-11-2024, 14:00:54",
+    "recorded-date": "21-11-2024, 14:49:51",
     "recorded-content": {
       "create-connection-auth": {
         "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
@@ -1839,7 +1839,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_with_auth[auth_params1]": {
-    "recorded-date": "21-11-2024, 14:00:55",
+    "recorded-date": "21-11-2024, 14:49:51",
     "recorded-content": {
       "create-connection-auth": {
         "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
@@ -1873,7 +1873,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_with_auth[auth_params2]": {
-    "recorded-date": "21-11-2024, 14:00:55",
+    "recorded-date": "21-11-2024, 14:49:51",
     "recorded-content": {
       "create-connection-auth": {
         "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
@@ -1911,7 +1911,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_list_connections": {
-    "recorded-date": "21-11-2024, 14:00:56",
+    "recorded-date": "21-11-2024, 14:49:52",
     "recorded-content": {
       "list-connections": {
         "Connections": [
@@ -1933,7 +1933,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_invalid_parameters": {
-    "recorded-date": "21-11-2024, 14:00:58",
+    "recorded-date": "21-11-2024, 14:49:53",
     "recorded-content": {
       "create-connection-invalid-auth-error": {
         "Error": {
@@ -1948,7 +1948,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_update_connection": {
-    "recorded-date": "21-11-2024, 14:00:59",
+    "recorded-date": "21-11-2024, 14:49:54",
     "recorded-content": {
       "create-connection": {
         "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
@@ -1994,7 +1994,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_name_validation": {
-    "recorded-date": "21-11-2024, 14:00:59",
+    "recorded-date": "21-11-2024, 14:49:54",
     "recorded-content": {
       "create-connection-invalid-name-error": {
         "Error": {
@@ -2009,7 +2009,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_delete_connection": {
-    "recorded-date": "21-11-2024, 14:00:58",
+    "recorded-date": "21-11-2024, 14:49:53",
     "recorded-content": {
       "create-connection-response": {
         "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
@@ -2474,6 +2474,165 @@
           }
         ],
         "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[auth_params0]": {
+    "recorded-date": "21-11-2024, 14:49:54",
+    "recorded-content": {
+      "create-connection-auth": {
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
+        "ConnectionState": "AUTHORIZED",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-connection-auth": {
+        "AuthParameters": {
+          "BasicAuthParameters": {
+            "Username": "user"
+          }
+        },
+        "AuthorizationType": "BASIC",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
+        "ConnectionState": "AUTHORIZED",
+        "CreationTime": "datetime",
+        "LastAuthorizedTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<connection-name>",
+        "SecretArn": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<secret-uuid>-<secret-id-suffix>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "connection-secret": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<secret-uuid>-<secret-id-suffix>",
+        "CreatedDate": "datetime",
+        "Name": "events!connection/<connection-name>/<secret-uuid>",
+        "SecretString": {
+          "username": "user",
+          "password": "pass"
+        },
+        "VersionId": "<uuid:1>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[auth_params1]": {
+    "recorded-date": "21-11-2024, 14:49:55",
+    "recorded-content": {
+      "create-connection-auth": {
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
+        "ConnectionState": "AUTHORIZED",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-connection-auth": {
+        "AuthParameters": {
+          "ApiKeyAuthParameters": {
+            "ApiKeyName": "ApiKey"
+          }
+        },
+        "AuthorizationType": "API_KEY",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
+        "ConnectionState": "AUTHORIZED",
+        "CreationTime": "datetime",
+        "LastAuthorizedTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<connection-name>",
+        "SecretArn": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<secret-uuid>-<secret-id-suffix>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "connection-secret": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<secret-uuid>-<secret-id-suffix>",
+        "CreatedDate": "datetime",
+        "Name": "events!connection/<connection-name>/<secret-uuid>",
+        "SecretString": {
+          "api_key_name": "ApiKey",
+          "api_key_value": "secret"
+        },
+        "VersionId": "<uuid:1>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[auth_params2]": {
+    "recorded-date": "21-11-2024, 14:49:55",
+    "recorded-content": {
+      "create-connection-auth": {
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
+        "ConnectionState": "AUTHORIZING",
+        "CreationTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-connection-auth": {
+        "AuthParameters": {
+          "OAuthParameters": {
+            "AuthorizationEndpoint": "https://example.com/oauth",
+            "ClientParameters": {
+              "ClientID": "client_id"
+            },
+            "HttpMethod": "POST"
+          }
+        },
+        "AuthorizationType": "OAUTH_CLIENT_CREDENTIALS",
+        "ConnectionArn": "arn:<partition>:events:<region>:111111111111:connection/<connection-name>/<resource:1>",
+        "ConnectionState": "AUTHORIZING",
+        "CreationTime": "datetime",
+        "LastAuthorizedTime": "datetime",
+        "LastModifiedTime": "datetime",
+        "Name": "<connection-name>",
+        "SecretArn": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<secret-uuid>-<secret-id-suffix>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "connection-secret": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:events!connection/<connection-name>/<secret-uuid>-<secret-id-suffix>",
+        "CreatedDate": "datetime",
+        "Name": "events!connection/<connection-name>/<secret-uuid>",
+        "SecretString": {
+          "client_id": "client_id",
+          "client_secret": "client_secret",
+          "authorization_endpoint": "https://example.com/oauth",
+          "http_method": "POST"
+        },
+        "VersionId": "<uuid:1>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -14,14 +14,14 @@
   "tests/aws/services/events/test_events.py::TestEventBridgeApiDestinations::test_create_api_destination_name_validation": {
     "last_validated_date": "2024-11-16T13:44:08+00:00"
   },
-  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[auth_params0]": {
-    "last_validated_date": "2024-11-21T14:58:31+00:00"
+  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[api-key]": {
+    "last_validated_date": "2024-11-21T15:16:35+00:00"
   },
-  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[auth_params1]": {
-    "last_validated_date": "2024-11-21T14:58:31+00:00"
+  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[basic]": {
+    "last_validated_date": "2024-11-21T15:16:35+00:00"
   },
-  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[auth_params2]": {
-    "last_validated_date": "2024-11-21T14:58:32+00:00"
+  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[oauth]": {
+    "last_validated_date": "2024-11-21T15:16:36+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection": {
     "last_validated_date": "2024-11-21T14:58:26+00:00"
@@ -42,13 +42,13 @@
     "last_validated_date": "2024-11-21T14:58:28+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_delete_connection": {
-    "last_validated_date": "2024-11-21T14:58:29+00:00"
+    "last_validated_date": "2024-11-21T15:47:45+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_list_connections": {
     "last_validated_date": "2024-11-21T14:58:28+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_update_connection": {
-    "last_validated_date": "2024-11-21T14:58:30+00:00"
+    "last_validated_date": "2024-11-21T15:39:32+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
     "last_validated_date": "2024-06-19T10:54:07+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -15,31 +15,31 @@
     "last_validated_date": "2024-11-16T13:44:08+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection": {
-    "last_validated_date": "2024-11-12T16:49:40+00:00"
+    "last_validated_date": "2024-11-21T14:02:52+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_invalid_parameters": {
-    "last_validated_date": "2024-11-12T16:49:47+00:00"
+    "last_validated_date": "2024-11-21T14:02:55+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_name_validation": {
-    "last_validated_date": "2024-11-12T16:49:49+00:00"
+    "last_validated_date": "2024-11-21T14:02:56+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_with_auth[auth_params0]": {
-    "last_validated_date": "2024-11-12T16:49:41+00:00"
+    "last_validated_date": "2024-11-21T14:02:53+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_with_auth[auth_params1]": {
-    "last_validated_date": "2024-11-12T16:49:41+00:00"
+    "last_validated_date": "2024-11-21T14:02:53+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_with_auth[auth_params2]": {
-    "last_validated_date": "2024-11-12T16:49:42+00:00"
+    "last_validated_date": "2024-11-21T14:02:53+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_delete_connection": {
-    "last_validated_date": "2024-11-12T16:49:46+00:00"
+    "last_validated_date": "2024-11-21T14:02:55+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_list_connections": {
-    "last_validated_date": "2024-11-12T16:49:42+00:00"
+    "last_validated_date": "2024-11-21T14:02:54+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_update_connection": {
-    "last_validated_date": "2024-11-12T16:49:48+00:00"
+    "last_validated_date": "2024-11-21T14:02:56+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
     "last_validated_date": "2024-06-19T10:54:07+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -14,32 +14,41 @@
   "tests/aws/services/events/test_events.py::TestEventBridgeApiDestinations::test_create_api_destination_name_validation": {
     "last_validated_date": "2024-11-16T13:44:08+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[auth_params0]": {
+    "last_validated_date": "2024-11-21T14:58:31+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[auth_params1]": {
+    "last_validated_date": "2024-11-21T14:58:31+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_connection_secrets[auth_params2]": {
+    "last_validated_date": "2024-11-21T14:58:32+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection": {
-    "last_validated_date": "2024-11-21T14:02:52+00:00"
+    "last_validated_date": "2024-11-21T14:58:26+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_invalid_parameters": {
-    "last_validated_date": "2024-11-21T14:02:55+00:00"
+    "last_validated_date": "2024-11-21T14:58:29+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_name_validation": {
-    "last_validated_date": "2024-11-21T14:02:56+00:00"
+    "last_validated_date": "2024-11-21T14:58:30+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_with_auth[auth_params0]": {
-    "last_validated_date": "2024-11-21T14:02:53+00:00"
+    "last_validated_date": "2024-11-21T14:58:27+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_with_auth[auth_params1]": {
-    "last_validated_date": "2024-11-21T14:02:53+00:00"
+    "last_validated_date": "2024-11-21T14:58:27+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_create_connection_with_auth[auth_params2]": {
-    "last_validated_date": "2024-11-21T14:02:53+00:00"
+    "last_validated_date": "2024-11-21T14:58:28+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_delete_connection": {
-    "last_validated_date": "2024-11-21T14:02:55+00:00"
+    "last_validated_date": "2024-11-21T14:58:29+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_list_connections": {
-    "last_validated_date": "2024-11-21T14:02:54+00:00"
+    "last_validated_date": "2024-11-21T14:58:28+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBridgeConnections::test_update_connection": {
-    "last_validated_date": "2024-11-21T14:02:56+00:00"
+    "last_validated_date": "2024-11-21T14:58:30+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
     "last_validated_date": "2024-06-19T10:54:07+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
In the current v2 provider, we do not support eventbridge API destinations.

As we do want this in 4.0.1, and I am unsure if we should do such a big code change, I staggered the commits in terms of escalating changes / complexity.

93822dd has the minimal changes necessary to make the feature work, we could cherry pick that into a separate PR.

After this commit, we increasingly increase parity, with more snapshots, creation of eventbridge secrets, bypass of secretmanager name assertions (since official EventBridge secrets contain a `!` in the name).

It might be too much for a release tomorrow, but I will let the reviewers judge that.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Allow persistence for connections and api destinations by moving them into the store (very simply, without dataclasses as for other models)
* Detect API destinations and forward events correctly
* Connections now correctly create secrets in secretsmanager for connection secrets
* Change snapshot transformers to add more assertions on the structure of ARNs
* Some minor testing improvements, to increase reliability of the tests (against AWS)
* Move the snapshots to an autouse fixture, to be able to use the `snapshot` name directly (honestly a preference, but I did quite some work in the tests)
* Add more snapshot on the event secrets
* Unskip test for api destinations
* Fix partitions in some ARNs

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
