### PR TITLE
[SFN] Activity Name and Arn Validation Logic

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -175,7 +175,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
     )
 
     _ACTIVITY_ARN_REGEX: Final[re.Pattern] = re.compile(
-        rf"{ARN_PARTITION_REGEX}:states:[a-z0-9-]+:[0-9]{{12}}:activity:[a-zA-Z0-9-_]+$"
+        rf"{ARN_PARTITION_REGEX}:states:[a-z0-9-]+:[0-9]{{12}}:activity:[a-zA-Z0-9-_\.]{{1,80}}$"
     )
 
     @staticmethod
@@ -221,6 +221,8 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         # - special characters " # % \ ^ | ~ ` $ & , ; : /
         # - control characters (U+0000-001F, U+007F-009F)
         # https://docs.aws.amazon.com/step-functions/latest/apireference/API_CreateActivity.html#API_CreateActivity_RequestSyntax
+        if not (1 <= len(name) <= 80):
+            raise InvalidName(f"Invalid Name: '{name}'")
         invalid_chars = set(' <>{}[]?*"#%\\^|~`$&,;:/')
         control_chars = {chr(i) for i in range(32)} | {chr(i) for i in range(127, 160)}
         invalid_chars |= control_chars

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_activities.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_activities.snapshot.json
@@ -1,62 +1,4 @@
 {
-  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity": {
-    "recorded-date": "03-03-2024, 06:03:28",
-    "recorded-content": {
-      "create_activity_response": {
-        "activityArn": "activity_arn",
-        "creationDate": "creation-date",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create_activity_response_duplicate": {
-        "activityArn": "activity_arn",
-        "creationDate": "creation-date",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe_activity_response": {
-        "activityArn": "activity_arn",
-        "creationDate": "creation-date",
-        "name": "activity_name",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete_activity_response": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete_activity_response_2": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name": {
-    "recorded-date": "04-03-2024, 14:18:50",
-    "recorded-content": {
-      "invalid_name": {
-        "Error": {
-          "Code": "InvalidName",
-          "Message": "Invalid Name: 'TestActivity InvalidName$'"
-        },
-        "message": "Invalid Name: 'TestActivity InvalidName$'",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_describe_deleted_activity": {
     "recorded-date": "17-03-2024, 10:33:44",
     "recorded-content": {
@@ -131,6 +73,827 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[Activity1]": {
+    "recorded-date": "25-11-2024, 19:02:40",
+    "recorded-content": {
+      "create_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_activity_response_duplicate": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "encryptionConfiguration": {
+          "type": "AWS_OWNED_KEY"
+        },
+        "name": "activity_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response_2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[activity-name_123]": {
+    "recorded-date": "25-11-2024, 19:02:40",
+    "recorded-content": {
+      "create_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_activity_response_duplicate": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "encryptionConfiguration": {
+          "type": "AWS_OWNED_KEY"
+        },
+        "name": "activity_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response_2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[ACTIVITY_NAME_ABC]": {
+    "recorded-date": "25-11-2024, 19:02:41",
+    "recorded-content": {
+      "create_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_activity_response_duplicate": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "encryptionConfiguration": {
+          "type": "AWS_OWNED_KEY"
+        },
+        "name": "activity_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response_2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[activity.name]": {
+    "recorded-date": "25-11-2024, 19:02:42",
+    "recorded-content": {
+      "create_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_activity_response_duplicate": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "encryptionConfiguration": {
+          "type": "AWS_OWNED_KEY"
+        },
+        "name": "activity_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response_2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[activity.name.v2]": {
+    "recorded-date": "25-11-2024, 19:02:42",
+    "recorded-content": {
+      "create_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_activity_response_duplicate": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "encryptionConfiguration": {
+          "type": "AWS_OWNED_KEY"
+        },
+        "name": "activity_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response_2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[activityName.with.dots]": {
+    "recorded-date": "25-11-2024, 19:02:42",
+    "recorded-content": {
+      "create_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_activity_response_duplicate": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "encryptionConfiguration": {
+          "type": "AWS_OWNED_KEY"
+        },
+        "name": "activity_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response_2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[activity-name.1]": {
+    "recorded-date": "25-11-2024, 19:02:43",
+    "recorded-content": {
+      "create_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_activity_response_duplicate": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "encryptionConfiguration": {
+          "type": "AWS_OWNED_KEY"
+        },
+        "name": "activity_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response_2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[activity_123.name]": {
+    "recorded-date": "25-11-2024, 19:02:43",
+    "recorded-content": {
+      "create_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_activity_response_duplicate": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "encryptionConfiguration": {
+          "type": "AWS_OWNED_KEY"
+        },
+        "name": "activity_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response_2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]": {
+    "recorded-date": "25-11-2024, 19:02:44",
+    "recorded-content": {
+      "create_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_activity_response_duplicate": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_activity_response": {
+        "activityArn": "activity_arn",
+        "creationDate": "creation-date",
+        "encryptionConfiguration": {
+          "type": "AWS_OWNED_KEY"
+        },
+        "name": "activity_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_activity_response_2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity name]": {
+    "recorded-date": "25-11-2024, 19:07:31",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity name'"
+        },
+        "message": "Invalid Name: 'activity name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity<name]": {
+    "recorded-date": "25-11-2024, 19:07:31",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity<name'"
+        },
+        "message": "Invalid Name: 'activity<name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity>name]": {
+    "recorded-date": "25-11-2024, 19:07:31",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity>name'"
+        },
+        "message": "Invalid Name: 'activity>name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity{name]": {
+    "recorded-date": "25-11-2024, 19:07:31",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity{name'"
+        },
+        "message": "Invalid Name: 'activity{name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity}name]": {
+    "recorded-date": "25-11-2024, 19:07:32",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity}name'"
+        },
+        "message": "Invalid Name: 'activity}name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity[name]": {
+    "recorded-date": "25-11-2024, 19:07:32",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity[name'"
+        },
+        "message": "Invalid Name: 'activity[name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity]name]": {
+    "recorded-date": "25-11-2024, 19:07:32",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity]name'"
+        },
+        "message": "Invalid Name: 'activity]name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity?name]": {
+    "recorded-date": "25-11-2024, 19:07:32",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity?name'"
+        },
+        "message": "Invalid Name: 'activity?name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity*name]": {
+    "recorded-date": "25-11-2024, 19:07:32",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity*name'"
+        },
+        "message": "Invalid Name: 'activity*name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity\"name]": {
+    "recorded-date": "25-11-2024, 19:07:32",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity\"name'"
+        },
+        "message": "Invalid Name: 'activity\"name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity#name]": {
+    "recorded-date": "25-11-2024, 19:07:32",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity#name'"
+        },
+        "message": "Invalid Name: 'activity#name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity%name]": {
+    "recorded-date": "25-11-2024, 19:07:32",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity%name'"
+        },
+        "message": "Invalid Name: 'activity%name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity\\\\name]": {
+    "recorded-date": "25-11-2024, 19:07:33",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity\\name'"
+        },
+        "message": "Invalid Name: 'activity\\name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity^name]": {
+    "recorded-date": "25-11-2024, 19:07:33",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity^name'"
+        },
+        "message": "Invalid Name: 'activity^name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity|name]": {
+    "recorded-date": "25-11-2024, 19:07:33",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity|name'"
+        },
+        "message": "Invalid Name: 'activity|name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity~name]": {
+    "recorded-date": "25-11-2024, 19:07:33",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity~name'"
+        },
+        "message": "Invalid Name: 'activity~name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity`name]": {
+    "recorded-date": "25-11-2024, 19:07:33",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity`name'"
+        },
+        "message": "Invalid Name: 'activity`name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity$name]": {
+    "recorded-date": "25-11-2024, 19:07:33",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity$name'"
+        },
+        "message": "Invalid Name: 'activity$name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity&name]": {
+    "recorded-date": "25-11-2024, 19:07:33",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity&name'"
+        },
+        "message": "Invalid Name: 'activity&name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity,name]": {
+    "recorded-date": "25-11-2024, 19:07:33",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity,name'"
+        },
+        "message": "Invalid Name: 'activity,name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity;name]": {
+    "recorded-date": "25-11-2024, 19:07:33",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity;name'"
+        },
+        "message": "Invalid Name: 'activity;name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity:name]": {
+    "recorded-date": "25-11-2024, 19:07:34",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity:name'"
+        },
+        "message": "Invalid Name: 'activity:name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity/name]": {
+    "recorded-date": "25-11-2024, 19:07:34",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity/name'"
+        },
+        "message": "Invalid Name: 'activity/name'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[\\x00activity]": {
+    "recorded-date": "25-11-2024, 19:07:34",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: '\u0000activity'"
+        },
+        "message": "Invalid Name: '\u0000activity'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity\\x1f]": {
+    "recorded-date": "25-11-2024, 19:07:34",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity\u001f'"
+        },
+        "message": "Invalid Name: 'activity\u001f'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity\\x7f]": {
+    "recorded-date": "25-11-2024, 19:07:34",
+    "recorded-content": {
+      "invalid_name": {
+        "Error": {
+          "Code": "InvalidName",
+          "Message": "Invalid Name: 'activity\u007f'"
+        },
+        "message": "Invalid Name: 'activity\u007f'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_activities.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_activities.validation.json
@@ -1,9 +1,108 @@
 {
-  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name": {
-    "last_validated_date": "2024-03-04T14:18:50+00:00"
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[\\x00activity]": {
+    "last_validated_date": "2024-11-25T19:07:34+00:00"
   },
-  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity": {
-    "last_validated_date": "2024-03-03T06:03:28+00:00"
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity name]": {
+    "last_validated_date": "2024-11-25T19:07:31+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity\"name]": {
+    "last_validated_date": "2024-11-25T19:07:32+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity#name]": {
+    "last_validated_date": "2024-11-25T19:07:32+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity$name]": {
+    "last_validated_date": "2024-11-25T19:07:33+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity%name]": {
+    "last_validated_date": "2024-11-25T19:07:32+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity&name]": {
+    "last_validated_date": "2024-11-25T19:07:33+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity*name]": {
+    "last_validated_date": "2024-11-25T19:07:32+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity,name]": {
+    "last_validated_date": "2024-11-25T19:07:33+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity/name]": {
+    "last_validated_date": "2024-11-25T19:07:34+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity:name]": {
+    "last_validated_date": "2024-11-25T19:07:34+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity;name]": {
+    "last_validated_date": "2024-11-25T19:07:33+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity<name]": {
+    "last_validated_date": "2024-11-25T19:07:31+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity>name]": {
+    "last_validated_date": "2024-11-25T19:07:31+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity?name]": {
+    "last_validated_date": "2024-11-25T19:07:32+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity[name]": {
+    "last_validated_date": "2024-11-25T19:07:32+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity\\\\name]": {
+    "last_validated_date": "2024-11-25T19:07:33+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity\\x1f]": {
+    "last_validated_date": "2024-11-25T19:07:34+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity\\x7f]": {
+    "last_validated_date": "2024-11-25T19:07:34+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity]name]": {
+    "last_validated_date": "2024-11-25T19:07:32+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity^name]": {
+    "last_validated_date": "2024-11-25T19:07:33+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity`name]": {
+    "last_validated_date": "2024-11-25T19:07:33+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity{name]": {
+    "last_validated_date": "2024-11-25T19:07:31+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity|name]": {
+    "last_validated_date": "2024-11-25T19:07:33+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity}name]": {
+    "last_validated_date": "2024-11-25T19:07:32+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_activity_invalid_name[activity~name]": {
+    "last_validated_date": "2024-11-25T19:07:33+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[ACTIVITY_NAME_ABC]": {
+    "last_validated_date": "2024-11-25T19:02:41+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[Activity1]": {
+    "last_validated_date": "2024-11-25T19:02:40+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]": {
+    "last_validated_date": "2024-11-25T19:02:44+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[activity-name.1]": {
+    "last_validated_date": "2024-11-25T19:02:43+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[activity-name_123]": {
+    "last_validated_date": "2024-11-25T19:02:40+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[activity.name.v2]": {
+    "last_validated_date": "2024-11-25T19:02:42+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[activity.name]": {
+    "last_validated_date": "2024-11-25T19:02:42+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[activityName.with.dots]": {
+    "last_validated_date": "2024-11-25T19:02:42+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_create_describe_delete_activity[activity_123.name]": {
+    "last_validated_date": "2024-11-25T19:02:43+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_activities.py::TestSnfApiActivities::test_describe_activity_invalid_arn": {
     "last_validated_date": "2024-03-11T20:38:07+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, the SFN v2 provider applies faulty activity arn and name validation logics, which can result is `InvalidName` exceptions during activity creation and especially during `DescribeActivity` api actions. This is espiecially true for activity names that contain punctuations,  as described in https://github.com/localstack/localstack/issues/11916. This is due to the activity arn validation not being aligned with AWS SFN and the activity name validation (used on creation). These changes address both issues and add positive and negative snapshot tests for the creation deletion and description of activity names and arns.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- positive and negative activity name/arn tests
- updated activity arn validation rule
- updated activity name validation logic to check for maximum name lenght

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
