### PR TITLE
fix ESM analytics

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_event_processor.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_event_processor.py
@@ -28,9 +28,14 @@ class EsmEventProcessor(EventProcessor):
         self.sender = sender
         self.logger = logger
 
-    def process_events_batch(self, input_events: list[dict]) -> None:
+    def process_events_batch(self, input_events: list[dict] | dict) -> None:
         # analytics
-        first_event = input_events[0] if input_events else {}
+        if isinstance(input_events, list) and input_events:
+            first_event = input_events[0]
+        elif input_events:
+            first_event = input_events
+        else:
+            first_event = {}
         event_source = first_event.get("eventSource")
         esm_invocation.record(event_source)
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
It seems #11883 has broken downstream dependencies, related to Kafka not having the same format (sending a dict when the signature is `list[dict]`). Tests are failing and are not validated against AWS, so I suppose we're supposed to be able to accept `dict` directly to `process_events_batch` as `input_events`. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add more safety around trying to access `first_event`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
