### PR TITLE
Fix put_targets validation regressions

### DIFF
--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -39,6 +39,8 @@ ARCHIVE_NAME_ARN_PATTERN = re.compile(
     rf"{ARN_PARTITION_REGEX}:events:[a-z0-9-]+:\d{{12}}:archive/(?P<name>.+)$"
 )
 
+TARGET_ID_PATTERN = re.compile(r"[\.\-_A-Za-z0-9]+")
+
 
 class EventJSONEncoder(json.JSONEncoder):
     """This json encoder is used to serialize datetime object

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -404,9 +404,9 @@ class TestEvents:
                 assert oauth_request.args["oauthquery"] == "value3"
 
     @markers.aws.validated
-    # @pytest.mark.skip(
-    #     reason="V2 provider does not support this feature yet and it also fails in V1 now"
-    # )
+    @pytest.mark.skip(
+        reason="V2 provider does not support this feature yet and it also fails in V1 now"
+    )
     def test_create_connection_validations(self, aws_client, snapshot):
         connection_name = "This should fail with two errors 123467890123412341234123412341234"
 

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -404,9 +404,9 @@ class TestEvents:
                 assert oauth_request.args["oauthquery"] == "value3"
 
     @markers.aws.validated
-    @pytest.mark.skip(
-        reason="V2 provider does not support this feature yet and it also fails in V1 now"
-    )
+    # @pytest.mark.skip(
+    #     reason="V2 provider does not support this feature yet and it also fails in V1 now"
+    # )
     def test_create_connection_validations(self, aws_client, snapshot):
         connection_name = "This should fail with two errors 123467890123412341234123412341234"
 
@@ -1670,7 +1670,6 @@ class TestEventTarget:
         snapshot.match("list-targets-limit-next-token", response)
 
     @markers.aws.validated
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_target_id_validation(
         self, sqs_create_queue, sqs_get_queue_arn, events_put_rule, snapshot, aws_client
     ):

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -168,7 +168,7 @@
     "last_validated_date": "2024-06-19T10:40:55+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_response_entries_order": {
-    "last_validated_date": "2024-11-20T12:32:18+00:00"
+    "last_validated_date": "2024-11-21T11:48:24+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_time": {
     "last_validated_date": "2024-08-27T10:02:33+00:00"


### PR DESCRIPTION
## Motivation

`put_targets` does not validate invalid inputs for `target_id`, which is a regression compared to EventBridge v1.

## Changes

* Add validation exceptions for `put_targets`