### PR TITLE
upgrade outdated github action in ASF update workflow

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Add changed services to template
         if: ${{ success() && steps.check-for-changes.outputs.diff-count != '0' && steps.check-for-changes.outputs.diff-count != '' }}
         id: markdown
-        uses: mad9000/actions-find-and-replace-string@4
+        uses: mad9000/actions-find-and-replace-string@5
         with:
           source: ${{ steps.template.outputs.content }}
           find: '{{ SERVICES }}'


### PR DESCRIPTION
## Motivation
This PR upgrades the version of `mad9000/actions-find-and-replace-string`.
This action is somehow not updated by dependabot, which is why we are doing it manually to avoid issues in the future (GitHub is has deprecated Node 16 support a long time ago):
![image](https://github.com/user-attachments/assets/736557c2-5e83-4fd3-a278-f33a3dfb98a6)

## Changes
- Upgrades `mad9000/actions-find-and-replace-string` to version 5