### PR TITLE
Add nodejs22.x AWS Lambda runtime

### DIFF
--- a/localstack-core/localstack/services/lambda_/runtimes.py
+++ b/localstack-core/localstack/services/lambda_/runtimes.py
@@ -27,7 +27,7 @@ from localstack.aws.api.lambda_ import Runtime
 # 6. Review special tests including:
 # a) [ext] tests.aws.services.lambda_.test_lambda_endpoint_injection
 # 7. Before merging, run the ext integration tests to cover transparent endpoint injection testing.
-# 8. Add the new runtime to the K8 image build: https://github.com/localstack/lambda-cve-mitigation
+# 8. Add the new runtime to the K8 image build: https://github.com/localstack/lambda-images
 # 9. Inform the web team to update the resource browser (consider offering an endpoint in the future)
 
 # Mapping from a) AWS Lambda runtime identifier => b) official AWS image on Amazon ECR Public

--- a/localstack-core/localstack/services/lambda_/runtimes.py
+++ b/localstack-core/localstack/services/lambda_/runtimes.py
@@ -36,7 +36,7 @@ from localstack.aws.api.lambda_ import Runtime
 # => Synchronize the order with the "Supported runtimes" under "AWS Lambda runtimes" (a)
 # => Add comments for deprecated runtimes using <Deprecation date> => <Block function create> => <Block function update>
 IMAGE_MAPPING: dict[Runtime, str] = {
-    # "nodejs22.x": "nodejs:22", expected November 2024
+    Runtime.nodejs22_x: "nodejs:22",
     Runtime.nodejs20_x: "nodejs:20",
     Runtime.nodejs18_x: "nodejs:18",
     Runtime.nodejs16_x: "nodejs:16",
@@ -111,6 +111,7 @@ ALL_RUNTIMES: list[Runtime] = list(IMAGE_MAPPING.keys())
 # => Remove deprecated runtimes from this testing list
 RUNTIMES_AGGREGATED = {
     "nodejs": [
+        Runtime.nodejs22_x,
         Runtime.nodejs20_x,
         Runtime.nodejs18_x,
         Runtime.nodejs16_x,
@@ -153,6 +154,6 @@ TESTED_RUNTIMES: list[Runtime] = [
 SNAP_START_SUPPORTED_RUNTIMES = [Runtime.java11, Runtime.java17, Runtime.java21]
 
 # An ordered list of all Lambda runtimes considered valid by AWS. Matching snapshots in test_create_lambda_exceptions
-VALID_RUNTIMES: str = "[nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]"
+VALID_RUNTIMES: str = "[nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]"
 # An ordered list of all Lambda runtimes for layers considered valid by AWS. Matching snapshots in test_layer_exceptions
 VALID_LAYER_RUNTIMES: str = "[ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java17, nodejs, nodejs4.3, java8.al2, go1.x, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, nodejs22.x, python3.10, java8, nodejs12.x, python3.11, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, python3.13, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby2.5, python3.6, python2.7]"

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -7836,7 +7836,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "recorded-date": "18-11-2024, 15:57:03",
+    "recorded-date": "26-11-2024, 09:27:31",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7851,10 +7851,10 @@
       "invalid_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7863,10 +7863,10 @@
       "uppercase_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7908,7 +7908,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "recorded-date": "18-11-2024, 15:57:06",
+    "recorded-date": "26-11-2024, 09:27:33",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7923,10 +7923,10 @@
       "invalid_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7935,10 +7935,10 @@
       "uppercase_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -8248,7 +8248,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_exceptions": {
-    "recorded-date": "18-11-2024, 15:57:22",
+    "recorded-date": "26-11-2024, 09:27:46",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8426,7 +8426,7 @@
       "publish_layer_version_exc_invalid_runtime_arch": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "2 validation errors detected: Value '[invalidruntime]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
+          "Message": "2 validation errors detected: Value '[invalidruntime]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8436,7 +8436,7 @@
       "publish_layer_version_exc_partially_invalid_values": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "2 validation errors detected: Value '[invalidruntime, invalidruntime2, nodejs20.x]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch, x86_64]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
+          "Message": "2 validation errors detected: Value '[invalidruntime, invalidruntime2, nodejs20.x]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch, x86_64]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -13759,7 +13759,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes0]": {
-    "recorded-date": "18-11-2024, 15:57:09",
+    "recorded-date": "26-11-2024, 09:27:34",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -13767,6 +13767,7 @@
           "x86_64"
         ],
         "CompatibleRuntimes": [
+          "nodejs22.x",
           "nodejs20.x",
           "nodejs18.x",
           "nodejs16.x",
@@ -13779,8 +13780,7 @@
           "python3.9",
           "python3.8",
           "python3.7",
-          "java21",
-          "java17"
+          "java21"
         ],
         "Content": {
           "CodeSha256": "<code-sha256:1>",
@@ -13800,7 +13800,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes1]": {
-    "recorded-date": "18-11-2024, 15:57:14",
+    "recorded-date": "26-11-2024, 09:27:38",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -13808,6 +13808,7 @@
           "x86_64"
         ],
         "CompatibleRuntimes": [
+          "java17",
           "java11",
           "java8.al2",
           "java8",
@@ -16304,7 +16305,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[java8]": {
-    "recorded-date": "18-11-2024, 15:57:00",
+    "recorded-date": "26-11-2024, 09:27:29",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16321,7 +16322,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[go1.x]": {
-    "recorded-date": "18-11-2024, 15:57:00",
+    "recorded-date": "26-11-2024, 09:27:29",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16338,7 +16339,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[provided]": {
-    "recorded-date": "18-11-2024, 15:57:01",
+    "recorded-date": "26-11-2024, 09:27:30",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16355,7 +16356,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[ruby2.7]": {
-    "recorded-date": "18-11-2024, 15:57:01",
+    "recorded-date": "26-11-2024, 09:27:30",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16372,7 +16373,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs14.x]": {
-    "recorded-date": "18-11-2024, 15:57:01",
+    "recorded-date": "26-11-2024, 09:27:30",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16389,7 +16390,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[python3.7]": {
-    "recorded-date": "18-11-2024, 15:57:01",
+    "recorded-date": "26-11-2024, 09:27:30",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16406,7 +16407,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[dotnetcore3.1]": {
-    "recorded-date": "18-11-2024, 15:57:02",
+    "recorded-date": "26-11-2024, 09:27:30",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16423,7 +16424,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs12.x]": {
-    "recorded-date": "18-11-2024, 15:57:02",
+    "recorded-date": "26-11-2024, 09:27:30",
     "recorded-content": {
       "deprecation_error": {
         "Error": {

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -57,7 +57,7 @@
     "last_validated_date": "2024-04-10T08:58:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "last_validated_date": "2024-11-18T15:57:03+00:00"
+    "last_validated_date": "2024-11-26T09:27:31+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_delete_on_nonexisting_version": {
     "last_validated_date": "2024-09-12T11:29:32+00:00"
@@ -411,7 +411,7 @@
     "last_validated_date": "2024-09-12T11:29:23+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "last_validated_date": "2024-11-18T15:57:06+00:00"
+    "last_validated_date": "2024-11-26T09:27:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_vpc_config": {
     "last_validated_date": "2024-09-12T11:34:40+00:00"
@@ -429,13 +429,13 @@
     "last_validated_date": "2024-04-10T09:10:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes0]": {
-    "last_validated_date": "2024-11-18T15:57:09+00:00"
+    "last_validated_date": "2024-11-26T09:27:34+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes1]": {
-    "last_validated_date": "2024-11-18T15:57:13+00:00"
+    "last_validated_date": "2024-11-26T09:27:38+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_exceptions": {
-    "last_validated_date": "2024-11-18T15:57:22+00:00"
+    "last_validated_date": "2024-11-26T09:27:46+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_function_exceptions": {
     "last_validated_date": "2024-04-10T09:23:18+00:00"
@@ -639,27 +639,27 @@
     "last_validated_date": "2024-06-12T14:19:11+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[dotnetcore3.1]": {
-    "last_validated_date": "2024-11-18T15:57:02+00:00"
+    "last_validated_date": "2024-11-26T09:27:30+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[go1.x]": {
-    "last_validated_date": "2024-11-18T15:57:00+00:00"
+    "last_validated_date": "2024-11-26T09:27:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[java8]": {
-    "last_validated_date": "2024-11-18T15:57:00+00:00"
+    "last_validated_date": "2024-11-26T09:27:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs12.x]": {
-    "last_validated_date": "2024-11-18T15:57:02+00:00"
+    "last_validated_date": "2024-11-26T09:27:30+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs14.x]": {
-    "last_validated_date": "2024-11-18T15:57:01+00:00"
+    "last_validated_date": "2024-11-26T09:27:30+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[provided]": {
-    "last_validated_date": "2024-11-18T15:57:01+00:00"
+    "last_validated_date": "2024-11-26T09:27:30+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[python3.7]": {
-    "last_validated_date": "2024-11-18T15:57:01+00:00"
+    "last_validated_date": "2024-11-26T09:27:30+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[ruby2.7]": {
-    "last_validated_date": "2024-11-18T15:57:01+00:00"
+    "last_validated_date": "2024-11-26T09:27:30+00:00"
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_common.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_common.snapshot.json
@@ -1,70 +1,70 @@
 {
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.8]": {
-    "recorded-date": "18-11-2024, 15:47:54",
+    "recorded-date": "26-11-2024, 09:28:27",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java11]": {
-    "recorded-date": "18-11-2024, 15:48:15",
+    "recorded-date": "26-11-2024, 09:29:13",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2]": {
-    "recorded-date": "18-11-2024, 15:48:57",
+    "recorded-date": "26-11-2024, 09:31:05",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8.al2]": {
-    "recorded-date": "18-11-2024, 15:48:20",
+    "recorded-date": "26-11-2024, 09:29:18",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.2]": {
-    "recorded-date": "18-11-2024, 15:48:25",
+    "recorded-date": "26-11-2024, 09:29:22",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.11]": {
-    "recorded-date": "18-11-2024, 15:47:38",
+    "recorded-date": "26-11-2024, 09:28:14",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java17]": {
-    "recorded-date": "18-11-2024, 15:48:04",
+    "recorded-date": "26-11-2024, 09:29:09",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs18.x]": {
-    "recorded-date": "18-11-2024, 15:47:18",
+    "recorded-date": "26-11-2024, 09:27:58",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java21]": {
-    "recorded-date": "18-11-2024, 15:47:59",
+    "recorded-date": "26-11-2024, 09:29:04",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2023]": {
-    "recorded-date": "18-11-2024, 15:48:48",
+    "recorded-date": "26-11-2024, 09:30:57",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.9]": {
-    "recorded-date": "18-11-2024, 15:47:48",
+    "recorded-date": "26-11-2024, 09:28:22",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.10]": {
-    "recorded-date": "18-11-2024, 15:47:43",
+    "recorded-date": "26-11-2024, 09:28:18",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.12]": {
-    "recorded-date": "18-11-2024, 15:47:33",
+    "recorded-date": "26-11-2024, 09:28:11",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs20.x]": {
-    "recorded-date": "18-11-2024, 15:47:12",
+    "recorded-date": "26-11-2024, 09:27:54",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet6]": {
-    "recorded-date": "18-11-2024, 15:48:36",
+    "recorded-date": "26-11-2024, 09:30:41",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs16.x]": {
-    "recorded-date": "18-11-2024, 15:47:23",
+    "recorded-date": "26-11-2024, 09:28:02",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.8]": {
-    "recorded-date": "18-11-2024, 15:49:26",
+    "recorded-date": "26-11-2024, 09:31:29",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -205,7 +205,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java11]": {
-    "recorded-date": "18-11-2024, 15:49:37",
+    "recorded-date": "26-11-2024, 09:31:44",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -344,7 +344,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2]": {
-    "recorded-date": "18-11-2024, 15:50:08",
+    "recorded-date": "26-11-2024, 09:33:29",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -477,7 +477,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8.al2]": {
-    "recorded-date": "18-11-2024, 15:49:41",
+    "recorded-date": "26-11-2024, 09:31:47",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -616,7 +616,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.2]": {
-    "recorded-date": "18-11-2024, 15:49:44",
+    "recorded-date": "26-11-2024, 09:31:49",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -761,7 +761,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.11]": {
-    "recorded-date": "18-11-2024, 15:49:16",
+    "recorded-date": "26-11-2024, 09:31:22",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -902,7 +902,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java17]": {
-    "recorded-date": "18-11-2024, 15:49:33",
+    "recorded-date": "26-11-2024, 09:31:41",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1037,7 +1037,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs18.x]": {
-    "recorded-date": "18-11-2024, 15:49:03",
+    "recorded-date": "26-11-2024, 09:31:13",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1178,7 +1178,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java21]": {
-    "recorded-date": "18-11-2024, 15:49:29",
+    "recorded-date": "26-11-2024, 09:31:38",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1313,7 +1313,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2023]": {
-    "recorded-date": "18-11-2024, 15:50:03",
+    "recorded-date": "26-11-2024, 09:33:25",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1446,7 +1446,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.9]": {
-    "recorded-date": "18-11-2024, 15:49:23",
+    "recorded-date": "26-11-2024, 09:31:26",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1587,7 +1587,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.10]": {
-    "recorded-date": "18-11-2024, 15:49:19",
+    "recorded-date": "26-11-2024, 09:31:24",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1728,7 +1728,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.12]": {
-    "recorded-date": "18-11-2024, 15:49:13",
+    "recorded-date": "26-11-2024, 09:31:20",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1871,7 +1871,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs20.x]": {
-    "recorded-date": "18-11-2024, 15:49:00",
+    "recorded-date": "26-11-2024, 09:31:10",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2010,7 +2010,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet6]": {
-    "recorded-date": "18-11-2024, 15:49:51",
+    "recorded-date": "26-11-2024, 09:32:01",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2155,7 +2155,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs16.x]": {
-    "recorded-date": "18-11-2024, 15:49:07",
+    "recorded-date": "26-11-2024, 09:31:15",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2296,7 +2296,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.8]": {
-    "recorded-date": "18-11-2024, 15:50:33",
+    "recorded-date": "26-11-2024, 09:33:50",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2358,7 +2358,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java11]": {
-    "recorded-date": "18-11-2024, 15:50:43",
+    "recorded-date": "26-11-2024, 09:34:06",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2420,7 +2420,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2]": {
-    "recorded-date": "18-11-2024, 15:51:07",
+    "recorded-date": "26-11-2024, 09:35:05",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2481,7 +2481,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8.al2]": {
-    "recorded-date": "18-11-2024, 15:50:47",
+    "recorded-date": "26-11-2024, 09:34:09",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2543,7 +2543,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.2]": {
-    "recorded-date": "18-11-2024, 15:50:50",
+    "recorded-date": "26-11-2024, 09:34:11",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2605,7 +2605,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.11]": {
-    "recorded-date": "18-11-2024, 15:50:25",
+    "recorded-date": "26-11-2024, 09:33:44",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2668,7 +2668,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java17]": {
-    "recorded-date": "18-11-2024, 15:50:40",
+    "recorded-date": "26-11-2024, 09:34:03",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2730,7 +2730,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs18.x]": {
-    "recorded-date": "18-11-2024, 15:50:13",
+    "recorded-date": "26-11-2024, 09:33:36",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2792,7 +2792,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java21]": {
-    "recorded-date": "18-11-2024, 15:50:37",
+    "recorded-date": "26-11-2024, 09:34:00",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2854,7 +2854,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2023]": {
-    "recorded-date": "18-11-2024, 15:51:03",
+    "recorded-date": "26-11-2024, 09:35:00",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2915,7 +2915,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.9]": {
-    "recorded-date": "18-11-2024, 15:50:30",
+    "recorded-date": "26-11-2024, 09:33:48",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2978,7 +2978,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.10]": {
-    "recorded-date": "18-11-2024, 15:50:27",
+    "recorded-date": "26-11-2024, 09:33:46",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3041,7 +3041,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.12]": {
-    "recorded-date": "18-11-2024, 15:50:22",
+    "recorded-date": "26-11-2024, 09:33:42",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3104,7 +3104,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs20.x]": {
-    "recorded-date": "18-11-2024, 15:50:11",
+    "recorded-date": "26-11-2024, 09:33:34",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3166,7 +3166,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet6]": {
-    "recorded-date": "18-11-2024, 15:50:56",
+    "recorded-date": "26-11-2024, 09:34:22",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3228,7 +3228,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs16.x]": {
-    "recorded-date": "18-11-2024, 15:50:16",
+    "recorded-date": "26-11-2024, 09:33:38",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3290,7 +3290,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.8]": {
-    "recorded-date": "18-11-2024, 15:51:20",
+    "recorded-date": "26-11-2024, 09:35:17",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3343,7 +3343,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java11]": {
-    "recorded-date": "18-11-2024, 15:51:17",
+    "recorded-date": "26-11-2024, 09:35:23",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3396,7 +3396,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java8.al2]": {
-    "recorded-date": "18-11-2024, 15:51:48",
+    "recorded-date": "26-11-2024, 09:35:33",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3449,7 +3449,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.2]": {
-    "recorded-date": "18-11-2024, 15:51:51",
+    "recorded-date": "26-11-2024, 09:35:20",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3502,7 +3502,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.11]": {
-    "recorded-date": "18-11-2024, 15:51:10",
+    "recorded-date": "26-11-2024, 09:35:49",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3555,7 +3555,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java17]": {
-    "recorded-date": "18-11-2024, 15:51:41",
+    "recorded-date": "26-11-2024, 09:35:45",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3608,7 +3608,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs18.x]": {
-    "recorded-date": "18-11-2024, 15:51:35",
+    "recorded-date": "26-11-2024, 09:35:35",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3661,7 +3661,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java21]": {
-    "recorded-date": "18-11-2024, 15:51:26",
+    "recorded-date": "26-11-2024, 09:35:30",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3714,7 +3714,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.9]": {
-    "recorded-date": "18-11-2024, 15:51:13",
+    "recorded-date": "26-11-2024, 09:35:37",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3767,7 +3767,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.10]": {
-    "recorded-date": "18-11-2024, 15:51:44",
+    "recorded-date": "26-11-2024, 09:35:11",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3820,7 +3820,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.12]": {
-    "recorded-date": "18-11-2024, 15:51:29",
+    "recorded-date": "26-11-2024, 09:35:25",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3873,7 +3873,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs20.x]": {
-    "recorded-date": "18-11-2024, 15:51:23",
+    "recorded-date": "26-11-2024, 09:35:47",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3926,7 +3926,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet6]": {
-    "recorded-date": "18-11-2024, 15:52:01",
+    "recorded-date": "26-11-2024, 09:35:40",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3979,7 +3979,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs16.x]": {
-    "recorded-date": "18-11-2024, 15:51:32",
+    "recorded-date": "26-11-2024, 09:35:27",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4032,47 +4032,47 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs20.x]": {
-    "recorded-date": "18-11-2024, 15:52:37",
+    "recorded-date": "26-11-2024, 09:38:09",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs18.x]": {
-    "recorded-date": "18-11-2024, 15:53:05",
+    "recorded-date": "26-11-2024, 09:37:43",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs16.x]": {
-    "recorded-date": "18-11-2024, 15:53:02",
+    "recorded-date": "26-11-2024, 09:36:44",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.8]": {
-    "recorded-date": "18-11-2024, 15:52:33",
+    "recorded-date": "26-11-2024, 09:36:15",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.9]": {
-    "recorded-date": "18-11-2024, 15:52:08",
+    "recorded-date": "26-11-2024, 09:37:45",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.10]": {
-    "recorded-date": "18-11-2024, 15:53:30",
+    "recorded-date": "26-11-2024, 09:35:56",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.11]": {
-    "recorded-date": "18-11-2024, 15:52:04",
+    "recorded-date": "26-11-2024, 09:38:12",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.12]": {
-    "recorded-date": "18-11-2024, 15:52:58",
+    "recorded-date": "26-11-2024, 09:36:40",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.2]": {
-    "recorded-date": "18-11-2024, 15:54:18",
+    "recorded-date": "26-11-2024, 09:36:18",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet8]": {
-    "recorded-date": "18-11-2024, 15:48:42",
+    "recorded-date": "26-11-2024, 09:30:52",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet8]": {
-    "recorded-date": "18-11-2024, 15:49:54",
+    "recorded-date": "26-11-2024, 09:32:13",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4219,7 +4219,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet8]": {
-    "recorded-date": "18-11-2024, 15:51:00",
+    "recorded-date": "26-11-2024, 09:34:30",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4281,7 +4281,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet8]": {
-    "recorded-date": "18-11-2024, 15:51:54",
+    "recorded-date": "26-11-2024, 09:35:15",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4334,35 +4334,35 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java17]": {
-    "recorded-date": "18-11-2024, 15:53:27",
+    "recorded-date": "26-11-2024, 09:38:07",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java21]": {
-    "recorded-date": "18-11-2024, 15:52:54",
+    "recorded-date": "26-11-2024, 09:36:54",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java11]": {
-    "recorded-date": "18-11-2024, 15:52:30",
+    "recorded-date": "26-11-2024, 09:36:37",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java8.al2]": {
-    "recorded-date": "18-11-2024, 15:54:14",
+    "recorded-date": "26-11-2024, 09:37:40",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet6]": {
-    "recorded-date": "18-11-2024, 15:54:43",
+    "recorded-date": "26-11-2024, 09:37:55",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet8]": {
-    "recorded-date": "18-11-2024, 15:54:29",
+    "recorded-date": "26-11-2024, 09:36:12",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.3]": {
-    "recorded-date": "18-11-2024, 15:48:31",
+    "recorded-date": "26-11-2024, 09:29:26",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.3]": {
-    "recorded-date": "18-11-2024, 15:49:47",
+    "recorded-date": "26-11-2024, 09:31:52",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4507,7 +4507,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.3]": {
-    "recorded-date": "18-11-2024, 15:50:53",
+    "recorded-date": "26-11-2024, 09:34:14",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4569,7 +4569,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.3]": {
-    "recorded-date": "18-11-2024, 15:51:57",
+    "recorded-date": "26-11-2024, 09:35:08",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4622,15 +4622,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.3]": {
-    "recorded-date": "18-11-2024, 15:54:34",
+    "recorded-date": "26-11-2024, 09:35:53",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.13]": {
-    "recorded-date": "18-11-2024, 15:47:28",
+    "recorded-date": "26-11-2024, 09:28:06",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.13]": {
-    "recorded-date": "18-11-2024, 15:49:10",
+    "recorded-date": "26-11-2024, 09:31:18",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4773,7 +4773,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.13]": {
-    "recorded-date": "18-11-2024, 15:50:19",
+    "recorded-date": "26-11-2024, 09:33:40",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4836,7 +4836,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.13]": {
-    "recorded-date": "18-11-2024, 15:51:38",
+    "recorded-date": "26-11-2024, 09:35:13",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4889,7 +4889,269 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.13]": {
-    "recorded-date": "18-11-2024, 15:53:09",
+    "recorded-date": "26-11-2024, 09:35:58",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs22.x]": {
+    "recorded-date": "26-11-2024, 09:27:50",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs22.x]": {
+    "recorded-date": "26-11-2024, 09:31:08",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "TEST_KEY": "TEST_VAL"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "index.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "nodejs22.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "invocation_result_payload": {
+        "ctx": {
+          "aws_request_id": "<uuid:2>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_nodejs22.x",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "NODE_PATH": "/opt/nodejs/node22/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules:/var/runtime:/var/task",
+          "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "PWD": "/var/task",
+          "SHLVL": "0",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "index.handler",
+          "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
+        },
+        "packages": []
+      },
+      "invocation_result_payload_qualified": {
+        "ctx": {
+          "aws_request_id": "<uuid:3>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:$LATEST",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_nodejs22.x",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "NODE_PATH": "/opt/nodejs/node22/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules:/var/runtime:/var/task",
+          "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "PWD": "/var/task",
+          "SHLVL": "0",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "index.handler",
+          "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
+        },
+        "packages": []
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs22.x]": {
+    "recorded-date": "26-11-2024, 09:33:31",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "index.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "nodejs22.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "error_result": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorType": "Error",
+          "errorMessage": "Error: some_error_msg",
+          "trace": "<stack-trace>"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs22.x]": {
+    "recorded-date": "26-11-2024, 09:35:42",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "AWS_LAMBDA_EXEC_WRAPPER": "/var/task/environment_wrapper"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "index.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "nodejs22.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs22.x]": {
+    "recorded-date": "26-11-2024, 09:37:57",
     "recorded-content": {}
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_common.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_common.validation.json
@@ -1,275 +1,290 @@
 {
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet6]": {
-    "last_validated_date": "2024-11-18T15:54:42+00:00"
+    "last_validated_date": "2024-11-26T09:37:54+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet8]": {
-    "last_validated_date": "2024-11-18T15:54:28+00:00"
+    "last_validated_date": "2024-11-26T09:36:12+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java11]": {
-    "last_validated_date": "2024-11-18T15:52:29+00:00"
+    "last_validated_date": "2024-11-26T09:36:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java17]": {
-    "last_validated_date": "2024-11-18T15:53:26+00:00"
+    "last_validated_date": "2024-11-26T09:38:07+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java21]": {
-    "last_validated_date": "2024-11-18T15:52:54+00:00"
+    "last_validated_date": "2024-11-26T09:36:53+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java8.al2]": {
-    "last_validated_date": "2024-11-18T15:54:13+00:00"
+    "last_validated_date": "2024-11-26T09:37:40+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs16.x]": {
-    "last_validated_date": "2024-11-18T15:53:01+00:00"
+    "last_validated_date": "2024-11-26T09:36:43+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs18.x]": {
-    "last_validated_date": "2024-11-18T15:53:05+00:00"
+    "last_validated_date": "2024-11-26T09:37:42+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs20.x]": {
-    "last_validated_date": "2024-11-18T15:52:36+00:00"
+    "last_validated_date": "2024-11-26T09:38:09+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs22.x]": {
+    "last_validated_date": "2024-11-26T09:37:57+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.10]": {
-    "last_validated_date": "2024-11-18T15:53:30+00:00"
+    "last_validated_date": "2024-11-26T09:35:55+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.11]": {
-    "last_validated_date": "2024-11-18T15:52:04+00:00"
+    "last_validated_date": "2024-11-26T09:38:12+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.12]": {
-    "last_validated_date": "2024-11-18T15:52:57+00:00"
+    "last_validated_date": "2024-11-26T09:36:40+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.13]": {
-    "last_validated_date": "2024-11-18T15:53:09+00:00"
+    "last_validated_date": "2024-11-26T09:35:58+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.8]": {
-    "last_validated_date": "2024-11-18T15:52:32+00:00"
+    "last_validated_date": "2024-11-26T09:36:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.9]": {
-    "last_validated_date": "2024-11-18T15:52:07+00:00"
+    "last_validated_date": "2024-11-26T09:37:45+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.2]": {
-    "last_validated_date": "2024-11-18T15:54:18+00:00"
+    "last_validated_date": "2024-11-26T09:36:18+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.3]": {
-    "last_validated_date": "2024-11-18T15:54:33+00:00"
+    "last_validated_date": "2024-11-26T09:35:53+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet6]": {
-    "last_validated_date": "2024-11-18T15:48:36+00:00"
+    "last_validated_date": "2024-11-26T09:30:41+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet8]": {
-    "last_validated_date": "2024-11-18T15:48:41+00:00"
+    "last_validated_date": "2024-11-26T09:30:52+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java11]": {
-    "last_validated_date": "2024-11-18T15:48:14+00:00"
+    "last_validated_date": "2024-11-26T09:29:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java17]": {
-    "last_validated_date": "2024-11-18T15:48:04+00:00"
+    "last_validated_date": "2024-11-26T09:29:09+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java21]": {
-    "last_validated_date": "2024-11-18T15:47:59+00:00"
+    "last_validated_date": "2024-11-26T09:29:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8.al2]": {
-    "last_validated_date": "2024-11-18T15:48:20+00:00"
+    "last_validated_date": "2024-11-26T09:29:18+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs16.x]": {
-    "last_validated_date": "2024-11-18T15:47:23+00:00"
+    "last_validated_date": "2024-11-26T09:28:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs18.x]": {
-    "last_validated_date": "2024-11-18T15:47:17+00:00"
+    "last_validated_date": "2024-11-26T09:27:58+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs20.x]": {
-    "last_validated_date": "2024-11-18T15:47:12+00:00"
+    "last_validated_date": "2024-11-26T09:27:54+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs22.x]": {
+    "last_validated_date": "2024-11-26T09:27:50+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2023]": {
-    "last_validated_date": "2024-11-18T15:48:48+00:00"
+    "last_validated_date": "2024-11-26T09:30:57+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2]": {
-    "last_validated_date": "2024-11-18T15:48:57+00:00"
+    "last_validated_date": "2024-11-26T09:31:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.10]": {
-    "last_validated_date": "2024-11-18T15:47:43+00:00"
+    "last_validated_date": "2024-11-26T09:28:18+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.11]": {
-    "last_validated_date": "2024-11-18T15:47:38+00:00"
+    "last_validated_date": "2024-11-26T09:28:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.12]": {
-    "last_validated_date": "2024-11-18T15:47:33+00:00"
+    "last_validated_date": "2024-11-26T09:28:10+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.13]": {
-    "last_validated_date": "2024-11-18T15:47:28+00:00"
+    "last_validated_date": "2024-11-26T09:28:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.8]": {
-    "last_validated_date": "2024-11-18T15:47:53+00:00"
+    "last_validated_date": "2024-11-26T09:28:27+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.9]": {
-    "last_validated_date": "2024-11-18T15:47:48+00:00"
+    "last_validated_date": "2024-11-26T09:28:22+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.2]": {
-    "last_validated_date": "2024-11-18T15:48:25+00:00"
+    "last_validated_date": "2024-11-26T09:29:22+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.3]": {
-    "last_validated_date": "2024-11-18T15:48:31+00:00"
+    "last_validated_date": "2024-11-26T09:29:26+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet6]": {
-    "last_validated_date": "2024-11-18T15:49:50+00:00"
+    "last_validated_date": "2024-11-26T09:32:01+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet8]": {
-    "last_validated_date": "2024-11-18T15:49:54+00:00"
+    "last_validated_date": "2024-11-26T09:32:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java11]": {
-    "last_validated_date": "2024-11-18T15:49:36+00:00"
+    "last_validated_date": "2024-11-26T09:31:43+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java17]": {
-    "last_validated_date": "2024-11-18T15:49:32+00:00"
+    "last_validated_date": "2024-11-26T09:31:40+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java21]": {
-    "last_validated_date": "2024-11-18T15:49:29+00:00"
+    "last_validated_date": "2024-11-26T09:31:38+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8.al2]": {
-    "last_validated_date": "2024-11-18T15:49:40+00:00"
+    "last_validated_date": "2024-11-26T09:31:46+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs16.x]": {
-    "last_validated_date": "2024-11-18T15:49:06+00:00"
+    "last_validated_date": "2024-11-26T09:31:15+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs18.x]": {
-    "last_validated_date": "2024-11-18T15:49:03+00:00"
+    "last_validated_date": "2024-11-26T09:31:12+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs20.x]": {
-    "last_validated_date": "2024-11-18T15:49:00+00:00"
+    "last_validated_date": "2024-11-26T09:31:10+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs22.x]": {
+    "last_validated_date": "2024-11-26T09:31:08+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2023]": {
-    "last_validated_date": "2024-11-18T15:50:03+00:00"
+    "last_validated_date": "2024-11-26T09:33:24+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2]": {
-    "last_validated_date": "2024-11-18T15:50:07+00:00"
+    "last_validated_date": "2024-11-26T09:33:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.10]": {
-    "last_validated_date": "2024-11-18T15:49:19+00:00"
+    "last_validated_date": "2024-11-26T09:31:24+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.11]": {
-    "last_validated_date": "2024-11-18T15:49:16+00:00"
+    "last_validated_date": "2024-11-26T09:31:22+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.12]": {
-    "last_validated_date": "2024-11-18T15:49:13+00:00"
+    "last_validated_date": "2024-11-26T09:31:20+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.13]": {
-    "last_validated_date": "2024-11-18T15:49:10+00:00"
+    "last_validated_date": "2024-11-26T09:31:17+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.8]": {
-    "last_validated_date": "2024-11-18T15:49:25+00:00"
+    "last_validated_date": "2024-11-26T09:31:28+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.9]": {
-    "last_validated_date": "2024-11-18T15:49:22+00:00"
+    "last_validated_date": "2024-11-26T09:31:26+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.2]": {
-    "last_validated_date": "2024-11-18T15:49:44+00:00"
+    "last_validated_date": "2024-11-26T09:31:49+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.3]": {
-    "last_validated_date": "2024-11-18T15:49:47+00:00"
+    "last_validated_date": "2024-11-26T09:31:51+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet6]": {
-    "last_validated_date": "2024-11-18T15:52:00+00:00"
+    "last_validated_date": "2024-11-26T09:35:40+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet8]": {
-    "last_validated_date": "2024-11-18T15:51:54+00:00"
+    "last_validated_date": "2024-11-26T09:35:15+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java11]": {
-    "last_validated_date": "2024-11-18T15:51:16+00:00"
+    "last_validated_date": "2024-11-26T09:35:22+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java17]": {
-    "last_validated_date": "2024-11-18T15:51:41+00:00"
+    "last_validated_date": "2024-11-26T09:35:45+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java21]": {
-    "last_validated_date": "2024-11-18T15:51:26+00:00"
+    "last_validated_date": "2024-11-26T09:35:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java8.al2]": {
-    "last_validated_date": "2024-11-18T15:51:48+00:00"
+    "last_validated_date": "2024-11-26T09:35:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs16.x]": {
-    "last_validated_date": "2024-11-18T15:51:32+00:00"
+    "last_validated_date": "2024-11-26T09:35:27+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs18.x]": {
-    "last_validated_date": "2024-11-18T15:51:35+00:00"
+    "last_validated_date": "2024-11-26T09:35:35+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs20.x]": {
-    "last_validated_date": "2024-11-18T15:51:22+00:00"
+    "last_validated_date": "2024-11-26T09:35:47+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs22.x]": {
+    "last_validated_date": "2024-11-26T09:35:42+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.10]": {
-    "last_validated_date": "2024-11-18T15:51:44+00:00"
+    "last_validated_date": "2024-11-26T09:35:10+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.11]": {
-    "last_validated_date": "2024-11-18T15:51:10+00:00"
+    "last_validated_date": "2024-11-26T09:35:49+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.12]": {
-    "last_validated_date": "2024-11-18T15:51:29+00:00"
+    "last_validated_date": "2024-11-26T09:35:24+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.13]": {
-    "last_validated_date": "2024-11-18T15:51:38+00:00"
+    "last_validated_date": "2024-11-26T09:35:12+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.8]": {
-    "last_validated_date": "2024-11-18T15:51:19+00:00"
+    "last_validated_date": "2024-11-26T09:35:17+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.9]": {
-    "last_validated_date": "2024-11-18T15:51:13+00:00"
+    "last_validated_date": "2024-11-26T09:35:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.2]": {
-    "last_validated_date": "2024-11-18T15:51:51+00:00"
+    "last_validated_date": "2024-11-26T09:35:20+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.3]": {
-    "last_validated_date": "2024-11-18T15:51:57+00:00"
+    "last_validated_date": "2024-11-26T09:35:08+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet6]": {
-    "last_validated_date": "2024-11-18T15:50:56+00:00"
+    "last_validated_date": "2024-11-26T09:34:21+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet8]": {
-    "last_validated_date": "2024-11-18T15:50:59+00:00"
+    "last_validated_date": "2024-11-26T09:34:30+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java11]": {
-    "last_validated_date": "2024-11-18T15:50:43+00:00"
+    "last_validated_date": "2024-11-26T09:34:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java17]": {
-    "last_validated_date": "2024-11-18T15:50:39+00:00"
+    "last_validated_date": "2024-11-26T09:34:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java21]": {
-    "last_validated_date": "2024-11-18T15:50:36+00:00"
+    "last_validated_date": "2024-11-26T09:34:00+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8.al2]": {
-    "last_validated_date": "2024-11-18T15:50:47+00:00"
+    "last_validated_date": "2024-11-26T09:34:09+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs16.x]": {
-    "last_validated_date": "2024-11-18T15:50:16+00:00"
+    "last_validated_date": "2024-11-26T09:33:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs18.x]": {
-    "last_validated_date": "2024-11-18T15:50:13+00:00"
+    "last_validated_date": "2024-11-26T09:33:35+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs20.x]": {
-    "last_validated_date": "2024-11-18T15:50:10+00:00"
+    "last_validated_date": "2024-11-26T09:33:33+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs22.x]": {
+    "last_validated_date": "2024-11-26T09:33:31+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2023]": {
-    "last_validated_date": "2024-11-18T15:51:03+00:00"
+    "last_validated_date": "2024-11-26T09:35:00+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2]": {
-    "last_validated_date": "2024-11-18T15:51:07+00:00"
+    "last_validated_date": "2024-11-26T09:35:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.10]": {
-    "last_validated_date": "2024-11-18T15:50:27+00:00"
+    "last_validated_date": "2024-11-26T09:33:46+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.11]": {
-    "last_validated_date": "2024-11-18T15:50:24+00:00"
+    "last_validated_date": "2024-11-26T09:33:44+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.12]": {
-    "last_validated_date": "2024-11-18T15:50:22+00:00"
+    "last_validated_date": "2024-11-26T09:33:42+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.13]": {
-    "last_validated_date": "2024-11-18T15:50:19+00:00"
+    "last_validated_date": "2024-11-26T09:33:40+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.8]": {
-    "last_validated_date": "2024-11-18T15:50:33+00:00"
+    "last_validated_date": "2024-11-26T09:33:50+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.9]": {
-    "last_validated_date": "2024-11-18T15:50:30+00:00"
+    "last_validated_date": "2024-11-26T09:33:48+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.2]": {
-    "last_validated_date": "2024-11-18T15:50:50+00:00"
+    "last_validated_date": "2024-11-26T09:34:11+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.3]": {
-    "last_validated_date": "2024-11-18T15:50:53+00:00"
+    "last_validated_date": "2024-11-26T09:34:13+00:00"
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_runtimes.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_runtimes.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs20.x]": {
-    "recorded-date": "13-03-2024, 08:54:28",
+    "recorded-date": "26-11-2024, 09:42:35",
     "recorded-content": {
       "creation-result": {
         "CreateEventSourceMappingResponse": null,
@@ -66,7 +66,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs18.x]": {
-    "recorded-date": "13-03-2024, 08:54:34",
+    "recorded-date": "26-11-2024, 09:42:45",
     "recorded-content": {
       "creation-result": {
         "CreateEventSourceMappingResponse": null,
@@ -132,7 +132,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs16.x]": {
-    "recorded-date": "13-03-2024, 08:54:44",
+    "recorded-date": "26-11-2024, 09:42:54",
     "recorded-content": {
       "creation-result": {
         "CreateEventSourceMappingResponse": null,
@@ -198,7 +198,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_java_runtime_with_lib": {
-    "recorded-date": "13-03-2024, 08:55:00",
+    "recorded-date": "26-11-2024, 09:43:08",
     "recorded-content": {
       "create-result-jar-with-lib": {
         "CreateEventSourceMappingResponse": null,
@@ -377,7 +377,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java21]": {
-    "recorded-date": "13-03-2024, 08:55:03",
+    "recorded-date": "26-11-2024, 09:43:11",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -391,7 +391,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java17]": {
-    "recorded-date": "13-03-2024, 08:55:06",
+    "recorded-date": "26-11-2024, 09:43:14",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -405,7 +405,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java11]": {
-    "recorded-date": "13-03-2024, 08:55:10",
+    "recorded-date": "26-11-2024, 09:43:17",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -419,7 +419,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java8.al2]": {
-    "recorded-date": "13-03-2024, 08:55:13",
+    "recorded-date": "26-11-2024, 09:43:20",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -433,7 +433,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java21]": {
-    "recorded-date": "13-03-2024, 08:55:20",
+    "recorded-date": "26-11-2024, 09:43:37",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -500,7 +500,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java17]": {
-    "recorded-date": "13-03-2024, 08:55:25",
+    "recorded-date": "26-11-2024, 09:43:52",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -567,7 +567,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java11]": {
-    "recorded-date": "13-03-2024, 08:55:31",
+    "recorded-date": "26-11-2024, 09:44:07",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -634,7 +634,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java8.al2]": {
-    "recorded-date": "13-03-2024, 08:55:36",
+    "recorded-date": "26-11-2024, 09:44:22",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -701,7 +701,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom::handleRequestCustom-CUSTOM]": {
-    "recorded-date": "13-03-2024, 08:55:45",
+    "recorded-date": "26-11-2024, 09:44:29",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -764,7 +764,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom-INTERFACE]": {
-    "recorded-date": "13-03-2024, 08:55:54",
+    "recorded-date": "26-11-2024, 09:44:39",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -827,7 +827,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom::handleRequest-INTERFACE]": {
-    "recorded-date": "13-03-2024, 08:56:01",
+    "recorded-date": "26-11-2024, 09:44:50",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -890,7 +890,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_java_lambda_subscribe_sns_topic": {
-    "recorded-date": "13-03-2024, 08:56:26",
+    "recorded-date": "26-11-2024, 09:45:22",
     "recorded-content": {
       "get-function": {
         "Code": {
@@ -966,47 +966,47 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.12]": {
-    "recorded-date": "18-11-2024, 16:39:19",
+    "recorded-date": "26-11-2024, 09:45:27",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.11]": {
-    "recorded-date": "18-11-2024, 16:39:22",
+    "recorded-date": "26-11-2024, 09:45:30",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.10]": {
-    "recorded-date": "18-11-2024, 16:39:26",
+    "recorded-date": "26-11-2024, 09:45:32",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.9]": {
-    "recorded-date": "18-11-2024, 16:39:30",
+    "recorded-date": "26-11-2024, 09:45:35",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.8]": {
-    "recorded-date": "18-11-2024, 16:39:34",
+    "recorded-date": "26-11-2024, 09:45:38",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.12]": {
-    "recorded-date": "18-11-2024, 16:39:41",
+    "recorded-date": "26-11-2024, 09:45:42",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.11]": {
-    "recorded-date": "18-11-2024, 16:39:45",
+    "recorded-date": "26-11-2024, 09:45:45",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.10]": {
-    "recorded-date": "18-11-2024, 16:39:48",
+    "recorded-date": "26-11-2024, 09:45:47",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.9]": {
-    "recorded-date": "18-11-2024, 16:39:52",
+    "recorded-date": "26-11-2024, 09:45:49",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.8]": {
-    "recorded-date": "18-11-2024, 16:39:55",
+    "recorded-date": "26-11-2024, 09:45:51",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestGoProvidedRuntimes::test_uncaught_exception_invoke[provided.al2023]": {
-    "recorded-date": "14-03-2024, 17:15:53",
+    "recorded-date": "26-11-2024, 09:46:26",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1067,7 +1067,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestGoProvidedRuntimes::test_uncaught_exception_invoke[provided.al2]": {
-    "recorded-date": "14-03-2024, 17:15:56",
+    "recorded-date": "26-11-2024, 09:46:32",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1128,19 +1128,85 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestGoProvidedRuntimes::test_manual_endpoint_injection[provided.al2023]": {
-    "recorded-date": "14-03-2024, 17:19:05",
+    "recorded-date": "26-11-2024, 09:46:59",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestGoProvidedRuntimes::test_manual_endpoint_injection[provided.al2]": {
-    "recorded-date": "14-03-2024, 17:19:10",
+    "recorded-date": "26-11-2024, 09:47:11",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.13]": {
-    "recorded-date": "18-11-2024, 16:39:15",
+    "recorded-date": "26-11-2024, 09:45:25",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.13]": {
-    "recorded-date": "18-11-2024, 16:39:38",
+    "recorded-date": "26-11-2024, 09:45:40",
     "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs22.x]": {
+    "recorded-date": "26-11-2024, 09:42:29",
+    "recorded-content": {
+      "creation-result": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<<code-sha-256>:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "lambda_handler_es6.handler",
+          "LastModified": "date",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+          "Runtime": "nodejs22.x",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "invocation-result": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "statusCode": 200,
+          "body": "\"response from localstack lambda: {\\\"event_type\\\":\\\"test_lambda\\\"}\""
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_runtimes.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_runtimes.validation.json
@@ -1,98 +1,101 @@
 {
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestGoProvidedRuntimes::test_manual_endpoint_injection[provided.al2023]": {
-    "last_validated_date": "2024-03-14T17:19:04+00:00"
+    "last_validated_date": "2024-11-26T09:46:59+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestGoProvidedRuntimes::test_manual_endpoint_injection[provided.al2]": {
-    "last_validated_date": "2024-03-14T17:19:09+00:00"
+    "last_validated_date": "2024-11-26T09:47:11+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestGoProvidedRuntimes::test_uncaught_exception_invoke[provided.al2023]": {
-    "last_validated_date": "2024-03-14T17:15:53+00:00"
+    "last_validated_date": "2024-11-26T09:46:26+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestGoProvidedRuntimes::test_uncaught_exception_invoke[provided.al2]": {
-    "last_validated_date": "2024-03-14T17:15:56+00:00"
+    "last_validated_date": "2024-11-26T09:46:31+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom-INTERFACE]": {
-    "last_validated_date": "2024-03-13T08:55:53+00:00"
+    "last_validated_date": "2024-11-26T09:44:39+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom::handleRequest-INTERFACE]": {
-    "last_validated_date": "2024-03-13T08:56:01+00:00"
+    "last_validated_date": "2024-11-26T09:44:50+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom::handleRequestCustom-CUSTOM]": {
-    "last_validated_date": "2024-03-13T08:55:45+00:00"
+    "last_validated_date": "2024-11-26T09:44:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_java_lambda_subscribe_sns_topic": {
-    "last_validated_date": "2024-03-13T08:56:24+00:00"
+    "last_validated_date": "2024-11-26T09:45:21+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_java_runtime_with_lib": {
-    "last_validated_date": "2024-03-13T08:54:58+00:00"
+    "last_validated_date": "2024-11-26T09:43:07+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java11]": {
-    "last_validated_date": "2024-03-13T08:55:30+00:00"
+    "last_validated_date": "2024-11-26T09:44:07+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java17]": {
-    "last_validated_date": "2024-03-13T08:55:24+00:00"
+    "last_validated_date": "2024-11-26T09:43:52+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java21]": {
-    "last_validated_date": "2024-03-13T08:55:19+00:00"
+    "last_validated_date": "2024-11-26T09:43:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java8.al2]": {
-    "last_validated_date": "2024-03-13T08:55:36+00:00"
+    "last_validated_date": "2024-11-26T09:44:22+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java11]": {
-    "last_validated_date": "2024-03-13T08:55:09+00:00"
+    "last_validated_date": "2024-11-26T09:43:16+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java17]": {
-    "last_validated_date": "2024-03-13T08:55:05+00:00"
+    "last_validated_date": "2024-11-26T09:43:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java21]": {
-    "last_validated_date": "2024-03-13T08:55:03+00:00"
+    "last_validated_date": "2024-11-26T09:43:11+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java8.al2]": {
-    "last_validated_date": "2024-03-13T08:55:12+00:00"
+    "last_validated_date": "2024-11-26T09:43:19+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs16.x]": {
-    "last_validated_date": "2024-03-13T08:54:44+00:00"
+    "last_validated_date": "2024-11-26T09:42:54+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs18.x]": {
-    "last_validated_date": "2024-03-13T08:54:33+00:00"
+    "last_validated_date": "2024-11-26T09:42:44+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs20.x]": {
-    "last_validated_date": "2024-03-13T08:54:27+00:00"
+    "last_validated_date": "2024-11-26T09:42:35+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs22.x]": {
+    "last_validated_date": "2024-11-26T09:42:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.10]": {
-    "last_validated_date": "2024-11-18T16:39:25+00:00"
+    "last_validated_date": "2024-11-26T09:45:32+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.11]": {
-    "last_validated_date": "2024-11-18T16:39:21+00:00"
+    "last_validated_date": "2024-11-26T09:45:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.12]": {
-    "last_validated_date": "2024-11-18T16:39:18+00:00"
+    "last_validated_date": "2024-11-26T09:45:27+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.13]": {
-    "last_validated_date": "2024-11-18T16:39:14+00:00"
+    "last_validated_date": "2024-11-26T09:45:24+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.8]": {
-    "last_validated_date": "2024-11-18T16:39:33+00:00"
+    "last_validated_date": "2024-11-26T09:45:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.9]": {
-    "last_validated_date": "2024-11-18T16:39:29+00:00"
+    "last_validated_date": "2024-11-26T09:45:35+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.10]": {
-    "last_validated_date": "2024-11-18T16:39:47+00:00"
+    "last_validated_date": "2024-11-26T09:45:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.11]": {
-    "last_validated_date": "2024-11-18T16:39:44+00:00"
+    "last_validated_date": "2024-11-26T09:45:44+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.12]": {
-    "last_validated_date": "2024-11-18T16:39:40+00:00"
+    "last_validated_date": "2024-11-26T09:45:42+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.13]": {
-    "last_validated_date": "2024-11-18T16:39:37+00:00"
+    "last_validated_date": "2024-11-26T09:45:40+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.8]": {
-    "last_validated_date": "2024-11-18T16:39:54+00:00"
+    "last_validated_date": "2024-11-26T09:45:51+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.9]": {
-    "last_validated_date": "2024-11-18T16:39:51+00:00"
+    "last_validated_date": "2024-11-26T09:45:49+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
AWS recently added the nodejs22.x runtime: https://aws.amazon.com/blogs/compute/node-js-22-runtime-now-available-in-aws-lambda/

We want to support this inside LocalStack as well.

Fixes #11901


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Creation of nodejs22.x lambdas is now available
* Update snapshot tests to keep parity with AWS

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
