### PR TITLE
[ESM] Handle Lambda TCP socket connection timeouts

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
@@ -36,6 +36,10 @@ from localstack.services.lambda_.event_source_mapping.pollers.sqs_poller import 
 from localstack.services.lambda_.event_source_mapping.senders.lambda_sender import LambdaSender
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.aws.client_types import ServicePrincipal
+from localstack.utils.lambda_debug_mode.lambda_debug_mode import (
+    DEFAULT_LAMBDA_DEBUG_MODE_TIMEOUT_SECONDS,
+    is_lambda_debug_mode,
+)
 
 
 class PollerHolder:
@@ -57,12 +61,22 @@ class EsmWorkerFactory:
     def get_esm_worker(self) -> EsmWorker:
         # Sender (always Lambda)
         function_arn = self.esm_config["FunctionArn"]
+
+        if is_lambda_debug_mode():
+            timeout_seconds = DEFAULT_LAMBDA_DEBUG_MODE_TIMEOUT_SECONDS
+        else:
+            # 900s is the maximum amount of time a Lambda can run for.
+            lambda_max_timeout_seconds = 900
+            invoke_timeout_buffer_seconds = 5
+            timeout_seconds = lambda_max_timeout_seconds + invoke_timeout_buffer_seconds
+
         lambda_client = get_internal_client(
             arn=function_arn,  # Only the function_arn is necessary since the Lambda should be able to invoke itself
             client_config=botocore.config.Config(
-                retries={"max_attempts": 0, "total_max_attempts": 1},
-                read_timeout=900,  # 900s is the maximum amount of time a Lambda can run for
-                connect_timeout=900,
+                retries={
+                    "total_max_attempts": 1
+                },  # Disable retries, to prevent re-invoking the Lambda
+                read_timeout=timeout_seconds,
                 tcp_keepalive=True,
             ),
         )

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
@@ -1,5 +1,7 @@
 from typing import Callable
 
+import botocore.config
+
 from localstack.aws.api.lambda_ import (
     EventSourceMappingConfiguration,
     FunctionResponseType,
@@ -57,6 +59,12 @@ class EsmWorkerFactory:
         function_arn = self.esm_config["FunctionArn"]
         lambda_client = get_internal_client(
             arn=function_arn,  # Only the function_arn is necessary since the Lambda should be able to invoke itself
+            client_config=botocore.config.Config(
+                retries={"max_attempts": 0, "total_max_attempts": 1},
+                read_timeout=900,  # 900s is the maximum amount of time a Lambda can run for
+                connect_timeout=900,
+                tcp_keepalive=True,
+            ),
         )
         sender = LambdaSender(
             target_arn=function_arn,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We need to handle the case where a synchronous Lambda invocation runs for an extended period of time -- ensuring the TCP socket remains open and alive.

See https://github.com/boto/boto3/issues/2424

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Adds defaults for `connect_timeout`, `read_timeout`, `tcp_keepalive`, and `retries` in the client for the ESM lambda sender 
- Since a Lambda can run for 900s, we will only throw an exception once this timeout is reached.
- In addition, we specify `tcp_keepalive=True` which ensures the TCP connection does not drop prior to timeout.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
