### PR TITLE
fix ASF code generation for recursive structures with keywords

### DIFF
--- a/localstack-core/localstack/aws/scaffold.py
+++ b/localstack-core/localstack/aws/scaffold.py
@@ -142,11 +142,11 @@ class ShapeNode:
 
     def _print_structure_declaration(self, output, doc=True, quote_types=False):
         if self.is_exception:
-            self._print_as_class(output, "ServiceException", doc)
+            self._print_as_class(output, "ServiceException", doc, quote_types=quote_types)
             return
 
         if any(map(is_keyword, self.shape.members.keys())):
-            self._print_as_typed_dict(output)
+            self._print_as_typed_dict(output, doc, quote_types)
             return
 
         if self.is_request:


### PR DESCRIPTION
## Motivation
The latest `botocore` specs [contain a new recursive type definition (`RetrievalFilter` -> `RetrievalFilterList` -> `RetrievalFilter`)](https://github.com/boto/botocore/blame/9cc27bdcde67df8c8792e66d5b88b806f4251301/botocore/data/bedrock/2023-04-20/service-2.json#L5917-L5981).
These new types have been added to `botocore` with https://github.com/boto/botocore/commit/667d4c65e960cf6b90af2c8665839bfe43e5b630, which landed in version `1.35.72`.
This caused an issue with the ASF scaffolding because of an issue in the code generation for recursive types which also contain a Python keyword (due to not using quoted "forward types").
The resulting (faulty) code looked like this (mind the missing forward references in `RetrievalFilter`):
```python
  RetrievalFilter = TypedDict(
      "RetrievalFilter",
      {
          "equals": Optional[FilterAttribute],
          ...
          "andAll": Optional[RetrievalFilterList],
          ...
      },
      total=False,
  )
  RetrievalFilterList = List[RetrievalFilter]
  
  class FilterValue(TypedDict, total=False):
      pass
  
  class FilterAttribute(TypedDict, total=False):
      key: FilterKey
      value: FilterValue
```

## Changes
- Properly forwards the `quote_types` parameter in the code generation logic to ensure that the recursive type handling also works for exceptions and shapes with members named with Python keywords.

## Testing
- Tested the ASF code generation for bedrock using botocore==1.35.72:
  ```
  pip install botocore==1.35.72
  python3 -m localstack.aws.scaffold generate bedrock
  ```
- Check that the resulting code is valid (uses forward references in `RetrievalFilter`):
  ```python
  RetrievalFilter = TypedDict(
      "RetrievalFilter",
      {
          "equals": Optional["FilterAttribute"],
          "notEquals": Optional["FilterAttribute"],
          "greaterThan": Optional["FilterAttribute"],
          "greaterThanOrEquals": Optional["FilterAttribute"],
          "lessThan": Optional["FilterAttribute"],
          "lessThanOrEquals": Optional["FilterAttribute"],
          "in": Optional["FilterAttribute"],
          "notIn": Optional["FilterAttribute"],
          "startsWith": Optional["FilterAttribute"],
          "listContains": Optional["FilterAttribute"],
          "stringContains": Optional["FilterAttribute"],
          "andAll": Optional["RetrievalFilterList"],
          "orAll": Optional["RetrievalFilterList"],
      },
      total=False,
  )
  RetrievalFilterList = List[RetrievalFilter]
  
  
  class FilterValue(TypedDict, total=False):
      pass
  
  
  class FilterAttribute(TypedDict, total=False):
      key: FilterKey
      value: FilterValue
  ```