### PR TITLE
Bug fix: Dynamodb update_table missing table entries in output

### DIFF
--- a/localstack-core/localstack/services/dynamodb/provider.py
+++ b/localstack-core/localstack/services/dynamodb/provider.py
@@ -851,6 +851,10 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
 
         SchemaExtractor.invalidate_table_schema(table_name, context.account_id, global_table_region)
 
+        schema = SchemaExtractor.get_table_schema(
+            table_name, context.account_id, global_table_region
+        )
+
         # TODO: DDB streams must also be created for replicas
         if update_table_input.get("StreamSpecification"):
             create_dynamodb_stream(
@@ -860,7 +864,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                 result["TableDescription"].get("LatestStreamLabel"),
             )
 
-        return result
+        return UpdateTableOutput(TableDescription=schema["Table"])
 
     def list_tables(
         self,

--- a/localstack-core/localstack/services/dynamodb/v2/provider.py
+++ b/localstack-core/localstack/services/dynamodb/v2/provider.py
@@ -614,7 +614,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         global_table_region = self.get_global_table_region(context, table_name)
 
         try:
-            result = self._forward_request(context=context, region=global_table_region)
+            self._forward_request(context=context, region=global_table_region)
         except CommonServiceException as exc:
             # DynamoDBLocal refuses to update certain table params and raises.
             # But we still need to update this info in LocalStack stores
@@ -689,7 +689,11 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
 
         SchemaExtractor.invalidate_table_schema(table_name, context.account_id, global_table_region)
 
-        return result
+        schema = SchemaExtractor.get_table_schema(
+            table_name, context.account_id, global_table_region
+        )
+
+        return UpdateTableOutput(TableDescription=schema["Table"])
 
     def list_tables(
         self,

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -4,7 +4,6 @@ import time
 from datetime import datetime
 from time import sleep
 from typing import Dict
-import sys
 
 import botocore.exceptions
 import pytest
@@ -1676,14 +1675,16 @@ class TestDynamoDB:
         )
 
         update_result = aws_client.dynamodb.update_table(
-            TableName=table_name,
-            BillingMode="PAY_PER_REQUEST"
+            TableName=table_name, BillingMode="PAY_PER_REQUEST"
         )
 
         assert update_result["TableDescription"]["SSEDescription"]
         assert update_result["TableDescription"]["SSEDescription"]["Status"] == "ENABLED"
-        assert update_result['TableDescription']['SSEDescription']['SSEType'] == 'KMS'
-        assert update_result["TableDescription"]["SSEDescription"]["KMSMasterKeyArn"] == kms_master_key_arn
+        assert update_result["TableDescription"]["SSEDescription"]["SSEType"] == "KMS"
+        assert (
+            update_result["TableDescription"]["SSEDescription"]["KMSMasterKeyArn"]
+            == kms_master_key_arn
+        )
 
     @markers.aws.validated
     def test_dynamodb_get_batch_items(

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -1685,10 +1685,7 @@ class TestDynamoDB:
         # Verify that SSEDescription exists and remains unchanged after update_table
         assert result["TableDescription"]["SSEDescription"]["Status"] == "ENABLED"
         assert result["TableDescription"]["SSEDescription"]["SSEType"] == "KMS"
-        assert (
-            result["TableDescription"]["SSEDescription"]["KMSMasterKeyArn"]
-            == kms_master_key_arn
-        )
+        assert result["TableDescription"]["SSEDescription"]["KMSMasterKeyArn"] == kms_master_key_arn
 
     @markers.aws.validated
     def test_dynamodb_get_batch_items(

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1417,5 +1417,44 @@
         ]
       }
     }
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_update_table_without_sse_specification_change": {
+    "recorded-date": "09-12-2024, 16:09:53",
+    "recorded-content": {
+      "SSEDescription": {
+        "KMSMasterKeyArn": "arn:<partition>:kms:<region>:111111111111:key/<uuid:1>",
+        "SSEType": "KMS",
+        "Status": "ENABLED"
+      },
+      "KMSDescription": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:<partition>:kms:<region>:111111111111:key/<uuid:1>",
+          "CreationDate": "datetime",
+          "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+          "Description": "Default key that protects my DynamoDB data when no other key is defined",
+          "Enabled": true,
+          "EncryptionAlgorithms": [
+            "SYMMETRIC_DEFAULT"
+          ],
+          "KeyId": "<uuid:1>",
+          "KeyManager": "AWS",
+          "KeySpec": "SYMMETRIC_DEFAULT",
+          "KeyState": "Enabled",
+          "KeyUsage": "ENCRYPT_DECRYPT",
+          "MultiRegion": false,
+          "Origin": "AWS_KMS"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-table-unchanged-sse-spec": {
+        "KMSMasterKeyArn": "arn:<partition>:kms:<region>:111111111111:key/<uuid:1>",
+        "SSEType": "KMS",
+        "Status": "ENABLED"
+      }
+    }
   }
 }

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -53,6 +53,9 @@
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_streams_describe_with_exclusive_start_shard_id": {
     "last_validated_date": "2023-10-22T20:27:28+00:00"
   },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_update_table_without_sse_specification_change": {
+    "last_validated_date": "2024-12-09T16:09:21+00:00"
+  },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_empty_and_binary_values": {
     "last_validated_date": "2023-08-23T14:32:29+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR resolves the issue: https://github.com/localstack/localstack/issues/11781
Description of issue: The output from the UpdateTable command does not include the SSEDescription for a table which was created with it.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Previous Behaviour
As described by the previous comment on line 781 of localstack-core\localstack\services\dynamodb\provider.py, **DynamoDBLocal cannot change certain table parameters**, including SSEDescription and replica.
As a result, the return value of update_table is a **table returned by DynamoDBLocal, which does not contain these parameters**.

## Changes
After DynamoDBLocal makes changes to the table, use get_table_schema to **retrieve the entire schema definition of the table, which includes the original and changed parameters.** 
Change return value such that the update_table function returns the schema obtained.


<!-- Optional section: How to test these changes? -->
## Testing
Create a dynamodb table:
`awslocal dynamodb create-table --table-name Example --attribute-definitions AttributeName=key,AttributeType=S  --key-schema AttributeName=key,KeyType=HASH  --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5  --sse-specification Enabled=true,SSEType=KMS,KMSMasterKeyId=some-kms`

Update the dynamodb table:
`awslocal dynamodb update-table --table-name Example --billing-mode PAY_PER_REQUEST`

Original code will not return the original SSEDescription. New changes will include both SSEDescription and the changed "Billing Mode" parameters.


<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
