### PR TITLE
StepFunctions: Fix ErrorName Value for Lambda Task Errors

### DIFF
--- a/tests/aws/services/stepfunctions/templates/errorhandling/error_handling_templates.py
+++ b/tests/aws/services/stepfunctions/templates/errorhandling/error_handling_templates.py
@@ -28,6 +28,10 @@ class ErrorHandlingTemplate(TemplateLoader):
         _THIS_FOLDER, "statemachines/task_lambda_invoke_catch_unknown.json5"
     )
 
+    AWS_LAMBDA_INVOKE_CATCH_TBD: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/task_lambda_invoke_catch_tbd.json5"
+    )
+
     AWS_LAMBDA_INVOKE_CATCH_RELEVANT: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/task_lambda_invoke_catch_relevant.json5"
     )
@@ -56,6 +60,10 @@ class ErrorHandlingTemplate(TemplateLoader):
         _THIS_FOLDER, "statemachines/task_service_lambda_invoke_catch_relevant.json5"
     )
 
+    AWS_SERVICE_LAMBDA_INVOKE_CATCH_TBD: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/task_service_lambda_invoke_catch_tbd.json5"
+    )
+
     AWS_SERVICE_SQS_SEND_MSG_CATCH: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/task_service_sqs_send_msg_catch.json5"
     )
@@ -70,4 +78,7 @@ class ErrorHandlingTemplate(TemplateLoader):
     )
     LAMBDA_FUNC_RAISE_EXCEPTION: Final[str] = os.path.join(
         _THIS_FOLDER, "lambdafunctions/raise_exception.py"
+    )
+    LAMBDA_FUNC_RAISE_CUSTOM_EXCEPTION: Final[str] = os.path.join(
+        _THIS_FOLDER, "lambdafunctions/raise_custom_exception.py"
     )

--- a/tests/aws/services/stepfunctions/templates/errorhandling/lambdafunctions/raise_custom_exception.py
+++ b/tests/aws/services/stepfunctions/templates/errorhandling/lambdafunctions/raise_custom_exception.py
@@ -1,0 +1,9 @@
+class CustomException(Exception):
+    message: str
+
+    def __init__(self):
+        self.message = "CustomException message"
+
+
+def handler(event, context):
+    raise CustomException()

