### PR TITLE
Add UsageMultiSetCounter (up for discussion)

### DIFF
--- a/tests/unit/utils/analytics/test_usage.py
+++ b/tests/unit/utils/analytics/test_usage.py
@@ -1,0 +1,21 @@
+from localstack.utils.analytics.usage import UsageMultiSetCounter
+
+
+def test_multi_set_counter():
+    my_feature_counter = UsageMultiSetCounter("pipes:invocation")
+    my_feature_counter.record("aws:sqs", "aws:lambda")
+    my_feature_counter.record("aws:sqs", "aws:lambda")
+    my_feature_counter.record("aws:sqs", "aws:stepfunctions")
+    my_feature_counter.record("aws:kinesis", "aws:lambda")
+    assert my_feature_counter.aggregate() == {
+        "pipes:invocation:aws:sqs": {
+            "aws:lambda": 2,
+            "aws:stepfunctions": 1,
+        },
+        "pipes:invocation:aws:kinesis": {"aws:lambda": 1},
+    }
+    assert my_feature_counter._counters["pipes:invocation:aws:sqs"].state == {
+        "aws:lambda": 2,
+        "aws:stepfunctions": 1,
+    }
+    assert my_feature_counter._counters["pipes:invocation:aws:kinesis"].state == {"aws:lambda": 1}


### PR DESCRIPTION
Extracted from https://github.com/localstack/localstack/pull/11883

## Motivation

Our current `UsageSetCounter` can record events of different categories (i.e., set), but cannot record multi-dimensional data (e.g., source, target). This PR contains a possible implementation for a two-dimensional multi-set counter.

We decided not to move forward with this approach until the data requirements are clearer (e.g., allow for generic analysis/materialization rather than feature-specific solutions that don't scale). Therefore, this PR is parked for now and up for discussion.

## Discussion

The flat record structure (`pipes:invocation:aws:sqs`) is not ideal and would be cumbersome to analyze. 
Something like this might be more suitable, but still not ideal if the namespace is feature-specific:

```json
{"outer_namespace": {"inner_namespace": {"key": "count"}}}
```

## Changes

* Add `UsageMultiSetCounter`
* Add unit test `test_multi_set_counter`
