### PR TITLE
added sql plugin validated test

### DIFF
--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -907,7 +907,7 @@ def opensearch_wait_for_cluster(aws_client):
             return status["Processing"] is False and "Endpoint" in status
 
         assert poll_condition(
-            finished_processing, timeout=25 * 60, interval=20
+            finished_processing, timeout=25 * 60, **({"interval": 10} if is_aws_cloud() else {})
         ), f"could not start domain: {domain_name}"
 
     return _wait_for_cluster

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -904,10 +904,10 @@ def opensearch_wait_for_cluster(aws_client):
     def _wait_for_cluster(domain_name: str):
         def finished_processing():
             status = aws_client.opensearch.describe_domain(DomainName=domain_name)["DomainStatus"]
-            return status["Processing"] is False
+            return status["Processing"] is False and "Endpoint" in status
 
         assert poll_condition(
-            finished_processing, timeout=5 * 60
+            finished_processing, timeout=25 * 60, interval=20
         ), f"could not start domain: {domain_name}"
 
     return _wait_for_cluster

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -151,7 +151,7 @@ class TestOpensearchProvider:
             # wait for the cluster
             opensearch_wait_for_cluster(domain_name=domain_name)
 
-            # make sure the plugins are installed
+            # make sure the plugins are installed (Sort and display component)
             plugins_url = (
                 f"https://{domain_status['Endpoint']}/_cat/plugins?s=component&h=component"
             )
@@ -180,7 +180,7 @@ class TestOpensearchProvider:
             "Endpoint"
         ]
 
-        # make sure the plugins are installed
+        # make sure the plugins are installed (Sort and display component)
         plugins_url = f"https://{endpoint}/_cat/plugins?s=component&h=component"
 
         # request without credentials fails
@@ -293,7 +293,7 @@ class TestOpensearchProvider:
             "Endpoint"
         ]
 
-        # ensure opensearch-sql plugin is installed
+        # make sure the sql plugin is installed (Sort and display component)
         plugins_url = f"https://{endpoint}/_cat/plugins?s=component&h=component"
         response = requests.get(
             plugins_url, auth=master_user_auth, headers={"Accept": "application/json"}

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -271,7 +271,6 @@ class TestOpensearchProvider:
                 }
             ],
         }
-        # domain_name = f"sql-test-domain-six"
 
         # create a domain that works on aws
         opensearch_create_domain(

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -300,7 +300,9 @@ class TestOpensearchProvider:
         # make sure the sql plugin is installed (Sort and display component)
         plugins_url = f"https://{endpoint}/_cat/plugins?s=component&h=component"
         response = requests.get(
-            plugins_url, auth=master_user_auth, headers={**COMMON_HEADERS, "Accept": "application/json"}
+            plugins_url,
+            auth=master_user_auth,
+            headers={**COMMON_HEADERS, "Accept": "application/json"},
         )
         installed_plugins = {plugin["component"] for plugin in response.json()}
         assert "opensearch-sql" in installed_plugins

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -300,7 +300,7 @@ class TestOpensearchProvider:
         # make sure the sql plugin is installed (Sort and display component)
         plugins_url = f"https://{endpoint}/_cat/plugins?s=component&h=component"
         response = requests.get(
-            plugins_url, auth=master_user_auth, headers={"Accept": "application/json"}
+            plugins_url, auth=master_user_auth, headers={**COMMON_HEADERS, "Accept": "application/json"}
         )
         installed_plugins = {plugin["component"] for plugin in response.json()}
         assert "opensearch-sql" in installed_plugins

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -313,12 +313,17 @@ class TestOpensearchProvider:
             "interests": ["mandalorian armor", "tusken culture"],
         }
         document_path = f"https://{endpoint}/bountyhunters/_doc/1"
-        requests.put(
+        response = requests.put(
             document_path,
             auth=master_user_auth,
             data=json.dumps(document),
             headers=COMMON_HEADERS,
         )
+        assert response.ok
+
+        # force the refresh of the index after the document was added, so it can appear in search
+        response = requests.post(f"https://{endpoint}/_refresh", auth=master_user_auth, headers=COMMON_HEADERS)
+        assert response.ok
 
         # ensure sql query returns correct
         index = document_path.split("/")[-3]

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -157,7 +157,7 @@ class TestOpensearchProvider:
             plugins_url = (
                 f"https://{domain_status['Endpoint']}/_cat/plugins?s=component&h=component"
             )
-            plugins_response = requests.get(plugins_url, headers=COMMON_HEADERS)
+            plugins_response = requests.get(plugins_url, headers={"Accept": "application/json"})
             installed_plugins = {plugin["component"] for plugin in plugins_response.json()}
             requested_plugins = set(OPENSEARCH_PLUGIN_LIST)
             assert requested_plugins.issubset(installed_plugins)

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -303,7 +303,7 @@ class TestOpensearchProvider:
             plugins_url, auth=master_user_auth, headers={"Accept": "application/json"}
         )
         installed_plugins = {plugin["component"] for plugin in response.json()}
