### PR TITLE
Add deprecation for Java-based event ruler

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -846,9 +846,10 @@ if not DOCKER_BRIDGE_IP:
 # get-function call.
 INTERNAL_RESOURCE_ACCOUNT = os.environ.get("INTERNAL_RESOURCE_ACCOUNT") or "949334387222"
 
+# TODO: remove with 4.1.0
 # Determine which implementation to use for the event rule / event filtering engine used by multiple services:
 # EventBridge, EventBridge Pipes, Lambda Event Source Mapping
-# Options: python (default) | java (preview)
+# Options: python (default) | java (deprecated since 4.0.3)
 EVENT_RULE_ENGINE = os.environ.get("EVENT_RULE_ENGINE", "python").strip()
 
 # -----

--- a/localstack-core/localstack/deprecations.py
+++ b/localstack-core/localstack/deprecations.py
@@ -270,6 +270,11 @@ DEPRECATIONS = [
         "This option has no effect anymore. Please use OPENSEARCH_ENDPOINT_STRATEGY instead.",
     ),
     EnvVarDeprecation(
+        "PERSIST_ALL",
+        "2.3.2",
+        "LocalStack treats backends and assets the same with respect to persistence. Please remove PERSIST_ALL.",
+    ),
+    EnvVarDeprecation(
         "DNS_LOCAL_NAME_PATTERNS",
         "3.0.0",
         "This option was confusingly named. Please use DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM "
@@ -299,9 +304,11 @@ DEPRECATIONS = [
         " Please remove PROVIDER_OVERRIDE_STEPFUNCTIONS.",
     ),
     EnvVarDeprecation(
-        "PERSIST_ALL",
-        "2.3.2",
-        "LocalStack treats backends and assets the same with respect to persistence. Please remove PERSIST_ALL.",
+        "EVENT_RULE_ENGINE",
+        "4.0.3",
+        "The Java-based event ruler is deprecated because our latest Python-native implementation introduced in 4.0.3"
+        " is faster, achieves great AWS parity, and fixes compatibility issues with the StepFunctions JSONata feature."
+        " Please remove EVENT_RULE_ENGINE.",
     ),
 ]
 

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/poller.py
@@ -21,8 +21,6 @@ class PipeStateReasonValues(PipeStateReason):
     # TODO: add others (e.g., failure)
 
 
-POLL_INTERVAL_SEC: float = 1
-
 LOG = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Depends on https://github.com/localstack/localstack/pull/11960

## Motivation

The Java-based event ruler is deprecated because our latest Python-native implementation introduced in 4.0.3 is faster, achieves great AWS parity, and fixes compatibility issues with the StepFunctions JSONata feature.

## Changes

* Deprecate `EVENT_RULE_ENGINE` config used for opt-into the Java-based event ruler
* Remove unused `POLL_INTERVAL_SEC`

## Notes

We now have a comprehensive test suite and can be confident that (almost) all cases are covered.
