### PR TITLE
implement new native EventBridge EventRuleEngine

### DIFF
--- a/localstack-core/localstack/services/events/event_rule_engine.py
+++ b/localstack-core/localstack/services/events/event_rule_engine.py
@@ -1,0 +1,515 @@
+import ipaddress
+import json
+import re
+import typing as t
+
+from localstack.aws.api.events import InvalidEventPatternException
+
+
+class EventRuleEngine:
+    def evaluate_pattern_on_event(self, filter_policy: dict, message_body: str):
+        try:
+            body = json.loads(message_body)
+            if not isinstance(body, dict):
+                return False
+        except json.JSONDecodeError:
+            # Filter policies for the message body assume that the message payload is a well-formed JSON object.
+            # See https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html
+            return False
+
+        return self._evaluate_nested_filter_policy_on_dict(filter_policy, payload=body)
+
+    def _evaluate_nested_filter_policy_on_dict(self, filter_policy, payload: dict) -> bool:
+        """
+        This method evaluates the filter policy against the JSON decoded payload.
+        Although it's not documented anywhere, AWS allows `.` in the fields name in the filter policy and the payload,
+        and will evaluate them. However, it's not JSONPath compatible:
+        Example:
+        Policy: `{"field1.field2": "value1"}`
+        This policy will match both `{"field1.field2": "value1"}` and  {"field1: {"field2": "value1"}}`, unlike JSONPath
+        for which `.` points to a child node.
+        This might show they are flattening the both dictionaries to a single level for an easier matching without
+        recursion.
+        :param filter_policy: a dict, starting at the FilterPolicy
+        :param payload: a dict, starting at the MessageBody
+        :return: True if the payload respect the filter policy, otherwise False
+        """
+        if not filter_policy:
+            return True
+
+        # TODO: maybe save/cache the flattened/expanded policy?
+        flat_policy_conditions = self.flatten_policy(filter_policy)
+        print(f"{flat_policy_conditions=}")
+        flat_payloads = self.flatten_payload(payload)
+        print(f"{flat_payloads=}")
+
+        return any(
+            all(
+                any(
+                    self._evaluate_condition(
+                        flat_payload.get(key), condition, field_exists=key in flat_payload
+                    )
+                    for condition in values
+                    for flat_payload in flat_payloads
+                )
+                for key, values in flat_policy.items()
+            )
+            for flat_policy in flat_policy_conditions
+        )
+
+    def _evaluate_condition(self, value, condition, field_exists: bool):
+        if not isinstance(condition, dict):
+            return field_exists and value == condition
+        elif (must_exist := condition.get("exists")) is not None:
+            # if must_exists is True then field_exists must be True
+            # if must_exists is False then fields_exists must be False
+            return must_exist == field_exists
+        elif value is None:
+            # the remaining conditions require the value to not be None
+            return False
+        elif anything_but := condition.get("anything-but"):
+            if isinstance(anything_but, dict):
+                if not_prefix := anything_but.get("prefix"):
+                    return not value.startswith(not_prefix)
+                elif not_suffix := anything_but.get("suffix"):
+                    return not value.endswith(not_suffix)
+                elif not_equal_ignore_case := anything_but.get("equals-ignore-case"):
+                    if isinstance(not_equal_ignore_case, str):
+                        return not_equal_ignore_case.lower() != value.lower()
+                    elif isinstance(not_equal_ignore_case, list):
+                        return all(value.lower() != v.lower() for v in not_equal_ignore_case)
+
+            elif isinstance(anything_but, list):
+                return value not in anything_but
+            else:
+                return value != anything_but
+
+        elif prefix := condition.get("prefix"):
+            if isinstance(prefix, dict):
+                if prefix_equal_ignore_case := prefix.get("equals-ignore-case"):
+                    return value.lower().startswith(prefix_equal_ignore_case.lower())
+
+            return value.startswith(prefix)
+
+        elif suffix := condition.get("suffix"):
+            if isinstance(suffix, dict):
+                if suffix_equal_ignore_case := suffix.get("equals-ignore-case"):
+                    return value.lower().endswith(suffix_equal_ignore_case.lower())
+
+            return value.endswith(suffix)
+
+        elif equal_ignore_case := condition.get("equals-ignore-case"):
+            return equal_ignore_case.lower() == value.lower()
+        elif numeric_condition := condition.get("numeric"):
+            return self._evaluate_numeric_condition(numeric_condition, value)
+
+        elif cidr := condition.get("cidr"):
+            ips = [str(ip) for ip in ipaddress.IPv4Network(cidr)]
+            return value in ips
+
+        elif wildcard := condition.get("wildcard"):
+            return re.match(re.escape(wildcard).replace("\\*", ".+") + "$", value)
+
+        return False
+
+    @staticmethod
+    def _evaluate_numeric_condition(conditions, value):
+        try:
+            # try if the value is numeric
+            value = float(value)
+        except ValueError:
+            # the value is not numeric, the condition is False
+            return False
+
+        for i in range(0, len(conditions), 2):
+            operator = conditions[i]
+            operand = float(conditions[i + 1])
+
+            if operator == "=":
+                if value != operand:
+                    return False
+            elif operator == ">":
+                if value <= operand:
+                    return False
+            elif operator == "<":
+                if value >= operand:
+                    return False
+            elif operator == ">=":
+                if value < operand:
+                    return False
+            elif operator == "<=":
+                if value > operand:
+                    return False
+
+        return True
+
+    @staticmethod
+    def flatten_policy(nested_dict: dict) -> list[dict]:
+        """
+        Takes a dictionary as input and will output the dictionary on a single level.
+        Input:
+        `{"field1": {"field2": {"field3": "val1", "field4": "val2"}}}`
+        Output:
+        `[
+            {
+                "field1.field2.field3": "val1",
+                "field1.field2.field4": "val2"
+            }
+        ]`
+        Input with $or will create multiple outputs:
+        `{"$or": [{"field1": "val1"}, {"field2": "val2"}], "field3": "val3"}`
+        Output:
+        `[
+            {"field1": "val1", "field3": "val3"},
+            {"field2": "val2", "field3": "val3"}
+        ]`
+        :param nested_dict: a (nested) dictionary
+        :return: a list of flattened dictionaries with no nested dict or list inside, flattened to a
+        single level, one list item for every list item encountered
+        """
+
+        def _traverse_policy(obj, array=None, parent_key=None) -> list:
+            if array is None:
+                array = [{}]
+
+            for key, values in obj.items():
+                if key == "$or" and isinstance(values, list) and len(values) > 1:
+                    # $or will create multiple new branches in the array.
+                    # Each current branch will traverse with each choice in $or
+                    array = [
+                        i for value in values for i in _traverse_policy(value, array, parent_key)
+                    ]
+                else:
+                    # We update the parent key do that {"key1": {"key2": ""}} becomes "key1.key2"
+                    _parent_key = f"{parent_key}.{key}" if parent_key else key
+                    if isinstance(values, dict):
+                        # If the current key has child dict -- key: "key1", child: {"key2": ["val1", val2"]}
+                        # We only update the parent_key and traverse its children with the current branches
+                        array = _traverse_policy(values, array, _parent_key)
+                    else:
+                        # If the current key has no child, this means we found the values to match -- child: ["val1", val2"]
+                        # we update the branches with the parent chain and the values -- {"key1.key2": ["val1, val2"]}
+                        array = [{**item, _parent_key: values} for item in array]
+
+            return array
+
+        return _traverse_policy(nested_dict)
+
+    @staticmethod
+    def flatten_payload(nested_dict: dict) -> list[dict]:
+        """
+        Takes a dictionary as input and will output the dictionary on a single level.
+        The dictionary can have lists containing other dictionaries, and one root level entry will be created for every
+        item in a list.
+        Input:
+        `{"field1": {
+            "field2: [
+                {"field3: "val1", "field4": "val2"},
+                {"field3: "val3", "field4": "val4"},
+            }
+        ]}`
+        Output:
+        `[
+            {
+                "field1.field2.field3": "val1",
+                "field1.field2.field4": "val2"
+            },
+            {
+                "field1.field2.field3": "val3",
+                "field1.field2.field4": "val4"
+            },
+        ]`
+        :param nested_dict: a (nested) dictionary
+        :return: flatten_dict: a dictionary with no nested dict inside, flattened to a single level
+        """
+
+        def _traverse(_object: dict, array=None, parent_key=None) -> list:
+            print(f"{_object=}: {array=}")
+            if isinstance(_object, dict):
+                for key, values in _object.items():
+                    # We update the parent key do that {"key1": {"key2": ""}} becomes "key1.key2"
+                    _parent_key = f"{parent_key}.{key}" if parent_key else key
+                    array = _traverse(values, array, _parent_key)
+
+            elif isinstance(_object, list):
+                if not _object:
+                    return array
+                array = [i for value in _object for i in _traverse(value, array, parent_key)]
+            else:
+                array = [{**item, parent_key: _object} for item in array]
+            return array
+
+        return _traverse(nested_dict, array=[{}], parent_key=None)
+
+
+class EventPatternValidator:
+    def __init__(self):
+        self.error_prefix = "Event pattern is not valid. Reason: "
+
+    def validate_event_pattern(self, event_pattern: str) -> dict[str, t.Any]:
+        # # A filter policy can have a maximum of five attribute names. For a nested policy, only parent keys are counted.
+        # if len(filter_policy.values()) > 5:
+        #     raise InvalidEventPatternException(
+        #         f"{self.error_prefix}FilterPolicy: Filter policy can not have more than 5 keys"
+        #     )
+        try:
+            event_pattern = json.loads(event_pattern)
+        except json.JSONDecodeError:
+            raise InvalidEventPatternException()
+
+        aggregated_rules, combinations = self.aggregate_rules(event_pattern)
+        # For the complexity of the filter policy, the total combination of values must not exceed 150.
+        # https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html
+        # if combinations > 1000:
+        #     raise InvalidEventPatternException(
+        #         f"{self.error_prefix}Filter policy is too complex"
+        #     )
+
+        for rules in aggregated_rules:
+            for rule in rules:
+                self._validate_rule(rule)
+
+        return event_pattern
+
+    def aggregate_rules(self, filter_policy: dict[str, t.Any]) -> tuple[list[list[t.Any]], int]:
+        """
+        This method evaluate the filter policy recursively, and returns only a list of lists of rules.
+        It also calculates the combinations of rules, calculated depending on the nesting of the rules.
+        Example:
+        nested_filter_policy = {
+            "key_a": {
+                "key_b": {
+                    "key_c": ["value_one", "value_two", "value_three", "value_four"]
+                }
+            },
+            "key_d": {
+                "key_e": ["value_one", "value_two", "value_three"]
+            }
+        }
+        This function then iterates on the values of the top level keys of the filter policy: ("key_a", "key_d")
+        If the iterated value is not a list, it means it is a nested property. If the scope is `MessageBody`, it is
+        allowed, we call this method on the value, adding a level to the depth to keep track on how deep the key is.
+        If the value is a list, it means it contains rules: we will append this list of rules in _rules, and
+        calculate the combinations it adds.
+        For the example filter policy containing nested properties, we calculate it this way
+        The first array has four values in a three-level nested key, and the second has three values in a two-level
+        nested key. 3 x 4 x 2 x 3 = 72
+        The return value would be:
+        [["value_one", "value_two", "value_three", "value_four"], ["value_one", "value_two", "value_three"]]
+        It allows us to later iterate of the list of rules in an easy way, to verify its conditions only.
+
+        :param filter_policy: a dict, starting at the FilterPolicy
+        :return: a tuple with a list of lists of rules and the calculated number of combinations
+        """
+
+        def _inner(
+            policy_elements: dict[str, t.Any], depth: int = 1, combinations: int = 1
+        ) -> tuple[list[list[t.Any]], int]:
+            _rules = []
+            for key, _value in policy_elements.items():
+                if isinstance(_value, dict):
+                    # From AWS docs: "unlike attribute-based policies, payload-based policies support property nesting."
+                    sub_rules, combinations = _inner(
+                        _value, depth=depth + 1, combinations=combinations
+                    )
+                    _rules.extend(sub_rules)
+                elif isinstance(_value, list):
+                    if not _value:
+                        raise InvalidEventPatternException(
+                            f"{self.error_prefix}Empty arrays are not allowed"
+                        )
+
+                    current_combination = 0
+                    if key == "$or":
+                        for val in _value:
+                            sub_rules, or_combinations = _inner(
+                                val, depth=depth, combinations=combinations
+                            )
+                            _rules.extend(sub_rules)
+                            current_combination += or_combinations
+
+                        combinations = current_combination
+                    else:
+                        _rules.append(_value)
+                        combinations = combinations * len(_value) * depth
+                else:
+                    raise InvalidEventPatternException(
+                        f'{self.error_prefix}"{key}" must be an object or an array'
+                    )
+
+            # if self.scope == "MessageAttributes" and depth > 1:
+            #     raise InvalidEventPatternException(
+            #         f"{self.error_prefix}Filter policy scope MessageAttributes does not support nested filter policy"
+            #     )
+
+            return _rules, combinations
+
+        return _inner(filter_policy)
+
+    def _validate_rule(self, rule: t.Any) -> None:
+        match rule:
+            case None | str() | bool():
+                return
+
+            case int() | float():
+                # TODO: AWS says they support only from -10^9 to 10^9 but seems to accept it, so we just return
+                # if rule <= -1000000000 or rule >= 1000000000:
+                #     raise ""
+                return
+
+            case {**kwargs}:
+                if len(kwargs) != 1:
+                    raise InvalidEventPatternException(
+                        f"{self.error_prefix}Only one key allowed in match expression"
+                    )
+
+                operator, value = None, None
+                for k, v in kwargs.items():
+                    operator, value = k, v
+
+                if operator in (
+                    "prefix",
+                    "suffix",
+                ):
+                    if isinstance(value, dict):
+                        for inner_operator in value.keys():
+                            if inner_operator != "equals-ignore-case":
+                                raise InvalidEventPatternException(
+                                    f"{self.error_prefix}Unsupported anything-but pattern: {inner_operator}"
+                                )
+
+                    elif not isinstance(value, str):
+                        raise InvalidEventPatternException(
+                            f"{self.error_prefix}{operator} match pattern must be a string"
+                        )
+                    return
+
+                elif operator == "equals-ignore-case":
+                    if not isinstance(value, (str, list)):
+                        raise InvalidEventPatternException(
+                            # TODO: validate
+                            f"{self.error_prefix}{operator} match pattern must be a string or an array???"
+                        )
+                    return
+
+                elif operator == "anything-but":
+                    # anything-but can actually contain any kind of simple rule (str, number, and list)
+                    if isinstance(value, list):
+                        for v in value:
+                            self._validate_rule(v)
+
+                        return
+
+                    # or have a nested `prefix`, `suffix` or `equals-ignore-case` pattern
+                    elif isinstance(value, dict):
+                        for inner_operator in value.keys():
+                            if inner_operator not in ("prefix", "equals-ignore-case", "suffix"):
+                                raise InvalidEventPatternException(
+                                    f"{self.error_prefix}Unsupported anything-but pattern: {inner_operator}"
+                                )
+
+                    self._validate_rule(value)
+                    return
+
+                elif operator == "exists":
+                    if not isinstance(value, bool):
+                        raise InvalidEventPatternException(
+                            f"{self.error_prefix}exists match pattern must be either true or false."
+                        )
+                    return
+
+                elif operator == "numeric":
+                    self._validate_numeric_condition(value)
+
+                elif operator == "cidr":
+                    try:
+                        ipaddress.IPv4Network(value)
+                    except ValueError:
+                        # TODO: validate
+                        raise InvalidEventPatternException(f"{self.error_prefix}?????")
+                elif operator == "wildcard":
+                    self._validate_wildcard(value)
+
+                else:
+                    raise InvalidEventPatternException(
+                        f"{self.error_prefix}Unrecognized match type {operator}"
+                    )
+
+            case _:
+                raise InvalidEventPatternException(
+                    f"{self.error_prefix}Match value must be String, number, true, false, or null"
+                )
+
+    def _validate_numeric_condition(self, value):
+        if not value:
+            raise InvalidEventPatternException(
+                f"{self.error_prefix}Invalid member in numeric match: ]"
+            )
+        num_values = value[::-1]
+
+        operator = num_values.pop()
+        if not isinstance(operator, str):
+            raise InvalidEventPatternException(
+                f"{self.error_prefix}Invalid member in numeric match: {operator}"
+            )
+        elif operator not in ("<", "<=", "=", ">", ">="):
+            raise InvalidEventPatternException(
+                f"{self.error_prefix}Unrecognized numeric range operator: {operator}"
+            )
+
+        value = num_values.pop() if num_values else None
+        if not isinstance(value, (int, float)):
+            exc_operator = "equals" if operator == "=" else operator
+            raise InvalidEventPatternException(
+                f"{self.error_prefix}Value of {exc_operator} must be numeric"
+            )
+
+        if not num_values:
+            return
+
+        if operator not in (">", ">="):
+            raise InvalidEventPatternException(
+                f"{self.error_prefix}Too many elements in numeric expression"
+            )
+
+        second_operator = num_values.pop()
+        if not isinstance(second_operator, str):
+            raise InvalidEventPatternException(
+                f"{self.error_prefix}Bad value in numeric range: {second_operator}"
+            )
+        elif second_operator not in ("<", "<="):
+            raise InvalidEventPatternException(
+                f"{self.error_prefix}Bad numeric range operator: {second_operator}"
+            )
+
+        second_value = num_values.pop() if num_values else None
+        if not isinstance(second_value, (int, float)):
+            exc_operator = "equals" if second_operator == "=" else second_operator
+            raise InvalidEventPatternException(
+                f"{self.error_prefix}Value of {exc_operator} must be numeric"
+            )
+
+        elif second_value <= value:
+            raise InvalidEventPatternException(f"{self.error_prefix}Bottom must be less than top")
+
+        elif num_values:
+            raise InvalidEventPatternException(
+                f"{self.error_prefix}Too many terms in numeric range expression"
+            )
+
+    def _validate_wildcard(self, value: t.Any):
+        if not isinstance(value, str):
+            raise InvalidEventPatternException(
+                f"{self.error_prefix}wildcard match pattern must be a string"
+            )
+        # TODO: properly calculate complexity of wildcard
+        # https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-pattern-operators.html#eb-filtering-wildcard-matching-complexity
+        # > calculate complexity of repeating character sequences that occur after a wildcard character
+        if "**" in value:
+            # TODO: validate
+            raise InvalidEventPatternException(f"{self.error_prefix}Consecutive are supported!!!!!")
+
+        if value.count("*") > 5:
+            raise InvalidEventPatternException(
+                f"{self.error_prefix}Rule is too complex - try using fewer wildcard characters or fewer repeating character sequences after a wildcard character"
+            )