-        snapshot.match("sql_plugin_installed", "opensearch-sql" in installed_plugins)
+        assert "opensearch-sql" in installed_plugins
         assert "opensearch-sql" in installed_plugins, "Opensearch sql plugin is not present"
 
         # data insert preparation for sql query

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -322,7 +322,9 @@ class TestOpensearchProvider:
         assert response.ok
 
         # force the refresh of the index after the document was added, so it can appear in search
-        response = requests.post(f"https://{endpoint}/_refresh", auth=master_user_auth, headers=COMMON_HEADERS)
+        response = requests.post(
+            f"https://{endpoint}/_refresh", auth=master_user_auth, headers=COMMON_HEADERS
+        )
         assert response.ok
 
         # ensure sql query returns correct

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -14,9 +14,12 @@ from opensearchpy.exceptions import AuthorizationException
 from localstack import config
 from localstack.aws.api.opensearch import (
     AdvancedSecurityOptionsInput,
+    ClusterConfig,
     DomainEndpointOptions,
+    EBSOptions,
     EncryptionAtRestOptions,
     MasterUserOptions,
+    NodeToNodeEncryptionOptions,
 )
 from localstack.constants import (
     ELASTICSEARCH_DEFAULT_VERSION,
@@ -34,11 +37,6 @@ from localstack.services.opensearch.cluster_manager import (
     create_cluster_manager,
 )
 from localstack.services.opensearch.packages import opensearch_package
-from localstack.services.opensearch.resource_providers.aws_opensearchservice_domain import (
-    ClusterConfig,
-    EBSOptions,
-    NodeToNodeEncryptionOptions,
-)
 from localstack.testing.pytest import markers
 from localstack.utils.common import call_safe, poll_condition, retry, short_uid, start_worker_thread
 from localstack.utils.common import safe_requests as requests

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -12,7 +12,12 @@ from opensearchpy import OpenSearch
 from opensearchpy.exceptions import AuthorizationException
 
 from localstack import config
-from localstack.aws.api.opensearch import AdvancedSecurityOptionsInput, MasterUserOptions
+from localstack.aws.api.opensearch import (
+    AdvancedSecurityOptionsInput,
+    DomainEndpointOptions,
+    EncryptionAtRestOptions,
+    MasterUserOptions,
+)
 from localstack.constants import (
     ELASTICSEARCH_DEFAULT_VERSION,
     OPENSEARCH_DEFAULT_VERSION,
@@ -29,6 +34,11 @@ from localstack.services.opensearch.cluster_manager import (
     create_cluster_manager,
 )
 from localstack.services.opensearch.packages import opensearch_package
+from localstack.services.opensearch.resource_providers.aws_opensearchservice_domain import (
+    ClusterConfig,
+    EBSOptions,
+    NodeToNodeEncryptionOptions,
+)
 from localstack.testing.pytest import markers
 from localstack.utils.common import call_safe, poll_condition, retry, short_uid, start_worker_thread
 from localstack.utils.common import safe_requests as requests
@@ -245,6 +255,86 @@ class TestOpensearchProvider:
         # ensure the user can now write and create a new index
         test_user_client.create("new-index2", id="new-index-id2", body={})
         test_user_client.index(test_index_name, body={"test-key1": "test-value1"})
+
+    @markers.aws.validated
+    def test_sql_plugin(self, opensearch_create_domain, aws_client, snapshot, account_id):
+        master_user_auth = ("admin", "QWERTYuiop123!")
+        domain_name = f"sql-test-domain-{short_uid()}"
+        access_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": "*"},
+                    "Action": "es:*",
+                    "Resource": f"arn:aws:es:*:{account_id}:domain/{domain_name}/*",
+                }
+            ],
+        }
+        # domain_name = f"sql-test-domain-six"
+
+        # create a domain that works on aws
+        opensearch_create_domain(
+            DomainName=domain_name,
+            EngineVersion=OPENSEARCH_DEFAULT_VERSION,
+            ClusterConfig=ClusterConfig(InstanceType="t3.small.search", InstanceCount=1),
+            EBSOptions=EBSOptions(EBSEnabled=True, VolumeType="gp2", VolumeSize=10),
+            AdvancedSecurityOptions=AdvancedSecurityOptionsInput(
+                Enabled=True,
+                InternalUserDatabaseEnabled=True,
+                MasterUserOptions=MasterUserOptions(
+                    MasterUserName=master_user_auth[0],
+                    MasterUserPassword=master_user_auth[1],
+                ),
+            ),
+            NodeToNodeEncryptionOptions=NodeToNodeEncryptionOptions(Enabled=True),
+            EncryptionAtRestOptions=EncryptionAtRestOptions(Enabled=True),
+            DomainEndpointOptions=DomainEndpointOptions(EnforceHTTPS=True),
+            AccessPolicies=json.dumps(access_policy),
+        )
+        endpoint = aws_client.opensearch.describe_domain(DomainName=domain_name)["DomainStatus"][
+            "Endpoint"
+        ]
+
+        # ensure opensearch-sql plugin is installed
+        plugins_url = f"https://{endpoint}/_cat/plugins?s=component&h=component"
+        response = requests.get(
+            plugins_url, auth=master_user_auth, headers={"Accept": "application/json"}
+        )
+        installed_plugins = {plugin["component"] for plugin in response.json()}
+        snapshot.match("sql_plugin_installed", "opensearch-sql" in installed_plugins)
+        assert "opensearch-sql" in installed_plugins, "Opensearch sql plugin is not present"
+
+        # data insert preparation for sql query
+        document = {
+            "first_name": "Boba",
+            "last_name": "Fett",
+            "age": 41,
+            "about": "I'm just a simple man, trying to make my way in the universe.",
+            "interests": ["mandalorian armor", "tusken culture"],
+        }
+        document_path = f"https://{endpoint}/bountyhunters/_doc/1"
+        requests.put(
+            document_path,
+            auth=master_user_auth,
+            data=json.dumps(document),
+            headers=COMMON_HEADERS,
+        )
+
+        # ensure sql query returns correct
+        index = document_path.split("/")[-3]
+        query = {"query": f"SELECT * FROM {index} WHERE last_name = 'Fett'"}
+        response = requests.post(
+            f"https://{endpoint}/_plugins/_sql",
+            auth=master_user_auth,
+            data=json.dumps(query),
+            headers=COMMON_HEADERS,
+        )
+        snapshot.match("sql_query_response", response.json())
+
+        assert (
+            "I'm just a simple man" in response.text
+        ), f"query unsuccessful({response.status_code}): {response.text}"
 
     @markers.aws.validated
     def test_create_domain_with_invalid_name(self, aws_client):

