### PR TITLE
fix SNS test with region replacement

### DIFF
--- a/tests/aws/services/sns/test_sns_filter_policy.py
+++ b/tests/aws/services/sns/test_sns_filter_policy.py
@@ -1181,7 +1181,7 @@ class TestSNSFilterPolicyBody:
             "source": "aws.autoscaling",
             "account": "123456789012",
             "time": "2015-11-11T21:31:47Z",
-            "region": "us-east-1",
+            "region": "my-region",
             "resources": [],
             "detail": {
                 "eventVersion": "",
@@ -1238,34 +1238,34 @@ class TestSNSFilterPolicyBody:
                 "source": "test-source",
                 "detail-type": "test-detail-type",
                 "account": "123456789012",
-                "region": "us-east-2",
+                "region": "my-region",
                 "time": "2022-07-13T13:48:01Z",
                 "detail": {"sourceIPAddress": "10.0.0.255"},
             },
             {
-                "id": "1",
+                "id": "2",
                 "source": "test-source",
                 "detail-type": "test-detail-type",
                 "account": "123456789012",
-                "region": "us-east-2",
+                "region": "my-region",
                 "time": "2022-07-13T13:48:01Z",
                 "detail": {"sourceIPAddress": "10.0.0.256"},
             },
             {
-                "id": "1",
+                "id": "3",
                 "source": "test-source",
                 "detail-type": "test-detail-type",
                 "account": "123456789012",
-                "region": "us-east-2",
+                "region": "my-region",
                 "time": "2022-07-13T13:48:01Z",
                 "detail": {"sourceIPAddressV6": "2001:0db8:1234:1a00:0000:0000:0000:0000"},
             },
             {
-                "id": "1",
+                "id": "4",
                 "source": "test-source",
                 "detail-type": "test-detail-type",
                 "account": "123456789012",
-                "region": "us-east-2",
+                "region": "my-region",
                 "time": "2022-07-13T13:48:01Z",
                 "detail": {"sourceIPAddressV6": "2001:0db8:123f:1a01:0000:0000:0000:0000"},
             },
@@ -1286,6 +1286,7 @@ class TestSNSFilterPolicyBody:
             _msg_list=recv_messages,
             expected=2,
         )
+        recv_messages.sort(key=itemgetter("Body"))
         snapshot.match("messages-queue", {"Messages": recv_messages})
 
 

--- a/tests/aws/services/sns/test_sns_filter_policy.snapshot.json
+++ b/tests/aws/services/sns/test_sns_filter_policy.snapshot.json
@@ -1787,7 +1787,7 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_empty_array_payload": {
-    "recorded-date": "03-12-2024, 15:03:15",
+    "recorded-date": "04-12-2024, 10:22:15",
     "recorded-content": {
       "messages-queue": {
         "Messages": [
@@ -1805,7 +1805,7 @@
               "source": "aws.autoscaling",
               "account": "123456789012",
               "time": "date",
-              "region": "<region>",
+              "region": "my-region",
               "resources": [],
               "detail": {
                 "eventVersion": "",
@@ -1821,7 +1821,7 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_ip_address_condition": {
-    "recorded-date": "03-12-2024, 22:05:08",
+    "recorded-date": "04-12-2024, 10:36:46",
     "recorded-content": {
       "messages-queue": {
         "Messages": [
@@ -1837,7 +1837,7 @@
               "source": "test-source",
               "detail-type": "test-detail-type",
               "account": "123456789012",
-              "region": "us-east-2",
+              "region": "my-region",
               "time": "date",
               "detail": {
                 "sourceIPAddress": "10.0.0.255"
@@ -1855,11 +1855,11 @@
               "SentTimestamp": "timestamp"
             },
             "Body": {
-              "id": "1",
+              "id": "3",
               "source": "test-source",
               "detail-type": "test-detail-type",
               "account": "123456789012",
-              "region": "us-east-2",
+              "region": "my-region",
               "time": "date",
               "detail": {
                 "sourceIPAddressV6": "2001:0db8:1234:1a00:0000:0000:0000:0000"

--- a/tests/aws/services/sns/test_sns_filter_policy.validation.json
+++ b/tests/aws/services/sns/test_sns_filter_policy.validation.json
@@ -9,13 +9,13 @@
     "last_validated_date": "2024-05-14T16:49:28+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_empty_array_payload": {
-    "last_validated_date": "2024-12-03T15:03:14+00:00"
+    "last_validated_date": "2024-12-04T10:22:14+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_for_batch": {
     "last_validated_date": "2024-12-03T15:02:26+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_ip_address_condition": {
-    "last_validated_date": "2024-12-03T22:05:07+00:00"
+    "last_validated_date": "2024-12-04T10:36:45+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body[False]": {
     "last_validated_date": "2024-12-03T15:02:09+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
New tests implemented with #11979 had quite the flaw, which was hardcoded region values in the event, even if not relevant to the test itself. 

This PR removes the region values. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- remove the region values in the test and make sort the snapshot as the queue is not FIFO

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
