### PR TITLE
ci/prevent init file to break packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ test-coverage: TEST_EXEC = python -m coverage run $(COVERAGE_ARGS) -m
 test-coverage: test	  ## Run automated tests and create coverage report
 
 lint:              		  ## Run code linter to check code style, check if formatter would make changes and check if dependency pins need to be updated
+	@[ -f localstack-core/localstack/__init__.py ] && echo "localstack-core/localstack/version.py will break packaging. Please delete end retry" && exit 1 || :
 	($(VENV_RUN); python -m ruff check --output-format=full . && python -m ruff format --check .)
 	$(VENV_RUN); pre-commit run check-pinned-deps-for-needed-upgrade --files pyproject.toml # run pre-commit hook manually here to ensure that this check runs in CI as well
 	$(VENV_RUN); openapi-spec-validator localstack-core/localstack/openapi.yaml

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ test-coverage: TEST_EXEC = python -m coverage run $(COVERAGE_ARGS) -m
 test-coverage: test	  ## Run automated tests and create coverage report
 
 lint:              		  ## Run code linter to check code style, check if formatter would make changes and check if dependency pins need to be updated
-	@[ -f localstack-core/localstack/__init__.py ] && echo "localstack-core/localstack/__init__.py will break packaging. Please delete end retry" && exit 1 || :
+	@[ -f localstack-core/localstack/__init__.py ] && echo "localstack-core/localstack/__init__.py will break packaging." && exit 1 || :
 	($(VENV_RUN); python -m ruff check --output-format=full . && python -m ruff format --check .)
 	$(VENV_RUN); pre-commit run check-pinned-deps-for-needed-upgrade --files pyproject.toml # run pre-commit hook manually here to ensure that this check runs in CI as well
 	$(VENV_RUN); openapi-spec-validator localstack-core/localstack/openapi.yaml

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ test-coverage: TEST_EXEC = python -m coverage run $(COVERAGE_ARGS) -m
 test-coverage: test	  ## Run automated tests and create coverage report
 
 lint:              		  ## Run code linter to check code style, check if formatter would make changes and check if dependency pins need to be updated
-	@[ -f localstack-core/localstack/__init__.py ] && echo "localstack-core/localstack/version.py will break packaging. Please delete end retry" && exit 1 || :
+	@[ -f localstack-core/localstack/__init__.py ] && echo "localstack-core/localstack/__init__.py will break packaging. Please delete end retry" && exit 1 || :
 	($(VENV_RUN); python -m ruff check --output-format=full . && python -m ruff format --check .)
 	$(VENV_RUN); pre-commit run check-pinned-deps-for-needed-upgrade --files pyproject.toml # run pre-commit hook manually here to ensure that this check runs in CI as well
 	$(VENV_RUN); openapi-spec-validator localstack-core/localstack/openapi.yaml


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

During 4.0.1 deploy the -ext build failed because of a namespace issue. Some tricky debugging lead to finding the issue stemmed from the addition of  `localstack-core/localstack/__init__.py`. The result was that `localstack.pro.core` could no longer be found.

Pr fixing: #11012 and #11913

Kudos @bentsku for finding the issue

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Add a check during linting that will raise loud and clear the error if and when this would happen again.

From ci run https://app.circleci.com/pipelines/github/localstack/localstack/29774/workflows/8c2feac2-9780-471e-9e96-ab1005811f4f

![image](https://github.com/user-attachments/assets/4d372245-982d-48b9-ba5b-10e482994341)


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
