### PR TITLE
SNS: improve SNS Filter Policy engine and implement `cidr` operator

### DIFF
--- a/localstack-core/localstack/services/sns/filter.py
+++ b/localstack-core/localstack/services/sns/filter.py
@@ -218,8 +218,8 @@ class SubscriptionFilter:
         Input:
         `{"field1": {
             "field2: [
-                {"field3: "val1", "field4": "val2"},
-                {"field3: "val3", "field4": "val4"},
+                {"field3": "val1", "field4": "val2"},
+                {"field3": "val3", "field4": "val4"}
             }
         ]}`
         Output:
@@ -231,7 +231,7 @@ class SubscriptionFilter:
             {
                 "field1.field2.field3": "val3",
                 "field1.field2.field4": "val4"
-            },
+            }
         ]`
         :param nested_dict: a (nested) dictionary
         :return: flatten_dict: a dictionary with no nested dict inside, flattened to a single level
@@ -245,6 +245,8 @@ class SubscriptionFilter:
                     array = _traverse(values, array, _parent_key)
 
             elif isinstance(_object, list):
+                if not _object:
+                    return array
                 array = [i for value in _object for i in _traverse(value, array, parent_key)]
             else:
                 array = [{**item, parent_key: _object} for item in array]

--- a/tests/aws/services/events/event_pattern_templates/exists_list_empty_NEG.json5
+++ b/tests/aws/services/events/event_pattern_templates/exists_list_empty_NEG.json5
@@ -15,8 +15,6 @@
     }
   },
   "EventPattern": {
-    "detail": {
-      "eventVersion": [""]
-    }
+    "resources": [{ "exists": true }]
   }
 }

--- a/tests/aws/services/events/test_events_patterns.snapshot.json
+++ b/tests/aws/services/events/test_events_patterns.snapshot.json
@@ -1,22 +1,22 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "recorded-date": "29-11-2024, 01:41:23",
+    "recorded-date": "29-11-2024, 21:46:53",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "recorded-date": "29-11-2024, 01:41:23",
+    "recorded-date": "29-11-2024, 21:46:54",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:24",
+    "recorded-date": "29-11-2024, 21:46:54",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "recorded-date": "29-11-2024, 01:41:24",
+    "recorded-date": "29-11-2024, 21:46:54",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:24",
+    "recorded-date": "29-11-2024, 21:46:54",
     "recorded-content": {
       "int_nolist_EXC": {
         "exception_message": {
@@ -35,39 +35,39 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "recorded-date": "29-11-2024, 01:41:25",
+    "recorded-date": "29-11-2024, 21:46:55",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:25",
+    "recorded-date": "29-11-2024, 21:46:55",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:25",
+    "recorded-date": "29-11-2024, 21:46:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "recorded-date": "29-11-2024, 01:41:26",
+    "recorded-date": "29-11-2024, 21:46:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "recorded-date": "29-11-2024, 01:41:26",
+    "recorded-date": "29-11-2024, 21:46:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "recorded-date": "29-11-2024, 01:41:26",
+    "recorded-date": "29-11-2024, 21:46:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:27",
+    "recorded-date": "29-11-2024, 21:46:57",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "recorded-date": "29-11-2024, 01:41:27",
+    "recorded-date": "29-11-2024, 21:46:57",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:27",
+    "recorded-date": "29-11-2024, 21:46:57",
     "recorded-content": {
       "content_numeric_operatorcasing_EXC": {
         "exception_message": {
@@ -86,19 +86,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:28",
+    "recorded-date": "29-11-2024, 21:46:57",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "recorded-date": "29-11-2024, 01:41:28",
+    "recorded-date": "29-11-2024, 21:46:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:28",
+    "recorded-date": "29-11-2024, 21:46:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:29",
+    "recorded-date": "29-11-2024, 21:46:58",
     "recorded-content": {
       "string_nolist_EXC": {
         "exception_message": {
@@ -117,27 +117,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:29",
+    "recorded-date": "29-11-2024, 21:46:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:29",
+    "recorded-date": "29-11-2024, 21:46:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:29",
+    "recorded-date": "29-11-2024, 21:46:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "recorded-date": "29-11-2024, 01:41:29",
+    "recorded-date": "29-11-2024, 21:46:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "recorded-date": "29-11-2024, 01:41:29",
+    "recorded-date": "29-11-2024, 21:46:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:29",
+    "recorded-date": "29-11-2024, 21:46:59",
     "recorded-content": {
       "arrays_empty_EXC": {
         "exception_message": {
@@ -156,55 +156,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:30",
+    "recorded-date": "29-11-2024, 21:47:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "recorded-date": "29-11-2024, 01:41:30",
+    "recorded-date": "29-11-2024, 21:47:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "recorded-date": "29-11-2024, 01:41:30",
+    "recorded-date": "29-11-2024, 21:47:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "recorded-date": "29-11-2024, 01:41:30",
+    "recorded-date": "29-11-2024, 21:47:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "recorded-date": "29-11-2024, 01:41:30",
+    "recorded-date": "29-11-2024, 21:47:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "recorded-date": "29-11-2024, 01:41:30",
+    "recorded-date": "29-11-2024, 21:47:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "recorded-date": "29-11-2024, 01:41:30",
+    "recorded-date": "29-11-2024, 21:47:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "recorded-date": "29-11-2024, 01:41:31",
+    "recorded-date": "29-11-2024, 21:47:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "recorded-date": "29-11-2024, 01:41:31",
+    "recorded-date": "29-11-2024, 21:47:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "recorded-date": "29-11-2024, 01:41:31",
+    "recorded-date": "29-11-2024, 21:47:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:32",
+    "recorded-date": "29-11-2024, 21:47:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:32",
+    "recorded-date": "29-11-2024, 21:47:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:32",
+    "recorded-date": "29-11-2024, 21:47:02",
     "recorded-content": {
       "operator_case_sensitive_EXC": {
         "exception_message": {
@@ -223,15 +223,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "recorded-date": "29-11-2024, 01:41:33",
+    "recorded-date": "29-11-2024, 21:47:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:33",
+    "recorded-date": "29-11-2024, 21:47:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:33",
+    "recorded-date": "29-11-2024, 21:47:03",
     "recorded-content": {
       "content_numeric_EXC": {
         "exception_message": {
@@ -250,87 +250,87 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:34",
+    "recorded-date": "29-11-2024, 21:47:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "recorded-date": "29-11-2024, 01:41:34",
+    "recorded-date": "29-11-2024, 21:47:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:34",
+    "recorded-date": "29-11-2024, 21:47:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "recorded-date": "29-11-2024, 01:41:34",
+    "recorded-date": "29-11-2024, 21:47:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:35",
+    "recorded-date": "29-11-2024, 21:47:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "recorded-date": "29-11-2024, 01:41:35",
+    "recorded-date": "29-11-2024, 21:47:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "recorded-date": "29-11-2024, 01:41:35",
+    "recorded-date": "29-11-2024, 21:47:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:35",
+    "recorded-date": "29-11-2024, 21:47:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:35",
+    "recorded-date": "29-11-2024, 21:47:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "recorded-date": "29-11-2024, 01:41:35",
+    "recorded-date": "29-11-2024, 21:47:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "recorded-date": "29-11-2024, 01:41:35",
+    "recorded-date": "29-11-2024, 21:47:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:35",
+    "recorded-date": "29-11-2024, 21:47:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:36",
+    "recorded-date": "29-11-2024, 21:47:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "recorded-date": "29-11-2024, 01:41:36",
+    "recorded-date": "29-11-2024, 21:47:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "recorded-date": "29-11-2024, 01:41:36",
+    "recorded-date": "29-11-2024, 21:47:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "recorded-date": "29-11-2024, 01:41:36",
+    "recorded-date": "29-11-2024, 21:47:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:36",
+    "recorded-date": "29-11-2024, 21:47:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "recorded-date": "29-11-2024, 01:41:37",
+    "recorded-date": "29-11-2024, 21:47:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:37",
+    "recorded-date": "29-11-2024, 21:47:07",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:37",
+    "recorded-date": "29-11-2024, 21:47:07",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:38",
+    "recorded-date": "29-11-2024, 21:47:08",
     "recorded-content": {
       "content_wildcard_complex_EXC": {
         "exception_message": {
@@ -349,55 +349,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:39",
+    "recorded-date": "29-11-2024, 21:47:09",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "recorded-date": "29-11-2024, 01:41:40",
+    "recorded-date": "29-11-2024, 21:47:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:40",
+    "recorded-date": "29-11-2024, 21:47:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "recorded-date": "29-11-2024, 01:41:40",
+    "recorded-date": "29-11-2024, 21:47:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "recorded-date": "29-11-2024, 01:41:41",
+    "recorded-date": "29-11-2024, 21:47:12",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "recorded-date": "29-11-2024, 01:41:42",
+    "recorded-date": "29-11-2024, 21:47:12",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:42",
+    "recorded-date": "29-11-2024, 21:47:12",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "recorded-date": "29-11-2024, 01:41:42",
+    "recorded-date": "29-11-2024, 21:47:12",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:43",
+    "recorded-date": "29-11-2024, 21:47:13",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "recorded-date": "29-11-2024, 01:41:43",
+    "recorded-date": "29-11-2024, 21:47:13",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:43",
+    "recorded-date": "29-11-2024, 21:47:14",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:43",
+    "recorded-date": "29-11-2024, 21:47:14",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:43",
+    "recorded-date": "29-11-2024, 21:47:14",
     "recorded-content": {
       "content_numeric_syntax_EXC": {
         "exception_message": {
@@ -416,19 +416,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "recorded-date": "29-11-2024, 01:41:44",
+    "recorded-date": "29-11-2024, 21:47:14",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "recorded-date": "29-11-2024, 01:41:44",
+    "recorded-date": "29-11-2024, 21:47:14",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "recorded-date": "29-11-2024, 01:41:44",
+    "recorded-date": "29-11-2024, 21:47:14",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "recorded-date": "29-11-2024, 01:41:44",
+    "recorded-date": "29-11-2024, 21:47:15",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
@@ -580,7 +580,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:26",
+    "recorded-date": "29-11-2024, 21:46:56",
     "recorded-content": {
       "content_wildcard_repeating_star_EXC": {
         "exception_message": {
@@ -599,7 +599,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:31",
+    "recorded-date": "29-11-2024, 21:47:01",
     "recorded-content": {
       "content_ignorecase_EXC": {
         "exception_message": {
@@ -618,7 +618,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:41",
+    "recorded-date": "29-11-2024, 21:47:11",
     "recorded-content": {
       "content_ip_address_EXC": {
         "exception_message": {
@@ -637,7 +637,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:33",
+    "recorded-date": "29-11-2024, 21:47:03",
     "recorded-content": {
       "content_anything_but_ignorecase_EXC": {
         "exception_message": {
@@ -656,7 +656,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:36",
+    "recorded-date": "29-11-2024, 21:47:06",
     "recorded-content": {
       "content_anything_but_ignorecase_list_EXC": {
         "exception_message": {
@@ -675,7 +675,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:38",
+    "recorded-date": "29-11-2024, 21:47:08",
     "recorded-content": {
       "content_ignorecase_list_EXC": {
         "exception_message": {
@@ -754,27 +754,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
-    "recorded-date": "29-11-2024, 01:41:33",
+    "recorded-date": "29-11-2024, 21:47:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:25",
+    "recorded-date": "29-11-2024, 21:46:55",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list]": {
-    "recorded-date": "29-11-2024, 01:41:27",
+    "recorded-date": "29-11-2024, 21:46:57",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:31",
+    "recorded-date": "29-11-2024, 21:47:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard]": {
-    "recorded-date": "29-11-2024, 01:41:41",
+    "recorded-date": "29-11-2024, 21:47:11",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_int_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:40",
+    "recorded-date": "29-11-2024, 21:47:11",
     "recorded-content": {
       "content_wildcard_int_EXC": {
         "exception_message": {
@@ -793,7 +793,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_list_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:43",
+    "recorded-date": "29-11-2024, 21:47:13",
     "recorded-content": {
       "content_wildcard_list_EXC": {
         "exception_message": {
@@ -812,7 +812,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_type_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:25",
+    "recorded-date": "29-11-2024, 21:46:55",
     "recorded-content": {
       "content_anything_wildcard_list_type_EXC": {
         "exception_message": {
@@ -831,7 +831,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_type_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:39",
+    "recorded-date": "29-11-2024, 21:47:09",
     "recorded-content": {
       "content_anything_wildcard_type_EXC": {
         "exception_message": {
@@ -850,7 +850,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_type_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:24",
+    "recorded-date": "29-11-2024, 21:46:54",
     "recorded-content": {
       "content_anything_suffix_list_type_EXC": {
         "exception_message": {
@@ -869,15 +869,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list]": {
-    "recorded-date": "29-11-2024, 01:41:25",
+    "recorded-date": "29-11-2024, 21:46:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:26",
+    "recorded-date": "29-11-2024, 21:46:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_int_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:31",
+    "recorded-date": "29-11-2024, 21:47:00",
     "recorded-content": {
       "content_anything_suffix_int_EXC": {
         "exception_message": {
@@ -896,15 +896,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list]": {
-    "recorded-date": "29-11-2024, 01:41:35",
+    "recorded-date": "29-11-2024, 21:47:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_NEG]": {
-    "recorded-date": "29-11-2024, 01:41:38",
+    "recorded-date": "29-11-2024, 21:47:08",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_type_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:40",
+    "recorded-date": "29-11-2024, 21:47:10",
     "recorded-content": {
       "content_anything_prefix_list_type_EXC": {
         "exception_message": {
@@ -923,7 +923,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_int_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:42",
+    "recorded-date": "29-11-2024, 21:47:12",
     "recorded-content": {
       "content_anything_prefix_int_EXC": {
         "exception_message": {
@@ -942,7 +942,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_list_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:28",
+    "recorded-date": "29-11-2024, 21:46:58",
     "recorded-content": {
       "content_prefix_list_EXC": {
         "exception_message": {
@@ -961,7 +961,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_int_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:34",
+    "recorded-date": "29-11-2024, 21:47:04",
     "recorded-content": {
       "content_prefix_int_EXC": {
         "exception_message": {
@@ -980,7 +980,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_int_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:37",
+    "recorded-date": "29-11-2024, 21:47:07",
     "recorded-content": {
       "content_suffix_int_EXC": {
         "exception_message": {
@@ -999,7 +999,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_list_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:41",
+    "recorded-date": "29-11-2024, 21:47:12",
     "recorded-content": {
       "content_suffix_list_EXC": {
         "exception_message": {
@@ -1018,7 +1018,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_ignorecase_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:37",
+    "recorded-date": "29-11-2024, 21:47:07",
     "recorded-content": {
       "content_anything_prefix_ignorecase_EXC": {
         "exception_message": {
@@ -1037,7 +1037,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_ignorecase_EXC]": {
-    "recorded-date": "29-11-2024, 01:41:39",
+    "recorded-date": "29-11-2024, 21:47:09",
     "recorded-content": {
       "content_anything_suffix_ignorecase_EXC": {
         "exception_message": {
@@ -1054,5 +1054,13 @@
         "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
       }
     }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_list_empty]": {
+    "recorded-date": "29-11-2024, 21:45:57",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_list_empty_NEG]": {
+    "recorded-date": "29-11-2024, 21:46:55",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/events/test_events_patterns.validation.json
+++ b/tests/aws/services/events/test_events_patterns.validation.json
@@ -1,324 +1,327 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "last_validated_date": "2024-11-29T01:41:25+00:00"
+    "last_validated_date": "2024-11-29T21:46:55+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:43+00:00"
+    "last_validated_date": "2024-11-29T21:47:13+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:29+00:00"
+    "last_validated_date": "2024-11-29T21:46:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:37+00:00"
+    "last_validated_date": "2024-11-29T21:47:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "last_validated_date": "2024-11-29T01:41:44+00:00"
+    "last_validated_date": "2024-11-29T21:47:14+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:29+00:00"
+    "last_validated_date": "2024-11-29T21:46:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "last_validated_date": "2024-11-29T01:41:31+00:00"
+    "last_validated_date": "2024-11-29T21:47:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "last_validated_date": "2024-11-29T01:41:24+00:00"
+    "last_validated_date": "2024-11-29T21:46:54+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:27+00:00"
+    "last_validated_date": "2024-11-29T21:46:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "last_validated_date": "2024-11-29T01:41:34+00:00"
+    "last_validated_date": "2024-11-29T21:47:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:34+00:00"
+    "last_validated_date": "2024-11-29T21:47:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "last_validated_date": "2024-11-29T01:41:30+00:00"
+    "last_validated_date": "2024-11-29T21:47:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:33+00:00"
+    "last_validated_date": "2024-11-29T21:47:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:42+00:00"
+    "last_validated_date": "2024-11-29T21:47:12+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "last_validated_date": "2024-11-29T01:41:36+00:00"
+    "last_validated_date": "2024-11-29T21:47:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:36+00:00"
+    "last_validated_date": "2024-11-29T21:47:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:25+00:00"
+    "last_validated_date": "2024-11-29T21:46:56+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "last_validated_date": "2024-11-29T01:41:44+00:00"
+    "last_validated_date": "2024-11-29T21:47:14+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:32+00:00"
+    "last_validated_date": "2024-11-29T21:47:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "last_validated_date": "2024-11-29T01:41:31+00:00"
+    "last_validated_date": "2024-11-29T21:47:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:28+00:00"
+    "last_validated_date": "2024-11-29T21:46:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "last_validated_date": "2024-11-29T01:41:27+00:00"
+    "last_validated_date": "2024-11-29T21:46:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:29+00:00"
+    "last_validated_date": "2024-11-29T21:46:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "last_validated_date": "2024-11-29T01:41:30+00:00"
+    "last_validated_date": "2024-11-29T21:47:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:39+00:00"
+    "last_validated_date": "2024-11-29T21:47:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
-    "last_validated_date": "2024-11-29T01:41:33+00:00"
+    "last_validated_date": "2024-11-29T21:47:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "last_validated_date": "2024-11-29T01:41:35+00:00"
+    "last_validated_date": "2024-11-29T21:47:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:28+00:00"
+    "last_validated_date": "2024-11-29T21:46:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_ignorecase_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:37+00:00"
+    "last_validated_date": "2024-11-29T21:47:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_int_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:42+00:00"
+    "last_validated_date": "2024-11-29T21:47:12+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list]": {
-    "last_validated_date": "2024-11-29T01:41:25+00:00"
+    "last_validated_date": "2024-11-29T21:46:56+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:26+00:00"
+    "last_validated_date": "2024-11-29T21:46:56+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_type_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:40+00:00"
+    "last_validated_date": "2024-11-29T21:47:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "last_validated_date": "2024-11-29T01:41:36+00:00"
+    "last_validated_date": "2024-11-29T21:47:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:35+00:00"
+    "last_validated_date": "2024-11-29T21:47:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_ignorecase_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:39+00:00"
+    "last_validated_date": "2024-11-29T21:47:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_int_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:31+00:00"
+    "last_validated_date": "2024-11-29T21:47:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list]": {
-    "last_validated_date": "2024-11-29T01:41:35+00:00"
+    "last_validated_date": "2024-11-29T21:47:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:38+00:00"
+    "last_validated_date": "2024-11-29T21:47:08+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_type_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:24+00:00"
+    "last_validated_date": "2024-11-29T21:46:54+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard]": {
-    "last_validated_date": "2024-11-29T01:41:41+00:00"
+    "last_validated_date": "2024-11-29T21:47:11+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:25+00:00"
+    "last_validated_date": "2024-11-29T21:46:55+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list]": {
-    "last_validated_date": "2024-11-29T01:41:27+00:00"
+    "last_validated_date": "2024-11-29T21:46:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:31+00:00"
+    "last_validated_date": "2024-11-29T21:47:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_type_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:25+00:00"
+    "last_validated_date": "2024-11-29T21:46:55+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_type_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:39+00:00"
+    "last_validated_date": "2024-11-29T21:47:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "last_validated_date": "2024-11-29T01:41:33+00:00"
+    "last_validated_date": "2024-11-29T21:47:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:43+00:00"
+    "last_validated_date": "2024-11-29T21:47:14+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "last_validated_date": "2024-11-29T01:41:41+00:00"
+    "last_validated_date": "2024-11-29T21:47:12+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:43+00:00"
+    "last_validated_date": "2024-11-29T21:47:14+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "last_validated_date": "2024-11-29T01:41:43+00:00"
+    "last_validated_date": "2024-11-29T21:47:13+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:31+00:00"
+    "last_validated_date": "2024-11-29T21:47:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:40+00:00"
+    "last_validated_date": "2024-11-29T21:47:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:38+00:00"
+    "last_validated_date": "2024-11-29T21:47:08+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "last_validated_date": "2024-11-29T01:41:28+00:00"
+    "last_validated_date": "2024-11-29T21:46:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:41+00:00"
+    "last_validated_date": "2024-11-29T21:47:11+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:33+00:00"
+    "last_validated_date": "2024-11-29T21:47:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:33+00:00"
+    "last_validated_date": "2024-11-29T21:47:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "last_validated_date": "2024-11-29T01:41:44+00:00"
+    "last_validated_date": "2024-11-29T21:47:14+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:34+00:00"
+    "last_validated_date": "2024-11-29T21:47:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:27+00:00"
+    "last_validated_date": "2024-11-29T21:46:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:43+00:00"
+    "last_validated_date": "2024-11-29T21:47:14+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "last_validated_date": "2024-11-29T01:41:40+00:00"
+    "last_validated_date": "2024-11-29T21:47:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:36+00:00"
+    "last_validated_date": "2024-11-29T21:47:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "last_validated_date": "2024-11-29T01:41:35+00:00"
+    "last_validated_date": "2024-11-29T21:47:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_int_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:34+00:00"
+    "last_validated_date": "2024-11-29T21:47:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_list_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:28+00:00"
+    "last_validated_date": "2024-11-29T21:46:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "last_validated_date": "2024-11-29T01:41:42+00:00"
+    "last_validated_date": "2024-11-29T21:47:12+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:24+00:00"
+    "last_validated_date": "2024-11-29T21:46:54+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "last_validated_date": "2024-11-29T01:41:35+00:00"
+    "last_validated_date": "2024-11-29T21:47:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:37+00:00"
+    "last_validated_date": "2024-11-29T21:47:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_int_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:37+00:00"
+    "last_validated_date": "2024-11-29T21:47:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_list_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:41+00:00"
+    "last_validated_date": "2024-11-29T21:47:12+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:38+00:00"
+    "last_validated_date": "2024-11-29T21:47:08+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_int_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:40+00:00"
+    "last_validated_date": "2024-11-29T21:47:11+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_list_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:43+00:00"
+    "last_validated_date": "2024-11-29T21:47:13+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "last_validated_date": "2024-11-29T01:41:26+00:00"
+    "last_validated_date": "2024-11-29T21:46:56+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:32+00:00"
+    "last_validated_date": "2024-11-29T21:47:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "last_validated_date": "2024-11-29T01:41:23+00:00"
+    "last_validated_date": "2024-11-29T21:46:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:25+00:00"
+    "last_validated_date": "2024-11-29T21:46:55+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:26+00:00"
+    "last_validated_date": "2024-11-29T21:46:56+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "last_validated_date": "2024-11-29T01:41:26+00:00"
+    "last_validated_date": "2024-11-29T21:46:56+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "last_validated_date": "2024-11-29T01:41:34+00:00"
+    "last_validated_date": "2024-11-29T21:47:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:36+00:00"
+    "last_validated_date": "2024-11-29T21:47:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "last_validated_date": "2024-11-29T01:41:30+00:00"
+    "last_validated_date": "2024-11-29T21:47:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:35+00:00"
+    "last_validated_date": "2024-11-29T21:47:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "last_validated_date": "2024-11-29T01:41:30+00:00"
+    "last_validated_date": "2024-11-29T21:47:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "last_validated_date": "2024-11-29T01:41:29+00:00"
+    "last_validated_date": "2024-11-29T21:46:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:29+00:00"
+    "last_validated_date": "2024-11-29T21:46:59+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_list_empty_NEG]": {
+    "last_validated_date": "2024-11-29T21:46:55+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:24+00:00"
+    "last_validated_date": "2024-11-29T21:46:54+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:35+00:00"
+    "last_validated_date": "2024-11-29T21:47:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "last_validated_date": "2024-11-29T01:41:23+00:00"
+    "last_validated_date": "2024-11-29T21:46:54+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "last_validated_date": "2024-11-29T01:41:40+00:00"
+    "last_validated_date": "2024-11-29T21:47:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:30+00:00"
+    "last_validated_date": "2024-11-29T21:47:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "last_validated_date": "2024-11-29T01:41:31+00:00"
+    "last_validated_date": "2024-11-29T21:47:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "last_validated_date": "2024-11-29T01:41:35+00:00"
+    "last_validated_date": "2024-11-29T21:47:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "last_validated_date": "2024-11-29T01:41:42+00:00"
+    "last_validated_date": "2024-11-29T21:47:12+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:32+00:00"
+    "last_validated_date": "2024-11-29T21:47:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "last_validated_date": "2024-11-29T01:41:30+00:00"
+    "last_validated_date": "2024-11-29T21:47:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "last_validated_date": "2024-11-29T01:41:44+00:00"
+    "last_validated_date": "2024-11-29T21:47:15+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "last_validated_date": "2024-11-29T01:41:29+00:00"
+    "last_validated_date": "2024-11-29T21:46:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "last_validated_date": "2024-11-29T01:41:26+00:00"
+    "last_validated_date": "2024-11-29T21:46:56+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "last_validated_date": "2024-11-29T01:41:36+00:00"
+    "last_validated_date": "2024-11-29T21:47:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "last_validated_date": "2024-11-29T01:41:35+00:00"
+    "last_validated_date": "2024-11-29T21:47:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "last_validated_date": "2024-11-29T01:41:36+00:00"
+    "last_validated_date": "2024-11-29T21:47:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "last_validated_date": "2024-11-29T01:41:30+00:00"
+    "last_validated_date": "2024-11-29T21:47:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "last_validated_date": "2024-11-29T01:41:29+00:00"
+    "last_validated_date": "2024-11-29T21:46:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
     "last_validated_date": "2024-07-11T13:55:39+00:00"

--- a/tests/aws/services/sns/test_sns_filter_policy.py
+++ b/tests/aws/services/sns/test_sns_filter_policy.py
@@ -1178,6 +1178,32 @@ class TestSNSFilterPolicyBody:
             recv_messages.sort(key=itemgetter("Body"))
             snapshot.match("messages-queue", {"Messages": recv_messages})
 
+    @markers.aws.validated
+    def test_filter_policy_empty_array_payload(self):
+        pass
+
+        # {
+        #   "Event": {
+        #     "version": "0",
+        #     "id": "3e3c153a-8339-4e30-8c35-687ebef853fe",
+        #     "detail-type": "EC2 Instance Launch Successful",
+        #     "source": "aws.autoscaling",
+        #     "account": "123456789012",
+        #     "time": "2015-11-11T21:31:47Z",
+        #     "region": "us-east-1",
+        #     "resources": [],
+        #     "detail": {
+        #       "eventVersion": "",
+        #       "responseElements": null
+        #     }
+        #   },
+        #   "EventPattern": {
+        #     "detail": {
+        #       "eventVersion": [""]
+        #     }
+        #   }
+        # }
+
 
 class TestSNSFilterPolicyConditions:
     @staticmethod

--- a/tests/aws/services/sns/test_sns_filter_policy.py
+++ b/tests/aws/services/sns/test_sns_filter_policy.py
@@ -529,6 +529,24 @@ class TestSNSFilterPolicyAttributes:
 
 
 class TestSNSFilterPolicyBody:
+    @staticmethod
+    def get_messages(aws_client, _queue_url: str, _msg_list: list, expected: int):
+        # due to the random nature of receiving SQS messages, we need to consolidate a single object to match
+        sqs_response = aws_client.sqs.receive_message(
+            QueueUrl=_queue_url,
+            WaitTimeSeconds=1,
+            VisibilityTimeout=0,
+            MessageAttributeNames=["All"],
+            AttributeNames=["All"],
+        )
+        for _message in sqs_response["Messages"]:
+            _msg_list.append(_message)
+            aws_client.sqs.delete_message(
+                QueueUrl=_queue_url, ReceiptHandle=_message["ReceiptHandle"]
+            )
+
+        assert len(_msg_list) == expected
+
     @markers.aws.validated
     @pytest.mark.parametrize("raw_message_delivery", [True, False])
     def test_filter_policy_on_message_body(
@@ -908,31 +926,16 @@ class TestSNSFilterPolicyBody:
                 Message=json.dumps(message),
             )
 
-        def get_messages(_queue_url: str, _recv_messages: list):
-            # due to the random nature of receiving SQS messages, we need to consolidate a single object to match
-            sqs_response = aws_client.sqs.receive_message(
-                QueueUrl=_queue_url,
-                WaitTimeSeconds=1,
-                VisibilityTimeout=0,
-                MessageAttributeNames=["All"],
-                AttributeNames=["All"],
-            )
-            for _message in sqs_response["Messages"]:
-                _recv_messages.append(_message)
-                aws_client.sqs.delete_message(
-                    QueueUrl=_queue_url, ReceiptHandle=_message["ReceiptHandle"]
-                )
-
-            assert len(_recv_messages) == 2
-
         for i, queue_url in enumerate(queues):
             recv_messages = []
             retry(
-                get_messages,
+                self.get_messages,
                 retries=10,
                 sleep=0.1,
+                aws_client=aws_client,
                 _queue_url=queue_url,
-                _recv_messages=recv_messages,
+                _msg_list=recv_messages,
+                expected=2,
             )
             # we need to sort the list (the order does not matter as we're not using FIFO)
             recv_messages.sort(key=itemgetter("Body"))
@@ -1039,30 +1042,15 @@ class TestSNSFilterPolicyBody:
                 Message=json.dumps(message),
             )
 
-        def get_messages(_queue_url: str, _received_messages: list):
-            # due to the random nature of receiving SQS messages, we need to consolidate a single object to match
-            sqs_response = aws_client.sqs.receive_message(
-                QueueUrl=_queue_url,
-                WaitTimeSeconds=1,
-                VisibilityTimeout=0,
-                MessageAttributeNames=["All"],
-                AttributeNames=["All"],
-            )
-            for _message in sqs_response["Messages"]:
-                _received_messages.append(_message)
-                aws_client.sqs.delete_message(
-                    QueueUrl=_queue_url, ReceiptHandle=_message["ReceiptHandle"]
-                )
-
-            assert len(_received_messages) == 2
-
         received_messages = []
         retry(
-            get_messages,
+            self.get_messages,
             retries=10,
             sleep=0.1,
+            aws_client=aws_client,
             _queue_url=queue_url,
-            _received_messages=received_messages,
+            _msg_list=received_messages,
+            expected=2,
         )
         # we need to sort the list (the order does not matter as we're not using FIFO)
         received_messages.sort(key=itemgetter("Body"))
@@ -1103,7 +1091,7 @@ class TestSNSFilterPolicyBody:
         # publish messages that satisfies the filter policy, assert that messages are received
         messages = [
             # not passing
-            # wrong value for `metricName`
+            # wrong value for `detail.scope`
             {
                 "metricName": "CPUUtilization",
                 "detail": {"scope": "aws.cloudwatch", "type": "CloudWatch Alarm State Change"},
@@ -1119,6 +1107,16 @@ class TestSNSFilterPolicyBody:
             {"metricName": "CPUUtilization", "detail": {"scope": "Service"}},
             # missing value for `detail.scope` AND `detail.source` or `detail.type`
             {"metricName": "CPUUtilization", "scope": "Service"},
+            # wrong value for `metricName`
+            {
+                "metricName": "AWS/EC2",
+                "detail": {"scope": "Service", "type": "CloudWatch Alarm State Change"},
+            },
+            # wrong value for `namespace`
+            {
+                "namespace": "CPUUtilization",
+                "detail": {"scope": "Service", "type": "CloudWatch Alarm State Change"},
+            },
             # passing
             {
                 "metricName": "CPUUtilization",
@@ -1134,13 +1132,117 @@ class TestSNSFilterPolicyBody:
                 "metricName": "CPUUtilization",
                 "detail": {"scope": "Service", "type": "CloudWatch Alarm State Change"},
             },
+        ]
+        for message in messages:
+            aws_client.sns.publish(
+                TopicArn=topic_arn,
+                Message=json.dumps(message),
+            )
+
+        recv_messages = []
+        retry(
+            self.get_messages,
+            retries=10,
+            sleep=0.1,
+            aws_client=aws_client,
+            _queue_url=queue_url,
+            _msg_list=recv_messages,
+            expected=5,
+        )
+        # we need to sort the list (the order does not matter as we're not using FIFO)
+        recv_messages.sort(key=itemgetter("Body"))
+        snapshot.match("messages-queue", {"Messages": recv_messages})
+
+    @markers.aws.validated
+    def test_filter_policy_empty_array_payload(
+        self,
+        sqs_create_queue,
+        sns_create_topic,
+        sns_create_sqs_subscription_with_filter_policy,
+        snapshot,
+        aws_client,
+    ):
+        # this test is a regression test for having an empty array in the payload, which could fail the logic and is
+        # a special condition (`resources` would fail `exists`)
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+
+        filter_policy = {"detail": {"eventVersion": [""]}}
+        sns_create_sqs_subscription_with_filter_policy(
+            topic_arn=topic_arn,
+            queue_url=queue_url,
+            filter_scope="MessageBody",
+            filter_policy=filter_policy,
+        )
+        message = {
+            "version": "0",
+            "id": "3e3c153a-8339-4e30-8c35-687ebef853fe",
+            "detail-type": "EC2 Instance Launch Successful",
+            "source": "aws.autoscaling",
+            "account": "123456789012",
+            "time": "2015-11-11T21:31:47Z",
+            "region": "us-east-1",
+            "resources": [],
+            "detail": {
+                "eventVersion": "",
+                "responseElements": None,
+            },
+        }
+
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=json.dumps(message),
+        )
+
+        recv_messages = []
+        retry(
+            self.get_messages,
+            retries=10,
+            sleep=0.1,
+            aws_client=aws_client,
+            _queue_url=queue_url,
+            _msg_list=recv_messages,
+            expected=1,
+        )
+        snapshot.match("messages-queue", {"Messages": recv_messages})
+
+    @markers.aws.validated
+    def test_filter_policy_ip_address_condition(
+        self,
+        sqs_create_queue,
+        sns_create_topic,
+        sns_create_sqs_subscription_with_filter_policy,
+        snapshot,
+        aws_client,
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+
+        filter_policy = {"detail": {"sourceIPAddress": [{"cidr": "10.0.0.0/24"}]}}
+        sns_create_sqs_subscription_with_filter_policy(
+            topic_arn=topic_arn,
+            queue_url=queue_url,
+            filter_scope="MessageBody",
+            filter_policy=filter_policy,
+        )
+        messages = [
             {
-                "metricName": "AWS/EC2",
-                "detail": {"scope": "Service", "type": "CloudWatch Alarm State Change"},
+                "id": "1",
+                "source": "test-source",
+                "detail-type": "test-detail-type",
+                "account": "123456789012",
+                "region": "us-east-2",
+                "time": "2022-07-13T13:48:01Z",
+                "detail": {"sourceIPAddress": "10.0.0.255"},
             },
             {
-                "namespace": "CPUUtilization",
-                "detail": {"scope": "Service", "type": "CloudWatch Alarm State Change"},
+                "id": "1",
+                "source": "test-source",
+                "detail-type": "test-detail-type",
+                "account": "123456789012",
+                "region": "us-east-2",
+                "time": "2022-07-13T13:48:01Z",
+                "detail": {"sourceIPAddress": "10.0.0.256"},
             },
         ]
         for message in messages:
@@ -1149,60 +1251,17 @@ class TestSNSFilterPolicyBody:
                 Message=json.dumps(message),
             )
 
-        def get_messages(_queue_url: str, _recv_messages: list):
-            # due to the random nature of receiving SQS messages, we need to consolidate a single object to match
-            sqs_response = aws_client.sqs.receive_message(
-                QueueUrl=_queue_url,
-                WaitTimeSeconds=1,
-                VisibilityTimeout=0,
-                MessageAttributeNames=["All"],
-                AttributeNames=["All"],
-            )
-            for _message in sqs_response["Messages"]:
-                _recv_messages.append(_message)
-                aws_client.sqs.delete_message(
-                    QueueUrl=_queue_url, ReceiptHandle=_message["ReceiptHandle"]
-                )
-
-            assert len(_recv_messages) == 7
-
-            recv_messages = []
-            retry(
-                get_messages,
-                retries=10,
-                sleep=0.1,
-                _queue_url=queue_url,
-                _recv_messages=recv_messages,
-            )
-            # we need to sort the list (the order does not matter as we're not using FIFO)
-            recv_messages.sort(key=itemgetter("Body"))
-            snapshot.match("messages-queue", {"Messages": recv_messages})
-
-    @markers.aws.validated
-    def test_filter_policy_empty_array_payload(self):
-        pass
-
-        # {
-        #   "Event": {
-        #     "version": "0",
-        #     "id": "3e3c153a-8339-4e30-8c35-687ebef853fe",
-        #     "detail-type": "EC2 Instance Launch Successful",
-        #     "source": "aws.autoscaling",
-        #     "account": "123456789012",
-        #     "time": "2015-11-11T21:31:47Z",
-        #     "region": "us-east-1",
-        #     "resources": [],
-        #     "detail": {
-        #       "eventVersion": "",
-        #       "responseElements": null
-        #     }
-        #   },
-        #   "EventPattern": {
-        #     "detail": {
-        #       "eventVersion": [""]
-        #     }
-        #   }
-        # }
+        recv_messages = []
+        retry(
+            self.get_messages,
+            retries=10,
+            sleep=0.1,
+            aws_client=aws_client,
+            _queue_url=queue_url,
+            _msg_list=recv_messages,
+            expected=1,
+        )
+        snapshot.match("messages-queue", {"Messages": recv_messages})
 
 
 class TestSNSFilterPolicyConditions:
@@ -1272,6 +1331,12 @@ class TestSNSFilterPolicyConditions:
             )
 
         with pytest.raises(ClientError) as e:
+            filter_policy = {"key": []}
+            _subscribe(filter_policy)
+        self._add_normalized_field_to_snapshot(e.value.response)
+        snapshot.match("error-condition-empty-array", e.value.response)
+
+        with pytest.raises(ClientError) as e:
             filter_policy = {"key": [{"suffix": 100}]}
             _subscribe(filter_policy)
         self._add_normalized_field_to_snapshot(e.value.response)
@@ -1312,6 +1377,12 @@ class TestSNSFilterPolicyConditions:
             _subscribe(filter_policy)
         self._add_normalized_field_to_snapshot(e.value.response)
         snapshot.match("error-condition-is-not-list-and-no-operator", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            filter_policy = {"key": [{"cidr": "bad-filter"}]}
+            _subscribe(filter_policy)
+        self._add_normalized_field_to_snapshot(e.value.response)
+        snapshot.match("error-condition-bad-cidr", e.value.response)
 
         # TODO: add `cidr` string operator
 

--- a/tests/aws/services/sns/test_sns_filter_policy.snapshot.json
+++ b/tests/aws/services/sns/test_sns_filter_policy.snapshot.json
@@ -41,7 +41,7 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyConditions::test_validate_policy_string_operators": {
-    "recorded-date": "03-12-2024, 15:19:36",
+    "recorded-date": "03-12-2024, 22:11:13",
     "recorded-content": {
       "error-condition-empty-array": {
         "Error": {
@@ -139,12 +139,72 @@
           "HTTPStatusCode": 400
         }
       },
-      "error-condition-bad-cidr": {
+      "error-condition-bad-type": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: prefix match pattern must be a string\n at [Source: (String)\"{\"key\":[{\"cidr\":[\"bad-filter\"]}]}\"; line: 1, column: 18]",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: prefix match pattern must be a string"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-condition-bad-cidr-str": {
         "Error": {
           "Code": "InvalidParameter",
           "Message": "Invalid parameter: Attributes Reason: FilterPolicy: Malformed CIDR, one '/' required",
           "Type": "Sender",
           "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: Malformed CIDR, one '/' required"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-condition-bad-cidr-str-slash": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: Nonstandard IP address: bad-filter",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: Nonstandard IP address: bad-filter"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-condition-bad-cidr-str-slash-2": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: Malformed CIDR, mask bits must be an integer",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: Malformed CIDR, mask bits must be an integer"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-condition-bad-cidr-v4": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: Nonstandard IP address: xx.11.xx",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: Nonstandard IP address: xx.11.xx"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-condition-bad-cidr-v6": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: Nonstandard IP address: xxxx:db8:1234:1a00::",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: Nonstandard IP address: xxxx:db8:1234:1a00::"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1761,7 +1821,7 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_ip_address_condition": {
-    "recorded-date": "03-12-2024, 15:14:34",
+    "recorded-date": "03-12-2024, 22:05:08",
     "recorded-content": {
       "messages-queue": {
         "Messages": [
@@ -1786,6 +1846,28 @@
             "MD5OfBody": "<md5-hash>",
             "MessageId": "<uuid:1>",
             "ReceiptHandle": "<receipt-handle:1>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "id": "1",
+              "source": "test-source",
+              "detail-type": "test-detail-type",
+              "account": "123456789012",
+              "region": "us-east-2",
+              "time": "date",
+              "detail": {
+                "sourceIPAddressV6": "2001:0db8:1234:1a00:0000:0000:0000:0000"
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
           }
         ]
       }

--- a/tests/aws/services/sns/test_sns_filter_policy.snapshot.json
+++ b/tests/aws/services/sns/test_sns_filter_policy.snapshot.json
@@ -41,8 +41,20 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyConditions::test_validate_policy_string_operators": {
-    "recorded-date": "15-05-2024, 14:39:23",
+    "recorded-date": "03-12-2024, 15:19:36",
     "recorded-content": {
+      "error-condition-empty-array": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: Empty arrays are not allowed\n at [Source: (String)\"{\"key\":[]}\"; line: 1, column: 10]",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: Empty arrays are not allowed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
       "error-condition-is-numeric": {
         "Error": {
           "Code": "InvalidParameter",
@@ -121,6 +133,18 @@
           "Message": "Invalid parameter: Attributes Reason: FilterPolicy: \"not-an-operator\" must be an object or an array\n at [Source: (String)\"{\"key\":{\"not-an-operator\":\"value\"}}\"; line: 1, column: 28]",
           "Type": "Sender",
           "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: \"not-an-operator\" must be an object or an array"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-condition-bad-cidr": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: Malformed CIDR, one '/' required",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: Malformed CIDR, one '/' required"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -965,7 +989,7 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body[True]": {
-    "recorded-date": "14-05-2024, 16:49:57",
+    "recorded-date": "03-12-2024, 15:01:58",
     "recorded-content": {
       "recv-init": {
         "ResponseMetadata": {
@@ -1012,7 +1036,7 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body[False]": {
-    "recorded-date": "14-05-2024, 16:50:08",
+    "recorded-date": "03-12-2024, 15:02:10",
     "recorded-content": {
       "recv-init": {
         "ResponseMetadata": {
@@ -1071,7 +1095,7 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_for_batch": {
-    "recorded-date": "14-05-2024, 16:50:25",
+    "recorded-date": "03-12-2024, 15:02:27",
     "recorded-content": {
       "subscription-attributes-with-filter": {
         "Attributes": {
@@ -1231,7 +1255,7 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body_dot_attribute": {
-    "recorded-date": "14-05-2024, 16:50:50",
+    "recorded-date": "03-12-2024, 15:02:51",
     "recorded-content": {
       "recv-init": {
         "ResponseMetadata": {
@@ -1386,7 +1410,7 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body_array_attributes": {
-    "recorded-date": "14-05-2024, 16:50:55",
+    "recorded-date": "03-12-2024, 15:02:56",
     "recorded-content": {
       "messages-queue-0": {
         "Messages": [
@@ -1473,7 +1497,7 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body_array_of_object_attributes": {
-    "recorded-date": "14-05-2024, 16:50:58",
+    "recorded-date": "03-12-2024, 15:02:59",
     "recorded-content": {
       "messages": {
         "Messages": [
@@ -1551,8 +1575,103 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body_or_attribute": {
-    "recorded-date": "14-05-2024, 16:51:02",
-    "recorded-content": {}
+    "recorded-date": "03-12-2024, 15:05:46",
+    "recorded-content": {
+      "messages-queue": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "metricName": "CPUUtilization",
+              "detail": {
+                "scope": "Service",
+                "source": "aws.cloudwatch"
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "metricName": "CPUUtilization",
+              "detail": {
+                "scope": "Service",
+                "type": "CloudWatch Alarm State Change"
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "metricName": "ReadLatency",
+              "detail": {
+                "scope": "Service",
+                "source": "aws.cloudwatch"
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:3>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "namespace": "AWS/EC2",
+              "detail": {
+                "scope": "Service",
+                "source": "aws.cloudwatch"
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:4>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "namespace": "AWS/ES",
+              "detail": {
+                "scope": "Service",
+                "source": "aws.cloudwatch"
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:5>",
+            "ReceiptHandle": "<receipt-handle:5>"
+          }
+        ]
+      }
+    }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyConditions::test_validate_policy_nested_anything_but_operator": {
     "recorded-date": "15-05-2024, 14:39:32",
@@ -1604,6 +1723,71 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
         }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_empty_array_payload": {
+    "recorded-date": "03-12-2024, 15:03:15",
+    "recorded-content": {
+      "messages-queue": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "version": "0",
+              "id": "<uuid:1>",
+              "detail-type": "EC2 Instance Launch Successful",
+              "source": "aws.autoscaling",
+              "account": "123456789012",
+              "time": "date",
+              "region": "<region>",
+              "resources": [],
+              "detail": {
+                "eventVersion": "",
+                "responseElements": null
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ]
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_ip_address_condition": {
+    "recorded-date": "03-12-2024, 15:14:34",
+    "recorded-content": {
+      "messages-queue": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "id": "1",
+              "source": "test-source",
+              "detail-type": "test-detail-type",
+              "account": "123456789012",
+              "region": "us-east-2",
+              "time": "date",
+              "detail": {
+                "sourceIPAddress": "10.0.0.255"
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ]
       }
     }
   }

--- a/tests/aws/services/sns/test_sns_filter_policy.validation.json
+++ b/tests/aws/services/sns/test_sns_filter_policy.validation.json
@@ -15,7 +15,7 @@
     "last_validated_date": "2024-12-03T15:02:26+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_ip_address_condition": {
-    "last_validated_date": "2024-12-03T15:14:34+00:00"
+    "last_validated_date": "2024-12-03T22:05:07+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body[False]": {
     "last_validated_date": "2024-12-03T15:02:09+00:00"
@@ -54,7 +54,7 @@
     "last_validated_date": "2024-05-14T16:51:06+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyConditions::test_validate_policy_string_operators": {
-    "last_validated_date": "2024-12-03T15:19:36+00:00"
+    "last_validated_date": "2024-12-03T22:11:13+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyCrud::test_set_subscription_filter_policy_scope": {
     "last_validated_date": "2024-05-14T16:49:11+00:00"

--- a/tests/aws/services/sns/test_sns_filter_policy.validation.json
+++ b/tests/aws/services/sns/test_sns_filter_policy.validation.json
@@ -8,26 +8,32 @@
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyAttributes::test_filter_policy": {
     "last_validated_date": "2024-05-14T16:49:28+00:00"
   },
+  "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_empty_array_payload": {
+    "last_validated_date": "2024-12-03T15:03:14+00:00"
+  },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_for_batch": {
-    "last_validated_date": "2024-05-14T16:50:24+00:00"
+    "last_validated_date": "2024-12-03T15:02:26+00:00"
+  },
+  "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_ip_address_condition": {
+    "last_validated_date": "2024-12-03T15:14:34+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body[False]": {
-    "last_validated_date": "2024-05-14T16:50:08+00:00"
+    "last_validated_date": "2024-12-03T15:02:09+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body[True]": {
-    "last_validated_date": "2024-05-14T16:49:56+00:00"
+    "last_validated_date": "2024-12-03T15:01:57+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body_array_attributes": {
-    "last_validated_date": "2024-05-14T16:50:54+00:00"
+    "last_validated_date": "2024-12-03T15:02:55+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body_array_of_object_attributes": {
-    "last_validated_date": "2024-05-14T16:50:58+00:00"
+    "last_validated_date": "2024-12-03T15:02:58+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body_dot_attribute": {
-    "last_validated_date": "2024-05-14T16:50:49+00:00"
+    "last_validated_date": "2024-12-03T15:02:50+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body_or_attribute": {
-    "last_validated_date": "2024-05-14T16:51:01+00:00"
+    "last_validated_date": "2024-12-03T15:05:45+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyConditions::test_policy_complexity": {
     "last_validated_date": "2024-05-14T16:51:07+00:00"
@@ -48,7 +54,7 @@
     "last_validated_date": "2024-05-14T16:51:06+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyConditions::test_validate_policy_string_operators": {
-    "last_validated_date": "2024-05-15T14:39:23+00:00"
+    "last_validated_date": "2024-12-03T15:19:36+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyCrud::test_set_subscription_filter_policy_scope": {
     "last_validated_date": "2024-05-14T16:49:11+00:00"

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -638,6 +638,24 @@ class TestSns:
                 },
                 True,
             ),
+            (
+                "cidr filter with no match",
+                {"filter": [{"cidr": "10.0.0.0/24"}]},
+                {"filter": {"Type": "String", "Value": "10.0.0.256"}},
+                False,
+            ),
+            (
+                "cidr filter with no match 2",
+                {"filter": [{"cidr": "10.0.0.0/24"}]},
+                {"filter": {"Type": "String", "Value": "10.0.1.255"}},
+                False,
+            ),
+            (
+                "cidr filter with match",
+                {"filter": [{"cidr": "10.0.0.0/24"}]},
+                {"filter": {"Type": "String", "Value": "10.0.0.255"}},
+                True,
+            ),
         ]
 
         sub_filter = SubscriptionFilter()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When implementing the EventRuleEngine with #11960, I've implemented different and new behaviors from SNS, and some felt like we just missed them in SNS and were better covered by the event test suite. 

This PR implements the [`cidr` operator](https://docs.aws.amazon.com/sns/latest/dg/string-value-matching.html#string-address-matching), and a missed edge case where one of the field of the payload is an empty array. Also adds a bit of validation around empty list passed to operators. 

Sorry @maxhoheiser and @joe4dev, I've sneaked in a new test case for the EventRuleEngine here as I wanted to verify a very edge case behavior in both engine when the value is an empty array, making the field not exists, which is an edge case we're also having, which is somewhat funny. I didn't want to open a new PR just for this tiny test case 😅 hope that's ok! no change in behavior as we were already right! For the anecdote, this is because I think `exists` can only be applied to "leaf" nodes, and an empty array will make the field not be a leaf anymore, as we're going "into" the array. Funny enough, we have the same edge case 😄 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- adds the `cidr` operator and validation
- implements the empty array in payload edge case
- implements empty array in operator validation 
- adds new test cases for SNS
- add one test case for an edge case in `events` 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
