### PR TITLE
Add analytics for event rule engine

### DIFF
--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -31,6 +31,7 @@ TRACKED_ENV_VAR = [
     "ES_CUSTOM_BACKEND",  # deprecated in 0.14.0, removed in 3.0.0
     "ES_MULTI_CLUSTER",  # deprecated in 0.14.0, removed in 3.0.0
     "ES_ENDPOINT_STRATEGY",  # deprecated in 0.14.0, removed in 3.0.0
+    "EVENT_RULE_ENGINE",
     "IAM_SOFT_MODE",
     "KINESIS_PROVIDER",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
     "KINESIS_ERROR_PROBABILITY",

--- a/localstack-core/localstack/services/events/plugins.py
+++ b/localstack-core/localstack/services/events/plugins.py
@@ -1,0 +1,8 @@
+from localstack.packages import Package, package
+
+
+@package(name="event-ruler")
+def event_ruler_package() -> Package:
+    from localstack.services.events.packages import event_ruler_package
+
+    return event_ruler_package

--- a/tests/aws/services/events/test_events_patterns.py
+++ b/tests/aws/services/events/test_events_patterns.py
@@ -22,7 +22,7 @@ COMPLEX_MULTI_KEY_EVENT_PATTERN = os.path.join(
 COMPLEX_MULTI_KEY_EVENT = os.path.join(REQUEST_TEMPLATE_DIR, "complex_multi_key_event.json")
 
 SKIP_LABELS = [
-    # Failing exception tests:
+    # TODO: fix failing exception tests (not yet implemented)
     "arrays_empty_EXC",
     "content_numeric_EXC",
     "content_numeric_operatorcasing_EXC",
@@ -31,7 +31,7 @@ SKIP_LABELS = [
     "int_nolist_EXC",
     "operator_case_sensitive_EXC",
     "string_nolist_EXC",
-    # Failing tests:
+    # TODO: fix failing tests for Python event rule engine
     "complex_or",
     "content_anything_but_ignorecase",
     "content_anything_but_ignorecase_list",


### PR DESCRIPTION
Supersedes https://github.com/localstack/localstack/pull/11807

## Motivation

We are missing analytics tracking for the event ruler and a plugins.py to make the package installable (if we decide to ship it). Currently, we don't see the need for shipping it as the Java-based event ruler is opt-in.


## Changes

* Add env var tracking for `EVENT_RULE_ENGINE`
* Make `event-ruler` package installable (in case we need to ship it to unblock users facing dynamic installation issues)