--- a/tests/aws/services/opensearch/test_opensearch.snapshot.json
+++ b/tests/aws/services/opensearch/test_opensearch.snapshot.json
@@ -221,5 +221,47 @@
         "OpenSearch_2.9"
       ]
     }
+  },
+  "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_sql_plugin": {
+    "recorded-date": "01-12-2024, 17:11:32",
+    "recorded-content": {
+      "sql_plugin_installed": true,
+      "sql_query_response": {
+        "datarows": [
+          [
+            "I'm just a simple man, trying to make my way in the universe.",
+            "Fett",
+            "mandalorian armor",
+            "Boba",
+            41
+          ]
+        ],
+        "schema": [
+          {
+            "name": "about",
+            "type": "text"
+          },
+          {
+            "name": "last_name",
+            "type": "text"
+          },
+          {
+            "name": "interests",
+            "type": "text"
+          },
+          {
+            "name": "first_name",
+            "type": "text"
+          },
+          {
+            "name": "age",
+            "type": "long"
+          }
+        ],
+        "size": 1,
+        "status": 200,
+        "total": 1
+      }
+    }
   }
 }

--- a/tests/aws/services/opensearch/test_opensearch.snapshot.json
+++ b/tests/aws/services/opensearch/test_opensearch.snapshot.json
@@ -223,7 +223,7 @@
     }
   },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_sql_plugin": {
-    "recorded-date": "01-12-2024, 17:11:32",
+    "recorded-date": "03-12-2024, 21:07:16",
     "recorded-content": {
       "sql_plugin_installed": true,
       "sql_query_response": {

--- a/tests/aws/services/opensearch/test_opensearch.validation.json
+++ b/tests/aws/services/opensearch/test_opensearch.validation.json
@@ -4,5 +4,8 @@
   },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_list_versions": {
     "last_validated_date": "2024-07-16T13:18:18+00:00"
+  },
+  "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_sql_plugin": {
+    "last_validated_date": "2024-12-01T20:04:44+00:00"
   }
 }

--- a/tests/aws/services/opensearch/test_opensearch.validation.json
+++ b/tests/aws/services/opensearch/test_opensearch.validation.json
@@ -6,6 +6,6 @@
     "last_validated_date": "2024-07-16T13:18:18+00:00"
   },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_sql_plugin": {
-    "last_validated_date": "2024-12-01T20:04:44+00:00"
+    "last_validated_date": "2024-12-03T21:07:16+00:00"
   }
 }


### PR DESCRIPTION
## Motivation
This PR introduces a parity test case to verify that the "opensearch-sql" plugin is installed on newly created domains and functions as expected.

## Changes
- Added test_sql_plugin test
- Modified _wait_for_cluster fixture to better adapt with AWS behavior

## TODO
Part of the code from the test_sql_plugin test is reusable and could serve as a replacement for some of the existing fixtures used in tests marked with needs_fixing, once those tests are addressed.