### PR TITLE
[SFN] Add usage analytics for Variable Workflow and JSONata features

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/usage_metrics_static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/usage_metrics_static_analyser.py
@@ -1,0 +1,56 @@
+import logging
+
+import localstack.services.stepfunctions.usage as UsageMetrics
+from localstack.services.stepfunctions.asl.antlr.runtime.ASLParser import ASLParser
+from localstack.services.stepfunctions.asl.component.common.query_language import (
+    QueryLanguageMode,
+)
+from localstack.services.stepfunctions.asl.static_analyser.static_analyser import StaticAnalyser
+
+LOG = logging.getLogger(__name__)
+
+
+class UsageMetricsStaticAnalyser(StaticAnalyser):
+    @staticmethod
+    def process(definition: str) -> "UsageMetricsStaticAnalyser":
+        analyser = UsageMetricsStaticAnalyser()
+        analyser.analyse(definition=definition)
+
+        try:
+            if analyser.has_jsonata:
+                UsageMetrics.jsonata_create_counter.increment()
+            else:
+                UsageMetrics.jsonpath_create_counter.increment()
+        except Exception as e:
+            LOG.warning(
+                "Failed to record metrics for StepFunctions QueryLanguage usage",
+                exc_info=e,
+            )
+
+        try:
+            if analyser.has_variable_sampling:
+                UsageMetrics.variables_create_counter.increment()
+        except Exception as e:
+            LOG.warning(
+                "Failed to record usage metrics for StepFunctions Variable Sampling usage",
+                exc_info=e,
+            )
+
+        return analyser
+
+    def __init__(self):
+        super().__init__()
+        self.has_jsonata: bool = False
+        self.has_variable_sampling = False
+
+    def visitQuery_language_decl(self, ctx: ASLParser.Query_language_declContext):
+        query_language_mode_int = ctx.children[-1].getSymbol().type
+        query_language_mode = QueryLanguageMode(value=query_language_mode_int)
+        if query_language_mode == QueryLanguageMode.JSONata:
+            self.has_jsonata = True
+
+    def visitVariable_sample(self, ctx: ASLParser.Variable_sampleContext):
+        self.has_variable_sampling = True
+
+    def visitAssign_decl(self, ctx: ASLParser.Assign_declContext):
+        self.has_variable_sampling = True

--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/usage_metrics_static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/usage_metrics_static_analyser.py
@@ -14,28 +14,21 @@ class UsageMetricsStaticAnalyser(StaticAnalyser):
     @staticmethod
     def process(definition: str) -> "UsageMetricsStaticAnalyser":
         analyser = UsageMetricsStaticAnalyser()
-        analyser.analyse(definition=definition)
-
         try:
+            analyser.analyse(definition=definition)
+
             if analyser.has_jsonata:
                 UsageMetrics.jsonata_create_counter.increment()
             else:
                 UsageMetrics.jsonpath_create_counter.increment()
-        except Exception as e:
-            LOG.warning(
-                "Failed to record metrics for StepFunctions QueryLanguage usage",
-                exc_info=e,
-            )
 
-        try:
             if analyser.has_variable_sampling:
                 UsageMetrics.variables_create_counter.increment()
         except Exception as e:
             LOG.warning(
-                "Failed to record usage metrics for StepFunctions Variable Sampling usage",
+                "Failed to record Step Functions metrics from static analysis",
                 exc_info=e,
             )
-
         return analyser
 
     def __init__(self):

--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/usage_metrics_static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/usage_metrics_static_analyser.py
@@ -37,6 +37,9 @@ class UsageMetricsStaticAnalyser(StaticAnalyser):
         self.has_variable_sampling = False
 
     def visitQuery_language_decl(self, ctx: ASLParser.Query_language_declContext):
+        if self.has_jsonata:
+            return
+
         query_language_mode_int = ctx.children[-1].getSymbol().type
         query_language_mode = QueryLanguageMode(value=query_language_mode_int)
         if query_language_mode == QueryLanguageMode.JSONata:

