### PR TITLE
fix postgres install in pro test pipeline

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -234,8 +234,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get update
-          # postgresql-14 pin is required to make explicit install of the version from the Ubuntu repos and not PGDG repos
-          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.13-0ubuntu0* postgresql-client postgresql-plpython3 libvirt-dev
+          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-16 postgresql-client postgresql-plpython3 libvirt-dev
 
       - name: Cache Ext Dependencies (venv)
         if: inputs.disableCaching != true

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -234,7 +234,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-16 postgresql-client postgresql-plpython3 libvirt-dev
+          sudo apt-get install -y --allow-downgrades libsnappy-dev jq libvirt-dev
 
       - name: Cache Ext Dependencies (venv)
         if: inputs.disableCaching != true


### PR DESCRIPTION
## Motivation
This PR fixes the [Community Integration Tests against Pro](https://github.com/localstack/localstack/actions/workflows/tests-pro-integration.yml) which are meant to inform us about changes that break our downstream project early.
This pipeline failed with the recent upgrade of the GitHub Runner to Ubuntu 24.04.

## Changes
- Removes the installation of `postgres` and related tools because they should not be necessary when running the Community Tests against Pro, and if they are needed they should be installed on demand by the respective package installer.