### PR TITLE
analytics for non-prefixed env var forwarding in CLI

### DIFF
--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -513,6 +513,7 @@ class ContainerConfigurators:
         if config.LOADED_PROFILES:
             load_environment(profiles=",".join(config.LOADED_PROFILES), env=profile_env)
 
+        non_prefixed_env_vars = []
         for env_var in config.CONFIG_ENV_VARS:
             value = os.environ.get(env_var, None)
             if value is not None:
@@ -521,16 +522,28 @@ class ContainerConfigurators:
                     and not env_var.startswith("LOCALSTACK_")
                     and env_var not in profile_env
                 ):
-                    # Show a warning here in case we are directly forwarding an environment variable from
-                    # the system env to the container which has not been prefixed with LOCALSTACK_.
-                    # Suppress the warning for the "CI" env var.
-                    # Suppress the warning if the env var was set from the profile.
-                    LOG.warning(
-                        "Non-prefixed environment variable %(env_var)s is forwarded to the LocalStack container! "
-                        "Please use `LOCALSTACK_%(env_var)s` instead of %(env_var)s to explicitly mark this environment variable to be forwarded form the CLI to the LocalStack Runtime.",
-                        {"env_var": env_var},
-                    )
+                    # Collect all env vars that are directly forwarded from the system env
+                    # to the container which has not been prefixed with LOCALSTACK_ here.
+                    # Suppress the "CI" env var.
+                    # Suppress if the env var was set from the profile.
+                    non_prefixed_env_vars.append(env_var)
                 cfg.env_vars[env_var] = value
+
+        # collectively log deprecation warnings for non-prefixed sys env vars
+        if non_prefixed_env_vars:
+            from localstack.utils.analytics import log
+
+            for non_prefixed_env_var in non_prefixed_env_vars:
+                # Show a deprecation warning for each individual env var collected above
+                LOG.warning(
+                    "Non-prefixed environment variable %(env_var)s is forwarded to the LocalStack container! "
+                    "Please use `LOCALSTACK_%(env_var)s` instead of %(env_var)s to explicitly mark this environment variable to be forwarded form the CLI to the LocalStack Runtime.",
+                    {"env_var": non_prefixed_env_var},
+                )
+
+            log.event(
+                event="non_prefixed_cli_env_vars", payload={"env_vars": non_prefixed_env_vars}
+            )
 
     @staticmethod
     def random_gateway_port(cfg: ContainerConfiguration):

--- a/tests/bootstrap/test_container_configurators.py
+++ b/tests/bootstrap/test_container_configurators.py
@@ -191,7 +191,7 @@ def test_container_configurator_no_deprecation_warning_on_prefix(
     assert "LOCALSTACK_SERVICES" in container.config.env_vars
 
 
-def test_container_configurator_no_deprecation_warning_for_CI_env_var(
+def test_container_configurator_no_deprecation_warning_for_ci_env_var(
     container_factory, monkeypatch, caplog
 ):
     # set the "CI" env var indicating that we are running in a CI environment


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/11810 we deprecated the forwarding of not-explicitly-prefixed environment variables from the system environment to the runtime environment.
However, this is definitely a change which will take quite a while to reach all our users.
In order to get an idea where we are, this PR adds a simple analytics log which tracks the environment variables (only those marked as "known" by the CLI and only the name and not the content) which are affected by this deprecation.

## Changes
- Add a simple analytics log message to the deprecation check to help us gain knowledge on the adoption of env var prefix.