### PR TITLE
APIGW: fix parsing invalid JSON template in MOCK integration

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/mock.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/mock.py
@@ -78,6 +78,10 @@ class RestApiMockIntegration(RestApiIntegration):
                 assert k
                 assert v
 
+                if k == "statusCode":
+                    statuscode = int(v)
+                    continue
+
                 if (first_char := k[0]) in "[{":
                     raise Exception
                 if first_char in "'\"":

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/mock.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/mock.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from json import JSONDecodeError
 
 from werkzeug.datastructures import Headers
@@ -39,20 +40,69 @@ class RestApiMockIntegration(RestApiIntegration):
 
         return EndpointResponse(status_code=status_code, body=b"", headers=Headers())
 
-    @staticmethod
-    def get_status_code(integration_req: IntegrationRequest) -> int | None:
+    def get_status_code(self, integration_req: IntegrationRequest) -> int | None:
         try:
-            body = json.loads(to_str(integration_req["body"]))
+            body = json.loads(integration_req["body"])
         except JSONDecodeError as e:
             LOG.debug(
-                "Exception while parsing integration request body: %s",
+                "Exception while JSON parsing integration request body: %s"
+                "Falling back to custom parser",
                 e,
                 exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
-            return
+            body = self.parse_invalid_json(to_str(integration_req["body"]))
 
         status_code = body.get("statusCode")
         if not isinstance(status_code, int):
             return
 
         return status_code
+
+    def parse_invalid_json(self, body: str) -> dict:
+        """This is a quick fix to unblock cdk users setting cors policy for rest apis.
+        CDK creates a MOCK OPTIONS route with in valid json. `{statusCode: 200}`
+        Aws probably has a custom token parser. We can implement one
+        at some point if we have user requests for it"""
+        try:
+            statuscode = ""
+            matched = re.match(r"^\s*{(.+)}\s*$", body).group(1)
+            splits = [m.strip() for m in matched.split(",")]
+            # TODO this is not right, but nested object would otherwise break the parsing
+            kvs = [s.split(":", maxsplit=1) for s in splits]
+            for kv in kvs:
+                assert len(kv) == 2
+                k, v = kv
+                k = k.strip()
+                v = v.strip()
+
+                assert k
+                assert v
+
+                if (first_char := k[0]) in "[{":
+                    raise Exception
+                if first_char in "'\"":
+                    assert len(k) > 2
+                    assert k[-1] == first_char
+                    k = k[1:-1]
+
+                if (v_first_char := v[0]) in "[{'\"":
+                    assert len(v) > 2
+                    if v_first_char == "{":
+                        # TODO reparse objects
+                        assert v[-1] == "}"
+                    elif v_first_char == "[":
+                        # TODO validate arrays
+                        assert v[-1] == "]"
+                    else:
+                        assert v[-1] == v_first_char
+                        v = v[1:-1]
+
+                if k == "statusCode":
+                    statuscode = int(v)
+
+            return {"statusCode": statuscode}
+        except Exception as e:
+            LOG.debug(
+                "Error Parsing an invalid json, %s", e, exc_info=LOG.isEnabledFor(logging.DEBUG)
+            )
+            return {"statusCode": ""}

--- a/tests/aws/services/apigateway/test_apigateway_integrations.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.snapshot.json
@@ -1056,5 +1056,27 @@
         "response": "this is the else clause"
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_path_param": {
+    "recorded-date": "29-11-2024, 19:27:54",
+    "recorded-content": {
+      "integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.path.integrationPath": "method.request.path.testPath"
+        },
+        "requestTemplates": {
+          "application/json": "{statusCode: 200}"
+        },
+        "timeoutInMillis": 29000,
+        "type": "MOCK",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
@@ -15,7 +15,7 @@
     "last_validated_date": "2024-04-15T23:07:07+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_path_param": {
-    "last_validated_date": "2024-11-05T12:55:51+00:00"
+    "last_validated_date": "2024-11-29T19:27:54+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_request_overrides_in_response_template": {
     "last_validated_date": "2024-11-06T23:09:04+00:00"

--- a/tests/unit/services/apigateway/test_mock_integration.py
+++ b/tests/unit/services/apigateway/test_mock_integration.py
@@ -51,3 +51,31 @@ class TestMockIntegration:
         with pytest.raises(InternalServerError) as exc_info:
             mock_integration.invoke(ctx)
         assert exc_info.match("Internal server error")
+
+    def test_custom_parser(self, create_default_context):
+        mock_integration = RestApiMockIntegration()
+
+        valid_templates = [
+            "{statusCode: 200,super{ f}oo: [ba r]}",
+            "{statusCode: 200, \"value\": 'goog'}",
+            "{statusCode: 200, foo}: [ba r]}",
+            "{statusCode: 200, foo'}: [ba r]}",
+            "{statusCode: 200, }foo: [ba r]}",
+        ]
+        invalid_templates = [
+            "statusCode: 200",
+            "{statusCode: 200, {foo: [ba r]}",
+            # This test fails as we do not support nested objects
+            # "{statusCode: 200, what:{}foo: [ba r]}}"
+        ]
+
+        for valid_template in valid_templates:
+            ctx = create_default_context(body=valid_template)
+            response = mock_integration.invoke(ctx)
+            assert response["status_code"] == 200
+
+        for invalid_template in invalid_templates:
+            ctx = create_default_context(body=invalid_template)
+            with pytest.raises(InternalServerError) as exc_info:
+                mock_integration.invoke(ctx)
+            assert exc_info.match("Internal server error")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When deploying a CDK stack with an APIGW REST API with "automatic" CORS management by APIGW, CDK will create an OPTIONS `method` with a MOCK integration. The problem is that this integration has a request template equal to `"application/json": "{statusCode: 200}"`, which is invalid JSON. 

From the documentation, nothing lets you think that invalid JSON would be accepted, as it needs the `statusCode` field. 
But it does, they don't JSON parse but use a custom token parser that we're tried to test the limit off. We're settling now on this basic implementation which still has flaws, but cover quite some ground already, as shown by the unit tests. We also updated an integration test to specifically cover the request template CDK was using. 

This custom parser will only be executed if the MOCK integration does not return valid JSON, meaning every existing use case will still work, and only people with very, very esoteric negative testing might be impacted by this new custom parser accepting data AWS wouldn't (but we already covered most of the bad negative cases). 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- create a small (bad) parser to try to get and validate the status code from MOCK integration
- add a unit test with some weird cases
- update an integration test for the CDK use-case

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