--- a/localstack-core/localstack/services/events/event_rule_engine.py
+++ b/localstack-core/localstack/services/events/event_rule_engine.py
@@ -64,9 +64,6 @@ class EventRuleEngine:
             # if must_exists is True then field_exists must be True
             # if must_exists is False then fields_exists must be False
             return must_exist == field_exists
-        elif value is None:
-            # the remaining conditions require the value to not be None
-            return False
         elif anything_but := condition.get("anything-but"):
             if isinstance(anything_but, dict):
                 if not_prefix := anything_but.get("prefix"):
@@ -84,6 +81,9 @@ class EventRuleEngine:
             else:
                 return value != anything_but
 
+        elif value is None:
+            # the remaining conditions require the value to not be None
+            return False
         elif prefix := condition.get("prefix"):
             if isinstance(prefix, dict):
                 if prefix_equal_ignore_case := prefix.get("equals-ignore-case"):
@@ -226,7 +226,6 @@ class EventRuleEngine:
         """
 
         def _traverse(_object: dict, array=None, parent_key=None) -> list:
-            print(f"{_object=}: {array=}")
             if isinstance(_object, dict):
                 for key, values in _object.items():
                     # We update the parent key do that {"key1": {"key2": ""}} becomes "key1.key2"
@@ -377,7 +376,6 @@ class EventPatternValidator:
                     return
 
                 elif operator == "equals-ignore-case":
-                    print(f"{operator=} / {from_=} / {value=}")
                     if from_ == "anything-but":
                         if (not isinstance(value, (str, list))) or (
                             isinstance(value, list) and not all(isinstance(v, str) for v in value)

--- a/localstack-core/localstack/services/events/event_rule_engine.py
+++ b/localstack-core/localstack/services/events/event_rule_engine.py
@@ -25,7 +25,9 @@ class EventRuleEngine:
         """
         This method evaluates the event pattern against the JSON decoded payload.
         Although it's not documented anywhere, AWS allows `.` in the fields name in the event pattern and the payload,
