### PR TITLE
fix: follow-up for null value in SES response

### DIFF
--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -158,11 +158,10 @@ components:
           additionalProperties: false
           properties:
             html_part:
-              type: [string, 'null']
+              type: string
             text_part:
               type: string
           required:
-          - html_part
           - text_part
           type: object
         Destination:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR is a follow-up fix for https://github.com/localstack/localstack/pull/11954.
It turns out that our code generator needs the change in this PR to output the right Pydantic model, i.e.,

```python
class SesSentEmailBody(BaseModel):
    """
    SesSentEmailBody
    """ # noqa: E501
    html_part: Optional[StrictStr] = None
    text_part: StrictStr
```

Setting the type to `null` did not lead to the wanted generated code (i.e., `html_part` won't be optional).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Minor fix of the specs;

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
