### PR TITLE
Handle null value in SES OpenAPI spec

### DIFF
--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -158,7 +158,7 @@ components:
           additionalProperties: false
           properties:
             html_part:
-              type: string
+              type: [string, 'null']
             text_part:
               type: string
           required:

--- a/localstack-core/localstack/services/ses/models.py
+++ b/localstack-core/localstack/services/ses/models.py
@@ -4,7 +4,7 @@ from localstack.aws.api.ses import Address, Destination, Subject, TemplateData, 
 
 
 class SentEmailBody(TypedDict):
-    html_part: str
+    html_part: str | None
     text_part: str
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes a minor gap in our SES OpenAPI specs.
In particular, the `htlm_part` property in the response to `GET /_aws/ses` can be `null`. 
This issue was detected by @HarshCasper when using the SDK generated from the spec (as the generated Pydantic model does not expect a null value).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Change `html_part` to nullable in the specs.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