--- a/tests/aws/services/stepfunctions/templates/errorhandling/statemachines/task_lambda_invoke_catch_tbd.json5
+++ b/tests/aws/services/stepfunctions/templates/errorhandling/statemachines/task_lambda_invoke_catch_tbd.json5
@@ -1,0 +1,24 @@
+{
+  "StartAt": "InvokeLambda",
+  "States": {
+    "InvokeLambda": {
+      "Type": "Task",
+      "Resource": "_tbd_",
+      "Next": "ProcessResult",
+      "Catch": [
+        {
+          "ErrorEquals": [],
+          "Next": "ErrorMatched"
+        }
+      ]
+    },
+    "ProcessResult": {
+      "Type": "Pass",
+      "End": true
+    },
+    "ErrorMatched": {
+      "Type": "Pass",
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/errorhandling/statemachines/task_service_lambda_invoke_catch_tbd.json5
+++ b/tests/aws/services/stepfunctions/templates/errorhandling/statemachines/task_service_lambda_invoke_catch_tbd.json5
@@ -1,0 +1,28 @@
+{
+  "StartAt": "InvokeLambda",
+  "States": {
+    "InvokeLambda": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName.$": "$.FunctionName",
+        "Payload.$": "$.Payload",
+      },
+      "Next": "ProcessResult",
+      "Catch": [
+        {
+          "ErrorEquals": [],
+          "Next": "ErrorMatched"
+        }
+      ]
+    },
+    "ProcessResult": {
+      "Type": "Pass",
+      "End": true
+    },
+    "ErrorMatched": {
+      "Type": "Pass",
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py
@@ -2,6 +2,7 @@ import json
 
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
+from localstack.aws.api.lambda_ import Runtime
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.stepfunctions.utils import (
     create_and_record_execution,
@@ -12,13 +13,7 @@ from tests.aws.services.stepfunctions.templates.errorhandling.error_handling_tem
 )
 
 
-@markers.snapshot.skip_snapshot_verify(
-    paths=[
-        "$..tracingConfiguration",
-        "$..cause",
-        "$..Cause",
-    ]
-)
+@markers.snapshot.skip_snapshot_verify(paths=["$..Cause"])
 class TestTaskLambda:
     @markers.aws.validated
     def test_raise_exception(
@@ -33,7 +28,7 @@ class TestTaskLambda:
         create_res = create_lambda_function(
             func_name=function_name,
             handler_file=EHT.LAMBDA_FUNC_RAISE_EXCEPTION,
-            runtime="python3.9",
+            runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "<lambda_function_name>"))
 
@@ -41,6 +36,40 @@ class TestTaskLambda:
         template["States"]["Start"]["Resource"] = create_res["CreateFunctionResponse"][
             "FunctionArn"
         ]
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"FunctionName": function_name, "Payload": None})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
+    def test_raise_custom_exception(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        create_lambda_function,
+        sfn_snapshot,
+    ):
+        function_name = f"lambda_func_{short_uid()}"
+        create_res = create_lambda_function(
+            func_name=function_name,
+            handler_file=EHT.LAMBDA_FUNC_RAISE_CUSTOM_EXCEPTION,
+            runtime=Runtime.python3_12,
+        )
+        sfn_snapshot.add_transformer(RegexTransformer(function_name, "<lambda_function_name>"))
+
+        template = EHT.load_sfn_template(EHT.AWS_LAMBDA_INVOKE_CATCH_TBD)
+        template["States"]["InvokeLambda"]["Resource"] = create_res["CreateFunctionResponse"][
+            "FunctionArn"
+        ]
+        template["States"]["InvokeLambda"]["Catch"][0]["ErrorEquals"].append("CustomException")
         definition = json.dumps(template)
 
         exec_input = json.dumps({"FunctionName": function_name, "Payload": None})
@@ -66,7 +95,7 @@ class TestTaskLambda:
         create_res = create_lambda_function(
             func_name=function_name,
             handler_file=EHT.LAMBDA_FUNC_RAISE_EXCEPTION,
-            runtime="python3.9",
+            runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "<lambda_function_name>"))
 
@@ -99,7 +128,7 @@ class TestTaskLambda:
         create_res = create_lambda_function(
             func_name=function_name,
             handler_file=EHT.LAMBDA_FUNC_RAISE_EXCEPTION,
-            runtime="python3.9",
+            runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "<lambda_function_name>"))
 
@@ -132,7 +161,7 @@ class TestTaskLambda:
         create_res = create_lambda_function(
             func_name=function_name,
             handler_file=EHT.LAMBDA_FUNC_RAISE_EXCEPTION,
-            runtime="python3.9",
+            runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "<lambda_function_name>"))
 

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py::TestTaskLambda::test_raise_exception": {
-    "recorded-date": "22-06-2023, 13:27:25",
+    "recorded-date": "28-11-2024, 12:40:57",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -100,8 +100,155 @@
       }
     }
   },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py::TestTaskLambda::test_raise_custom_exception": {
