### PR TITLE
Apigw fix openapi identity sources

### DIFF
--- a/tests/aws/files/openapi.cognito-auth.json
+++ b/tests/aws/files/openapi.cognito-auth.json
@@ -6,6 +6,75 @@
     "version": "1.0"
   },
   "paths": {
+    "/default-no-scope": {
+      "get": {
+        "security": [
+          {"cognito-test-identity-source": []}
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "responses": {
+            "default": {
+              "statusCode": "200"
+            }
+          },
+          "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "GET",
+          "type": "http"
+        }
+      }
+    },
+    "/default-scope-override": {
+      "get": {
+        "security": [
+          {"cognito-test-identity-source": ["openid"]}
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "responses": {
+            "default": {
+              "statusCode": "200"
+            }
+          },
+          "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "GET",
+          "type": "http"
+        }
+      }
+    },
+    "/non-default-authorizer": {
+      "get": {
+        "security": [
+          {"extra-test-identity-source": ["email", "openid"]}
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "responses": {
+            "default": {
+              "statusCode": "200"
+            }
+          },
+          "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "GET",
+          "type": "http"
+        }
+      }
+    },
     "/pets": {
       "get": {
         "operationId": "GET HTTP",
@@ -66,6 +135,18 @@
             "${cognito_pool_arn}"
           ]
         }
+      },
+      "extra-test-identity-source": {
+        "type": "apiKey",
+        "name": "TestHeaderAuth",
+        "in": "header",
+        "x-amazon-apigateway-authtype": "cognito_user_pools",
+        "x-amazon-apigateway-authorizer": {
+          "type": "cognito_user_pools",
+          "providerARNs": [
+            "${cognito_pool_arn}"
+          ]
+        }
       }
     },
     "schemas": {
@@ -93,5 +174,6 @@
         }
       }
     }
-  }
+  },
+  "security": [{"cognito-test-identity-source":  ["email"]}]
 }

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -4810,7 +4810,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_cognito_auth_identity_source": {
-    "recorded-date": "05-11-2024, 11:37:35",
+    "recorded-date": "26-11-2024, 21:33:17",
     "recorded-content": {
       "import-swagger": {
         "apiKeySource": "HEADER",
@@ -4824,29 +4824,354 @@
         },
         "id": "<rest-id:1>",
         "name": "Example Pet Store",
-        "rootResourceId": "<root-resource-id:1>",
+        "rootResourceId": "<resource-id:1>",
         "version": "1.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
         }
       },