-        and will evaluate them. However, it's not JSONPath compatible:
+        and will evaluate them. However, it's not JSONPath compatible.
+        See:
+        https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-pattern.html#eb-create-pattern-considerations
         Example:
         Pattern: `{"field1.field2": "value1"}`
         This pattern will match both `{"field1.field2": "value1"}` and  {"field1: {"field2": "value1"}}`, unlike JSONPath

--- a/localstack-core/localstack/services/events/event_rule_engine.py
+++ b/localstack-core/localstack/services/events/event_rule_engine.py
@@ -7,19 +7,19 @@ from localstack.aws.api.events import InvalidEventPatternException
 
 
 class EventRuleEngine:
-    def evaluate_pattern_on_event(self, event_pattern: dict, message_body: str | dict):
-        if isinstance(message_body, str):
+    def evaluate_pattern_on_event(self, compiled_event_pattern: dict, event: str | dict):
+        if isinstance(event, str):
             try:
-                body = json.loads(message_body)
+                body = json.loads(event)
                 if not isinstance(body, dict):
                     return False
             except json.JSONDecodeError:
                 # Event pattern for the message body assume that the message payload is a well-formed JSON object.
                 return False
         else:
-            body = message_body
+            body = event
 
-        return self._evaluate_nested_event_pattern_on_dict(event_pattern, payload=body)
+        return self._evaluate_nested_event_pattern_on_dict(compiled_event_pattern, payload=body)
 
     def _evaluate_nested_event_pattern_on_dict(self, event_pattern, payload: dict) -> bool:
         """
@@ -270,11 +270,11 @@ class EventRuleEngine:
         return _traverse(nested_dict, array=[{}], parent_key=None)
 
 
-class EventPatternValidator:
+class EventPatternCompiler:
     def __init__(self):
         self.error_prefix = "Event pattern is not valid. Reason: "
 
-    def validate_event_pattern(self, event_pattern: str | dict) -> dict[str, t.Any]:
+    def compile_event_pattern(self, event_pattern: str | dict) -> dict[str, t.Any]:
         if isinstance(event_pattern, str):
             try:
                 event_pattern = json.loads(event_pattern)

--- a/localstack-core/localstack/services/events/event_rule_engine.py
+++ b/localstack-core/localstack/services/events/event_rule_engine.py
@@ -7,7 +7,7 @@ from localstack.aws.api.events import InvalidEventPatternException
 
 
 class EventRuleEngine:
-    def evaluate_pattern_on_event(self, filter_policy: dict, message_body: str):
+    def evaluate_pattern_on_event(self, event_pattern: dict, message_body: str):
         try:
             body = json.loads(message_body)
             if not isinstance(body, dict):
@@ -17,31 +17,29 @@ class EventRuleEngine:
             # See https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html
             return False
 
-        return self._evaluate_nested_filter_policy_on_dict(filter_policy, payload=body)
+        return self._evaluate_nested_event_pattern_on_dict(event_pattern, payload=body)
 
-    def _evaluate_nested_filter_policy_on_dict(self, filter_policy, payload: dict) -> bool:
+    def _evaluate_nested_event_pattern_on_dict(self, event_pattern, payload: dict) -> bool:
         """
-        This method evaluates the filter policy against the JSON decoded payload.
-        Although it's not documented anywhere, AWS allows `.` in the fields name in the filter policy and the payload,
+        This method evaluates the event pattern against the JSON decoded payload.
+        Although it's not documented anywhere, AWS allows `.` in the fields name in the event pattern and the payload,
         and will evaluate them. However, it's not JSONPath compatible:
         Example:
-        Policy: `{"field1.field2": "value1"}`
-        This policy will match both `{"field1.field2": "value1"}` and  {"field1: {"field2": "value1"}}`, unlike JSONPath
+        Pattern: `{"field1.field2": "value1"}`
+        This pattern will match both `{"field1.field2": "value1"}` and  {"field1: {"field2": "value1"}}`, unlike JSONPath
         for which `.` points to a child node.
         This might show they are flattening the both dictionaries to a single level for an easier matching without
         recursion.
-        :param filter_policy: a dict, starting at the FilterPolicy
+        :param event_pattern: a dict, starting at the Event Pattern
         :param payload: a dict, starting at the MessageBody
-        :return: True if the payload respect the filter policy, otherwise False
+        :return: True if the payload respect the event pattern, otherwise False
         """
-        if not filter_policy:
+        if not event_pattern:
             return True
 
-        # TODO: maybe save/cache the flattened/expanded policy?
-        flat_policy_conditions = self.flatten_policy(filter_policy)
-        print(f"{flat_policy_conditions=}")
+        # TODO: maybe save/cache the flattened/expanded pattern?
+        flat_pattern_conditions = self.flatten_pattern(event_pattern)
         flat_payloads = self.flatten_payload(payload)
-        print(f"{flat_payloads=}")
 
         return any(
             all(
@@ -52,9 +50,9 @@ class EventRuleEngine:
                     for condition in values
                     for flat_payload in flat_payloads
                 )
-                for key, values in flat_policy.items()
+                for key, values in flat_pattern.items()
             )
-            for flat_policy in flat_policy_conditions
+            for flat_pattern in flat_pattern_conditions
         )
 
     def _evaluate_condition(self, value, condition, field_exists: bool):
@@ -144,7 +142,7 @@ class EventRuleEngine:
         return True
 
     @staticmethod
-    def flatten_policy(nested_dict: dict) -> list[dict]:
+    def flatten_pattern(nested_dict: dict) -> list[dict]:
         """
         Takes a dictionary as input and will output the dictionary on a single level.
         Input:
@@ -168,7 +166,7 @@ class EventRuleEngine:
         single level, one list item for every list item encountered
         """
 
-        def _traverse_policy(obj, array=None, parent_key=None) -> list:
+        def _traverse_event_pattern(obj, array=None, parent_key=None) -> list:
             if array is None:
                 array = [{}]
 
@@ -177,7 +175,9 @@ class EventRuleEngine:
                     # $or will create multiple new branches in the array.
                     # Each current branch will traverse with each choice in $or
                     array = [
-                        i for value in values for i in _traverse_policy(value, array, parent_key)
+                        i
+                        for value in values
+                        for i in _traverse_event_pattern(value, array, parent_key)
                     ]
                 else:
                     # We update the parent key do that {"key1": {"key2": ""}} becomes "key1.key2"
@@ -185,7 +185,7 @@ class EventRuleEngine:
                     if isinstance(values, dict):
                         # If the current key has child dict -- key: "key1", child: {"key2": ["val1", val2"]}
                         # We only update the parent_key and traverse its children with the current branches
-                        array = _traverse_policy(values, array, _parent_key)
+                        array = _traverse_event_pattern(values, array, _parent_key)
                     else:
                         # If the current key has no child, this means we found the values to match -- child: ["val1", val2"]
                         # we update the branches with the parent chain and the values -- {"key1.key2": ["val1, val2"]}
@@ -193,7 +193,7 @@ class EventRuleEngine:
 
             return array
 
-        return _traverse_policy(nested_dict)
+        return _traverse_event_pattern(nested_dict)
 
     @staticmethod
     def flatten_payload(nested_dict: dict) -> list[dict]:
@@ -247,23 +247,12 @@ class EventPatternValidator:
         self.error_prefix = "Event pattern is not valid. Reason: "
 
     def validate_event_pattern(self, event_pattern: str) -> dict[str, t.Any]:
-        # # A filter policy can have a maximum of five attribute names. For a nested policy, only parent keys are counted.
-        # if len(filter_policy.values()) > 5:
-        #     raise InvalidEventPatternException(
-        #         f"{self.error_prefix}FilterPolicy: Filter policy can not have more than 5 keys"
-        #     )
         try:
             event_pattern = json.loads(event_pattern)
         except json.JSONDecodeError:
             raise InvalidEventPatternException()
 
         aggregated_rules, combinations = self.aggregate_rules(event_pattern)
-        # For the complexity of the filter policy, the total combination of values must not exceed 150.
-        # https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html
-        # if combinations > 1000:
-        #     raise InvalidEventPatternException(
-        #         f"{self.error_prefix}Filter policy is too complex"
-        #     )
 
         for rules in aggregated_rules:
             for rule in rules:
@@ -271,12 +260,12 @@ class EventPatternValidator:
 
         return event_pattern
 
-    def aggregate_rules(self, filter_policy: dict[str, t.Any]) -> tuple[list[list[t.Any]], int]:
+    def aggregate_rules(self, event_pattern: dict[str, t.Any]) -> tuple[list[list[t.Any]], int]:
         """
-        This method evaluate the filter policy recursively, and returns only a list of lists of rules.
+        This method evaluate the event pattern recursively, and returns only a list of lists of rules.
         It also calculates the combinations of rules, calculated depending on the nesting of the rules.
         Example:
-        nested_filter_policy = {
+        nested_event_pattern = {
             "key_a": {
                 "key_b": {
                     "key_c": ["value_one", "value_two", "value_three", "value_four"]
@@ -286,27 +275,27 @@ class EventPatternValidator:
                 "key_e": ["value_one", "value_two", "value_three"]
             }
         }
-        This function then iterates on the values of the top level keys of the filter policy: ("key_a", "key_d")
+        This function then iterates on the values of the top level keys of the event pattern: ("key_a", "key_d")
         If the iterated value is not a list, it means it is a nested property. If the scope is `MessageBody`, it is
         allowed, we call this method on the value, adding a level to the depth to keep track on how deep the key is.
         If the value is a list, it means it contains rules: we will append this list of rules in _rules, and
         calculate the combinations it adds.
-        For the example filter policy containing nested properties, we calculate it this way
+        For the example event pattern containing nested properties, we calculate it this way
         The first array has four values in a three-level nested key, and the second has three values in a two-level
         nested key. 3 x 4 x 2 x 3 = 72
         The return value would be:
         [["value_one", "value_two", "value_three", "value_four"], ["value_one", "value_two", "value_three"]]
         It allows us to later iterate of the list of rules in an easy way, to verify its conditions only.
 
-        :param filter_policy: a dict, starting at the FilterPolicy
+        :param event_pattern: a dict, starting at the Event Pattern
         :return: a tuple with a list of lists of rules and the calculated number of combinations
         """
 
         def _inner(
-            policy_elements: dict[str, t.Any], depth: int = 1, combinations: int = 1
+            pattern_elements: dict[str, t.Any], depth: int = 1, combinations: int = 1
         ) -> tuple[list[list[t.Any]], int]:
             _rules = []
-            for key, _value in policy_elements.items():
+            for key, _value in pattern_elements.items():
                 if isinstance(_value, dict):
                     # From AWS docs: "unlike attribute-based policies, payload-based policies support property nesting."
                     sub_rules, combinations = _inner(
@@ -337,14 +326,9 @@ class EventPatternValidator:
                         f'{self.error_prefix}"{key}" must be an object or an array'
                     )
 
-            # if self.scope == "MessageAttributes" and depth > 1:
-            #     raise InvalidEventPatternException(
-            #         f"{self.error_prefix}Filter policy scope MessageAttributes does not support nested filter policy"
-            #     )
-
             return _rules, combinations
 
-        return _inner(filter_policy)
+        return _inner(event_pattern)
 
     def _validate_rule(self, rule: t.Any) -> None:
         match rule:

--- a/localstack-core/localstack/services/events/event_ruler.py
+++ b/localstack-core/localstack/services/events/event_ruler.py
@@ -4,7 +4,7 @@ from functools import cache
 from pathlib import Path
 from typing import Tuple
 
-from localstack.services.events.models import InvalidEventPatternException
+from localstack.aws.api.events import InvalidEventPatternException
 from localstack.services.events.packages import event_ruler_package
 from localstack.utils.objects import singleton_factory
 
@@ -66,4 +66,6 @@ def matches_rule(event: str, rule: str) -> bool:
         return Ruler.matchesRule(event, rule)
     except java.lang.Exception as e:
         reason = e.args[0]
-        raise InvalidEventPatternException(reason=reason) from e
+        raise InvalidEventPatternException(
+            message=f"Event pattern is not valid. Reason: {reason}"
+        ) from e

--- a/localstack-core/localstack/services/events/v1/utils.py
+++ b/localstack-core/localstack/services/events/v1/utils.py
@@ -4,9 +4,10 @@ import logging
 import re
 from typing import Any
 
-from localstack.services.events.models import InvalidEventPatternException
+from localstack.aws.api.events import InvalidEventPatternException
 
 CONTENT_BASE_FILTER_KEYWORDS = ["prefix", "anything-but", "numeric", "cidr", "exists"]
+_error_prefix = "Event pattern is not valid. Reason: "
 
 LOG = logging.getLogger(__name__)
 
@@ -245,11 +246,11 @@ def handle_numeric_conditions(conditions: list[any], value: int | float):
 
     # Invalid example for uneven list: { "numeric": [ ">", 0, "<" ] }
     if len(conditions) % 2 > 0:
-        raise InvalidEventPatternException("Bad numeric range operator")
+        raise InvalidEventPatternException(f"{_error_prefix}Bad numeric range operator")
 
     if not isinstance(value, (int, float)):
         raise InvalidEventPatternException(
-            f"The value {value} for the numeric comparison {conditions} is not a valid number"
+            f"{_error_prefix}The value {value} for the numeric comparison {conditions} is not a valid number"
         )
 
     for i in range(0, len(conditions), 2):
@@ -259,7 +260,7 @@ def handle_numeric_conditions(conditions: list[any], value: int | float):
             second_operand = float(second_operand_str)
         except ValueError:
             raise InvalidEventPatternException(
-                f"Could not convert filter value {second_operand_str} to a valid number"
+                f"{_error_prefix}Could not convert filter value {second_operand_str} to a valid number"
             )
 
         if operator == "<" and not (value < second_operand):

--- a/localstack-core/localstack/utils/event_matcher.py
+++ b/localstack-core/localstack/utils/event_matcher.py
@@ -2,10 +2,10 @@ import json
 from typing import Any
 
 from localstack import config
-from localstack.services.events.event_rule_engine import EventPatternValidator, EventRuleEngine
+from localstack.services.events.event_rule_engine import EventPatternCompiler, EventRuleEngine
 from localstack.services.events.event_ruler import matches_rule
 
-_event_pattern_validator = EventPatternValidator()
+_event_pattern_compiler = EventPatternCompiler()
 _event_rule_engine = EventRuleEngine()
 
 
@@ -51,7 +51,10 @@ def matches_event(event_pattern: dict[str, Any] | str | None, event: dict[str, A
         return matches_rule(event_str, pattern_str)
 
     # Python implementation (default)
-    event_pattern_dict = _event_pattern_validator.validate_event_pattern(
+    compiled_event_pattern = _event_pattern_compiler.compile_event_pattern(
         event_pattern=event_pattern
     )
-    return _event_rule_engine.evaluate_pattern_on_event(event_pattern_dict, event)
+    return _event_rule_engine.evaluate_pattern_on_event(
+        compiled_event_pattern=compiled_event_pattern,
+        event=event,
+    )

--- a/localstack-core/localstack/utils/event_matcher.py
+++ b/localstack-core/localstack/utils/event_matcher.py
@@ -2,8 +2,11 @@ import json
 from typing import Any
 
 from localstack import config
+from localstack.services.events.event_rule_engine import EventPatternValidator, EventRuleEngine
 from localstack.services.events.event_ruler import matches_rule
-from localstack.services.events.v1.utils import matches_event as python_matches_event
+
+_event_pattern_validator = EventPatternValidator()
+_event_rule_engine = EventRuleEngine()
 
 
 def matches_event(event_pattern: dict[str, Any] | str | None, event: dict[str, Any] | str) -> bool:
@@ -48,7 +51,7 @@ def matches_event(event_pattern: dict[str, Any] | str | None, event: dict[str, A
         return matches_rule(event_str, pattern_str)
 
     # Python implementation (default)
-    # Convert strings to dicts if necessary
-    event_dict = json.loads(event) if isinstance(event, str) else event
-    pattern_dict = json.loads(event_pattern) if isinstance(event_pattern, str) else event_pattern
-    return python_matches_event(pattern_dict, event_dict)
+    event_pattern_dict = _event_pattern_validator.validate_event_pattern(
+        event_pattern=event_pattern
+    )
+    return _event_rule_engine.evaluate_pattern_on_event(event_pattern_dict, event)

--- a/tests/aws/services/events/event_pattern_templates/content_anything_but_ignorecase_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_but_ignorecase_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "state": "pending"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "state" : [{ "anything-but": { "equals-ignore-case": 123 }}]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_but_ignorecase_list_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_but_ignorecase_list_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "state": "pending"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "state" : [{ "anything-but": { "equals-ignore-case": [123, 456] }}]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_but_string_null.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_but_string_null.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "state": null
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "state": [ { "anything-but": "initializing" } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_prefix_ignorecase_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_prefix_ignorecase_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "FileName": "file.txt.bak"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "FileName": [ { "anything-but": { "prefix": { "equals-ignore-case": "file" }} } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_prefix_int_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_prefix_int_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "state": "post-init"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "state": [ { "anything-but": { "prefix": 123 } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_prefix_list.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_prefix_list.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "state": "post-init"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "state": [ { "anything-but": { "prefix": ["init", "test"] } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_prefix_list_NEG.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_prefix_list_NEG.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "state": "post-init"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "state": [ { "anything-but": { "prefix": ["init", "post"] } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_prefix_list_type_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_prefix_list_type_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "state": "post-init"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "state": [ { "anything-but": { "prefix": [123, "test"] } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_suffix_ignorecase_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_suffix_ignorecase_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "FileName": "file.txt.bak"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "FileName": [ { "anything-but": { "suffix": { "equals-ignore-case": ".png" }} } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_suffix_int_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_suffix_int_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "FileName": "file.txt.bak"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "FileName": [ { "anything-but": { "suffix": 123 } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_suffix_list.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_suffix_list.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "FileName": "file.txt.bak"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "FileName": [ { "anything-but": { "suffix": [".txt", ".jpg"] } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_suffix_list_NEG.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_suffix_list_NEG.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "FileName": "file.jpg"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "FileName": [ { "anything-but": { "suffix": [".txt", ".jpg"] } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_suffix_list_type_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_suffix_list_type_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "FileName": "file.txt.bak"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "FileName": [ { "anything-but": { "suffix": [123, ".txt"] } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_wildcard.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_wildcard.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "FilePath": "dir/init/file"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "FilePath": [ { "anything-but": { "wildcard": "*/dir/*" } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_wildcard_NEG.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_wildcard_NEG.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "FilePath": "dir/init/file"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "FilePath": [ { "anything-but": { "wildcard": "*/init/*" } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_wildcard_list.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_wildcard_list.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "state": "dir/post/dir"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "state": [ { "anything-but": { "wildcard": ["*/init/*", "*/dir/*"] } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_wildcard_list_NEG.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_wildcard_list_NEG.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "state": "dir/init/dir"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "state": [ { "anything-but": { "wildcard": ["*/init/*", "*/dir/*"] } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_wildcard_list_type_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_wildcard_list_type_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "state": "dir/post/dir"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "state": [ { "anything-but": { "wildcard": [123, "*/dir/*"] } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_anything_wildcard_type_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_anything_wildcard_type_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-anything-but
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "FilePath": "dir/init/file"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "FilePath": [ { "anything-but": { "wildcard": 123 } } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_ignorecase_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_ignorecase_EXC.json5
@@ -1,0 +1,14 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-equals-ignore-case-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": [ "EC2 Instance State-change Notification" ],
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+  },
+  "EventPattern": {
+    "detail-type": [ { "equals-ignore-case": ["ec2 instance state-change notification"] } ]
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_ignorecase_list_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_ignorecase_list_EXC.json5
@@ -1,0 +1,14 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-equals-ignore-case-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": [ "EC2 Instance State-change Notification" ],
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+  },
+  "EventPattern": {
+    "detail-type": [ { "equals-ignore-case": {"prefix": "ec2"} } ]
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_ip_address_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_ip_address_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-ip-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "sourceIPAddress": "10.0.0.255"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "sourceIPAddress": [ { "cidr": "bad-filter" } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_prefix_int_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_prefix_int_EXC.json5
@@ -1,0 +1,14 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-prefix-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+  },
+  "EventPattern": {
+    "time": [ { "prefix": 123 } ]
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_prefix_list_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_prefix_list_EXC.json5
@@ -1,0 +1,14 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-prefix-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+  },
+  "EventPattern": {
+    "time": [ { "prefix": ["2022-07-13"] } ]
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_suffix_int_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_suffix_int_EXC.json5
@@ -1,0 +1,15 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-suffix-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "FileName": "image.png"
+  },
+  "EventPattern": {
+    "FileName": [ { "suffix": 123 } ]
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_suffix_list_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_suffix_list_EXC.json5
@@ -1,0 +1,15 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-suffix-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "FileName": "image.png"
+  },
+  "EventPattern": {
+    "FileName": [ { "suffix": [".png"] } ]
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_wildcard_int_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_wildcard_int_EXC.json5
@@ -1,0 +1,15 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-wildcard-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "EventBusArn": "arn:aws:events:us-east-1:123456789012:event-bus/myEventBus"
+  },
+  "EventPattern": {
+    "EventBusArn": [ { "wildcard": 123 } ]
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_wildcard_list_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_wildcard_list_EXC.json5
@@ -1,0 +1,15 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-wildcard-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "EventBusArn": "arn:aws:events:us-east-1:123456789012:event-bus/myEventBus"
+  },
+  "EventPattern": {
+    "EventBusArn": [ { "wildcard": ["arn:aws:events:us-east-1:**:event-bus/*"] } ]
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_wildcard_repeating_star_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_wildcard_repeating_star_EXC.json5
@@ -1,0 +1,15 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-wildcard-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "EventBusArn": "arn:aws:events:us-east-1:123456789012:event-bus/myEventBus"
+  },
+  "EventPattern": {
+    "EventBusArn": [ { "wildcard": "arn:aws:events:us-east-1:**:event-bus/*" } ]
+  }
+}

--- a/tests/aws/services/events/test_events_patterns.py
+++ b/tests/aws/services/events/test_events_patterns.py
@@ -204,7 +204,6 @@ class TestEventPattern:
     )
     def test_invalid_json_event_pattern(self, aws_client, pattern, snapshot):
         event = '{"id": "1", "source": "test-source", "detail-type": "test-detail-type", "account": "123456789012", "region": "us-east-2", "time": "2022-07-13T13:48:01Z", "detail": {"test": "test"}}'
-        # TODO: devise better testing strategy for * because the wildcard matches everything and "\\*" does not match.
 
         with pytest.raises(ClientError) as e:
             aws_client.events.test_event_pattern(

--- a/tests/aws/services/events/test_events_patterns.snapshot.json
+++ b/tests/aws/services/events/test_events_patterns.snapshot.json
@@ -692,5 +692,65 @@
         "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
       }
     }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_json_event_pattern[this is valid json but not a dict]": {
+    "recorded-date": "29-11-2024, 00:19:32",
+    "recorded-content": {
+      "invalid-pattern": {
+        "Error": {
+          "Code": "InvalidEventPatternException",
+          "Message": "Event pattern is not valid. Reason: Unrecognized token 'this': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n at [Source: (String)\"this is valid json but not a dict\"; line: 1, column: 5]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_json_event_pattern[{'bad': 'quotation'}]": {
+    "recorded-date": "29-11-2024, 00:19:32",
+    "recorded-content": {
+      "invalid-pattern": {
+        "Error": {
+          "Code": "InvalidEventPatternException",
+          "Message": "Event pattern is not valid. Reason: Unexpected character (''' (code 39)): was expecting double-quote to start field name\n at [Source: (String)\"{'bad': 'quotation'}\"; line: 1, column: 2]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_json_event_pattern[{\"not\": closed mark\"]": {
+    "recorded-date": "29-11-2024, 00:19:33",
+    "recorded-content": {
+      "invalid-pattern": {
+        "Error": {
+          "Code": "InvalidEventPatternException",
+          "Message": "Event pattern is not valid. Reason: Unrecognized token 'closed': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n at [Source: (String)\"{\"not\": closed mark\"\"; line: 1, column: 15]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_json_event_pattern[[\"not\", \"a\", \"dict\", \"but valid json\"]]": {
+    "recorded-date": "29-11-2024, 00:19:33",
+    "recorded-content": {
+      "invalid-pattern": {
+        "Error": {
+          "Code": "InvalidEventPatternException",
+          "Message": "Event pattern is not valid. Reason: Filter is not an object\n at [Source: (String)\"[\"not\", \"a\", \"dict\", \"but valid json\"]\"; line: 1, column: 2]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events_patterns.snapshot.json
+++ b/tests/aws/services/events/test_events_patterns.snapshot.json
@@ -1,22 +1,22 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "recorded-date": "28-11-2024, 22:10:12",
+    "recorded-date": "28-11-2024, 23:37:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "recorded-date": "28-11-2024, 22:10:13",
+    "recorded-date": "28-11-2024, 23:37:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:13",
+    "recorded-date": "28-11-2024, 23:37:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "recorded-date": "28-11-2024, 22:10:13",
+    "recorded-date": "28-11-2024, 23:37:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "recorded-date": "28-11-2024, 22:10:13",
+    "recorded-date": "28-11-2024, 23:37:22",
     "recorded-content": {
       "int_nolist_EXC": {
         "exception_message": {
@@ -35,39 +35,39 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "recorded-date": "28-11-2024, 22:10:13",
+    "recorded-date": "28-11-2024, 23:37:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:13",
+    "recorded-date": "28-11-2024, 23:37:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:14",
+    "recorded-date": "28-11-2024, 23:37:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "recorded-date": "28-11-2024, 22:10:14",
+    "recorded-date": "28-11-2024, 23:37:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "recorded-date": "28-11-2024, 22:10:14",
+    "recorded-date": "28-11-2024, 23:37:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "recorded-date": "28-11-2024, 22:10:14",
+    "recorded-date": "28-11-2024, 23:37:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:14",
+    "recorded-date": "28-11-2024, 23:37:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "recorded-date": "28-11-2024, 22:10:14",
+    "recorded-date": "28-11-2024, 23:37:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "recorded-date": "28-11-2024, 22:10:14",
+    "recorded-date": "28-11-2024, 23:37:23",
     "recorded-content": {
       "content_numeric_operatorcasing_EXC": {
         "exception_message": {
@@ -86,19 +86,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:15",
+    "recorded-date": "28-11-2024, 23:37:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "recorded-date": "28-11-2024, 22:10:15",
+    "recorded-date": "28-11-2024, 23:37:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:15",
+    "recorded-date": "28-11-2024, 23:37:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "recorded-date": "28-11-2024, 22:10:15",
+    "recorded-date": "28-11-2024, 23:37:24",
     "recorded-content": {
       "string_nolist_EXC": {
         "exception_message": {
@@ -117,27 +117,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:15",
+    "recorded-date": "28-11-2024, 23:37:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:15",
+    "recorded-date": "28-11-2024, 23:37:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:16",
+    "recorded-date": "28-11-2024, 23:37:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "recorded-date": "28-11-2024, 22:10:16",
+    "recorded-date": "28-11-2024, 23:37:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "recorded-date": "28-11-2024, 22:10:16",
+    "recorded-date": "28-11-2024, 23:37:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "recorded-date": "28-11-2024, 22:10:16",
+    "recorded-date": "28-11-2024, 23:37:25",
     "recorded-content": {
       "arrays_empty_EXC": {
         "exception_message": {
@@ -156,55 +156,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:16",
+    "recorded-date": "28-11-2024, 23:37:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "recorded-date": "28-11-2024, 22:10:16",
+    "recorded-date": "28-11-2024, 23:37:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "recorded-date": "28-11-2024, 22:10:17",
+    "recorded-date": "28-11-2024, 23:37:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "recorded-date": "28-11-2024, 22:10:17",
+    "recorded-date": "28-11-2024, 23:37:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "recorded-date": "28-11-2024, 22:10:17",
+    "recorded-date": "28-11-2024, 23:37:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "recorded-date": "28-11-2024, 22:10:17",
+    "recorded-date": "28-11-2024, 23:37:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "recorded-date": "28-11-2024, 22:10:17",
+    "recorded-date": "28-11-2024, 23:37:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "recorded-date": "28-11-2024, 22:10:17",
+    "recorded-date": "28-11-2024, 23:37:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "recorded-date": "28-11-2024, 22:10:17",
+    "recorded-date": "28-11-2024, 23:37:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "recorded-date": "28-11-2024, 22:10:17",
+    "recorded-date": "28-11-2024, 23:37:27",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:18",
+    "recorded-date": "28-11-2024, 23:37:27",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:18",
+    "recorded-date": "28-11-2024, 23:37:27",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "recorded-date": "28-11-2024, 22:10:18",
+    "recorded-date": "28-11-2024, 23:37:27",
     "recorded-content": {
       "operator_case_sensitive_EXC": {
         "exception_message": {
@@ -223,15 +223,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "recorded-date": "28-11-2024, 22:10:18",
+    "recorded-date": "28-11-2024, 23:37:28",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:18",
+    "recorded-date": "28-11-2024, 23:37:28",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "recorded-date": "28-11-2024, 22:10:19",
+    "recorded-date": "28-11-2024, 23:37:28",
     "recorded-content": {
       "content_numeric_EXC": {
         "exception_message": {
@@ -250,87 +250,87 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:19",
+    "recorded-date": "28-11-2024, 23:37:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "recorded-date": "28-11-2024, 22:10:19",
+    "recorded-date": "28-11-2024, 23:37:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:19",
+    "recorded-date": "28-11-2024, 23:37:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "recorded-date": "28-11-2024, 22:10:19",
+    "recorded-date": "28-11-2024, 23:37:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:19",
+    "recorded-date": "28-11-2024, 23:37:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "recorded-date": "28-11-2024, 22:10:20",
+    "recorded-date": "28-11-2024, 23:37:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "recorded-date": "28-11-2024, 22:10:20",
+    "recorded-date": "28-11-2024, 23:37:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:20",
+    "recorded-date": "28-11-2024, 23:37:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:20",
+    "recorded-date": "28-11-2024, 23:37:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "recorded-date": "28-11-2024, 22:10:20",
+    "recorded-date": "28-11-2024, 23:37:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "recorded-date": "28-11-2024, 22:10:20",
+    "recorded-date": "28-11-2024, 23:37:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:20",
+    "recorded-date": "28-11-2024, 23:37:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:20",
+    "recorded-date": "28-11-2024, 23:37:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "recorded-date": "28-11-2024, 22:10:20",
+    "recorded-date": "28-11-2024, 23:37:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "recorded-date": "28-11-2024, 22:10:21",
+    "recorded-date": "28-11-2024, 23:37:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "recorded-date": "28-11-2024, 22:10:21",
+    "recorded-date": "28-11-2024, 23:37:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:21",
+    "recorded-date": "28-11-2024, 23:37:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "recorded-date": "28-11-2024, 22:10:21",
+    "recorded-date": "28-11-2024, 23:37:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:21",
+    "recorded-date": "28-11-2024, 23:37:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:21",
+    "recorded-date": "28-11-2024, 23:37:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "recorded-date": "28-11-2024, 22:10:21",
+    "recorded-date": "28-11-2024, 23:37:31",
     "recorded-content": {
       "content_wildcard_complex_EXC": {
         "exception_message": {
@@ -349,55 +349,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:22",
+    "recorded-date": "28-11-2024, 23:37:32",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "recorded-date": "28-11-2024, 22:10:22",
+    "recorded-date": "28-11-2024, 23:37:32",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:22",
+    "recorded-date": "28-11-2024, 23:37:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "recorded-date": "28-11-2024, 22:10:22",
+    "recorded-date": "28-11-2024, 23:37:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "recorded-date": "28-11-2024, 22:10:22",
+    "recorded-date": "28-11-2024, 23:37:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "recorded-date": "28-11-2024, 22:10:22",
+    "recorded-date": "28-11-2024, 23:37:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:22",
+    "recorded-date": "28-11-2024, 23:37:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "recorded-date": "28-11-2024, 22:10:22",
+    "recorded-date": "28-11-2024, 23:37:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:23",
+    "recorded-date": "28-11-2024, 23:37:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "recorded-date": "28-11-2024, 22:10:23",
+    "recorded-date": "28-11-2024, 23:37:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:23",
+    "recorded-date": "28-11-2024, 23:37:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "recorded-date": "28-11-2024, 22:10:23",
+    "recorded-date": "28-11-2024, 23:37:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "recorded-date": "28-11-2024, 22:10:23",
+    "recorded-date": "28-11-2024, 23:37:34",
     "recorded-content": {
       "content_numeric_syntax_EXC": {
         "exception_message": {
@@ -416,19 +416,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "recorded-date": "28-11-2024, 22:10:24",
+    "recorded-date": "28-11-2024, 23:37:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "recorded-date": "28-11-2024, 22:10:24",
+    "recorded-date": "28-11-2024, 23:37:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "recorded-date": "28-11-2024, 22:10:24",
+    "recorded-date": "28-11-2024, 23:37:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "recorded-date": "28-11-2024, 22:10:24",
+    "recorded-date": "28-11-2024, 23:37:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
@@ -577,6 +577,120 @@
           }
         }
       ]
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
+    "recorded-date": "28-11-2024, 23:37:23",
+    "recorded-content": {
+      "content_wildcard_repeating_star_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: Consecutive wildcard characters at pos 26",
+            "MessageRaw": "Event pattern is not valid. Reason: Consecutive wildcard characters at pos 26\n at [Source: (String)\"{\"EventBusArn\": [{\"wildcard\": \"arn:<partition>:events:<region>:**:event-bus/*\"}]}\"; line: 1, column: 72]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
+    "recorded-date": "28-11-2024, 23:37:27",
+    "recorded-content": {
+      "content_ignorecase_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: equals-ignore-case match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: equals-ignore-case match pattern must be a string\n at [Source: (String)\"{\"detail-type\": [{\"equals-ignore-case\": [\"ec2 instance state-change notification\"]}]}\"; line: 1, column: 42]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
+    "recorded-date": "28-11-2024, 23:37:33",
+    "recorded-content": {
+      "content_ip_address_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: Malformed CIDR, one '/' required",
+            "MessageRaw": "Event pattern is not valid. Reason: Malformed CIDR, one '/' required"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
+    "recorded-date": "28-11-2024, 23:37:28",
+    "recorded-content": {
+      "content_anything_but_ignorecase_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: Inside anything-but/equals-ignore-case list, number|start|null|boolean is not supported.",
+            "MessageRaw": "Event pattern is not valid. Reason: Inside anything-but/equals-ignore-case list, number|start|null|boolean is not supported.\n at [Source: (String)\"{\"detail\": {\"state\": [{\"anything-but\": {\"equals-ignore-case\": 123}}]}}\"; line: 1, column: 66]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
+    "recorded-date": "28-11-2024, 23:37:31",
+    "recorded-content": {
+      "content_anything_but_ignorecase_list_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: Inside anything-but/equals-ignore-case list, number|start|null|boolean is not supported.",
+            "MessageRaw": "Event pattern is not valid. Reason: Inside anything-but/equals-ignore-case list, number|start|null|boolean is not supported.\n at [Source: (String)\"{\"detail\": {\"state\": [{\"anything-but\": {\"equals-ignore-case\": [123, 456]}}]}}\"; line: 1, column: 67]\n at [Source: (String)\"{\"detail\": {\"state\": [{\"anything-but\": {\"equals-ignore-case\": [123, 456]}}]}}\"; line: 1, column: 67]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
+    "recorded-date": "28-11-2024, 23:37:32",
+    "recorded-content": {
+      "content_ignorecase_list_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: equals-ignore-case match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: equals-ignore-case match pattern must be a string\n at [Source: (String)\"{\"detail-type\": [{\"equals-ignore-case\": {\"prefix\": \"ec2\"}}]}\"; line: 1, column: 42]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
     }
   }
 }

--- a/tests/aws/services/events/test_events_patterns.snapshot.json
+++ b/tests/aws/services/events/test_events_patterns.snapshot.json
@@ -1,22 +1,22 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "recorded-date": "29-11-2024, 00:30:56",
+    "recorded-date": "29-11-2024, 01:41:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "recorded-date": "29-11-2024, 00:30:57",
+    "recorded-date": "29-11-2024, 01:41:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "recorded-date": "29-11-2024, 00:30:57",
+    "recorded-date": "29-11-2024, 01:41:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "recorded-date": "29-11-2024, 00:30:57",
+    "recorded-date": "29-11-2024, 01:41:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "recorded-date": "29-11-2024, 00:30:57",
+    "recorded-date": "29-11-2024, 01:41:24",
     "recorded-content": {
       "int_nolist_EXC": {
         "exception_message": {
@@ -35,39 +35,39 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "recorded-date": "29-11-2024, 00:30:57",
+    "recorded-date": "29-11-2024, 01:41:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "recorded-date": "29-11-2024, 00:30:58",
+    "recorded-date": "29-11-2024, 01:41:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "recorded-date": "29-11-2024, 00:30:58",
+    "recorded-date": "29-11-2024, 01:41:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "recorded-date": "29-11-2024, 00:30:58",
+    "recorded-date": "29-11-2024, 01:41:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "recorded-date": "29-11-2024, 00:30:58",
+    "recorded-date": "29-11-2024, 01:41:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "recorded-date": "29-11-2024, 00:30:58",
+    "recorded-date": "29-11-2024, 01:41:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "recorded-date": "29-11-2024, 00:30:59",
+    "recorded-date": "29-11-2024, 01:41:27",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "recorded-date": "29-11-2024, 00:30:59",
+    "recorded-date": "29-11-2024, 01:41:27",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "recorded-date": "29-11-2024, 00:30:59",
+    "recorded-date": "29-11-2024, 01:41:27",
     "recorded-content": {
       "content_numeric_operatorcasing_EXC": {
         "exception_message": {
@@ -86,19 +86,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "recorded-date": "29-11-2024, 00:30:59",
+    "recorded-date": "29-11-2024, 01:41:28",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "recorded-date": "29-11-2024, 00:30:59",
+    "recorded-date": "29-11-2024, 01:41:28",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:00",
+    "recorded-date": "29-11-2024, 01:41:28",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "recorded-date": "29-11-2024, 00:31:00",
+    "recorded-date": "29-11-2024, 01:41:29",
     "recorded-content": {
       "string_nolist_EXC": {
         "exception_message": {
@@ -117,27 +117,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:00",
+    "recorded-date": "29-11-2024, 01:41:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:00",
+    "recorded-date": "29-11-2024, 01:41:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:00",
+    "recorded-date": "29-11-2024, 01:41:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "recorded-date": "29-11-2024, 00:31:00",
+    "recorded-date": "29-11-2024, 01:41:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "recorded-date": "29-11-2024, 00:31:00",
+    "recorded-date": "29-11-2024, 01:41:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "recorded-date": "29-11-2024, 00:31:01",
+    "recorded-date": "29-11-2024, 01:41:29",
     "recorded-content": {
       "arrays_empty_EXC": {
         "exception_message": {
@@ -156,55 +156,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:01",
+    "recorded-date": "29-11-2024, 01:41:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "recorded-date": "29-11-2024, 00:31:01",
+    "recorded-date": "29-11-2024, 01:41:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "recorded-date": "29-11-2024, 00:31:01",
+    "recorded-date": "29-11-2024, 01:41:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "recorded-date": "29-11-2024, 00:31:01",
+    "recorded-date": "29-11-2024, 01:41:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "recorded-date": "29-11-2024, 00:31:01",
+    "recorded-date": "29-11-2024, 01:41:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "recorded-date": "29-11-2024, 00:31:02",
+    "recorded-date": "29-11-2024, 01:41:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "recorded-date": "29-11-2024, 00:31:02",
+    "recorded-date": "29-11-2024, 01:41:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "recorded-date": "29-11-2024, 00:31:02",
+    "recorded-date": "29-11-2024, 01:41:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "recorded-date": "29-11-2024, 00:31:02",
+    "recorded-date": "29-11-2024, 01:41:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "recorded-date": "29-11-2024, 00:31:02",
+    "recorded-date": "29-11-2024, 01:41:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:02",
+    "recorded-date": "29-11-2024, 01:41:32",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:03",
+    "recorded-date": "29-11-2024, 01:41:32",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "recorded-date": "29-11-2024, 00:31:03",
+    "recorded-date": "29-11-2024, 01:41:32",
     "recorded-content": {
       "operator_case_sensitive_EXC": {
         "exception_message": {
@@ -223,15 +223,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "recorded-date": "29-11-2024, 00:31:03",
+    "recorded-date": "29-11-2024, 01:41:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:03",
+    "recorded-date": "29-11-2024, 01:41:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "recorded-date": "29-11-2024, 00:31:04",
+    "recorded-date": "29-11-2024, 01:41:33",
     "recorded-content": {
       "content_numeric_EXC": {
         "exception_message": {
@@ -250,87 +250,87 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:04",
+    "recorded-date": "29-11-2024, 01:41:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "recorded-date": "29-11-2024, 00:31:05",
+    "recorded-date": "29-11-2024, 01:41:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:05",
+    "recorded-date": "29-11-2024, 01:41:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "recorded-date": "29-11-2024, 00:31:05",
+    "recorded-date": "29-11-2024, 01:41:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:05",
+    "recorded-date": "29-11-2024, 01:41:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "recorded-date": "29-11-2024, 00:31:05",
+    "recorded-date": "29-11-2024, 01:41:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "recorded-date": "29-11-2024, 00:31:05",
+    "recorded-date": "29-11-2024, 01:41:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:05",
+    "recorded-date": "29-11-2024, 01:41:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:05",
+    "recorded-date": "29-11-2024, 01:41:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "recorded-date": "29-11-2024, 00:31:05",
+    "recorded-date": "29-11-2024, 01:41:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "recorded-date": "29-11-2024, 00:31:06",
+    "recorded-date": "29-11-2024, 01:41:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:06",
+    "recorded-date": "29-11-2024, 01:41:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:06",
+    "recorded-date": "29-11-2024, 01:41:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "recorded-date": "29-11-2024, 00:31:06",
+    "recorded-date": "29-11-2024, 01:41:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "recorded-date": "29-11-2024, 00:31:06",
+    "recorded-date": "29-11-2024, 01:41:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "recorded-date": "29-11-2024, 00:31:07",
+    "recorded-date": "29-11-2024, 01:41:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:07",
+    "recorded-date": "29-11-2024, 01:41:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "recorded-date": "29-11-2024, 00:31:07",
+    "recorded-date": "29-11-2024, 01:41:37",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:07",
+    "recorded-date": "29-11-2024, 01:41:37",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:07",
+    "recorded-date": "29-11-2024, 01:41:37",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "recorded-date": "29-11-2024, 00:31:07",
+    "recorded-date": "29-11-2024, 01:41:38",
     "recorded-content": {
       "content_wildcard_complex_EXC": {
         "exception_message": {
@@ -349,55 +349,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:08",
+    "recorded-date": "29-11-2024, 01:41:39",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "recorded-date": "29-11-2024, 00:31:08",
+    "recorded-date": "29-11-2024, 01:41:40",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:08",
+    "recorded-date": "29-11-2024, 01:41:40",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "recorded-date": "29-11-2024, 00:31:08",
+    "recorded-date": "29-11-2024, 01:41:40",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "recorded-date": "29-11-2024, 00:31:09",
+    "recorded-date": "29-11-2024, 01:41:41",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "recorded-date": "29-11-2024, 00:31:09",
+    "recorded-date": "29-11-2024, 01:41:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:09",
+    "recorded-date": "29-11-2024, 01:41:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "recorded-date": "29-11-2024, 00:31:09",
+    "recorded-date": "29-11-2024, 01:41:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:09",
+    "recorded-date": "29-11-2024, 01:41:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "recorded-date": "29-11-2024, 00:31:09",
+    "recorded-date": "29-11-2024, 01:41:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:10",
+    "recorded-date": "29-11-2024, 01:41:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "recorded-date": "29-11-2024, 00:31:10",
+    "recorded-date": "29-11-2024, 01:41:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "recorded-date": "29-11-2024, 00:31:10",
+    "recorded-date": "29-11-2024, 01:41:43",
     "recorded-content": {
       "content_numeric_syntax_EXC": {
         "exception_message": {
@@ -416,19 +416,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "recorded-date": "29-11-2024, 00:31:10",
+    "recorded-date": "29-11-2024, 01:41:44",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "recorded-date": "29-11-2024, 00:31:10",
+    "recorded-date": "29-11-2024, 01:41:44",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "recorded-date": "29-11-2024, 00:31:10",
+    "recorded-date": "29-11-2024, 01:41:44",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "recorded-date": "29-11-2024, 00:31:11",
+    "recorded-date": "29-11-2024, 01:41:44",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
@@ -580,7 +580,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "recorded-date": "29-11-2024, 00:30:58",
+    "recorded-date": "29-11-2024, 01:41:26",
     "recorded-content": {
       "content_wildcard_repeating_star_EXC": {
         "exception_message": {
@@ -599,7 +599,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "recorded-date": "29-11-2024, 00:31:02",
+    "recorded-date": "29-11-2024, 01:41:31",
     "recorded-content": {
       "content_ignorecase_EXC": {
         "exception_message": {
@@ -618,7 +618,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "recorded-date": "29-11-2024, 00:31:08",
+    "recorded-date": "29-11-2024, 01:41:41",
     "recorded-content": {
       "content_ip_address_EXC": {
         "exception_message": {
@@ -637,7 +637,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "recorded-date": "29-11-2024, 00:31:04",
+    "recorded-date": "29-11-2024, 01:41:33",
     "recorded-content": {
       "content_anything_but_ignorecase_EXC": {
         "exception_message": {
@@ -656,7 +656,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "recorded-date": "29-11-2024, 00:31:06",
+    "recorded-date": "29-11-2024, 01:41:36",
     "recorded-content": {
       "content_anything_but_ignorecase_list_EXC": {
         "exception_message": {
@@ -675,7 +675,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "recorded-date": "29-11-2024, 00:31:08",
+    "recorded-date": "29-11-2024, 01:41:38",
     "recorded-content": {
       "content_ignorecase_list_EXC": {
         "exception_message": {
@@ -754,7 +754,305 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
-    "recorded-date": "29-11-2024, 00:31:04",
+    "recorded-date": "29-11-2024, 01:41:33",
     "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_NEG]": {
+    "recorded-date": "29-11-2024, 01:41:25",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list]": {
+    "recorded-date": "29-11-2024, 01:41:27",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_NEG]": {
+    "recorded-date": "29-11-2024, 01:41:31",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard]": {
+    "recorded-date": "29-11-2024, 01:41:41",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_int_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:40",
+    "recorded-content": {
+      "content_wildcard_int_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: wildcard match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: wildcard match pattern must be a string\n at [Source: (String)\"{\"EventBusArn\": [{\"wildcard\": 123}]}\"; line: 1, column: 34]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_list_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:43",
+    "recorded-content": {
+      "content_wildcard_list_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: wildcard match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: wildcard match pattern must be a string\n at [Source: (String)\"{\"EventBusArn\": [{\"wildcard\": [\"arn:<partition>:events:<region>:**:event-bus/*\"]}]}\"; line: 1, column: 32]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_type_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:25",
+    "recorded-content": {
+      "content_anything_wildcard_list_type_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: wildcard match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: wildcard match pattern must be a string\n at [Source: (String)\"{\"detail\": {\"state\": [{\"anything-but\": {\"wildcard\": [123, \"*/dir/*\"]}}]}}\"; line: 1, column: 57]\n at [Source: (String)\"{\"detail\": {\"state\": [{\"anything-but\": {\"wildcard\": [123, \"*/dir/*\"]}}]}}\"; line: 1, column: 57]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_type_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:39",
+    "recorded-content": {
+      "content_anything_wildcard_type_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: wildcard match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: wildcard match pattern must be a string\n at [Source: (String)\"{\"detail\": {\"FilePath\": [{\"anything-but\": {\"wildcard\": 123}}]}}\"; line: 1, column: 59]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_type_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:24",
+    "recorded-content": {
+      "content_anything_suffix_list_type_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: prefix/suffix match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: prefix/suffix match pattern must be a string\n at [Source: (String)\"{\"detail\": {\"FileName\": [{\"anything-but\": {\"suffix\": [123, \".txt\"]}}]}}\"; line: 1, column: 58]\n at [Source: (String)\"{\"detail\": {\"FileName\": [{\"anything-but\": {\"suffix\": [123, \".txt\"]}}]}}\"; line: 1, column: 58]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list]": {
+    "recorded-date": "29-11-2024, 01:41:25",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_NEG]": {
+    "recorded-date": "29-11-2024, 01:41:26",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_int_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:31",
+    "recorded-content": {
+      "content_anything_suffix_int_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: prefix/suffix match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: prefix/suffix match pattern must be a string\n at [Source: (String)\"{\"detail\": {\"FileName\": [{\"anything-but\": {\"suffix\": 123}}]}}\"; line: 1, column: 57]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list]": {
+    "recorded-date": "29-11-2024, 01:41:35",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_NEG]": {
+    "recorded-date": "29-11-2024, 01:41:38",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_type_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:40",
+    "recorded-content": {
+      "content_anything_prefix_list_type_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: prefix/suffix match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: prefix/suffix match pattern must be a string\n at [Source: (String)\"{\"detail\": {\"state\": [{\"anything-but\": {\"prefix\": [123, \"test\"]}}]}}\"; line: 1, column: 55]\n at [Source: (String)\"{\"detail\": {\"state\": [{\"anything-but\": {\"prefix\": [123, \"test\"]}}]}}\"; line: 1, column: 55]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_int_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:42",
+    "recorded-content": {
+      "content_anything_prefix_int_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: prefix/suffix match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: prefix/suffix match pattern must be a string\n at [Source: (String)\"{\"detail\": {\"state\": [{\"anything-but\": {\"prefix\": 123}}]}}\"; line: 1, column: 54]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_list_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:28",
+    "recorded-content": {
+      "content_prefix_list_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: prefix match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: prefix match pattern must be a string\n at [Source: (String)\"{\"time\": [{\"prefix\": [\"2022-07-13\"]}]}\"; line: 1, column: 23]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_int_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:34",
+    "recorded-content": {
+      "content_prefix_int_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: prefix match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: prefix match pattern must be a string\n at [Source: (String)\"{\"time\": [{\"prefix\": 123}]}\"; line: 1, column: 25]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_int_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:37",
+    "recorded-content": {
+      "content_suffix_int_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: suffix match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: suffix match pattern must be a string\n at [Source: (String)\"{\"FileName\": [{\"suffix\": 123}]}\"; line: 1, column: 29]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_list_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:41",
+    "recorded-content": {
+      "content_suffix_list_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: suffix match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: suffix match pattern must be a string\n at [Source: (String)\"{\"FileName\": [{\"suffix\": [\".png\"]}]}\"; line: 1, column: 27]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_ignorecase_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:37",
+    "recorded-content": {
+      "content_anything_prefix_ignorecase_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: Value of anything-but must be an array or single string/number value.",
+            "MessageRaw": "Event pattern is not valid. Reason: Value of anything-but must be an array or single string/number value.\n at [Source: (String)\"{\"detail\": {\"FileName\": [{\"anything-but\": {\"prefix\": {\"equals-ignore-case\": \"file\"}}}]}}\"; line: 1, column: 55]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_ignorecase_EXC]": {
+    "recorded-date": "29-11-2024, 01:41:39",
+    "recorded-content": {
+      "content_anything_suffix_ignorecase_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: Value of anything-but must be an array or single string/number value.",
+            "MessageRaw": "Event pattern is not valid. Reason: Value of anything-but must be an array or single string/number value.\n at [Source: (String)\"{\"detail\": {\"FileName\": [{\"anything-but\": {\"suffix\": {\"equals-ignore-case\": \".png\"}}}]}}\"; line: 1, column: 55]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events_patterns.snapshot.json
+++ b/tests/aws/services/events/test_events_patterns.snapshot.json
@@ -1,28 +1,29 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "recorded-date": "11-07-2024, 13:55:25",
+    "recorded-date": "28-11-2024, 22:10:12",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "recorded-date": "11-07-2024, 13:55:25",
+    "recorded-date": "28-11-2024, 22:10:13",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:25",
+    "recorded-date": "28-11-2024, 22:10:13",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "recorded-date": "11-07-2024, 13:55:25",
+    "recorded-date": "28-11-2024, 22:10:13",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "recorded-date": "11-07-2024, 13:55:25",
+    "recorded-date": "28-11-2024, 22:10:13",
     "recorded-content": {
       "int_nolist_EXC": {
         "exception_message": {
           "Error": {
             "Code": "InvalidEventPatternException",
-            "Message": "Event pattern is not valid. Reason: \"int\" must be an object or an array\n at [Source: (String)\"{\"int\": 42}\"; line: 1, column: 11]"
+            "Message": "Event pattern is not valid. Reason: \"int\" must be an object or an array",
+            "MessageRaw": "Event pattern is not valid. Reason: \"int\" must be an object or an array\n at [Source: (String)\"{\"int\": 42}\"; line: 1, column: 11]"
           },
           "ResponseMetadata": {
             "HTTPHeaders": {},
@@ -34,45 +35,46 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "recorded-date": "11-07-2024, 13:55:26",
+    "recorded-date": "28-11-2024, 22:10:13",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:26",
+    "recorded-date": "28-11-2024, 22:10:13",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:26",
+    "recorded-date": "28-11-2024, 22:10:14",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "recorded-date": "11-07-2024, 13:55:26",
+    "recorded-date": "28-11-2024, 22:10:14",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "recorded-date": "11-07-2024, 13:55:26",
+    "recorded-date": "28-11-2024, 22:10:14",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "recorded-date": "11-07-2024, 13:55:26",
+    "recorded-date": "28-11-2024, 22:10:14",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:27",
+    "recorded-date": "28-11-2024, 22:10:14",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "recorded-date": "11-07-2024, 13:55:27",
+    "recorded-date": "28-11-2024, 22:10:14",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "recorded-date": "11-07-2024, 13:55:27",
+    "recorded-date": "28-11-2024, 22:10:14",
     "recorded-content": {
       "content_numeric_operatorcasing_EXC": {
         "exception_message": {
           "Error": {
             "Code": "InvalidEventPatternException",
-            "Message": "Event pattern is not valid. Reason: Unrecognized match type NUMERIC\n at [Source: (String)\"{\"detail\": {\"equal\": [{\"NUMERIC\": [\"=\", 5]}]}}\"; line: 1, column: 36]"
+            "Message": "Event pattern is not valid. Reason: Unrecognized match type NUMERIC",
+            "MessageRaw": "Event pattern is not valid. Reason: Unrecognized match type NUMERIC\n at [Source: (String)\"{\"detail\": {\"equal\": [{\"NUMERIC\": [\"=\", 5]}]}}\"; line: 1, column: 36]"
           },
           "ResponseMetadata": {
             "HTTPHeaders": {},
@@ -84,25 +86,26 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:27",
+    "recorded-date": "28-11-2024, 22:10:15",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "recorded-date": "11-07-2024, 13:55:28",
+    "recorded-date": "28-11-2024, 22:10:15",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:28",
+    "recorded-date": "28-11-2024, 22:10:15",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "recorded-date": "11-07-2024, 13:55:28",
+    "recorded-date": "28-11-2024, 22:10:15",
     "recorded-content": {
       "string_nolist_EXC": {
         "exception_message": {
           "Error": {
             "Code": "InvalidEventPatternException",
-            "Message": "Event pattern is not valid. Reason: \"string\" must be an object or an array\n at [Source: (String)\"{\"string\": \"my-value\"}\"; line: 1, column: 13]"
+            "Message": "Event pattern is not valid. Reason: \"string\" must be an object or an array",
+            "MessageRaw": "Event pattern is not valid. Reason: \"string\" must be an object or an array\n at [Source: (String)\"{\"string\": \"my-value\"}\"; line: 1, column: 13]"
           },
           "ResponseMetadata": {
             "HTTPHeaders": {},
@@ -114,33 +117,34 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:28",
+    "recorded-date": "28-11-2024, 22:10:15",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:28",
+    "recorded-date": "28-11-2024, 22:10:15",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:29",
+    "recorded-date": "28-11-2024, 22:10:16",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "recorded-date": "11-07-2024, 13:55:29",
+    "recorded-date": "28-11-2024, 22:10:16",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "recorded-date": "11-07-2024, 13:55:29",
+    "recorded-date": "28-11-2024, 22:10:16",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "recorded-date": "11-07-2024, 13:55:29",
+    "recorded-date": "28-11-2024, 22:10:16",
     "recorded-content": {
       "arrays_empty_EXC": {
         "exception_message": {
           "Error": {
             "Code": "InvalidEventPatternException",
-            "Message": "Event pattern is not valid. Reason: Empty arrays are not allowed\n at [Source: (String)\"{\"resources\": []}\"; line: 1, column: 17]"
+            "Message": "Event pattern is not valid. Reason: Empty arrays are not allowed",
+            "MessageRaw": "Event pattern is not valid. Reason: Empty arrays are not allowed\n at [Source: (String)\"{\"resources\": []}\"; line: 1, column: 17]"
           },
           "ResponseMetadata": {
             "HTTPHeaders": {},
@@ -152,61 +156,62 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:29",
+    "recorded-date": "28-11-2024, 22:10:16",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "recorded-date": "11-07-2024, 13:55:30",
+    "recorded-date": "28-11-2024, 22:10:16",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "recorded-date": "11-07-2024, 13:55:30",
+    "recorded-date": "28-11-2024, 22:10:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "recorded-date": "11-07-2024, 13:55:30",
+    "recorded-date": "28-11-2024, 22:10:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "recorded-date": "11-07-2024, 13:55:30",
+    "recorded-date": "28-11-2024, 22:10:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "recorded-date": "11-07-2024, 13:55:30",
+    "recorded-date": "28-11-2024, 22:10:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "recorded-date": "11-07-2024, 13:55:30",
+    "recorded-date": "28-11-2024, 22:10:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "recorded-date": "11-07-2024, 13:55:30",
+    "recorded-date": "28-11-2024, 22:10:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "recorded-date": "11-07-2024, 13:55:30",
+    "recorded-date": "28-11-2024, 22:10:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "recorded-date": "11-07-2024, 13:55:31",
+    "recorded-date": "28-11-2024, 22:10:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:31",
+    "recorded-date": "28-11-2024, 22:10:18",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:31",
+    "recorded-date": "28-11-2024, 22:10:18",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "recorded-date": "11-07-2024, 13:55:31",
+    "recorded-date": "28-11-2024, 22:10:18",
     "recorded-content": {
       "operator_case_sensitive_EXC": {
         "exception_message": {
           "Error": {
             "Code": "InvalidEventPatternException",
-            "Message": "Event pattern is not valid. Reason: Unrecognized match type EXISTS\n at [Source: (String)\"{\"my_key\": [{\"EXISTS\": true}]}\"; line: 1, column: 28]"
+            "Message": "Event pattern is not valid. Reason: Unrecognized match type EXISTS",
+            "MessageRaw": "Event pattern is not valid. Reason: Unrecognized match type EXISTS\n at [Source: (String)\"{\"my_key\": [{\"EXISTS\": true}]}\"; line: 1, column: 28]"
           },
           "ResponseMetadata": {
             "HTTPHeaders": {},
@@ -218,21 +223,22 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "recorded-date": "11-07-2024, 13:55:31",
+    "recorded-date": "28-11-2024, 22:10:18",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:32",
+    "recorded-date": "28-11-2024, 22:10:18",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "recorded-date": "11-07-2024, 13:55:32",
+    "recorded-date": "28-11-2024, 22:10:19",
     "recorded-content": {
       "content_numeric_EXC": {
         "exception_message": {
           "Error": {
             "Code": "InvalidEventPatternException",
-            "Message": "Event pattern is not valid. Reason: Bad numeric range operator: >\n at [Source: (String)\"{\"detail\": {\"c-count\": [{\"numeric\": [\">\", 0, \">\", 0]}]}}\"; line: 1, column: 49]"
+            "Message": "Event pattern is not valid. Reason: Bad numeric range operator: >",
+            "MessageRaw": "Event pattern is not valid. Reason: Bad numeric range operator: >\n at [Source: (String)\"{\"detail\": {\"c-count\": [{\"numeric\": [\">\", 0, \">\", 0]}]}}\"; line: 1, column: 49]"
           },
           "ResponseMetadata": {
             "HTTPHeaders": {},
@@ -244,93 +250,94 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:32",
+    "recorded-date": "28-11-2024, 22:10:19",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "recorded-date": "11-07-2024, 13:55:32",
+    "recorded-date": "28-11-2024, 22:10:19",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:33",
+    "recorded-date": "28-11-2024, 22:10:19",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "recorded-date": "11-07-2024, 13:55:33",
+    "recorded-date": "28-11-2024, 22:10:19",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:33",
+    "recorded-date": "28-11-2024, 22:10:19",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "recorded-date": "11-07-2024, 13:55:33",
+    "recorded-date": "28-11-2024, 22:10:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "recorded-date": "11-07-2024, 13:55:33",
+    "recorded-date": "28-11-2024, 22:10:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:33",
+    "recorded-date": "28-11-2024, 22:10:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:33",
+    "recorded-date": "28-11-2024, 22:10:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "recorded-date": "11-07-2024, 13:55:33",
+    "recorded-date": "28-11-2024, 22:10:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "recorded-date": "11-07-2024, 13:55:34",
+    "recorded-date": "28-11-2024, 22:10:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:34",
+    "recorded-date": "28-11-2024, 22:10:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:34",
+    "recorded-date": "28-11-2024, 22:10:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "recorded-date": "11-07-2024, 13:55:34",
+    "recorded-date": "28-11-2024, 22:10:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "recorded-date": "11-07-2024, 13:55:34",
+    "recorded-date": "28-11-2024, 22:10:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "recorded-date": "11-07-2024, 13:55:34",
+    "recorded-date": "28-11-2024, 22:10:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:34",
+    "recorded-date": "28-11-2024, 22:10:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "recorded-date": "11-07-2024, 13:55:34",
+    "recorded-date": "28-11-2024, 22:10:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:35",
+    "recorded-date": "28-11-2024, 22:10:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:35",
+    "recorded-date": "28-11-2024, 22:10:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "recorded-date": "11-07-2024, 13:55:35",
+    "recorded-date": "28-11-2024, 22:10:21",
     "recorded-content": {
       "content_wildcard_complex_EXC": {
         "exception_message": {
           "Error": {
             "Code": "InvalidEventPatternException",
-            "Message": "Event pattern is not valid. Reason: Rule is too complex - try using fewer wildcard characters or fewer repeating character sequences after a wildcard character"
+            "Message": "Event pattern is not valid. Reason: Rule is too complex - try using fewer wildcard characters or fewer repeating character sequences after a wildcard character",
+            "MessageRaw": "Event pattern is not valid. Reason: Rule is too complex - try using fewer wildcard characters or fewer repeating character sequences after a wildcard character"
           },
           "ResponseMetadata": {
             "HTTPHeaders": {},
@@ -342,61 +349,62 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:35",
+    "recorded-date": "28-11-2024, 22:10:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "recorded-date": "11-07-2024, 13:55:36",
+    "recorded-date": "28-11-2024, 22:10:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:36",
+    "recorded-date": "28-11-2024, 22:10:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "recorded-date": "11-07-2024, 13:55:36",
+    "recorded-date": "28-11-2024, 22:10:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "recorded-date": "11-07-2024, 13:55:36",
+    "recorded-date": "28-11-2024, 22:10:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "recorded-date": "11-07-2024, 13:55:36",
+    "recorded-date": "28-11-2024, 22:10:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:36",
+    "recorded-date": "28-11-2024, 22:10:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "recorded-date": "11-07-2024, 13:55:36",
+    "recorded-date": "28-11-2024, 22:10:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:36",
+    "recorded-date": "28-11-2024, 22:10:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "recorded-date": "11-07-2024, 13:55:37",
+    "recorded-date": "28-11-2024, 22:10:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:37",
+    "recorded-date": "28-11-2024, 22:10:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "recorded-date": "11-07-2024, 13:55:37",
+    "recorded-date": "28-11-2024, 22:10:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "recorded-date": "11-07-2024, 13:55:37",
+    "recorded-date": "28-11-2024, 22:10:23",
     "recorded-content": {
       "content_numeric_syntax_EXC": {
         "exception_message": {
           "Error": {
             "Code": "InvalidEventPatternException",
-            "Message": "Event pattern is not valid. Reason: Value of < must be numeric\n at [Source: (String)\"{\"detail\": {\"c-count\": [{\"numeric\": [\">\", 0, \"<\"]}]}}\"; line: 1, column: 50]"
+            "Message": "Event pattern is not valid. Reason: Value of < must be numeric",
+            "MessageRaw": "Event pattern is not valid. Reason: Value of < must be numeric\n at [Source: (String)\"{\"detail\": {\"c-count\": [{\"numeric\": [\">\", 0, \"<\"]}]}}\"; line: 1, column: 50]"
           },
           "ResponseMetadata": {
             "HTTPHeaders": {},
@@ -408,19 +416,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "recorded-date": "11-07-2024, 13:55:38",
+    "recorded-date": "28-11-2024, 22:10:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "recorded-date": "11-07-2024, 13:55:38",
+    "recorded-date": "28-11-2024, 22:10:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "recorded-date": "11-07-2024, 13:55:38",
+    "recorded-date": "28-11-2024, 22:10:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "recorded-date": "11-07-2024, 13:55:38",
+    "recorded-date": "28-11-2024, 22:10:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {

--- a/tests/aws/services/events/test_events_patterns.snapshot.json
+++ b/tests/aws/services/events/test_events_patterns.snapshot.json
@@ -1,22 +1,22 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "recorded-date": "28-11-2024, 23:37:21",
+    "recorded-date": "29-11-2024, 00:30:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "recorded-date": "28-11-2024, 23:37:21",
+    "recorded-date": "29-11-2024, 00:30:57",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:21",
+    "recorded-date": "29-11-2024, 00:30:57",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "recorded-date": "28-11-2024, 23:37:21",
+    "recorded-date": "29-11-2024, 00:30:57",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:22",
+    "recorded-date": "29-11-2024, 00:30:57",
     "recorded-content": {
       "int_nolist_EXC": {
         "exception_message": {
@@ -35,39 +35,39 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "recorded-date": "28-11-2024, 23:37:22",
+    "recorded-date": "29-11-2024, 00:30:57",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:22",
+    "recorded-date": "29-11-2024, 00:30:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:22",
+    "recorded-date": "29-11-2024, 00:30:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "recorded-date": "28-11-2024, 23:37:22",
+    "recorded-date": "29-11-2024, 00:30:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "recorded-date": "28-11-2024, 23:37:22",
+    "recorded-date": "29-11-2024, 00:30:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "recorded-date": "28-11-2024, 23:37:23",
+    "recorded-date": "29-11-2024, 00:30:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:23",
+    "recorded-date": "29-11-2024, 00:30:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "recorded-date": "28-11-2024, 23:37:23",
+    "recorded-date": "29-11-2024, 00:30:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:23",
+    "recorded-date": "29-11-2024, 00:30:59",
     "recorded-content": {
       "content_numeric_operatorcasing_EXC": {
         "exception_message": {
@@ -86,19 +86,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:24",
+    "recorded-date": "29-11-2024, 00:30:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "recorded-date": "28-11-2024, 23:37:24",
+    "recorded-date": "29-11-2024, 00:30:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:24",
+    "recorded-date": "29-11-2024, 00:31:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:24",
+    "recorded-date": "29-11-2024, 00:31:00",
     "recorded-content": {
       "string_nolist_EXC": {
         "exception_message": {
@@ -117,27 +117,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:25",
+    "recorded-date": "29-11-2024, 00:31:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:25",
+    "recorded-date": "29-11-2024, 00:31:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:25",
+    "recorded-date": "29-11-2024, 00:31:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "recorded-date": "28-11-2024, 23:37:25",
+    "recorded-date": "29-11-2024, 00:31:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "recorded-date": "28-11-2024, 23:37:25",
+    "recorded-date": "29-11-2024, 00:31:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:25",
+    "recorded-date": "29-11-2024, 00:31:01",
     "recorded-content": {
       "arrays_empty_EXC": {
         "exception_message": {
@@ -156,55 +156,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:25",
+    "recorded-date": "29-11-2024, 00:31:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "recorded-date": "28-11-2024, 23:37:26",
+    "recorded-date": "29-11-2024, 00:31:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "recorded-date": "28-11-2024, 23:37:26",
+    "recorded-date": "29-11-2024, 00:31:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "recorded-date": "28-11-2024, 23:37:26",
+    "recorded-date": "29-11-2024, 00:31:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "recorded-date": "28-11-2024, 23:37:26",
+    "recorded-date": "29-11-2024, 00:31:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "recorded-date": "28-11-2024, 23:37:26",
+    "recorded-date": "29-11-2024, 00:31:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "recorded-date": "28-11-2024, 23:37:26",
+    "recorded-date": "29-11-2024, 00:31:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "recorded-date": "28-11-2024, 23:37:26",
+    "recorded-date": "29-11-2024, 00:31:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "recorded-date": "28-11-2024, 23:37:26",
+    "recorded-date": "29-11-2024, 00:31:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "recorded-date": "28-11-2024, 23:37:27",
+    "recorded-date": "29-11-2024, 00:31:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:27",
+    "recorded-date": "29-11-2024, 00:31:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:27",
+    "recorded-date": "29-11-2024, 00:31:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:27",
+    "recorded-date": "29-11-2024, 00:31:03",
     "recorded-content": {
       "operator_case_sensitive_EXC": {
         "exception_message": {
@@ -223,15 +223,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "recorded-date": "28-11-2024, 23:37:28",
+    "recorded-date": "29-11-2024, 00:31:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:28",
+    "recorded-date": "29-11-2024, 00:31:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:28",
+    "recorded-date": "29-11-2024, 00:31:04",
     "recorded-content": {
       "content_numeric_EXC": {
         "exception_message": {
@@ -250,87 +250,87 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:29",
+    "recorded-date": "29-11-2024, 00:31:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "recorded-date": "28-11-2024, 23:37:29",
+    "recorded-date": "29-11-2024, 00:31:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:29",
+    "recorded-date": "29-11-2024, 00:31:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "recorded-date": "28-11-2024, 23:37:29",
+    "recorded-date": "29-11-2024, 00:31:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:29",
+    "recorded-date": "29-11-2024, 00:31:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "recorded-date": "28-11-2024, 23:37:29",
+    "recorded-date": "29-11-2024, 00:31:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "recorded-date": "28-11-2024, 23:37:30",
+    "recorded-date": "29-11-2024, 00:31:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:30",
+    "recorded-date": "29-11-2024, 00:31:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:30",
+    "recorded-date": "29-11-2024, 00:31:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "recorded-date": "28-11-2024, 23:37:30",
+    "recorded-date": "29-11-2024, 00:31:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "recorded-date": "28-11-2024, 23:37:30",
+    "recorded-date": "29-11-2024, 00:31:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:30",
+    "recorded-date": "29-11-2024, 00:31:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:30",
+    "recorded-date": "29-11-2024, 00:31:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "recorded-date": "28-11-2024, 23:37:30",
+    "recorded-date": "29-11-2024, 00:31:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "recorded-date": "28-11-2024, 23:37:30",
+    "recorded-date": "29-11-2024, 00:31:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "recorded-date": "28-11-2024, 23:37:31",
+    "recorded-date": "29-11-2024, 00:31:07",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:31",
+    "recorded-date": "29-11-2024, 00:31:07",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "recorded-date": "28-11-2024, 23:37:31",
+    "recorded-date": "29-11-2024, 00:31:07",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:31",
+    "recorded-date": "29-11-2024, 00:31:07",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:31",
+    "recorded-date": "29-11-2024, 00:31:07",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:31",
+    "recorded-date": "29-11-2024, 00:31:07",
     "recorded-content": {
       "content_wildcard_complex_EXC": {
         "exception_message": {
@@ -349,55 +349,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:32",
+    "recorded-date": "29-11-2024, 00:31:08",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "recorded-date": "28-11-2024, 23:37:32",
+    "recorded-date": "29-11-2024, 00:31:08",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:33",
+    "recorded-date": "29-11-2024, 00:31:08",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "recorded-date": "28-11-2024, 23:37:33",
+    "recorded-date": "29-11-2024, 00:31:08",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "recorded-date": "28-11-2024, 23:37:33",
+    "recorded-date": "29-11-2024, 00:31:09",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "recorded-date": "28-11-2024, 23:37:33",
+    "recorded-date": "29-11-2024, 00:31:09",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:33",
+    "recorded-date": "29-11-2024, 00:31:09",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "recorded-date": "28-11-2024, 23:37:33",
+    "recorded-date": "29-11-2024, 00:31:09",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:34",
+    "recorded-date": "29-11-2024, 00:31:09",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "recorded-date": "28-11-2024, 23:37:34",
+    "recorded-date": "29-11-2024, 00:31:09",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:34",
+    "recorded-date": "29-11-2024, 00:31:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "recorded-date": "28-11-2024, 23:37:34",
+    "recorded-date": "29-11-2024, 00:31:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:34",
+    "recorded-date": "29-11-2024, 00:31:10",
     "recorded-content": {
       "content_numeric_syntax_EXC": {
         "exception_message": {
@@ -416,19 +416,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "recorded-date": "28-11-2024, 23:37:34",
+    "recorded-date": "29-11-2024, 00:31:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "recorded-date": "28-11-2024, 23:37:35",
+    "recorded-date": "29-11-2024, 00:31:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "recorded-date": "28-11-2024, 23:37:35",
+    "recorded-date": "29-11-2024, 00:31:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "recorded-date": "28-11-2024, 23:37:35",
+    "recorded-date": "29-11-2024, 00:31:11",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
@@ -580,7 +580,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:23",
+    "recorded-date": "29-11-2024, 00:30:58",
     "recorded-content": {
       "content_wildcard_repeating_star_EXC": {
         "exception_message": {
@@ -599,7 +599,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:27",
+    "recorded-date": "29-11-2024, 00:31:02",
     "recorded-content": {
       "content_ignorecase_EXC": {
         "exception_message": {
@@ -618,7 +618,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:33",
+    "recorded-date": "29-11-2024, 00:31:08",
     "recorded-content": {
       "content_ip_address_EXC": {
         "exception_message": {
@@ -637,7 +637,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:28",
+    "recorded-date": "29-11-2024, 00:31:04",
     "recorded-content": {
       "content_anything_but_ignorecase_EXC": {
         "exception_message": {
@@ -656,7 +656,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:31",
+    "recorded-date": "29-11-2024, 00:31:06",
     "recorded-content": {
       "content_anything_but_ignorecase_list_EXC": {
         "exception_message": {
@@ -675,7 +675,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "recorded-date": "28-11-2024, 23:37:32",
+    "recorded-date": "29-11-2024, 00:31:08",
     "recorded-content": {
       "content_ignorecase_list_EXC": {
         "exception_message": {
@@ -752,5 +752,9 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
+    "recorded-date": "29-11-2024, 00:31:04",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/events/test_events_patterns.validation.json
+++ b/tests/aws/services/events/test_events_patterns.validation.json
@@ -260,6 +260,18 @@
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_with_multi_key": {
     "last_validated_date": "2024-07-11T13:55:38+00:00"
   },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_json_event_pattern[[\"not\", \"a\", \"dict\", \"but valid json\"]]": {
+    "last_validated_date": "2024-11-29T00:19:33+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_json_event_pattern[this is valid json but not a dict]": {
+    "last_validated_date": "2024-11-29T00:19:32+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_json_event_pattern[{\"not\": closed mark\"]": {
+    "last_validated_date": "2024-11-29T00:19:33+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_json_event_pattern[{'bad': 'quotation'}]": {
+    "last_validated_date": "2024-11-29T00:19:32+00:00"
+  },
   "tests/aws/services/events/test_events_patterns.py::TestRuleWithPattern::test_put_event_with_content_base_rule_in_pattern": {
     "last_validated_date": "2024-07-11T14:14:42+00:00"
   },

--- a/tests/aws/services/events/test_events_patterns.validation.json
+++ b/tests/aws/services/events/test_events_patterns.validation.json
@@ -1,4 +1,247 @@
 {
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
+    "last_validated_date": "2024-11-28T22:10:13+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:23+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
+    "last_validated_date": "2024-11-28T22:10:16+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:21+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
+    "last_validated_date": "2024-11-28T22:10:24+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:16+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
+    "last_validated_date": "2024-11-28T22:10:17+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
+    "last_validated_date": "2024-11-28T22:10:13+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:14+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
+    "last_validated_date": "2024-11-28T22:10:19+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:19+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
+    "last_validated_date": "2024-11-28T22:10:17+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:22+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
+    "last_validated_date": "2024-11-28T22:10:21+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:14+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
+    "last_validated_date": "2024-11-28T22:10:24+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:18+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
+    "last_validated_date": "2024-11-28T22:10:17+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:15+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
+    "last_validated_date": "2024-11-28T22:10:14+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:15+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
+    "last_validated_date": "2024-11-28T22:10:17+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:22+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
+    "last_validated_date": "2024-11-28T22:10:20+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:15+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
+    "last_validated_date": "2024-11-28T22:10:21+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:19+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
+    "last_validated_date": "2024-11-28T22:10:18+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:23+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
+    "last_validated_date": "2024-11-28T22:10:22+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:23+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
+    "last_validated_date": "2024-11-28T22:10:23+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:22+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
+    "last_validated_date": "2024-11-28T22:10:15+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:18+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
+    "last_validated_date": "2024-11-28T22:10:19+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
+    "last_validated_date": "2024-11-28T22:10:24+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:19+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
+    "last_validated_date": "2024-11-28T22:10:14+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
+    "last_validated_date": "2024-11-28T22:10:23+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
+    "last_validated_date": "2024-11-28T22:10:22+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:21+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
+    "last_validated_date": "2024-11-28T22:10:20+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
+    "last_validated_date": "2024-11-28T22:10:22+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:13+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
+    "last_validated_date": "2024-11-28T22:10:20+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:21+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
+    "last_validated_date": "2024-11-28T22:10:21+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
+    "last_validated_date": "2024-11-28T22:10:14+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:18+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
+    "last_validated_date": "2024-11-28T22:10:12+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:13+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
+    "last_validated_date": "2024-11-28T22:10:14+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
+    "last_validated_date": "2024-11-28T22:10:19+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:20+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
+    "last_validated_date": "2024-11-28T22:10:16+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:20+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
+    "last_validated_date": "2024-11-28T22:10:17+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
+    "last_validated_date": "2024-11-28T22:10:16+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:15+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
+    "last_validated_date": "2024-11-28T22:10:13+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:20+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
+    "last_validated_date": "2024-11-28T22:10:13+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
+    "last_validated_date": "2024-11-28T22:10:22+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:16+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
+    "last_validated_date": "2024-11-28T22:10:17+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
+    "last_validated_date": "2024-11-28T22:10:20+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
+    "last_validated_date": "2024-11-28T22:10:22+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
+    "last_validated_date": "2024-11-28T22:10:18+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
+    "last_validated_date": "2024-11-28T22:10:17+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
+    "last_validated_date": "2024-11-28T22:10:24+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
+    "last_validated_date": "2024-11-28T22:10:16+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
+    "last_validated_date": "2024-11-28T22:10:14+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
+    "last_validated_date": "2024-11-28T22:10:20+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
+    "last_validated_date": "2024-11-28T22:10:20+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
+    "last_validated_date": "2024-11-28T22:10:21+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
+    "last_validated_date": "2024-11-28T22:10:17+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
+    "last_validated_date": "2024-11-28T22:10:15+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
+    "last_validated_date": "2024-07-11T13:55:39+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_with_escape_characters": {
+    "last_validated_date": "2024-07-11T13:55:38+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_with_multi_key": {
+    "last_validated_date": "2024-07-11T13:55:38+00:00"
+  },
   "tests/aws/services/events/test_events_patterns.py::TestRuleWithPattern::test_put_event_with_content_base_rule_in_pattern": {
     "last_validated_date": "2024-07-11T14:14:42+00:00"
   },
@@ -10,248 +253,5 @@
   },
   "tests/aws/services/events/test_events_patterns.py::TestRuleWithPattern::test_put_events_with_rule_pattern_exists_true": {
     "last_validated_date": "2024-07-11T13:55:54+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "last_validated_date": "2024-07-11T13:55:26+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:36+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "last_validated_date": "2024-07-11T13:55:29+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:35+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "last_validated_date": "2024-07-11T13:55:38+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:29+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "last_validated_date": "2024-07-11T13:55:30+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "last_validated_date": "2024-07-11T13:55:25+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:27+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "last_validated_date": "2024-07-11T13:55:32+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:32+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "last_validated_date": "2024-07-11T13:55:30+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:36+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "last_validated_date": "2024-07-11T13:55:34+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:26+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "last_validated_date": "2024-07-11T13:55:38+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:31+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "last_validated_date": "2024-07-11T13:55:31+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:27+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "last_validated_date": "2024-07-11T13:55:27+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:28+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "last_validated_date": "2024-07-11T13:55:30+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:35+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "last_validated_date": "2024-07-11T13:55:33+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:28+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "last_validated_date": "2024-07-11T13:55:34+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:33+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "last_validated_date": "2024-07-11T13:55:31+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:37+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "last_validated_date": "2024-07-11T13:55:36+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:37+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "last_validated_date": "2024-07-11T13:55:37+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:36+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "last_validated_date": "2024-07-11T13:55:28+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:32+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "last_validated_date": "2024-07-11T13:55:32+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "last_validated_date": "2024-07-11T13:55:38+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:33+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "last_validated_date": "2024-07-11T13:55:27+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "last_validated_date": "2024-07-11T13:55:37+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "last_validated_date": "2024-07-11T13:55:36+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:34+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "last_validated_date": "2024-07-11T13:55:33+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "last_validated_date": "2024-07-11T13:55:36+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:25+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "last_validated_date": "2024-07-11T13:55:33+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:35+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "last_validated_date": "2024-07-11T13:55:35+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "last_validated_date": "2024-07-11T13:55:26+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:31+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "last_validated_date": "2024-07-11T13:55:25+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:26+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "last_validated_date": "2024-07-11T13:55:26+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "last_validated_date": "2024-07-11T13:55:33+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:34+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "last_validated_date": "2024-07-11T13:55:30+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:33+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "last_validated_date": "2024-07-11T13:55:30+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "last_validated_date": "2024-07-11T13:55:29+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:28+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "last_validated_date": "2024-07-11T13:55:25+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:34+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "last_validated_date": "2024-07-11T13:55:25+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "last_validated_date": "2024-07-11T13:55:36+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:29+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "last_validated_date": "2024-07-11T13:55:30+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "last_validated_date": "2024-07-11T13:55:33+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "last_validated_date": "2024-07-11T13:55:36+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "last_validated_date": "2024-07-11T13:55:31+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "last_validated_date": "2024-07-11T13:55:30+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "last_validated_date": "2024-07-11T13:55:38+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "last_validated_date": "2024-07-11T13:55:29+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "last_validated_date": "2024-07-11T13:55:26+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "last_validated_date": "2024-07-11T13:55:34+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "last_validated_date": "2024-07-11T13:55:34+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "last_validated_date": "2024-07-11T13:55:34+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "last_validated_date": "2024-07-11T13:55:30+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "last_validated_date": "2024-07-11T13:55:28+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
-    "last_validated_date": "2024-07-11T13:55:39+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_with_escape_characters": {
-    "last_validated_date": "2024-07-11T13:55:38+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_with_multi_key": {
-    "last_validated_date": "2024-07-11T13:55:38+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_patterns.validation.json
+++ b/tests/aws/services/events/test_events_patterns.validation.json
@@ -1,258 +1,324 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "last_validated_date": "2024-11-29T00:30:57+00:00"
+    "last_validated_date": "2024-11-29T01:41:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:09+00:00"
+    "last_validated_date": "2024-11-29T01:41:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "last_validated_date": "2024-11-29T00:31:01+00:00"
+    "last_validated_date": "2024-11-29T01:41:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:07+00:00"
+    "last_validated_date": "2024-11-29T01:41:37+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "last_validated_date": "2024-11-29T00:31:10+00:00"
+    "last_validated_date": "2024-11-29T01:41:44+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:00+00:00"
+    "last_validated_date": "2024-11-29T01:41:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "last_validated_date": "2024-11-29T00:31:02+00:00"
+    "last_validated_date": "2024-11-29T01:41:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "last_validated_date": "2024-11-29T00:30:57+00:00"
+    "last_validated_date": "2024-11-29T01:41:24+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "last_validated_date": "2024-11-29T00:30:59+00:00"
+    "last_validated_date": "2024-11-29T01:41:27+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "last_validated_date": "2024-11-29T00:31:05+00:00"
+    "last_validated_date": "2024-11-29T01:41:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:04+00:00"
+    "last_validated_date": "2024-11-29T01:41:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "last_validated_date": "2024-11-29T00:31:02+00:00"
+    "last_validated_date": "2024-11-29T01:41:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "last_validated_date": "2024-11-29T00:31:04+00:00"
+    "last_validated_date": "2024-11-29T01:41:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:09+00:00"
+    "last_validated_date": "2024-11-29T01:41:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "last_validated_date": "2024-11-29T00:31:07+00:00"
+    "last_validated_date": "2024-11-29T01:41:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-11-29T00:31:06+00:00"
+    "last_validated_date": "2024-11-29T01:41:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "last_validated_date": "2024-11-29T00:30:58+00:00"
+    "last_validated_date": "2024-11-29T01:41:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "last_validated_date": "2024-11-29T00:31:10+00:00"
+    "last_validated_date": "2024-11-29T01:41:44+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:03+00:00"
+    "last_validated_date": "2024-11-29T01:41:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "last_validated_date": "2024-11-29T00:31:02+00:00"
+    "last_validated_date": "2024-11-29T01:41:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "last_validated_date": "2024-11-29T00:30:59+00:00"
+    "last_validated_date": "2024-11-29T01:41:28+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "last_validated_date": "2024-11-29T00:30:59+00:00"
+    "last_validated_date": "2024-11-29T01:41:27+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:00+00:00"
+    "last_validated_date": "2024-11-29T01:41:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "last_validated_date": "2024-11-29T00:31:01+00:00"
+    "last_validated_date": "2024-11-29T01:41:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:08+00:00"
+    "last_validated_date": "2024-11-29T01:41:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
-    "last_validated_date": "2024-11-29T00:31:04+00:00"
+    "last_validated_date": "2024-11-29T01:41:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "last_validated_date": "2024-11-29T00:31:05+00:00"
+    "last_validated_date": "2024-11-29T01:41:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:00+00:00"
+    "last_validated_date": "2024-11-29T01:41:28+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_ignorecase_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:37+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_int_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:42+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list]": {
+    "last_validated_date": "2024-11-29T01:41:25+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_NEG]": {
+    "last_validated_date": "2024-11-29T01:41:26+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_type_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "last_validated_date": "2024-11-29T00:31:06+00:00"
+    "last_validated_date": "2024-11-29T01:41:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:05+00:00"
+    "last_validated_date": "2024-11-29T01:41:35+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_ignorecase_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:39+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_int_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:31+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list]": {
+    "last_validated_date": "2024-11-29T01:41:35+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_NEG]": {
+    "last_validated_date": "2024-11-29T01:41:38+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_type_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:24+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard]": {
+    "last_validated_date": "2024-11-29T01:41:41+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_NEG]": {
+    "last_validated_date": "2024-11-29T01:41:25+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list]": {
+    "last_validated_date": "2024-11-29T01:41:27+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_NEG]": {
+    "last_validated_date": "2024-11-29T01:41:31+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_type_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:25+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_type_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "last_validated_date": "2024-11-29T00:31:03+00:00"
+    "last_validated_date": "2024-11-29T01:41:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:10+00:00"
+    "last_validated_date": "2024-11-29T01:41:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "last_validated_date": "2024-11-29T00:31:09+00:00"
+    "last_validated_date": "2024-11-29T01:41:41+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:10+00:00"
+    "last_validated_date": "2024-11-29T01:41:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "last_validated_date": "2024-11-29T00:31:09+00:00"
+    "last_validated_date": "2024-11-29T01:41:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "last_validated_date": "2024-11-29T00:31:02+00:00"
+    "last_validated_date": "2024-11-29T01:41:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:08+00:00"
+    "last_validated_date": "2024-11-29T01:41:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-11-29T00:31:08+00:00"
+    "last_validated_date": "2024-11-29T01:41:38+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "last_validated_date": "2024-11-29T00:30:59+00:00"
+    "last_validated_date": "2024-11-29T01:41:28+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "last_validated_date": "2024-11-29T00:31:08+00:00"
+    "last_validated_date": "2024-11-29T01:41:41+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:03+00:00"
+    "last_validated_date": "2024-11-29T01:41:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "last_validated_date": "2024-11-29T00:31:04+00:00"
+    "last_validated_date": "2024-11-29T01:41:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "last_validated_date": "2024-11-29T00:31:10+00:00"
+    "last_validated_date": "2024-11-29T01:41:44+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:05+00:00"
+    "last_validated_date": "2024-11-29T01:41:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "last_validated_date": "2024-11-29T00:30:59+00:00"
+    "last_validated_date": "2024-11-29T01:41:27+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "last_validated_date": "2024-11-29T00:31:10+00:00"
+    "last_validated_date": "2024-11-29T01:41:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "last_validated_date": "2024-11-29T00:31:08+00:00"
+    "last_validated_date": "2024-11-29T01:41:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:07+00:00"
+    "last_validated_date": "2024-11-29T01:41:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "last_validated_date": "2024-11-29T00:31:05+00:00"
+    "last_validated_date": "2024-11-29T01:41:35+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_int_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:34+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_list_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:28+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "last_validated_date": "2024-11-29T00:31:09+00:00"
+    "last_validated_date": "2024-11-29T01:41:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "last_validated_date": "2024-11-29T00:30:57+00:00"
+    "last_validated_date": "2024-11-29T01:41:24+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "last_validated_date": "2024-11-29T00:31:05+00:00"
+    "last_validated_date": "2024-11-29T01:41:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:07+00:00"
+    "last_validated_date": "2024-11-29T01:41:37+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_int_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:37+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_list_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:41+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "last_validated_date": "2024-11-29T00:31:07+00:00"
+    "last_validated_date": "2024-11-29T01:41:38+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_int_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:40+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_list_EXC]": {
+    "last_validated_date": "2024-11-29T01:41:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "last_validated_date": "2024-11-29T00:30:58+00:00"
+    "last_validated_date": "2024-11-29T01:41:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:02+00:00"
+    "last_validated_date": "2024-11-29T01:41:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "last_validated_date": "2024-11-29T00:30:56+00:00"
+    "last_validated_date": "2024-11-29T01:41:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "last_validated_date": "2024-11-29T00:30:58+00:00"
+    "last_validated_date": "2024-11-29T01:41:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "last_validated_date": "2024-11-29T00:30:58+00:00"
+    "last_validated_date": "2024-11-29T01:41:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "last_validated_date": "2024-11-29T00:30:58+00:00"
+    "last_validated_date": "2024-11-29T01:41:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "last_validated_date": "2024-11-29T00:31:05+00:00"
+    "last_validated_date": "2024-11-29T01:41:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:06+00:00"
+    "last_validated_date": "2024-11-29T01:41:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "last_validated_date": "2024-11-29T00:31:01+00:00"
+    "last_validated_date": "2024-11-29T01:41:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:05+00:00"
+    "last_validated_date": "2024-11-29T01:41:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "last_validated_date": "2024-11-29T00:31:01+00:00"
+    "last_validated_date": "2024-11-29T01:41:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "last_validated_date": "2024-11-29T00:31:00+00:00"
+    "last_validated_date": "2024-11-29T01:41:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:00+00:00"
+    "last_validated_date": "2024-11-29T01:41:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "last_validated_date": "2024-11-29T00:30:57+00:00"
+    "last_validated_date": "2024-11-29T01:41:24+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:06+00:00"
+    "last_validated_date": "2024-11-29T01:41:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "last_validated_date": "2024-11-29T00:30:57+00:00"
+    "last_validated_date": "2024-11-29T01:41:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "last_validated_date": "2024-11-29T00:31:08+00:00"
+    "last_validated_date": "2024-11-29T01:41:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:01+00:00"
+    "last_validated_date": "2024-11-29T01:41:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "last_validated_date": "2024-11-29T00:31:02+00:00"
+    "last_validated_date": "2024-11-29T01:41:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "last_validated_date": "2024-11-29T00:31:05+00:00"
+    "last_validated_date": "2024-11-29T01:41:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "last_validated_date": "2024-11-29T00:31:09+00:00"
+    "last_validated_date": "2024-11-29T01:41:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "last_validated_date": "2024-11-29T00:31:03+00:00"
+    "last_validated_date": "2024-11-29T01:41:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "last_validated_date": "2024-11-29T00:31:01+00:00"
+    "last_validated_date": "2024-11-29T01:41:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "last_validated_date": "2024-11-29T00:31:11+00:00"
+    "last_validated_date": "2024-11-29T01:41:44+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "last_validated_date": "2024-11-29T00:31:00+00:00"
+    "last_validated_date": "2024-11-29T01:41:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "last_validated_date": "2024-11-29T00:30:58+00:00"
+    "last_validated_date": "2024-11-29T01:41:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "last_validated_date": "2024-11-29T00:31:06+00:00"
+    "last_validated_date": "2024-11-29T01:41:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "last_validated_date": "2024-11-29T00:31:06+00:00"
+    "last_validated_date": "2024-11-29T01:41:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "last_validated_date": "2024-11-29T00:31:07+00:00"
+    "last_validated_date": "2024-11-29T01:41:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "last_validated_date": "2024-11-29T00:31:02+00:00"
+    "last_validated_date": "2024-11-29T01:41:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "last_validated_date": "2024-11-29T00:31:00+00:00"
+    "last_validated_date": "2024-11-29T01:41:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
     "last_validated_date": "2024-07-11T13:55:39+00:00"

--- a/tests/aws/services/events/test_events_patterns.validation.json
+++ b/tests/aws/services/events/test_events_patterns.validation.json
@@ -1,255 +1,258 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "last_validated_date": "2024-11-28T23:37:22+00:00"
+    "last_validated_date": "2024-11-29T00:30:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:34+00:00"
+    "last_validated_date": "2024-11-29T00:31:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:25+00:00"
+    "last_validated_date": "2024-11-29T00:31:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:31+00:00"
+    "last_validated_date": "2024-11-29T00:31:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "last_validated_date": "2024-11-28T23:37:35+00:00"
+    "last_validated_date": "2024-11-29T00:31:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:25+00:00"
+    "last_validated_date": "2024-11-29T00:31:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "last_validated_date": "2024-11-28T23:37:26+00:00"
+    "last_validated_date": "2024-11-29T00:31:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "last_validated_date": "2024-11-28T23:37:21+00:00"
+    "last_validated_date": "2024-11-29T00:30:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:23+00:00"
+    "last_validated_date": "2024-11-29T00:30:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "last_validated_date": "2024-11-28T23:37:29+00:00"
+    "last_validated_date": "2024-11-29T00:31:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:29+00:00"
+    "last_validated_date": "2024-11-29T00:31:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "last_validated_date": "2024-11-28T23:37:26+00:00"
+    "last_validated_date": "2024-11-29T00:31:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:28+00:00"
+    "last_validated_date": "2024-11-29T00:31:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:33+00:00"
+    "last_validated_date": "2024-11-29T00:31:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "last_validated_date": "2024-11-28T23:37:31+00:00"
+    "last_validated_date": "2024-11-29T00:31:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:31+00:00"
+    "last_validated_date": "2024-11-29T00:31:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:22+00:00"
+    "last_validated_date": "2024-11-29T00:30:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "last_validated_date": "2024-11-28T23:37:35+00:00"
+    "last_validated_date": "2024-11-29T00:31:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:27+00:00"
+    "last_validated_date": "2024-11-29T00:31:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "last_validated_date": "2024-11-28T23:37:27+00:00"
+    "last_validated_date": "2024-11-29T00:31:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:24+00:00"
+    "last_validated_date": "2024-11-29T00:30:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "last_validated_date": "2024-11-28T23:37:23+00:00"
+    "last_validated_date": "2024-11-29T00:30:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:25+00:00"
+    "last_validated_date": "2024-11-29T00:31:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "last_validated_date": "2024-11-28T23:37:26+00:00"
+    "last_validated_date": "2024-11-29T00:31:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:32+00:00"
+    "last_validated_date": "2024-11-29T00:31:08+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
+    "last_validated_date": "2024-11-29T00:31:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "last_validated_date": "2024-11-28T23:37:30+00:00"
+    "last_validated_date": "2024-11-29T00:31:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:24+00:00"
+    "last_validated_date": "2024-11-29T00:31:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "last_validated_date": "2024-11-28T23:37:30+00:00"
+    "last_validated_date": "2024-11-29T00:31:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:29+00:00"
+    "last_validated_date": "2024-11-29T00:31:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "last_validated_date": "2024-11-28T23:37:28+00:00"
+    "last_validated_date": "2024-11-29T00:31:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:34+00:00"
+    "last_validated_date": "2024-11-29T00:31:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "last_validated_date": "2024-11-28T23:37:33+00:00"
+    "last_validated_date": "2024-11-29T00:31:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:34+00:00"
+    "last_validated_date": "2024-11-29T00:31:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "last_validated_date": "2024-11-28T23:37:34+00:00"
+    "last_validated_date": "2024-11-29T00:31:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:27+00:00"
+    "last_validated_date": "2024-11-29T00:31:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:33+00:00"
+    "last_validated_date": "2024-11-29T00:31:08+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:32+00:00"
+    "last_validated_date": "2024-11-29T00:31:08+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "last_validated_date": "2024-11-28T23:37:24+00:00"
+    "last_validated_date": "2024-11-29T00:30:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:33+00:00"
+    "last_validated_date": "2024-11-29T00:31:08+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:28+00:00"
+    "last_validated_date": "2024-11-29T00:31:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:28+00:00"
+    "last_validated_date": "2024-11-29T00:31:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "last_validated_date": "2024-11-28T23:37:34+00:00"
+    "last_validated_date": "2024-11-29T00:31:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:29+00:00"
+    "last_validated_date": "2024-11-29T00:31:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:23+00:00"
+    "last_validated_date": "2024-11-29T00:30:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:34+00:00"
+    "last_validated_date": "2024-11-29T00:31:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "last_validated_date": "2024-11-28T23:37:32+00:00"
+    "last_validated_date": "2024-11-29T00:31:08+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:31+00:00"
+    "last_validated_date": "2024-11-29T00:31:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "last_validated_date": "2024-11-28T23:37:29+00:00"
+    "last_validated_date": "2024-11-29T00:31:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "last_validated_date": "2024-11-28T23:37:33+00:00"
+    "last_validated_date": "2024-11-29T00:31:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:21+00:00"
+    "last_validated_date": "2024-11-29T00:30:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "last_validated_date": "2024-11-28T23:37:30+00:00"
+    "last_validated_date": "2024-11-29T00:31:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:31+00:00"
+    "last_validated_date": "2024-11-29T00:31:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:31+00:00"
+    "last_validated_date": "2024-11-29T00:31:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "last_validated_date": "2024-11-28T23:37:23+00:00"
+    "last_validated_date": "2024-11-29T00:30:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:27+00:00"
+    "last_validated_date": "2024-11-29T00:31:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "last_validated_date": "2024-11-28T23:37:21+00:00"
+    "last_validated_date": "2024-11-29T00:30:56+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:22+00:00"
+    "last_validated_date": "2024-11-29T00:30:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:23+00:00"
+    "last_validated_date": "2024-11-29T00:30:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "last_validated_date": "2024-11-28T23:37:22+00:00"
+    "last_validated_date": "2024-11-29T00:30:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "last_validated_date": "2024-11-28T23:37:29+00:00"
+    "last_validated_date": "2024-11-29T00:31:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:30+00:00"
+    "last_validated_date": "2024-11-29T00:31:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "last_validated_date": "2024-11-28T23:37:26+00:00"
+    "last_validated_date": "2024-11-29T00:31:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:30+00:00"
+    "last_validated_date": "2024-11-29T00:31:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "last_validated_date": "2024-11-28T23:37:26+00:00"
+    "last_validated_date": "2024-11-29T00:31:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "last_validated_date": "2024-11-28T23:37:25+00:00"
+    "last_validated_date": "2024-11-29T00:31:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:25+00:00"
+    "last_validated_date": "2024-11-29T00:31:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:22+00:00"
+    "last_validated_date": "2024-11-29T00:30:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:30+00:00"
+    "last_validated_date": "2024-11-29T00:31:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "last_validated_date": "2024-11-28T23:37:21+00:00"
+    "last_validated_date": "2024-11-29T00:30:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "last_validated_date": "2024-11-28T23:37:33+00:00"
+    "last_validated_date": "2024-11-29T00:31:08+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:25+00:00"
+    "last_validated_date": "2024-11-29T00:31:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "last_validated_date": "2024-11-28T23:37:26+00:00"
+    "last_validated_date": "2024-11-29T00:31:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "last_validated_date": "2024-11-28T23:37:30+00:00"
+    "last_validated_date": "2024-11-29T00:31:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "last_validated_date": "2024-11-28T23:37:33+00:00"
+    "last_validated_date": "2024-11-29T00:31:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:27+00:00"
+    "last_validated_date": "2024-11-29T00:31:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "last_validated_date": "2024-11-28T23:37:26+00:00"
+    "last_validated_date": "2024-11-29T00:31:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "last_validated_date": "2024-11-28T23:37:35+00:00"
+    "last_validated_date": "2024-11-29T00:31:11+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "last_validated_date": "2024-11-28T23:37:25+00:00"
+    "last_validated_date": "2024-11-29T00:31:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "last_validated_date": "2024-11-28T23:37:22+00:00"
+    "last_validated_date": "2024-11-29T00:30:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "last_validated_date": "2024-11-28T23:37:30+00:00"
+    "last_validated_date": "2024-11-29T00:31:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "last_validated_date": "2024-11-28T23:37:30+00:00"
+    "last_validated_date": "2024-11-29T00:31:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "last_validated_date": "2024-11-28T23:37:31+00:00"
+    "last_validated_date": "2024-11-29T00:31:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "last_validated_date": "2024-11-28T23:37:26+00:00"
+    "last_validated_date": "2024-11-29T00:31:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "last_validated_date": "2024-11-28T23:37:24+00:00"
+    "last_validated_date": "2024-11-29T00:31:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
     "last_validated_date": "2024-07-11T13:55:39+00:00"

--- a/tests/aws/services/events/test_events_patterns.validation.json
+++ b/tests/aws/services/events/test_events_patterns.validation.json
@@ -1,237 +1,255 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "last_validated_date": "2024-11-28T22:10:13+00:00"
+    "last_validated_date": "2024-11-28T23:37:22+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:23+00:00"
+    "last_validated_date": "2024-11-28T23:37:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "last_validated_date": "2024-11-28T22:10:16+00:00"
+    "last_validated_date": "2024-11-28T23:37:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:21+00:00"
+    "last_validated_date": "2024-11-28T23:37:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "last_validated_date": "2024-11-28T22:10:24+00:00"
+    "last_validated_date": "2024-11-28T23:37:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:16+00:00"
+    "last_validated_date": "2024-11-28T23:37:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "last_validated_date": "2024-11-28T22:10:17+00:00"
+    "last_validated_date": "2024-11-28T23:37:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "last_validated_date": "2024-11-28T22:10:13+00:00"
+    "last_validated_date": "2024-11-28T23:37:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:14+00:00"
+    "last_validated_date": "2024-11-28T23:37:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "last_validated_date": "2024-11-28T22:10:19+00:00"
+    "last_validated_date": "2024-11-28T23:37:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:19+00:00"
+    "last_validated_date": "2024-11-28T23:37:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "last_validated_date": "2024-11-28T22:10:17+00:00"
+    "last_validated_date": "2024-11-28T23:37:26+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
+    "last_validated_date": "2024-11-28T23:37:28+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:22+00:00"
+    "last_validated_date": "2024-11-28T23:37:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "last_validated_date": "2024-11-28T22:10:21+00:00"
+    "last_validated_date": "2024-11-28T23:37:31+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
+    "last_validated_date": "2024-11-28T23:37:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:14+00:00"
+    "last_validated_date": "2024-11-28T23:37:22+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "last_validated_date": "2024-11-28T22:10:24+00:00"
+    "last_validated_date": "2024-11-28T23:37:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:18+00:00"
+    "last_validated_date": "2024-11-28T23:37:27+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "last_validated_date": "2024-11-28T22:10:17+00:00"
+    "last_validated_date": "2024-11-28T23:37:27+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:15+00:00"
+    "last_validated_date": "2024-11-28T23:37:24+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "last_validated_date": "2024-11-28T22:10:14+00:00"
+    "last_validated_date": "2024-11-28T23:37:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:15+00:00"
+    "last_validated_date": "2024-11-28T23:37:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "last_validated_date": "2024-11-28T22:10:17+00:00"
+    "last_validated_date": "2024-11-28T23:37:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:22+00:00"
+    "last_validated_date": "2024-11-28T23:37:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "last_validated_date": "2024-11-28T22:10:20+00:00"
+    "last_validated_date": "2024-11-28T23:37:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:15+00:00"
+    "last_validated_date": "2024-11-28T23:37:24+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "last_validated_date": "2024-11-28T22:10:21+00:00"
+    "last_validated_date": "2024-11-28T23:37:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:19+00:00"
+    "last_validated_date": "2024-11-28T23:37:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "last_validated_date": "2024-11-28T22:10:18+00:00"
+    "last_validated_date": "2024-11-28T23:37:28+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:23+00:00"
+    "last_validated_date": "2024-11-28T23:37:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "last_validated_date": "2024-11-28T22:10:22+00:00"
+    "last_validated_date": "2024-11-28T23:37:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:23+00:00"
+    "last_validated_date": "2024-11-28T23:37:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "last_validated_date": "2024-11-28T22:10:23+00:00"
+    "last_validated_date": "2024-11-28T23:37:34+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
+    "last_validated_date": "2024-11-28T23:37:27+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:22+00:00"
+    "last_validated_date": "2024-11-28T23:37:33+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
+    "last_validated_date": "2024-11-28T23:37:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "last_validated_date": "2024-11-28T22:10:15+00:00"
+    "last_validated_date": "2024-11-28T23:37:24+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
+    "last_validated_date": "2024-11-28T23:37:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:18+00:00"
+    "last_validated_date": "2024-11-28T23:37:28+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "last_validated_date": "2024-11-28T22:10:19+00:00"
+    "last_validated_date": "2024-11-28T23:37:28+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "last_validated_date": "2024-11-28T22:10:24+00:00"
+    "last_validated_date": "2024-11-28T23:37:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:19+00:00"
+    "last_validated_date": "2024-11-28T23:37:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "last_validated_date": "2024-11-28T22:10:14+00:00"
+    "last_validated_date": "2024-11-28T23:37:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "last_validated_date": "2024-11-28T22:10:23+00:00"
+    "last_validated_date": "2024-11-28T23:37:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "last_validated_date": "2024-11-28T22:10:22+00:00"
+    "last_validated_date": "2024-11-28T23:37:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:21+00:00"
+    "last_validated_date": "2024-11-28T23:37:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "last_validated_date": "2024-11-28T22:10:20+00:00"
+    "last_validated_date": "2024-11-28T23:37:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "last_validated_date": "2024-11-28T22:10:22+00:00"
+    "last_validated_date": "2024-11-28T23:37:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:13+00:00"
+    "last_validated_date": "2024-11-28T23:37:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "last_validated_date": "2024-11-28T22:10:20+00:00"
+    "last_validated_date": "2024-11-28T23:37:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:21+00:00"
+    "last_validated_date": "2024-11-28T23:37:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "last_validated_date": "2024-11-28T22:10:21+00:00"
+    "last_validated_date": "2024-11-28T23:37:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "last_validated_date": "2024-11-28T22:10:14+00:00"
+    "last_validated_date": "2024-11-28T23:37:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:18+00:00"
+    "last_validated_date": "2024-11-28T23:37:27+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "last_validated_date": "2024-11-28T22:10:12+00:00"
+    "last_validated_date": "2024-11-28T23:37:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:13+00:00"
+    "last_validated_date": "2024-11-28T23:37:22+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
+    "last_validated_date": "2024-11-28T23:37:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "last_validated_date": "2024-11-28T22:10:14+00:00"
+    "last_validated_date": "2024-11-28T23:37:22+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "last_validated_date": "2024-11-28T22:10:19+00:00"
+    "last_validated_date": "2024-11-28T23:37:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:20+00:00"
+    "last_validated_date": "2024-11-28T23:37:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "last_validated_date": "2024-11-28T22:10:16+00:00"
+    "last_validated_date": "2024-11-28T23:37:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:20+00:00"
+    "last_validated_date": "2024-11-28T23:37:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "last_validated_date": "2024-11-28T22:10:17+00:00"
+    "last_validated_date": "2024-11-28T23:37:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "last_validated_date": "2024-11-28T22:10:16+00:00"
+    "last_validated_date": "2024-11-28T23:37:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:15+00:00"
+    "last_validated_date": "2024-11-28T23:37:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "last_validated_date": "2024-11-28T22:10:13+00:00"
+    "last_validated_date": "2024-11-28T23:37:22+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:20+00:00"
+    "last_validated_date": "2024-11-28T23:37:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "last_validated_date": "2024-11-28T22:10:13+00:00"
+    "last_validated_date": "2024-11-28T23:37:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "last_validated_date": "2024-11-28T22:10:22+00:00"
+    "last_validated_date": "2024-11-28T23:37:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:16+00:00"
+    "last_validated_date": "2024-11-28T23:37:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "last_validated_date": "2024-11-28T22:10:17+00:00"
+    "last_validated_date": "2024-11-28T23:37:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "last_validated_date": "2024-11-28T22:10:20+00:00"
+    "last_validated_date": "2024-11-28T23:37:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "last_validated_date": "2024-11-28T22:10:22+00:00"
+    "last_validated_date": "2024-11-28T23:37:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "last_validated_date": "2024-11-28T22:10:18+00:00"
+    "last_validated_date": "2024-11-28T23:37:27+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "last_validated_date": "2024-11-28T22:10:17+00:00"
+    "last_validated_date": "2024-11-28T23:37:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "last_validated_date": "2024-11-28T22:10:24+00:00"
+    "last_validated_date": "2024-11-28T23:37:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "last_validated_date": "2024-11-28T22:10:16+00:00"
+    "last_validated_date": "2024-11-28T23:37:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "last_validated_date": "2024-11-28T22:10:14+00:00"
+    "last_validated_date": "2024-11-28T23:37:22+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "last_validated_date": "2024-11-28T22:10:20+00:00"
+    "last_validated_date": "2024-11-28T23:37:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "last_validated_date": "2024-11-28T22:10:20+00:00"
+    "last_validated_date": "2024-11-28T23:37:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "last_validated_date": "2024-11-28T22:10:21+00:00"
+    "last_validated_date": "2024-11-28T23:37:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "last_validated_date": "2024-11-28T22:10:17+00:00"
+    "last_validated_date": "2024-11-28T23:37:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "last_validated_date": "2024-11-28T22:10:15+00:00"
+    "last_validated_date": "2024-11-28T23:37:24+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
     "last_validated_date": "2024-07-11T13:55:39+00:00"

--- a/tests/unit/utils/test_event_matcher.py
+++ b/tests/unit/utils/test_event_matcher.py
@@ -72,15 +72,16 @@ def test_matches_event_non_matching_pattern():
 @pytest.mark.parametrize("engine", ("python", "java"))
 def test_matches_event_invalid_json(event_rule_engine, engine):
     """Test with invalid JSON strings"""
-    event_rule_engine(engine)
 
     if engine == "java":
         # this lets the exception bubble up to the provider, when AWS returns a proper exception, it should be fixed
         exception_type = json.JSONDecodeError
+        # do not re-enable this test, enabling jpype here will break StepFunctions
         pytest.skip("jpype conflict")
     else:
         exception_type = InvalidEventPatternException
 
+    event_rule_engine(engine)
     with pytest.raises(exception_type):
         matches_event("{invalid-json}", EVENT_STR)
 

--- a/tests/unit/utils/test_event_matcher.py
+++ b/tests/unit/utils/test_event_matcher.py
@@ -69,9 +69,19 @@ def test_matches_event_non_matching_pattern():
     assert not matches_event(non_matching_pattern, EVENT_DICT)
 
 
-def test_matches_event_invalid_json():
+@pytest.mark.parametrize("engine", ("python", "java"))
+def test_matches_event_invalid_json(event_rule_engine, engine):
     """Test with invalid JSON strings"""
-    with pytest.raises(InvalidEventPatternException):
+    event_rule_engine(engine)
+
+    if engine == "java":
+        # this lets the exception bubble up to the provider, when AWS returns a proper exception, it should be fixed
+        exception_type = json.JSONDecodeError
+        pytest.skip("jpype conflict")
+    else:
+        exception_type = InvalidEventPatternException
+
+    with pytest.raises(exception_type):
         matches_event("{invalid-json}", EVENT_STR)
 
 

--- a/tests/unit/utils/test_event_matcher.py
+++ b/tests/unit/utils/test_event_matcher.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from localstack import config
+from localstack.aws.api.events import InvalidEventPatternException
 from localstack.utils.event_matcher import matches_event
 
 EVENT_PATTERN_DICT = {
@@ -70,7 +71,7 @@ def test_matches_event_non_matching_pattern():
 
 def test_matches_event_invalid_json():
     """Test with invalid JSON strings"""
-    with pytest.raises(json.JSONDecodeError):
+    with pytest.raises(InvalidEventPatternException):
         matches_event("{invalid-json}", EVENT_STR)
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR copy-paste the SNS Filter Policy engine and modify it to be an `EventPatternEngine`. Implementations are close, but differs in quite a few ways. SNS has less features, maybe linked to complexity issues. They also allow way less complexity in rules. 

There a few differences with SNS in almost all methods, could maybe be consolidated by testing all the edge cases for SNS as well, but keeping the implementation different might just be a better idea, even if the base looks similar. Those are 2 different services and could evolve in different directions. 

Question: should it be behind a feature flag? ~Should probably be released after `4.0.3`~. It shouldn't be worse than the current implementation, but could probably have a few regression concerning validation (we might be stricter and wrong). 
edit: as the current Python implementation has a lot of flaws, merging this is most probably beneficial and should go in `4.0.3`, but I'll be on the lookout for any potential regression and jump on it next week if needed.

Note: 
In SNS, the filter policies are validated in a different step than the matching, which is why the current implementation is split into 2 classes. The validation (`EventPatternValidator`) could probably be consolidated into the `EventRuleEngine` for `events`. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- copy-paste the SNS filter policy engine to `events`, modify what was needed and add the missing implementation:
  - `wildcard` operator
  - `cidr` operator (should be ported back to SNS)
  - nested `anything-but` with `suffix`, `equals-ignore-case` and `wildcard` (untested before) 
    - `equals-ignore-case`, `wildcard`, `suffix` and `prefix` list values only when nested under `anything-but`
  - nested `equals-ignore-case` under `suffix` and `prefix` 
- modify the validation engine to be less strict than SNS, might still be too strict, we need to implement more tests in `events`
- add over 30 test cases for missing validation, new implementation has 114/114 🥳 

## Testing
All tests are passing, even the `_EXC` ones, I've added a few more as I had a few unanswered questions by doing the implementation.

Also testing downstream dependencies with a full run at #\2193 (seems to be failing for unrelated changes and #11961), new full run at #\2208 ✅ for AMD64, ARM timeout but surely unrelated

## TODO

What's left to do:

- [x] add the few tests marked with TODO in the implementation
- [x] maybe replace the logic in `matches_event` so that it used by Pipes, but this could be done in a follow up
