### PR TITLE
Added test and fix for wrong time format and serialization in events v2

### DIFF
--- a/localstack-core/localstack/aws/api/events/__init__.py
+++ b/localstack-core/localstack/aws/api/events/__init__.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import StrEnum
-from typing import Dict, List, Optional, TypedDict
+from typing import Dict, List, Optional, TypedDict, Union
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 
@@ -919,7 +919,7 @@ class EventSource(TypedDict, total=False):
 
 
 EventSourceList = List[EventSource]
-EventTime = datetime
+EventTime = Union[datetime, str]
 HeaderParametersMap = Dict[HeaderKey, HeaderValue]
 QueryStringParametersMap = Dict[QueryStringKey, QueryStringValue]
 PathParameterList = List[PathParameter]

--- a/localstack-core/localstack/aws/api/events/__init__.py
+++ b/localstack-core/localstack/aws/api/events/__init__.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import StrEnum
-from typing import Dict, List, Optional, TypedDict, Union
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 
@@ -919,7 +919,7 @@ class EventSource(TypedDict, total=False):
 
 
 EventSourceList = List[EventSource]
-EventTime = Union[datetime, str]
+EventTime = datetime | str
 HeaderParametersMap = Dict[HeaderKey, HeaderValue]
 QueryStringParametersMap = Dict[QueryStringKey, QueryStringValue]
 PathParameterList = List[PathParameter]

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -130,11 +130,6 @@ def get_event_time(event: PutEventsRequestEntry) -> EventTime:
     return event_time
 
 
-def format_event_time(event_time: datetime) -> str:
-    """Format datetime object to AWS EventBridge format."""
-    return event_time.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
 def event_time_to_time_string(event_time: EventTime) -> str:
     return event_time.strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -188,7 +183,7 @@ def format_event(
     account_id = message.get("original_account", account_id)
     # Format the datetime to ISO-8601 string
     event_time = get_event_time(event)
-    formatted_time = format_event_time(event_time)
+    formatted_time = event_time_to_time_string(event_time)
 
     formatted_event = {
         "version": "0",

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -130,6 +130,11 @@ def get_event_time(event: PutEventsRequestEntry) -> EventTime:
     return event_time
 
 
+def format_event_time(event_time: datetime) -> str:
+    """Format datetime object to AWS EventBridge format."""
+    return event_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def event_time_to_time_string(event_time: EventTime) -> str:
     return event_time.strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -181,6 +186,9 @@ def format_event(
     message_id = message.get("original_id", str(long_uid()))
     region = message.get("original_region", region)
     account_id = message.get("original_account", account_id)
+    # Format the datetime to ISO-8601 string
+    event_time = get_event_time(event)
+    formatted_time = format_event_time(event_time)
 
     formatted_event = {
         "version": "0",
@@ -188,7 +196,7 @@ def format_event(
         "detail-type": event.get("DetailType"),
         "source": event.get("Source"),
         "account": account_id,
-        "time": get_event_time(event),
+        "time": formatted_time,
         "region": region,
         "resources": event.get("Resources", []),
         "detail": json.loads(event.get("Detail", "{}")),

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -591,7 +591,7 @@ class TestEvents:
 
         snapshot.add_transformers_list(
             [
-                snapshot.transform.key_value("MD5OfBody"),
+                snapshot.transform.key_value("MD5OfBody", reference_replacement=False),
                 *snapshot.transform.sqs_api(),
             ]
         )

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2695,5 +2695,42 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_time_field": {
+    "recorded-date": "28-11-2024, 19:58:10",
+    "recorded-content": {
+      "put-events": {
+        "Entries": [
+          {
+            "EventId": "<uuid:1>"
+          }
+        ],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sqs-messages": [
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "f4c7eff18f5b1125e8b84b06ba756eb5",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:1>",
+            "detail-type": "test-detail-type",
+            "source": "test-source",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "message": "test message"
+            }
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2697,7 +2697,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_time_field": {
-    "recorded-date": "28-11-2024, 19:58:10",
+    "recorded-date": "28-11-2024, 21:25:00",
     "recorded-content": {
       "put-events": {
         "Entries": [
@@ -2715,7 +2715,7 @@
         {
           "MessageId": "<uuid:2>",
           "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "f4c7eff18f5b1125e8b84b06ba756eb5",
+          "MD5OfBody": "m-d5-of-body",
           "Body": {
             "version": "0",
             "id": "<uuid:1>",

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -188,6 +188,9 @@
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_target_delivery_failure": {
     "last_validated_date": "2024-11-20T17:19:19+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_time_field": {
+    "last_validated_date": "2024-11-28T19:58:10+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_without_source": {
     "last_validated_date": "2024-06-19T10:40:50+00:00"
   }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -189,7 +189,7 @@
     "last_validated_date": "2024-11-20T17:19:19+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_time_field": {
-    "last_validated_date": "2024-11-28T19:58:10+00:00"
+    "last_validated_date": "2024-11-28T21:25:00+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_without_source": {
     "last_validated_date": "2024-06-19T10:40:50+00:00"


### PR DESCRIPTION
## Motivation
Found through an issue: https://github.com/localstack/localstack/issues/11630
When using EventBridge v2, events containing datetime fields fail to be delivered due to JSON serialization error: `Object of type datetime is not JSON serializable`. This affects events with explicit Time fields as well as automatically generated timestamps.

## Changes
- Added `format_event_time` function to properly format datetime objects to ISO8601 strings
- Updated `format_event` to use the formatted time string
- Added test to verify datetime serialization and delivery behavior matches AWS

The fix ensures proper datetime handling in events while maintaining AWS parity by formatting all time values to ISO8601 strings (YYYY-MM-DDThh:mm:ssZ).