+    "recorded-date": "28-11-2024, 12:41:13",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionName": "<lambda_function_name>",
+                "Payload": null
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionName": "<lambda_function_name>",
+                "Payload": null
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "InvokeLambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "lambdaFunctionScheduledEventDetails": {
+              "input": {
+                "FunctionName": "<lambda_function_name>",
+                "Payload": null
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "resource": "arn:<partition>:lambda:<region>:111111111111:function:<lambda_function_name>"
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "LambdaFunctionScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "LambdaFunctionStarted"
+          },
+          {
+            "id": 5,
+            "lambdaFunctionFailedEventDetails": {
+              "cause": {
+                "errorMessage": "",
+                "errorType": "CustomException",
+                "requestId": "<uuid:1>",
+                "stackTrace": [
+                  "  File \"/var/task/handler.py\", line 9, in handler\n    raise CustomException()\n"
+                ]
+              },
+              "error": "CustomException"
+            },
+            "previousEventId": 4,
+            "timestamp": "timestamp",
+            "type": "LambdaFunctionFailed"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "InvokeLambda",
+              "output": {
+                "Error": "CustomException",
+                "Cause": "{\"errorMessage\": \"\", \"errorType\": \"CustomException\", \"requestId\": \"<uuid:1>\", \"stackTrace\": [\"  File \\\"/var/task/handler.py\\\", line 9, in handler\\n    raise CustomException()\\n\"]}"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Error": "CustomException",
+                "Cause": "{\"errorMessage\": \"\", \"errorType\": \"CustomException\", \"requestId\": \"<uuid:1>\", \"stackTrace\": [\"  File \\\"/var/task/handler.py\\\", line 9, in handler\\n    raise CustomException()\\n\"]}"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "ErrorMatched"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateExitedEventDetails": {
+              "name": "ErrorMatched",
+              "output": {
+                "Error": "CustomException",
+                "Cause": "{\"errorMessage\": \"\", \"errorType\": \"CustomException\", \"requestId\": \"<uuid:1>\", \"stackTrace\": [\"  File \\\"/var/task/handler.py\\\", line 9, in handler\\n    raise CustomException()\\n\"]}"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "Error": "CustomException",
+                "Cause": "{\"errorMessage\": \"\", \"errorType\": \"CustomException\", \"requestId\": \"<uuid:1>\", \"stackTrace\": [\"  File \\\"/var/task/handler.py\\\", line 9, in handler\\n    raise CustomException()\\n\"]}"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 9,
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py::TestTaskLambda::test_raise_exception_catch": {
-    "recorded-date": "22-06-2023, 13:27:43",
+    "recorded-date": "28-11-2024, 12:41:30",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -256,7 +403,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py::TestTaskLambda::test_no_such_function": {
-    "recorded-date": "22-06-2023, 13:28:01",
+    "recorded-date": "28-11-2024, 12:41:47",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -357,7 +504,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py::TestTaskLambda::test_no_such_function_catch": {
-    "recorded-date": "22-06-2023, 13:28:19",
+    "recorded-date": "28-11-2024, 12:42:04",
     "recorded-content": {
       "get_execution_history": {
         "events": [

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.validation.json
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.validation.json
@@ -1,14 +1,17 @@
 {
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py::TestTaskLambda::test_no_such_function": {
-    "last_validated_date": "2023-06-22T11:28:01+00:00"
+    "last_validated_date": "2024-11-28T12:41:47+00:00"
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py::TestTaskLambda::test_no_such_function_catch": {
-    "last_validated_date": "2023-06-22T11:28:19+00:00"
+    "last_validated_date": "2024-11-28T12:42:04+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py::TestTaskLambda::test_raise_custom_exception": {
+    "last_validated_date": "2024-11-28T12:41:13+00:00"
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py::TestTaskLambda::test_raise_exception": {
-    "last_validated_date": "2023-06-22T11:27:25+00:00"
+    "last_validated_date": "2024-11-28T12:40:57+00:00"
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py::TestTaskLambda::test_raise_exception_catch": {
-    "last_validated_date": "2023-06-22T11:27:43+00:00"
+    "last_validated_date": "2024-11-28T12:41:30+00:00"
   }
 }

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py
@@ -17,7 +17,6 @@ from tests.aws.services.stepfunctions.templates.timeouts.timeout_templates impor
 )
 
 
-@markers.snapshot.skip_snapshot_verify(paths=["$..tracingConfiguration"])
 class TestTaskServiceLambda:
     @markers.aws.validated
     def test_raise_exception(
@@ -32,11 +31,42 @@ class TestTaskServiceLambda:
         create_lambda_function(
             func_name=function_name,
             handler_file=EHT.LAMBDA_FUNC_RAISE_EXCEPTION,
-            runtime="python3.9",
+            runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "<lambda_function_name>"))
 
         template = EHT.load_sfn_template(EHT.AWS_SERVICE_LAMBDA_INVOKE_CATCH_UNKNOWN)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"FunctionName": function_name, "Payload": None})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
+    def test_raise_custom_exception(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        create_lambda_function,
+        sfn_snapshot,
+    ):
+        function_name = f"lambda_func_{short_uid()}"
+        create_lambda_function(
+            func_name=function_name,
+            handler_file=EHT.LAMBDA_FUNC_RAISE_CUSTOM_EXCEPTION,
+            runtime=Runtime.python3_12,
+        )
+        sfn_snapshot.add_transformer(RegexTransformer(function_name, "<lambda_function_name>"))
+
+        template = EHT.load_sfn_template(EHT.AWS_SERVICE_LAMBDA_INVOKE_CATCH_TBD)
+        template["States"]["InvokeLambda"]["Catch"][0]["ErrorEquals"].append("CustomException")
         definition = json.dumps(template)
 
         exec_input = json.dumps({"FunctionName": function_name, "Payload": None})
@@ -62,7 +92,7 @@ class TestTaskServiceLambda:
         create_lambda_function(
             func_name=function_name,
             handler_file=EHT.LAMBDA_FUNC_RAISE_EXCEPTION,
-            runtime="python3.9",
+            runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "<lambda_function_name>"))
 
@@ -127,7 +157,7 @@ class TestTaskServiceLambda:
         create_lambda_function(
             func_name=function_name,
             handler_file=EHT.LAMBDA_FUNC_RAISE_EXCEPTION,
-            runtime="python3.9",
+            runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "<lambda_function_name>"))
 
@@ -157,7 +187,7 @@ class TestTaskServiceLambda:
         create_lambda_function(
             func_name=function_name,
             handler_file=EHT.LAMBDA_FUNC_RAISE_EXCEPTION,
-            runtime="python3.9",
+            runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "<lambda_function_name>"))
 
