### PR TITLE
Fix provider signature for StepFunctions TestState operation

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -1143,10 +1143,11 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         self,
         context: RequestContext,
         definition: Definition,
-        role_arn: Arn,
+        role_arn: Arn = None,
         input: SensitiveData = None,
         inspection_level: InspectionLevel = None,
         reveal_secrets: RevealSecrets = None,
+        variables: SensitiveData = None,
         **kwargs,
     ) -> TestStateOutput:
         StepFunctionsProvider._validate_definition(


### PR DESCRIPTION
## Motivation

The ASF provider signature check unit test was failing for the `test_state` method in the StepFunctions provider.

This PR addresses the issue by making sure the signatures are aligned