### PR TITLE
Fix JVM startup for StepFunctions

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/jsonata/jsonata.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/jsonata/jsonata.py
@@ -47,7 +47,7 @@ class _JSONataJVMBridge:
 
         jpype_config.destroy_jvm = False
 
-        jvm_path = jpype.getDefaultJVMPath()
+        jvm_path = installer.get_java_lib_path()
         jsonata_libs_path = Path(installer.get_installed_dir())
         event_ruler_libs_pattern = jsonata_libs_path.joinpath("*")
         jpype.startJVM(jvm_path, classpath=[event_ruler_libs_pattern], interrupt=False)


### PR DESCRIPTION
## Motivation

Started seeing issues regarding JVM in the latest container:

```
...
    instance.set(factory())
                 ^^^^^^^^^
  File "/opt/code/localstack/localstack-core/localstack/services/stepfunctions/asl/jsonata/jsonata.py", line 64, in get
    return _JSONataJVMBridge()
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/localstack-core/localstack/services/stepfunctions/asl/jsonata/jsonata.py", line 50, in __init__
    jvm_path = jpype.getDefaultJVMPath()
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/jpype/_jvmfinder.py", line 70, in getDefaultJVMPath
    return finder.get_jvm_path()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/jpype/_jvmfinder.py", line 204, in get_jvm_path
    raise JVMNotFoundException("No JVM shared library file ({0}) "
```

This PR fixes this by pointing JPype to the correct JVM path