--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -125,6 +125,9 @@ from localstack.services.stepfunctions.asl.static_analyser.static_analyser impor
 from localstack.services.stepfunctions.asl.static_analyser.test_state.test_state_analyser import (
     TestStateStaticAnalyser,
 )
+from localstack.services.stepfunctions.asl.static_analyser.usage_metrics_static_analyser import (
+    UsageMetricsStaticAnalyser,
+)
 from localstack.services.stepfunctions.backend.activity import Activity, ActivityTask
 from localstack.services.stepfunctions.backend.execution import Execution, SyncExecution
 from localstack.services.stepfunctions.backend.state_machine import (
@@ -480,6 +483,9 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
                 state_machine_version_arn = state_machine_version.arn
                 state_machines[state_machine_version_arn] = state_machine_version
                 create_output["stateMachineVersionArn"] = state_machine_version_arn
+
+        # Run static analyser on definition and collect usage metrics
+        UsageMetricsStaticAnalyser.process(state_machine_definition)
 
         return create_output
 
@@ -974,6 +980,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         if not isinstance(state_machine, StateMachineRevision):
             self._raise_state_machine_does_not_exist(state_machine_arn)
 
+        # TODO: Add logic to handle metrics for when SFN definitions update
         if not any([definition, role_arn, logging_configuration]):
             raise MissingRequiredParameter(
                 "Either the definition, the role ARN, the LoggingConfiguration, "

--- a/localstack-core/localstack/services/stepfunctions/usage.py
+++ b/localstack-core/localstack/services/stepfunctions/usage.py
@@ -1,0 +1,20 @@
+"""
+Usage reporting for StepFunctions service
+"""
+
+from localstack.utils.analytics.usage import UsageCounter
+
+# Count of StepFunctions being created with JSONata QueryLanguage
+jsonata_create_counter = UsageCounter("stepfunctions:jsonata:create")
+
+# Count of StepFunctions being created with JSONPath QueryLanguage
+jsonpath_create_counter = UsageCounter("stepfunctions:jsonpath:create")
+
+# Count of StepFunctions being created that use Variable Sampling or the Assign block
+variables_create_counter = UsageCounter("stepfunctions:variables:create")
+
+# Successful invocations (also including expected error cases in line with AWS behaviour)
+invocation_counter = UsageCounter("stepfunctions:invocation")
+
+# Unexpected errors that we do not account for
+error_counter = UsageCounter("stepfunctions:error")

--- a/tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py
+++ b/tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py
@@ -36,7 +36,13 @@ class TestBaseEvaluateJsonata:
     @pytest.mark.parametrize(
         "expression_dict",
         [
-            {"TimeoutSeconds": EJT.JSONATA_NUMBER_EXPRESSION},
+            pytest.param(
+                {"TimeoutSeconds": EJT.JSONATA_NUMBER_EXPRESSION},
+                marks=pytest.mark.skipif(
+                    condition=not is_aws_cloud(),
+                    reason="Polling and timeouts are flakey.",
+                ),
+            ),
             {"HeartbeatSeconds": EJT.JSONATA_NUMBER_EXPRESSION},
         ],
         ids=[

--- a/tests/unit/services/stepfunctions/test_usage_metrics_static_analyser.py
+++ b/tests/unit/services/stepfunctions/test_usage_metrics_static_analyser.py
@@ -1,0 +1,96 @@
+import json
+
+import pytest
+
+from localstack.services.stepfunctions.asl.static_analyser.usage_metrics_static_analyser import (
+    UsageMetricsStaticAnalyser,
+)
+from tests.aws.services.stepfunctions.templates.assign.assign_templates import (
+    AssignTemplate,
+)
+from tests.aws.services.stepfunctions.templates.querylanguage.query_language_templates import (
+    QueryLanguageTemplate,
+)
+
+
+class TestUsageMetricsStaticAnalyser:
+    @staticmethod
+    def _get_query_language_definition(query_language_template_filepath: str) -> str:
+        template = QueryLanguageTemplate.load_sfn_template(query_language_template_filepath)
+        definition = json.dumps(template)
+        return definition
+
+    @staticmethod
+    def _get_variable_sampling_definition(variable_sampling_template_filepath: str) -> str:
+        template = AssignTemplate.load_sfn_template(variable_sampling_template_filepath)
+        definition = json.dumps(template)
+        return definition
+
+    @pytest.mark.parametrize(
+        "template_filepath",
+        [
+            QueryLanguageTemplate.BASE_PASS_JSONATA,
+            QueryLanguageTemplate.BASE_PASS_JSONATA_OVERRIDE,
+            QueryLanguageTemplate.BASE_PASS_JSONATA_OVERRIDE_DEFAULT,
+        ],
+        ids=[
+            "BASE_PASS_JSONATA",
+            "BASE_PASS_JSONATA_OVERRIDE",
+            "BASE_PASS_JSONATA_OVERRIDE_DEFAULT",
+        ],
+    )
+    def test_jsonata(self, template_filepath):
+        definition = self._get_query_language_definition(template_filepath)
+        analyser = UsageMetricsStaticAnalyser.process(definition)
+        assert analyser.has_jsonata
+        assert not analyser.has_variable_sampling
+
+    @pytest.mark.parametrize(
+        "template_filepath",
+        [
+            QueryLanguageTemplate.BASE_PASS_JSONPATH,
+        ],
+        ids=["BASE_PASS_JSONPATH"],
+    )
+    def test_jsonpath(self, template_filepath):
+        definition = self._get_query_language_definition(template_filepath)
+        analyser = UsageMetricsStaticAnalyser.process(definition)
+        assert not analyser.has_jsonata
+        assert not analyser.has_variable_sampling
+
+    @pytest.mark.parametrize(
+        "template_filepath",
+        [
+            QueryLanguageTemplate.JSONPATH_TO_JSONATA_DATAFLOW,
+            QueryLanguageTemplate.JSONPATH_ASSIGN_JSONATA_REF,
+        ],
+        ids=["JSONPATH_TO_JSONATA_DATAFLOW", "JSONPATH_ASSIGN_JSONATA_REF"],
+    )
+    def test_jsonata_and_variable_sampling(self, template_filepath):
+        definition = self._get_query_language_definition(template_filepath)
+        analyser = UsageMetricsStaticAnalyser.process(definition)
+        assert analyser.has_jsonata
+        assert analyser.has_variable_sampling
+
+    @pytest.mark.parametrize(
+        "template_filepath",
+        [
+            AssignTemplate.BASE_EMPTY,
+            AssignTemplate.BASE_PATHS,
+            AssignTemplate.BASE_SCOPE_MAP,
+            AssignTemplate.BASE_ASSIGN_FROM_LAMBDA_TASK_RESULT,
+            AssignTemplate.BASE_REFERENCE_IN_LAMBDA_TASK_FIELDS,
+        ],
+        ids=[
+            "BASE_EMPTY",
+            "BASE_PATHS",
+            "BASE_SCOPE_MAP",
+            "BASE_ASSIGN_FROM_LAMBDA_TASK_RESULT",
+            "BASE_REFERENCE_IN_LAMBDA_TASK_FIELDS",
+        ],
+    )
+    def test_jsonpath_and_variable_sampling(self, template_filepath):
+        definition = self._get_query_language_definition(template_filepath)
+        analyser = UsageMetricsStaticAnalyser.process(definition)
+        assert not analyser.has_jsonata
+        assert analyser.has_variable_sampling


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds analytics  the SFN provider to help ascertain usage of the new JSONata and Variable workflows. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Add a static analyser that will check for:
  -  Any variable sampling or assigning of variables
  - The query language being used by the state machine definition
- Metrics have been added that will record whether a sfn uses JSONata or variable workflows, respectively. 

## Testing
- Added unit tests to ensure the static analysis is correct.

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
