### PR TITLE
Extend patch decorator to add methods to class types

### DIFF
--- a/localstack-core/localstack/utils/patch.py
+++ b/localstack-core/localstack/utils/patch.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 import types
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Type
 
 
 def get_defining_object(method):
@@ -120,7 +120,7 @@ class Patch:
         return self
 
     @staticmethod
-    def extend_class(target: Callable, fn: Callable):
+    def extend_class(target: Type, fn: Callable):
         def _getattr(obj, name):
             if name != fn.__name__:
                 raise AttributeError(f"`{target.__name__}` object has no attribute `{name}`")

--- a/tests/unit/utils/test_patch.py
+++ b/tests/unit/utils/test_patch.py
@@ -206,11 +206,17 @@ def test_to_string():
 
 def test_patch_class_type():
     @patch(MyEchoer)
-    def new_echo(self, value):
-        return f"Message: {value}"
+    def new_echo(self, *args):
+        return args[1]
 
     echoer = MyEchoer()
-    assert echoer.new_echo("Hello world!") == "Message: Hello world!"
+    assert echoer.new_echo(1, 2, 3) == 2
     new_echo.patch.undo()
     with pytest.raises(AttributeError):
         echoer.new_echo("Hello world!")
+
+    with pytest.raises(AttributeError):
+
+        @patch(MyEchoer.new_echo)
+        def new_echo(self, *args):
+            pass

--- a/tests/unit/utils/test_patch.py
+++ b/tests/unit/utils/test_patch.py
@@ -202,3 +202,15 @@ def test_to_string():
     value = "Patch(function(tests.unit.utils.test_patch:MyEchoer.do_echo) -> function(tests.unit.utils.test_patch:test_to_string.<locals>.monkey), applied=True)"
     assert value in applied
     assert str(monkey.patch) == value
+
+
+def test_patch_class_type():
+    @patch(MyEchoer)
+    def new_echo(self, value):
+        return f"Message: {value}"
+
+    echoer = MyEchoer()
+    assert echoer.new_echo("Hello world!") == "Message: Hello world!"
+    new_echo.patch.undo()
+    with pytest.raises(AttributeError):
+        echoer.new_echo("Hello world!")

--- a/tests/unit/utils/test_patch.py
+++ b/tests/unit/utils/test_patch.py
@@ -215,6 +215,13 @@ def test_patch_class_type():
     with pytest.raises(AttributeError):
         echoer.new_echo("Hello world!")
 
+    @patch(MyEchoer)
+    def do_echo(self, arg):
+        return arg
+
+    echoer = MyEchoer()
+    assert echoer.do_echo(1) == "do_echo: 1", "existing method is overridden"
+
     with pytest.raises(AttributeError):
 
         @patch(MyEchoer.new_echo)

--- a/tests/unit/utils/test_patch.py
+++ b/tests/unit/utils/test_patch.py
@@ -202,6 +202,7 @@ def test_to_string():
     value = "Patch(function(tests.unit.utils.test_patch:MyEchoer.do_echo) -> function(tests.unit.utils.test_patch:test_to_string.<locals>.monkey), applied=True)"
     assert value in applied
     assert str(monkey.patch) == value
+    monkey.patch.undo()
 
 
 def test_patch_class_type():


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Our `patch` decorator easily allows us to patch a class method and extend its behavior.
However, it does not support the case where a given type does not implement a function and we want to add it.
Patch now would support the following use case:

```python
@patch(MyClass)
def new_method(self, *args):
    # some implementation
    ...

c = MyClass()
c.new_method()
```

If the class already implements a method with the given name, the patch won't have any effect.
Like our current implementation, a patch can be easily undone:

```python
new_method.patch.undo()
c.new_method() # raises AttributeError
```

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Extending `patch` to support the use case of adding a new function to a class type;
- Unit tests to verify the behavior of the new use case.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
