### PR TITLE
Cloudformation implement ssm param read

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/quirks.py
+++ b/localstack-core/localstack/services/cloudformation/engine/quirks.py
@@ -28,7 +28,6 @@ PHYSICAL_RESOURCE_ID_SPECIAL_CASES = {
     "AWS::Events::EventBus": "/properties/Name",
     "AWS::Logs::LogStream": "/properties/LogStreamName",
     "AWS::Logs::SubscriptionFilter": "/properties/LogGroupName",
-    "AWS::SSM::Parameter": "/properties/Name",
     "AWS::RDS::DBProxyTargetGroup": "/properties/TargetGroupName",
     "AWS::Glue::SchemaVersionMetadata": "</properties/SchemaVersionId>|</properties/Key>|</properties/Value>",  # composite
     "AWS::WAFv2::WebACL": "</properties/Name>|</properties/Id>|</properties/Scope>",

--- a/localstack-core/localstack/services/cloudformation/provider_utils.py
+++ b/localstack-core/localstack/services/cloudformation/provider_utils.py
@@ -227,7 +227,7 @@ def convert_values_to_numbers(input_dict: dict, keys_to_skip: Optional[List[str]
 
 
 #  LocalStack specific utilities
-def get_schema_path(file_path: Path) -> Path:
+def get_schema_path(file_path: Path) -> dict:
     file_name_base = file_path.name.removesuffix(".py").removesuffix(".py.enc")
     with Path(file_path).parent.joinpath(f"{file_name_base}.schema.json").open() as fd:
         return json.load(fd)

--- a/localstack-core/localstack/services/ssm/resource_providers/aws_ssm_parameter.py
+++ b/localstack-core/localstack/services/ssm/resource_providers/aws_ssm_parameter.py
@@ -213,11 +213,10 @@ class SSMParameterProvider(ResourceProvider[SSMParameterProperties]):
         request: ResourceRequest[SSMParameterProperties],
     ) -> ProgressEvent[SSMParameterProperties]:
         resources = request.aws_client_factory.ssm.describe_parameters()
-        discoverable_properties = ["Name"]
         return ProgressEvent(
             status=OperationStatus.SUCCESS,
             resource_models=[
-                SSMParameterProperties(**util.select_attributes(resource, discoverable_properties))
+                SSMParameterProperties(Name=resource["Name"])
                 for resource in resources["Parameters"]
             ],
         )

--- a/localstack-core/localstack/services/ssm/resource_providers/aws_ssm_parameter.py
+++ b/localstack-core/localstack/services/ssm/resource_providers/aws_ssm_parameter.py
@@ -19,7 +19,6 @@ class SSMParameterProperties(TypedDict):
     AllowedPattern: Optional[str]
     DataType: Optional[str]
     Description: Optional[str]
-    Id: Optional[str]
     Name: Optional[str]
     Policies: Optional[str]
     Tags: Optional[dict]
@@ -41,19 +40,21 @@ class SSMParameterProvider(ResourceProvider[SSMParameterProperties]):
         Create a new resource.
 
         Primary identifier fields:
-          - /properties/Id
+          - /properties/Name
 
         Required properties:
-          - Type
           - Value
+          - Type
 
         Create-only properties:
           - /properties/Name
 
-        Read-only properties:
-          - /properties/Id
 
 
+        IAM permissions required:
+          - ssm:PutParameter
+          - ssm:AddTagsToResource
+          - ssm:GetParameters
 
         """
         model = request.desired_state
@@ -96,7 +97,8 @@ class SSMParameterProvider(ResourceProvider[SSMParameterProperties]):
         """
         Fetch resource information
 
-
+        IAM permissions required:
+          - ssm:GetParameters
         """
         ssm = request.aws_client_factory.ssm
         parameter_name = request.desired_state.get("Name")
@@ -124,7 +126,8 @@ class SSMParameterProvider(ResourceProvider[SSMParameterProperties]):
         """
         Delete a resource
 
-
+        IAM permissions required:
+          - ssm:DeleteParameter
         """
         model = request.desired_state
         ssm = request.aws_client_factory.ssm
@@ -144,7 +147,11 @@ class SSMParameterProvider(ResourceProvider[SSMParameterProperties]):
         """
         Update a resource
 
-
+        IAM permissions required:
+          - ssm:PutParameter
+          - ssm:AddTagsToResource
+          - ssm:RemoveTagsFromResource
+          - ssm:GetParameters
         """
         model = request.desired_state
         ssm = request.aws_client_factory.ssm

--- a/localstack-core/localstack/services/ssm/resource_providers/aws_ssm_parameter.schema.json
+++ b/localstack-core/localstack/services/ssm/resource_providers/aws_ssm_parameter.schema.json
@@ -4,47 +4,118 @@
   "additionalProperties": false,
   "properties": {
     "Type": {
-      "type": "string"
-    },
-    "Description": {
-      "type": "string"
-    },
-    "Policies": {
-      "type": "string"
-    },
-    "AllowedPattern": {
-      "type": "string"
-    },
-    "Tier": {
-      "type": "string"
+      "type": "string",
+      "description": "The type of the parameter.",
+      "enum": [
+        "String",
+        "StringList",
+        "SecureString"
+      ]
     },
     "Value": {
-      "type": "string"
+      "type": "string",
+      "description": "The value associated with the parameter."
     },
-    "DataType": {
-      "type": "string"
+    "Description": {
+      "type": "string",
+      "description": "The information about the parameter."
     },
-    "Id": {
-      "type": "string"
+    "Policies": {
+      "type": "string",
+      "description": "The policies attached to the parameter."
+    },
+    "AllowedPattern": {
+      "type": "string",
+      "description": "The regular expression used to validate the parameter value."
+    },
+    "Tier": {
+      "type": "string",
+      "description": "The corresponding tier of the parameter.",
+      "enum": [
+        "Standard",
+        "Advanced",
+        "Intelligent-Tiering"
+      ]
     },
     "Tags": {
-      "type": "object"
+      "type": "object",
+      "description": "A key-value pair to associate with a resource.",
+      "patternProperties": {
+        "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DataType": {
+      "type": "string",
+      "description": "The corresponding DataType of the parameter.",
+      "enum": [
+        "text",
+        "aws:ec2:image"
+      ]
     },
     "Name": {
-      "type": "string"
+      "type": "string",
+      "description": "The name of the parameter."
     }
   },
   "required": [
-    "Type",
-    "Value"
+    "Value",
+    "Type"
   ],
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/Tags"
+  },
   "createOnlyProperties": [
     "/properties/Name"
   ],
   "primaryIdentifier": [
-    "/properties/Id"
+    "/properties/Name"
   ],
-  "readOnlyProperties": [
-    "/properties/Id"
-  ]
+  "writeOnlyProperties": [
+    "/properties/Tags",
+    "/properties/Description",
+    "/properties/Tier",
+    "/properties/AllowedPattern",
+    "/properties/Policies"
+  ],
+  "handlers": {
+    "create": {
+      "permissions": [
+        "ssm:PutParameter",
+        "ssm:AddTagsToResource",
+        "ssm:GetParameters"
+      ],
+      "timeoutInMinutes": 5
+    },
+    "read": {
+      "permissions": [
+        "ssm:GetParameters"
+      ]
+    },
+    "update": {
+      "permissions": [
+        "ssm:PutParameter",
+        "ssm:AddTagsToResource",
+        "ssm:RemoveTagsFromResource",
+        "ssm:GetParameters"
+      ],
+      "timeoutInMinutes": 5
+    },
+    "delete": {
+      "permissions": [
+        "ssm:DeleteParameter"
+      ]
+    },
+    "list": {
+      "permissions": [
+        "ssm:DescribeParameters"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Implementation of `read` along with fixing `list` for ssm parameters. While fixing I realised that the generated specs were out of date. So I recreated them, highlighting an issue with the previous list operation.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- update `create` method to return the `read` operation. (how can we test this?)
- added `read` operation
- updated `list` operation

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
