### PR TITLE
fix flaky SES test

### DIFF
--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -270,7 +270,7 @@ class TestSES:
 
         sender_email, recipient_email = setup_email_addresses()
         send_quota = aws_client.ses.get_send_quota()
-        snapshot.match("get-quota-0", send_quota)
+        # snapshot.match("get-quota-0", send_quota)
         counter = send_quota["SentLast24Hours"]
 
         aws_client.ses.send_email(

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -260,6 +260,9 @@ class TestSES:
         self, create_template, aws_client, snapshot, setup_email_addresses
     ):
         # Ensure all email send operations correctly update the `sent` email counter
+        snapshot.add_transformer(
+            snapshot.transform.key_value("SentLast24Hours", reference_replacement=False),
+        )
 
         def _assert_sent_quota(expected_counter: int) -> dict:
             _send_quota = aws_client.ses.get_send_quota()
@@ -270,7 +273,7 @@ class TestSES:
 
         sender_email, recipient_email = setup_email_addresses()
         send_quota = aws_client.ses.get_send_quota()
-        # snapshot.match("get-quota-0", send_quota)
+        snapshot.match("get-quota-0", send_quota)
         counter = send_quota["SentLast24Hours"]
 
         aws_client.ses.send_email(

--- a/tests/aws/services/ses/test_ses.snapshot.json
+++ b/tests/aws/services/ses/test_ses.snapshot.json
@@ -903,12 +903,12 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_sent_message_counter": {
-    "recorded-date": "25-08-2023, 23:40:26",
+    "recorded-date": "27-11-2024, 13:03:32",
     "recorded-content": {
       "get-quota-0": {
         "Max24HourSend": 200.0,
         "MaxSendRate": 1.0,
-        "SentLast24Hours": 0.0,
+        "SentLast24Hours": "sent-last24-hours",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/ses/test_ses.validation.json
+++ b/tests/aws/services/ses/test_ses.validation.json
@@ -51,7 +51,7 @@
     "last_validated_date": "2023-08-25T22:02:43+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_sent_message_counter": {
-    "last_validated_date": "2023-08-25T21:40:26+00:00"
+    "last_validated_date": "2024-11-27T13:03:32+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_ses_sns_topic_integration_send_email": {
     "last_validated_date": "2023-08-25T21:53:37+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following #11930, we were sending SES emails via SNS, and it incremented the counter. However, we were snapshotting the initial value to `0.0`, which is then sensitive to test run orders and such. 

The test needs fixing in AWS, but I've manually run the update snapshot with only the initial part of the test to still validate the proper format of `GetSendQuota` from AWS. 

The behavior of the test is still correctly validated via asserts (not working in AWS, probably because of sandbox account).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- transform the initial value of the usage counter to avoid sensitivity to test order

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