@@ -187,7 +217,7 @@ class TestTaskServiceLambda:
         create_lambda_function(
             func_name=function_name,
             handler_file=TT.LAMBDA_WAIT_60_SECONDS,
-            runtime="python3.9",
+            runtime=Runtime.python3_12,
         )
         sfn_snapshot.add_transformer(RegexTransformer(function_name, "<lambda_function_1_name>"))
 

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception": {
-    "recorded-date": "22-06-2023, 13:29:17",
+    "recorded-date": "28-11-2024, 13:03:36",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -105,15 +105,15 @@
       }
     }
   },
-  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_no_such_function": {
-    "recorded-date": "22-06-2023, 13:29:54",
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_custom_exception": {
+    "recorded-date": "28-11-2024, 13:03:53",
     "recorded-content": {
       "get_execution_history": {
         "events": [
           {
             "executionStartedEventDetails": {
               "input": {
-                "FunctionName": "no_such_<lambda_function_name>",
+                "FunctionName": "<lambda_function_name>",
                 "Payload": null
               },
               "inputDetails": {
@@ -131,13 +131,13 @@
             "previousEventId": 0,
             "stateEnteredEventDetails": {
               "input": {
-                "FunctionName": "no_such_<lambda_function_name>",
+                "FunctionName": "<lambda_function_name>",
                 "Payload": null
               },
               "inputDetails": {
                 "truncated": false
               },
-              "name": "Start"
+              "name": "InvokeLambda"
             },
             "timestamp": "timestamp",
             "type": "TaskStateEntered"
@@ -147,7 +147,7 @@
             "previousEventId": 2,
             "taskScheduledEventDetails": {
               "parameters": {
-                "FunctionName": "no_such_<lambda_function_name>",
+                "FunctionName": "<lambda_function_name>",
                 "Payload": null
               },
               "region": "<region>",
@@ -171,8 +171,15 @@
             "id": 5,
             "previousEventId": 4,
             "taskFailedEventDetails": {
-              "cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)",
-              "error": "Lambda.ResourceNotFoundException",
+              "cause": {
+                "errorMessage": "",
+                "errorType": "CustomException",
+                "requestId": "<uuid:1>",
+                "stackTrace": [
+                  "  File \"/var/task/handler.py\", line 9, in handler\n    raise CustomException()\n"
+                ]
+              },
+              "error": "CustomException",
               "resource": "invoke",
               "resourceType": "lambda"
             },
@@ -180,14 +187,67 @@
             "type": "TaskFailed"
           },
           {
-            "executionFailedEventDetails": {
-              "cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)",
-              "error": "Lambda.ResourceNotFoundException"
-            },
             "id": 6,
             "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "InvokeLambda",
+              "output": {
+                "Error": "CustomException",
+                "Cause": "{\"errorMessage\":\"\",\"errorType\":\"CustomException\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 9, in handler\\n    raise CustomException()\\n\"]}"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
             "timestamp": "timestamp",
-            "type": "ExecutionFailed"
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Error": "CustomException",
+                "Cause": "{\"errorMessage\":\"\",\"errorType\":\"CustomException\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 9, in handler\\n    raise CustomException()\\n\"]}"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "ErrorMatched"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateExitedEventDetails": {
+              "name": "ErrorMatched",
+              "output": {
+                "Error": "CustomException",
+                "Cause": "{\"errorMessage\":\"\",\"errorType\":\"CustomException\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 9, in handler\\n    raise CustomException()\\n\"]}"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "Error": "CustomException",
+                "Cause": "{\"errorMessage\":\"\",\"errorType\":\"CustomException\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 9, in handler\\n    raise CustomException()\\n\"]}"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 9,
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
           }
         ],
         "ResponseMetadata": {
@@ -198,7 +258,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch": {
-    "recorded-date": "22-06-2023, 13:29:36",
+    "recorded-date": "28-11-2024, 13:04:09",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -357,314 +417,8 @@
       }
     }
   },
-  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_no_such_function_catch": {
-    "recorded-date": "22-06-2023, 13:30:13",
-    "recorded-content": {
-      "get_execution_history": {
-        "events": [
-          {
-            "executionStartedEventDetails": {
-              "input": {
-                "FunctionName": "no_such_<lambda_function_name>",
-                "Payload": null
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "roleArn": "snf_role_arn"
-            },
-            "id": 1,
-            "previousEventId": 0,
-            "timestamp": "timestamp",
-            "type": "ExecutionStarted"
-          },
-          {
-            "id": 2,
-            "previousEventId": 0,
-            "stateEnteredEventDetails": {
-              "input": {
-                "FunctionName": "no_such_<lambda_function_name>",
-                "Payload": null
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "Start"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskStateEntered"
-          },
-          {
-            "id": 3,
-            "previousEventId": 2,
-            "taskScheduledEventDetails": {
-              "parameters": {
-                "FunctionName": "no_such_<lambda_function_name>",
-                "Payload": null
-              },
-              "region": "<region>",
-              "resource": "invoke",
-              "resourceType": "lambda"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskScheduled"
-          },
-          {
-            "id": 4,
-            "previousEventId": 3,
-            "taskStartedEventDetails": {
-              "resource": "invoke",
-              "resourceType": "lambda"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskStarted"
-          },
-          {
-            "id": 5,
-            "previousEventId": 4,
-            "taskFailedEventDetails": {
-              "cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)",
-              "error": "Lambda.ResourceNotFoundException",
-              "resource": "invoke",
-              "resourceType": "lambda"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskFailed"
-          },
-          {
-            "id": 6,
-            "previousEventId": 5,
-            "stateExitedEventDetails": {
-              "name": "Start",
-              "output": {
-                "Error": "Lambda.ResourceNotFoundException",
-                "Cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)"
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "TaskStateExited"
-          },
-          {
-            "id": 7,
-            "previousEventId": 6,
-            "stateEnteredEventDetails": {
-              "input": {
-                "Error": "Lambda.ResourceNotFoundException",
-                "Cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)"
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "EndWithStateTaskFailedHandler"
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateEntered"
-          },
-          {
-            "id": 8,
-            "previousEventId": 7,
-            "stateExitedEventDetails": {
-              "name": "EndWithStateTaskFailedHandler",
-              "output": {
-                "Error": "Lambda.ResourceNotFoundException",
-                "Cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)",
-                "task_failed_error": {
-                  "Error": "Lambda.ResourceNotFoundException",
-                  "Cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)"
-                }
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateExited"
-          },
-          {
-            "executionSucceededEventDetails": {
-              "output": {
-                "Error": "Lambda.ResourceNotFoundException",
-                "Cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)",
-                "task_failed_error": {
-                  "Error": "Lambda.ResourceNotFoundException",
-                  "Cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)"
-                }
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "id": 9,
-            "previousEventId": 8,
-            "timestamp": "timestamp",
-            "type": "ExecutionSucceeded"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_invoke_timeout": {
-    "recorded-date": "10-03-2024, 16:41:35",
-    "recorded-content": {
-      "get_execution_history": {
-        "events": [
-          {
-            "executionStartedEventDetails": {
-              "input": {
-                "FunctionName": "<lambda_function_1_name>",
-                "Payload": null
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "roleArn": "snf_role_arn"
-            },
-            "id": 1,
-            "previousEventId": 0,
-            "timestamp": "timestamp",
-            "type": "ExecutionStarted"
-          },
-          {
-            "id": 2,
-            "previousEventId": 0,
-            "stateEnteredEventDetails": {
-              "input": {
-                "FunctionName": "<lambda_function_1_name>",
-                "Payload": null
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "Start"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskStateEntered"
-          },
-          {
-            "id": 3,
-            "previousEventId": 2,
-            "taskScheduledEventDetails": {
-              "parameters": {
-                "FunctionName": "<lambda_function_1_name>",
-                "Payload": null
-              },
-              "region": "<region>",
-              "resource": "invoke",
-              "resourceType": "lambda",
-              "timeoutInSeconds": 5
-            },
-            "timestamp": "timestamp",
-            "type": "TaskScheduled"
-          },
-          {
-            "id": 4,
-            "previousEventId": 3,
-            "taskStartedEventDetails": {
-              "resource": "invoke",
-              "resourceType": "lambda"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskStarted"
-          },
-          {
-            "id": 5,
-            "previousEventId": 4,
-            "taskTimedOutEventDetails": {
-              "error": "States.Timeout",
-              "resource": "invoke",
-              "resourceType": "lambda"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskTimedOut"
-          },
-          {
-            "id": 6,
-            "previousEventId": 5,
-            "stateExitedEventDetails": {
-              "name": "Start",
-              "output": {
-                "Error": "States.Timeout",
-                "Cause": ""
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "TaskStateExited"
-          },
-          {
-            "id": 7,
-            "previousEventId": 6,
-            "stateEnteredEventDetails": {
-              "input": {
-                "Error": "States.Timeout",
-                "Cause": ""
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "EndWithHandler"
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateEntered"
-          },
-          {
-            "id": 8,
-            "previousEventId": 7,
-            "stateExitedEventDetails": {
-              "name": "EndWithHandler",
-              "output": {
-                "Error": "States.Timeout",
-                "Cause": "",
-                "error": {
-                  "Error": "States.Timeout",
-                  "Cause": ""
-                }
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateExited"
-          },
-          {
-            "executionSucceededEventDetails": {
-              "output": {
-                "Error": "States.Timeout",
-                "Cause": "",
-                "error": {
-                  "Error": "States.Timeout",
-                  "Cause": ""
-                }
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "id": 9,
-            "previousEventId": 8,
-            "timestamp": "timestamp",
-            "type": "ExecutionSucceeded"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch_output_path[None]": {
-    "recorded-date": "20-09-2024, 15:50:50",
+    "recorded-date": "28-11-2024, 13:08:15",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -826,7 +580,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch_output_path[$.Payload]": {
-    "recorded-date": "20-09-2024, 15:51:07",
+    "recorded-date": "28-11-2024, 13:08:26",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -988,7 +742,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch_output_path[$.no.such.path]": {
-    "recorded-date": "20-09-2024, 15:51:29",
+    "recorded-date": "28-11-2024, 13:08:43",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -1130,6 +884,404 @@
                 "InputValue": {
                   "Error": "Exception",
                   "Cause": "{\"errorMessage\":\"Some exception was raised.\",\"errorType\":\"Exception\",\"requestId\":\"<uuid:1>\",\"stackTrace\":[\"  File \\\"/var/task/handler.py\\\", line 2, in handler\\n    raise Exception(\\\"Some exception was raised.\\\")\\n\"]}"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 9,
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_no_such_function": {
+    "recorded-date": "28-11-2024, 13:05:16",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionName": "no_such_<lambda_function_name>",
+                "Payload": null
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionName": "no_such_<lambda_function_name>",
+                "Payload": null
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "FunctionName": "no_such_<lambda_function_name>",
+                "Payload": null
+              },
+              "region": "<region>",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskFailedEventDetails": {
+              "cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)",
+              "error": "Lambda.ResourceNotFoundException",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)",
+              "error": "Lambda.ResourceNotFoundException"
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_no_such_function_catch": {
+    "recorded-date": "28-11-2024, 13:05:33",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionName": "no_such_<lambda_function_name>",
+                "Payload": null
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionName": "no_such_<lambda_function_name>",
+                "Payload": null
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "FunctionName": "no_such_<lambda_function_name>",
+                "Payload": null
+              },
+              "region": "<region>",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskFailedEventDetails": {
+              "cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)",
+              "error": "Lambda.ResourceNotFoundException",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "Start",
+              "output": {
+                "Error": "Lambda.ResourceNotFoundException",
+                "Cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Error": "Lambda.ResourceNotFoundException",
+                "Cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "EndWithStateTaskFailedHandler"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateExitedEventDetails": {
+              "name": "EndWithStateTaskFailedHandler",
+              "output": {
+                "Error": "Lambda.ResourceNotFoundException",
+                "Cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)",
+                "task_failed_error": {
+                  "Error": "Lambda.ResourceNotFoundException",
+                  "Cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "Error": "Lambda.ResourceNotFoundException",
+                "Cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)",
+                "task_failed_error": {
+                  "Error": "Lambda.ResourceNotFoundException",
+                  "Cause": "Function not found: arn:<partition>:lambda:<region>:111111111111:function:no_such_<lambda_function_name> (Service: AWSLambda; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: <request_id>; Proxy: null)"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 9,
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_invoke_timeout": {
+    "recorded-date": "28-11-2024, 13:05:54",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionName": "<lambda_function_1_name>",
+                "Payload": null
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionName": "<lambda_function_1_name>",
+                "Payload": null
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "FunctionName": "<lambda_function_1_name>",
+                "Payload": null
+              },
+              "region": "<region>",
+              "resource": "invoke",
+              "resourceType": "lambda",
+              "timeoutInSeconds": 5
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskTimedOutEventDetails": {
+              "error": "States.Timeout",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskTimedOut"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "Start",
+              "output": {
+                "Error": "States.Timeout",
+                "Cause": ""
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Error": "States.Timeout",
+                "Cause": ""
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "EndWithHandler"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateExitedEventDetails": {
+              "name": "EndWithHandler",
+              "output": {
+                "Error": "States.Timeout",
+                "Cause": "",
+                "error": {
+                  "Error": "States.Timeout",
+                  "Cause": ""
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "Error": "States.Timeout",
+                "Cause": "",
+                "error": {
+                  "Error": "States.Timeout",
+                  "Cause": ""
                 }
               },
               "outputDetails": {

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.validation.json
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.validation.json
@@ -1,26 +1,29 @@
 {
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_invoke_timeout": {
-    "last_validated_date": "2024-03-10T16:41:35+00:00"
+    "last_validated_date": "2024-11-28T13:05:54+00:00"
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_no_such_function": {
-    "last_validated_date": "2023-06-22T11:29:54+00:00"
+    "last_validated_date": "2024-11-28T13:05:16+00:00"
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_no_such_function_catch": {
-    "last_validated_date": "2023-06-22T11:30:13+00:00"
+    "last_validated_date": "2024-11-28T13:05:33+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_custom_exception": {
+    "last_validated_date": "2024-11-28T13:03:53+00:00"
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception": {
-    "last_validated_date": "2023-06-22T11:29:17+00:00"
+    "last_validated_date": "2024-11-28T13:03:36+00:00"
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch": {
-    "last_validated_date": "2023-06-22T11:29:36+00:00"
+    "last_validated_date": "2024-11-28T13:04:09+00:00"
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch_output_path[$.Payload]": {
-    "last_validated_date": "2024-09-20T15:51:07+00:00"
+    "last_validated_date": "2024-11-28T13:08:26+00:00"
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch_output_path[$.no.such.path]": {
-    "last_validated_date": "2024-09-20T15:51:29+00:00"
+    "last_validated_date": "2024-11-28T13:08:43+00:00"
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_raise_exception_catch_output_path[None]": {
-    "last_validated_date": "2024-09-20T15:50:50+00:00"
+    "last_validated_date": "2024-11-28T13:08:15+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, the SFN v2 interpreter incorrectly assigns the error name "Exception" to Lambda task failures that result in a LambdaFunctionErrorException, rather than utilising the exception's errorType value. This limitation prevents users from catching or retrying Lambda task failures using custom exception values, as reported in [this issue](https://github.com/localstack/localstack/issues/11943). These changes address the error name computation, correcting the behaviour, and introduce relevant tests for both legacy Lambda invocations and service task Lambda invocations.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- revised error name computation for legacy task lambda states
- revised error name computation for service task lambda states
- added related snapshot tests

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