-      "get-authorizers": {
+      "get-authorizers": [
+        {
+          "id": "<authorizer-id:1>",
+          "name": "cognito-test-identity-source",
+          "type": "COGNITO_USER_POOLS",
+          "providerARNs": [
+            "arn:<partition>:cognito-idp:<region>:111111111111:userpool/<region>_ABC123"
+          ],
+          "authType": "cognito_user_pools",
+          "identitySource": "method.request.header.TestHeaderAuth"
+        },
+        {
+          "id": "<authorizer-id:2>",
+          "name": "extra-test-identity-source",
+          "type": "COGNITO_USER_POOLS",
+          "providerARNs": [
+            "arn:<partition>:cognito-idp:<region>:111111111111:userpool/<region>_ABC123"
+          ],
+          "authType": "cognito_user_pools",
+          "identitySource": "method.request.header.TestHeaderAuth"
+        }
+      ],
+      "resources": {
         "items": [
           {
-            "authType": "cognito_user_pools",
-            "id": "<authorizer-id:1>",
-            "identitySource": "method.request.header.TestHeaderAuth",
-            "name": "cognito-test-identity-source",
-            "providerARNs": [
-              "arn:<partition>:cognito-idp:<region>:111111111111:userpool/<region>_ABC123"
-            ],
-            "type": "COGNITO_USER_POOLS"
+            "id": "<resource-id:1>",
+            "path": "/"
+          },
+          {
+            "id": "<resource-id:2>",
+            "parentId": "<resource-id:1>",
+            "path": "/default-no-scope",
+            "pathPart": "default-no-scope",
+            "resourceMethods": {
+              "GET": {}
+            }
+          },
+          {
+            "id": "<resource-id:3>",
+            "parentId": "<resource-id:1>",
+            "path": "/default-scope-override",
+            "pathPart": "default-scope-override",
+            "resourceMethods": {
+              "GET": {}
+            }
+          },
+          {
+            "id": "<resource-id:4>",
+            "parentId": "<resource-id:1>",
+            "path": "/non-default-authorizer",
+            "pathPart": "non-default-authorizer",
+            "resourceMethods": {
+              "GET": {}
+            }
+          },
+          {
+            "id": "<resource-id:5>",
+            "parentId": "<resource-id:1>",
+            "path": "/pets",
+            "pathPart": "pets",
+            "resourceMethods": {
+              "GET": {}
+            }
           }
         ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "method-default-no-scope-get": {
+        "apiKeyRequired": false,
+        "authorizationType": "COGNITO_USER_POOLS",
+        "authorizerId": "<authorizer-id:1>",
+        "httpMethod": "GET",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<resource-id:2>",
+          "connectionType": "INTERNET",
+          "httpMethod": "GET",
+          "integrationResponses": {
+            "200": {
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "timeoutInMillis": 29000,
+          "type": "HTTP",
+          "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets"
+        },
+        "methodResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-response-default-no-scope-get": {
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-default-no-scope-get": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<resource-id:2>",
+        "connectionType": "INTERNET",
+        "httpMethod": "GET",
+        "integrationResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "timeoutInMillis": 29000,
+        "type": "HTTP",
+        "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-response-default-no-scope-get": {
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-default-scope-override-get": {
+        "apiKeyRequired": false,
+        "authorizationScopes": [
+          "openid"
+        ],
+        "authorizationType": "COGNITO_USER_POOLS",
+        "authorizerId": "<authorizer-id:1>",
+        "httpMethod": "GET",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<resource-id:3>",
+          "connectionType": "INTERNET",
+          "httpMethod": "GET",
+          "integrationResponses": {
+            "200": {
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "timeoutInMillis": 29000,
+          "type": "HTTP",
+          "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets"
+        },
+        "methodResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-response-default-scope-override-get": {
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-default-scope-override-get": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<resource-id:3>",
+        "connectionType": "INTERNET",
+        "httpMethod": "GET",
+        "integrationResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "timeoutInMillis": 29000,
+        "type": "HTTP",
+        "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-response-default-scope-override-get": {
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-non-default-authorizer-get": {
+        "apiKeyRequired": false,
+        "authorizationScopes": [
+          "email",
+          "openid"
+        ],
+        "authorizationType": "COGNITO_USER_POOLS",
+        "authorizerId": "<authorizer-id:2>",
+        "httpMethod": "GET",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<resource-id:4>",
+          "connectionType": "INTERNET",
+          "httpMethod": "GET",
+          "integrationResponses": {
+            "200": {
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "timeoutInMillis": 29000,
+          "type": "HTTP",
+          "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets"
+        },
+        "methodResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-response-non-default-authorizer-get": {
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-non-default-authorizer-get": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<resource-id:4>",
+        "connectionType": "INTERNET",
+        "httpMethod": "GET",
+        "integrationResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "timeoutInMillis": 29000,
+        "type": "HTTP",
+        "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-response-non-default-authorizer-get": {
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-pets-get": {
+        "apiKeyRequired": false,
+        "authorizationScopes": [
+          "email"
+        ],
+        "authorizationType": "COGNITO_USER_POOLS",
+        "authorizerId": "<authorizer-id:1>",
+        "httpMethod": "GET",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<resource-id:5>",
+          "connectionType": "INTERNET",
+          "httpMethod": "GET",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "timeoutInMillis": 29000,
+          "type": "HTTP_PROXY",
+          "uri": "http://petstore.execute-api.us-west-1.amazonaws.com/petstore/pets"
+        },
+        "methodResponses": {
+          "200": {
+            "responseModels": {
+              "application/json": "Pets"
+            },
+            "responseParameters": {
+              "method.response.header.Access-Control-Allow-Origin": false
+            },
+            "statusCode": "200"
+          }
+        },
+        "operationName": "GET HTTP",
+        "requestParameters": {
+          "method.request.querystring.page": false,
+          "method.request.querystring.type": false
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-response-pets-get": {
+        "responseModels": {
+          "application/json": "Pets"
+        },
+        "responseParameters": {
+          "method.response.header.Access-Control-Allow-Origin": false
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-pets-get": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<resource-id:5>",
+        "connectionType": "INTERNET",
+        "httpMethod": "GET",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "timeoutInMillis": 29000,
+        "type": "HTTP_PROXY",
+        "uri": "http://petstore.execute-api.us-west-1.amazonaws.com/petstore/pets",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-response-pets-get": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Response status code specified"
+        },
+        "message": "Invalid Response status code specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
         }
       }
     }

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -36,7 +36,7 @@
     "last_validated_date": "2024-04-15T21:37:44+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_cognito_auth_identity_source": {
-    "last_validated_date": "2024-11-05T11:37:34+00:00"
+    "last_validated_date": "2024-11-26T21:33:17+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_global_api_key_authorizer": {
     "last_validated_date": "2024-04-15T21:36:29+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Our current implementation of the OpenApi import did not add authorization scopes when creating a method with an authorizer. This was not an issue with Legacy apigw, as we did not handle the scopes properly.

Authorization scopes can be added to Cognito authorizers. They directly impact whether the api accepts an Identity token or an Access Token see [docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-integrate-with-cognito.html). As Next Gen provider does enforce this, providing a greater compatibility with aws, user's configs would fail to authorize a request when an Access token is used to authenticate.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Get the scopes from the default authorizer or the method if specified
- Added tests

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
