### PR TITLE
Events: EventRuleEngine: improve `cidr` to support ipv6 and better validation

### DIFF
--- a/tests/aws/services/events/event_pattern_templates/content_ip_address_bad_ip_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_ip_address_bad_ip_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-ip-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "sourceIPAddress": "10.0.0.255"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "sourceIPAddress": [ { "cidr": "xx.11.xx/8" } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_ip_address_bad_mask_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_ip_address_bad_mask_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-ip-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "sourceIPAddress": "10.0.0.255"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "sourceIPAddress": [ { "cidr": "bad-/64filter" } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_ip_address_type_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_ip_address_type_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-ip-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "sourceIPAddress": "10.0.0.255"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "sourceIPAddress": [ { "cidr": ["bad-type"] } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_ip_address_v6.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_ip_address_v6.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-ip-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "sourceIPAddress": "2001:0db8:1234:1a00:0000:0000:0000:0000"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "sourceIPAddress": [ { "cidr": "2001:db8:1234:1a00::/64" } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_ip_address_v6_NEG.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_ip_address_v6_NEG.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-ip-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "sourceIPAddress": "2001:0db8:123f:1a01:0000:0000:0000:0000"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "sourceIPAddress": [ { "cidr": "2001:db8:1234:1a00::/64" } ]
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/content_ip_address_v6_bad_ip_EXC.json5
+++ b/tests/aws/services/events/event_pattern_templates/content_ip_address_v6_bad_ip_EXC.json5
@@ -1,0 +1,19 @@
+// Based on https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-ip-matching
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "sourceIPAddress": "10.0.0.255"
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "sourceIPAddress": [ { "cidr": "xxxx:db8:1234:1a00::/64" } ]
+    }
+  }
+}

--- a/tests/aws/services/events/test_events_patterns.snapshot.json
+++ b/tests/aws/services/events/test_events_patterns.snapshot.json
@@ -1,22 +1,22 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "recorded-date": "29-11-2024, 21:46:53",
+    "recorded-date": "03-12-2024, 22:27:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "recorded-date": "29-11-2024, 21:46:54",
+    "recorded-date": "03-12-2024, 22:27:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "recorded-date": "29-11-2024, 21:46:54",
+    "recorded-date": "03-12-2024, 22:27:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "recorded-date": "29-11-2024, 21:46:54",
+    "recorded-date": "03-12-2024, 22:27:18",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "recorded-date": "29-11-2024, 21:46:54",
+    "recorded-date": "03-12-2024, 22:27:18",
     "recorded-content": {
       "int_nolist_EXC": {
         "exception_message": {
@@ -35,39 +35,39 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "recorded-date": "29-11-2024, 21:46:55",
+    "recorded-date": "03-12-2024, 22:27:19",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "recorded-date": "29-11-2024, 21:46:55",
+    "recorded-date": "03-12-2024, 22:27:19",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "recorded-date": "29-11-2024, 21:46:56",
+    "recorded-date": "03-12-2024, 22:27:19",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "recorded-date": "29-11-2024, 21:46:56",
+    "recorded-date": "03-12-2024, 22:27:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "recorded-date": "29-11-2024, 21:46:56",
+    "recorded-date": "03-12-2024, 22:27:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "recorded-date": "29-11-2024, 21:46:56",
+    "recorded-date": "03-12-2024, 22:27:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "recorded-date": "29-11-2024, 21:46:57",
+    "recorded-date": "03-12-2024, 22:27:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "recorded-date": "29-11-2024, 21:46:57",
+    "recorded-date": "03-12-2024, 22:27:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "recorded-date": "29-11-2024, 21:46:57",
+    "recorded-date": "03-12-2024, 22:27:21",
     "recorded-content": {
       "content_numeric_operatorcasing_EXC": {
         "exception_message": {
@@ -86,19 +86,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "recorded-date": "29-11-2024, 21:46:57",
+    "recorded-date": "03-12-2024, 22:27:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "recorded-date": "29-11-2024, 21:46:58",
+    "recorded-date": "03-12-2024, 22:27:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "recorded-date": "29-11-2024, 21:46:58",
+    "recorded-date": "03-12-2024, 22:27:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "recorded-date": "29-11-2024, 21:46:58",
+    "recorded-date": "03-12-2024, 22:27:22",
     "recorded-content": {
       "string_nolist_EXC": {
         "exception_message": {
@@ -117,27 +117,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "recorded-date": "29-11-2024, 21:46:59",
+    "recorded-date": "03-12-2024, 22:27:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "recorded-date": "29-11-2024, 21:46:59",
+    "recorded-date": "03-12-2024, 22:27:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "recorded-date": "29-11-2024, 21:46:59",
+    "recorded-date": "03-12-2024, 22:27:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "recorded-date": "29-11-2024, 21:46:59",
+    "recorded-date": "03-12-2024, 22:27:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "recorded-date": "29-11-2024, 21:46:59",
+    "recorded-date": "03-12-2024, 22:27:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "recorded-date": "29-11-2024, 21:46:59",
+    "recorded-date": "03-12-2024, 22:27:23",
     "recorded-content": {
       "arrays_empty_EXC": {
         "exception_message": {
@@ -156,55 +156,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:00",
+    "recorded-date": "03-12-2024, 22:27:23",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "recorded-date": "29-11-2024, 21:47:00",
+    "recorded-date": "03-12-2024, 22:27:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "recorded-date": "29-11-2024, 21:47:00",
+    "recorded-date": "03-12-2024, 22:27:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "recorded-date": "29-11-2024, 21:47:00",
+    "recorded-date": "03-12-2024, 22:27:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "recorded-date": "29-11-2024, 21:47:00",
+    "recorded-date": "03-12-2024, 22:27:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "recorded-date": "29-11-2024, 21:47:00",
+    "recorded-date": "03-12-2024, 22:27:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "recorded-date": "29-11-2024, 21:47:00",
+    "recorded-date": "03-12-2024, 22:27:24",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "recorded-date": "29-11-2024, 21:47:00",
+    "recorded-date": "03-12-2024, 22:27:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "recorded-date": "29-11-2024, 21:47:01",
+    "recorded-date": "03-12-2024, 22:27:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "recorded-date": "29-11-2024, 21:47:01",
+    "recorded-date": "03-12-2024, 22:27:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:02",
+    "recorded-date": "03-12-2024, 22:27:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:02",
+    "recorded-date": "03-12-2024, 22:27:26",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:02",
+    "recorded-date": "03-12-2024, 22:27:26",
     "recorded-content": {
       "operator_case_sensitive_EXC": {
         "exception_message": {
@@ -223,15 +223,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "recorded-date": "29-11-2024, 21:47:02",
+    "recorded-date": "03-12-2024, 22:27:27",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:02",
+    "recorded-date": "03-12-2024, 22:27:27",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:03",
+    "recorded-date": "03-12-2024, 22:27:28",
     "recorded-content": {
       "content_numeric_EXC": {
         "exception_message": {
@@ -250,87 +250,87 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:04",
+    "recorded-date": "03-12-2024, 22:27:28",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "recorded-date": "29-11-2024, 21:47:04",
+    "recorded-date": "03-12-2024, 22:27:28",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:04",
+    "recorded-date": "03-12-2024, 22:27:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "recorded-date": "29-11-2024, 21:47:04",
+    "recorded-date": "03-12-2024, 22:27:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:04",
+    "recorded-date": "03-12-2024, 22:27:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "recorded-date": "29-11-2024, 21:47:05",
+    "recorded-date": "03-12-2024, 22:27:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "recorded-date": "29-11-2024, 21:47:05",
+    "recorded-date": "03-12-2024, 22:27:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:05",
+    "recorded-date": "03-12-2024, 22:27:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:05",
+    "recorded-date": "03-12-2024, 22:27:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "recorded-date": "29-11-2024, 21:47:05",
+    "recorded-date": "03-12-2024, 22:27:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "recorded-date": "29-11-2024, 21:47:05",
+    "recorded-date": "03-12-2024, 22:27:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:05",
+    "recorded-date": "03-12-2024, 22:27:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:05",
+    "recorded-date": "03-12-2024, 22:27:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "recorded-date": "29-11-2024, 21:47:05",
+    "recorded-date": "03-12-2024, 22:27:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "recorded-date": "29-11-2024, 21:47:06",
+    "recorded-date": "03-12-2024, 22:27:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "recorded-date": "29-11-2024, 21:47:06",
+    "recorded-date": "03-12-2024, 22:27:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:06",
+    "recorded-date": "03-12-2024, 22:27:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "recorded-date": "29-11-2024, 21:47:06",
+    "recorded-date": "03-12-2024, 22:27:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:07",
+    "recorded-date": "03-12-2024, 22:27:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:07",
+    "recorded-date": "03-12-2024, 22:27:32",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:08",
+    "recorded-date": "03-12-2024, 22:27:32",
     "recorded-content": {
       "content_wildcard_complex_EXC": {
         "exception_message": {
@@ -349,55 +349,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:09",
+    "recorded-date": "03-12-2024, 22:27:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "recorded-date": "29-11-2024, 21:47:10",
+    "recorded-date": "03-12-2024, 22:27:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:10",
+    "recorded-date": "03-12-2024, 22:27:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "recorded-date": "29-11-2024, 21:47:10",
+    "recorded-date": "03-12-2024, 22:27:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "recorded-date": "29-11-2024, 21:47:12",
+    "recorded-date": "03-12-2024, 22:27:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "recorded-date": "29-11-2024, 21:47:12",
+    "recorded-date": "03-12-2024, 22:27:37",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:12",
+    "recorded-date": "03-12-2024, 22:27:37",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "recorded-date": "29-11-2024, 21:47:12",
+    "recorded-date": "03-12-2024, 22:27:37",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:13",
+    "recorded-date": "03-12-2024, 22:27:39",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "recorded-date": "29-11-2024, 21:47:13",
+    "recorded-date": "03-12-2024, 22:27:39",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:14",
+    "recorded-date": "03-12-2024, 22:27:39",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:14",
+    "recorded-date": "03-12-2024, 22:27:39",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:14",
+    "recorded-date": "03-12-2024, 22:27:39",
     "recorded-content": {
       "content_numeric_syntax_EXC": {
         "exception_message": {
@@ -416,19 +416,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "recorded-date": "29-11-2024, 21:47:14",
+    "recorded-date": "03-12-2024, 22:27:40",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "recorded-date": "29-11-2024, 21:47:14",
+    "recorded-date": "03-12-2024, 22:27:40",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "recorded-date": "29-11-2024, 21:47:14",
+    "recorded-date": "03-12-2024, 22:27:40",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "recorded-date": "29-11-2024, 21:47:15",
+    "recorded-date": "03-12-2024, 22:27:40",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
@@ -580,7 +580,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "recorded-date": "29-11-2024, 21:46:56",
+    "recorded-date": "03-12-2024, 22:27:20",
     "recorded-content": {
       "content_wildcard_repeating_star_EXC": {
         "exception_message": {
@@ -599,7 +599,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:01",
+    "recorded-date": "03-12-2024, 22:27:25",
     "recorded-content": {
       "content_ignorecase_EXC": {
         "exception_message": {
@@ -618,7 +618,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:11",
+    "recorded-date": "03-12-2024, 22:27:36",
     "recorded-content": {
       "content_ip_address_EXC": {
         "exception_message": {
@@ -637,7 +637,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:03",
+    "recorded-date": "03-12-2024, 22:27:27",
     "recorded-content": {
       "content_anything_but_ignorecase_EXC": {
         "exception_message": {
@@ -656,7 +656,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:06",
+    "recorded-date": "03-12-2024, 22:27:31",
     "recorded-content": {
       "content_anything_but_ignorecase_list_EXC": {
         "exception_message": {
@@ -675,7 +675,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:08",
+    "recorded-date": "03-12-2024, 22:27:33",
     "recorded-content": {
       "content_ignorecase_list_EXC": {
         "exception_message": {
@@ -754,27 +754,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
-    "recorded-date": "29-11-2024, 21:47:03",
+    "recorded-date": "03-12-2024, 22:27:27",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_NEG]": {
-    "recorded-date": "29-11-2024, 21:46:55",
+    "recorded-date": "03-12-2024, 22:27:19",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list]": {
-    "recorded-date": "29-11-2024, 21:46:57",
+    "recorded-date": "03-12-2024, 22:27:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:01",
+    "recorded-date": "03-12-2024, 22:27:25",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard]": {
-    "recorded-date": "29-11-2024, 21:47:11",
+    "recorded-date": "03-12-2024, 22:27:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_int_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:11",
+    "recorded-date": "03-12-2024, 22:27:35",
     "recorded-content": {
       "content_wildcard_int_EXC": {
         "exception_message": {
@@ -793,7 +793,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_list_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:13",
+    "recorded-date": "03-12-2024, 22:27:38",
     "recorded-content": {
       "content_wildcard_list_EXC": {
         "exception_message": {
@@ -812,7 +812,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_type_EXC]": {
-    "recorded-date": "29-11-2024, 21:46:55",
+    "recorded-date": "03-12-2024, 22:27:19",
     "recorded-content": {
       "content_anything_wildcard_list_type_EXC": {
         "exception_message": {
@@ -831,7 +831,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_type_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:09",
+    "recorded-date": "03-12-2024, 22:27:34",
     "recorded-content": {
       "content_anything_wildcard_type_EXC": {
         "exception_message": {
@@ -850,7 +850,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_type_EXC]": {
-    "recorded-date": "29-11-2024, 21:46:54",
+    "recorded-date": "03-12-2024, 22:27:17",
     "recorded-content": {
       "content_anything_suffix_list_type_EXC": {
         "exception_message": {
@@ -869,15 +869,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list]": {
-    "recorded-date": "29-11-2024, 21:46:56",
+    "recorded-date": "03-12-2024, 22:27:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_NEG]": {
-    "recorded-date": "29-11-2024, 21:46:56",
+    "recorded-date": "03-12-2024, 22:27:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_int_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:00",
+    "recorded-date": "03-12-2024, 22:27:25",
     "recorded-content": {
       "content_anything_suffix_int_EXC": {
         "exception_message": {
@@ -896,15 +896,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list]": {
-    "recorded-date": "29-11-2024, 21:47:05",
+    "recorded-date": "03-12-2024, 22:27:29",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_NEG]": {
-    "recorded-date": "29-11-2024, 21:47:08",
+    "recorded-date": "03-12-2024, 22:27:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_type_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:10",
+    "recorded-date": "03-12-2024, 22:27:35",
     "recorded-content": {
       "content_anything_prefix_list_type_EXC": {
         "exception_message": {
@@ -923,7 +923,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_int_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:12",
+    "recorded-date": "03-12-2024, 22:27:38",
     "recorded-content": {
       "content_anything_prefix_int_EXC": {
         "exception_message": {
@@ -942,7 +942,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_list_EXC]": {
-    "recorded-date": "29-11-2024, 21:46:58",
+    "recorded-date": "03-12-2024, 22:27:21",
     "recorded-content": {
       "content_prefix_list_EXC": {
         "exception_message": {
@@ -961,7 +961,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_int_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:04",
+    "recorded-date": "03-12-2024, 22:27:28",
     "recorded-content": {
       "content_prefix_int_EXC": {
         "exception_message": {
@@ -980,7 +980,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_int_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:07",
+    "recorded-date": "03-12-2024, 22:27:32",
     "recorded-content": {
       "content_suffix_int_EXC": {
         "exception_message": {
@@ -999,7 +999,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_list_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:12",
+    "recorded-date": "03-12-2024, 22:27:36",
     "recorded-content": {
       "content_suffix_list_EXC": {
         "exception_message": {
@@ -1018,7 +1018,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_ignorecase_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:07",
+    "recorded-date": "03-12-2024, 22:27:32",
     "recorded-content": {
       "content_anything_prefix_ignorecase_EXC": {
         "exception_message": {
@@ -1037,7 +1037,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_ignorecase_EXC]": {
-    "recorded-date": "29-11-2024, 21:47:09",
+    "recorded-date": "03-12-2024, 22:27:33",
     "recorded-content": {
       "content_anything_suffix_ignorecase_EXC": {
         "exception_message": {
@@ -1045,6 +1045,90 @@
             "Code": "InvalidEventPatternException",
             "Message": "Event pattern is not valid. Reason: Value of anything-but must be an array or single string/number value.",
             "MessageRaw": "Event pattern is not valid. Reason: Value of anything-but must be an array or single string/number value.\n at [Source: (String)\"{\"detail\": {\"FileName\": [{\"anything-but\": {\"suffix\": {\"equals-ignore-case\": \".png\"}}}]}}\"; line: 1, column: 55]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_mask_EXC]": {
+    "recorded-date": "03-12-2024, 22:27:18",
+    "recorded-content": {
+      "content_ip_address_bad_mask_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: Malformed CIDR, mask bits must be an integer",
+            "MessageRaw": "Event pattern is not valid. Reason: Malformed CIDR, mask bits must be an integer"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_NEG]": {
+    "recorded-date": "03-12-2024, 22:27:22",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6]": {
+    "recorded-date": "03-12-2024, 22:27:24",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_ip_EXC]": {
+    "recorded-date": "03-12-2024, 22:27:30",
+    "recorded-content": {
+      "content_ip_address_bad_ip_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: Nonstandard IP address: xx.11.xx",
+            "MessageRaw": "Event pattern is not valid. Reason: Nonstandard IP address: xx.11.xx"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_type_EXC]": {
+    "recorded-date": "03-12-2024, 22:27:37",
+    "recorded-content": {
+      "content_ip_address_type_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: prefix match pattern must be a string",
+            "MessageRaw": "Event pattern is not valid. Reason: prefix match pattern must be a string\n at [Source: (String)\"{\"detail\": {\"sourceIPAddress\": [{\"cidr\": [\"bad-type\"]}]}}\"; line: 1, column: 43]"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
+        },
+        "exception_type": "<class 'botocore.errorfactory.InvalidEventPatternException'>"
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_bad_ip_EXC]": {
+    "recorded-date": "03-12-2024, 22:27:39",
+    "recorded-content": {
+      "content_ip_address_v6_bad_ip_EXC": {
+        "exception_message": {
+          "Error": {
+            "Code": "InvalidEventPatternException",
+            "Message": "Event pattern is not valid. Reason: Nonstandard IP address: xxxx:db8:1234:1a00::",
+            "MessageRaw": "Event pattern is not valid. Reason: Nonstandard IP address: xxxx:db8:1234:1a00::"
           },
           "ResponseMetadata": {
             "HTTPHeaders": {},

--- a/tests/aws/services/events/test_events_patterns.validation.json
+++ b/tests/aws/services/events/test_events_patterns.validation.json
@@ -1,327 +1,342 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "last_validated_date": "2024-11-29T21:46:55+00:00"
+    "last_validated_date": "2024-12-03T22:27:19+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:13+00:00"
+    "last_validated_date": "2024-12-03T22:27:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "last_validated_date": "2024-11-29T21:46:59+00:00"
+    "last_validated_date": "2024-12-03T22:27:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:07+00:00"
+    "last_validated_date": "2024-12-03T22:27:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "last_validated_date": "2024-11-29T21:47:14+00:00"
+    "last_validated_date": "2024-12-03T22:27:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "last_validated_date": "2024-11-29T21:46:59+00:00"
+    "last_validated_date": "2024-12-03T22:27:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "last_validated_date": "2024-11-29T21:47:00+00:00"
+    "last_validated_date": "2024-12-03T22:27:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "last_validated_date": "2024-11-29T21:46:54+00:00"
+    "last_validated_date": "2024-12-03T22:27:18+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "last_validated_date": "2024-11-29T21:46:57+00:00"
+    "last_validated_date": "2024-12-03T22:27:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "last_validated_date": "2024-11-29T21:47:04+00:00"
+    "last_validated_date": "2024-12-03T22:27:28+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:04+00:00"
+    "last_validated_date": "2024-12-03T22:27:28+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "last_validated_date": "2024-11-29T21:47:00+00:00"
+    "last_validated_date": "2024-12-03T22:27:24+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:03+00:00"
+    "last_validated_date": "2024-12-03T22:27:27+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:12+00:00"
+    "last_validated_date": "2024-12-03T22:27:37+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "last_validated_date": "2024-11-29T21:47:06+00:00"
+    "last_validated_date": "2024-12-03T22:27:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:06+00:00"
+    "last_validated_date": "2024-12-03T22:27:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "last_validated_date": "2024-11-29T21:46:56+00:00"
+    "last_validated_date": "2024-12-03T22:27:19+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "last_validated_date": "2024-11-29T21:47:14+00:00"
+    "last_validated_date": "2024-12-03T22:27:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:02+00:00"
+    "last_validated_date": "2024-12-03T22:27:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "last_validated_date": "2024-11-29T21:47:01+00:00"
+    "last_validated_date": "2024-12-03T22:27:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "last_validated_date": "2024-11-29T21:46:57+00:00"
+    "last_validated_date": "2024-12-03T22:27:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "last_validated_date": "2024-11-29T21:46:57+00:00"
+    "last_validated_date": "2024-12-03T22:27:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "last_validated_date": "2024-11-29T21:46:59+00:00"
+    "last_validated_date": "2024-12-03T22:27:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "last_validated_date": "2024-11-29T21:47:00+00:00"
+    "last_validated_date": "2024-12-03T22:27:24+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:09+00:00"
+    "last_validated_date": "2024-12-03T22:27:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
-    "last_validated_date": "2024-11-29T21:47:03+00:00"
+    "last_validated_date": "2024-12-03T22:27:27+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "last_validated_date": "2024-11-29T21:47:05+00:00"
+    "last_validated_date": "2024-12-03T22:27:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "last_validated_date": "2024-11-29T21:46:58+00:00"
+    "last_validated_date": "2024-12-03T22:27:22+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_ignorecase_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:07+00:00"
+    "last_validated_date": "2024-12-03T22:27:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_int_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:12+00:00"
+    "last_validated_date": "2024-12-03T22:27:38+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list]": {
-    "last_validated_date": "2024-11-29T21:46:56+00:00"
+    "last_validated_date": "2024-12-03T22:27:20+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_NEG]": {
-    "last_validated_date": "2024-11-29T21:46:56+00:00"
+    "last_validated_date": "2024-12-03T22:27:20+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_type_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:10+00:00"
+    "last_validated_date": "2024-12-03T22:27:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "last_validated_date": "2024-11-29T21:47:06+00:00"
+    "last_validated_date": "2024-12-03T22:27:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:04+00:00"
+    "last_validated_date": "2024-12-03T22:27:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_ignorecase_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:09+00:00"
+    "last_validated_date": "2024-12-03T22:27:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_int_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:00+00:00"
+    "last_validated_date": "2024-12-03T22:27:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list]": {
-    "last_validated_date": "2024-11-29T21:47:05+00:00"
+    "last_validated_date": "2024-12-03T22:27:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:08+00:00"
+    "last_validated_date": "2024-12-03T22:27:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_type_EXC]": {
-    "last_validated_date": "2024-11-29T21:46:54+00:00"
+    "last_validated_date": "2024-12-03T22:27:17+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard]": {
-    "last_validated_date": "2024-11-29T21:47:11+00:00"
+    "last_validated_date": "2024-12-03T22:27:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_NEG]": {
-    "last_validated_date": "2024-11-29T21:46:55+00:00"
+    "last_validated_date": "2024-12-03T22:27:19+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list]": {
-    "last_validated_date": "2024-11-29T21:46:57+00:00"
+    "last_validated_date": "2024-12-03T22:27:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:01+00:00"
+    "last_validated_date": "2024-12-03T22:27:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_type_EXC]": {
-    "last_validated_date": "2024-11-29T21:46:55+00:00"
+    "last_validated_date": "2024-12-03T22:27:19+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_type_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:09+00:00"
+    "last_validated_date": "2024-12-03T22:27:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "last_validated_date": "2024-11-29T21:47:02+00:00"
+    "last_validated_date": "2024-12-03T22:27:27+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:14+00:00"
+    "last_validated_date": "2024-12-03T22:27:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "last_validated_date": "2024-11-29T21:47:12+00:00"
+    "last_validated_date": "2024-12-03T22:27:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:14+00:00"
+    "last_validated_date": "2024-12-03T22:27:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "last_validated_date": "2024-11-29T21:47:13+00:00"
+    "last_validated_date": "2024-12-03T22:27:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:01+00:00"
+    "last_validated_date": "2024-12-03T22:27:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:10+00:00"
+    "last_validated_date": "2024-12-03T22:27:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:08+00:00"
+    "last_validated_date": "2024-12-03T22:27:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "last_validated_date": "2024-11-29T21:46:58+00:00"
+    "last_validated_date": "2024-12-03T22:27:22+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:11+00:00"
+    "last_validated_date": "2024-12-03T22:27:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:02+00:00"
+    "last_validated_date": "2024-12-03T22:27:27+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_ip_EXC]": {
+    "last_validated_date": "2024-12-03T22:27:30+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_mask_EXC]": {
+    "last_validated_date": "2024-12-03T22:27:18+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_type_EXC]": {
+    "last_validated_date": "2024-12-03T22:27:37+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6]": {
+    "last_validated_date": "2024-12-03T22:27:24+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_NEG]": {
+    "last_validated_date": "2024-12-03T22:27:22+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_bad_ip_EXC]": {
+    "last_validated_date": "2024-12-03T22:27:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:03+00:00"
+    "last_validated_date": "2024-12-03T22:27:28+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "last_validated_date": "2024-11-29T21:47:14+00:00"
+    "last_validated_date": "2024-12-03T22:27:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:04+00:00"
+    "last_validated_date": "2024-12-03T22:27:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "last_validated_date": "2024-11-29T21:46:57+00:00"
+    "last_validated_date": "2024-12-03T22:27:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:14+00:00"
+    "last_validated_date": "2024-12-03T22:27:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "last_validated_date": "2024-11-29T21:47:10+00:00"
+    "last_validated_date": "2024-12-03T22:27:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:06+00:00"
+    "last_validated_date": "2024-12-03T22:27:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "last_validated_date": "2024-11-29T21:47:04+00:00"
+    "last_validated_date": "2024-12-03T22:27:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_int_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:04+00:00"
+    "last_validated_date": "2024-12-03T22:27:28+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_list_EXC]": {
-    "last_validated_date": "2024-11-29T21:46:58+00:00"
+    "last_validated_date": "2024-12-03T22:27:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "last_validated_date": "2024-11-29T21:47:12+00:00"
+    "last_validated_date": "2024-12-03T22:27:37+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "last_validated_date": "2024-11-29T21:46:54+00:00"
+    "last_validated_date": "2024-12-03T22:27:17+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "last_validated_date": "2024-11-29T21:47:05+00:00"
+    "last_validated_date": "2024-12-03T22:27:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:07+00:00"
+    "last_validated_date": "2024-12-03T22:27:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_int_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:07+00:00"
+    "last_validated_date": "2024-12-03T22:27:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_list_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:12+00:00"
+    "last_validated_date": "2024-12-03T22:27:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:08+00:00"
+    "last_validated_date": "2024-12-03T22:27:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_int_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:11+00:00"
+    "last_validated_date": "2024-12-03T22:27:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_list_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:13+00:00"
+    "last_validated_date": "2024-12-03T22:27:38+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "last_validated_date": "2024-11-29T21:46:56+00:00"
+    "last_validated_date": "2024-12-03T22:27:20+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:02+00:00"
+    "last_validated_date": "2024-12-03T22:27:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "last_validated_date": "2024-11-29T21:46:53+00:00"
+    "last_validated_date": "2024-12-03T22:27:17+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "last_validated_date": "2024-11-29T21:46:55+00:00"
+    "last_validated_date": "2024-12-03T22:27:19+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "last_validated_date": "2024-11-29T21:46:56+00:00"
+    "last_validated_date": "2024-12-03T22:27:20+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "last_validated_date": "2024-11-29T21:46:56+00:00"
+    "last_validated_date": "2024-12-03T22:27:20+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "last_validated_date": "2024-11-29T21:47:04+00:00"
+    "last_validated_date": "2024-12-03T22:27:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:05+00:00"
+    "last_validated_date": "2024-12-03T22:27:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "last_validated_date": "2024-11-29T21:47:00+00:00"
+    "last_validated_date": "2024-12-03T22:27:24+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:05+00:00"
+    "last_validated_date": "2024-12-03T22:27:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "last_validated_date": "2024-11-29T21:47:00+00:00"
+    "last_validated_date": "2024-12-03T22:27:24+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "last_validated_date": "2024-11-29T21:46:59+00:00"
+    "last_validated_date": "2024-12-03T22:27:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "last_validated_date": "2024-11-29T21:46:59+00:00"
-  },
-  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_list_empty_NEG]": {
-    "last_validated_date": "2024-11-29T21:46:55+00:00"
+    "last_validated_date": "2024-12-03T22:27:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "last_validated_date": "2024-11-29T21:46:54+00:00"
+    "last_validated_date": "2024-12-03T22:27:18+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:05+00:00"
+    "last_validated_date": "2024-12-03T22:27:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "last_validated_date": "2024-11-29T21:46:54+00:00"
+    "last_validated_date": "2024-12-03T22:27:17+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "last_validated_date": "2024-11-29T21:47:10+00:00"
+    "last_validated_date": "2024-12-03T22:27:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:00+00:00"
+    "last_validated_date": "2024-12-03T22:27:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "last_validated_date": "2024-11-29T21:47:01+00:00"
+    "last_validated_date": "2024-12-03T22:27:25+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "last_validated_date": "2024-11-29T21:47:05+00:00"
+    "last_validated_date": "2024-12-03T22:27:29+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "last_validated_date": "2024-11-29T21:47:12+00:00"
+    "last_validated_date": "2024-12-03T22:27:37+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "last_validated_date": "2024-11-29T21:47:02+00:00"
+    "last_validated_date": "2024-12-03T22:27:26+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "last_validated_date": "2024-11-29T21:47:00+00:00"
+    "last_validated_date": "2024-12-03T22:27:24+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "last_validated_date": "2024-11-29T21:47:15+00:00"
+    "last_validated_date": "2024-12-03T22:27:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "last_validated_date": "2024-11-29T21:46:59+00:00"
+    "last_validated_date": "2024-12-03T22:27:23+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "last_validated_date": "2024-11-29T21:46:56+00:00"
+    "last_validated_date": "2024-12-03T22:27:20+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "last_validated_date": "2024-11-29T21:47:05+00:00"
+    "last_validated_date": "2024-12-03T22:27:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "last_validated_date": "2024-11-29T21:47:05+00:00"
+    "last_validated_date": "2024-12-03T22:27:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "last_validated_date": "2024-11-29T21:47:06+00:00"
+    "last_validated_date": "2024-12-03T22:27:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "last_validated_date": "2024-11-29T21:47:00+00:00"
+    "last_validated_date": "2024-12-03T22:27:24+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "last_validated_date": "2024-11-29T21:46:58+00:00"
+    "last_validated_date": "2024-12-03T22:27:22+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
     "last_validated_date": "2024-07-11T13:55:39+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
After backporting `cidr` back to SNS, @cloutierMat made a really solid point in his review: 
https://github.com/localstack/localstack/pull/11979#discussion_r1868383162

After improving it for SNS, I'm backporting it back again to `events`

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add `cidr` support for IPv6, and better validation

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
