### PR TITLE
enable localstack instance creation override for testing

### DIFF
--- a/docs/testing/integration-tests/README.md
+++ b/docs/testing/integration-tests/README.md
@@ -166,3 +166,17 @@ Once you verified that your test is running against AWS, you can record snapshot
 Snapshot tests helps to increase the parity with AWS and to raise the confidence in the service implementations. Therefore, snapshot tests are preferred over normal integrations tests.
 
 Please check our subsequent guide on [Parity Testing](../parity-testing/README.md) for a detailed explanation on how to write AWS validated snapshot tests.
+
+#### Force the start of a local instance
+
+When running test with `TEST_TARGET=AWS_CLOUD`, by default, no localstack instance will be created. This can be bypassed by also setting `TEST_FORCE_LOCALSTACK_START=1`.
+
+Note that the `aws_client` fixture will keep pointing at the aws instance and you will need to create your own client factory using the `aws_client_factory`.
+
+```python
+local_client = aws_client_factory(
+    endpoint_url=f"http://{localstack_host()}",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+```

--- a/localstack-core/localstack/testing/pytest/in_memory_localstack.py
+++ b/localstack-core/localstack/testing/pytest/in_memory_localstack.py
@@ -53,8 +53,12 @@ def pytest_runtestloop(session: Session):
 
     from localstack.testing.aws.util import is_aws_cloud
 
-    if is_env_true("TEST_SKIP_LOCALSTACK_START") or is_aws_cloud():
+    if is_env_true("TEST_SKIP_LOCALSTACK_START"):
         LOG.info("TEST_SKIP_LOCALSTACK_START is set, not starting localstack")
+        return
+
+    if is_aws_cloud() and not is_env_true("TEST_FORCE_LOCALSTACK_START"):
+        LOG.info("Test running against aws, not starting localstack")
         return
 
     from localstack.utils.common import safe_requests

--- a/localstack-core/localstack/testing/pytest/in_memory_localstack.py
+++ b/localstack-core/localstack/testing/pytest/in_memory_localstack.py
@@ -57,9 +57,11 @@ def pytest_runtestloop(session: Session):
         LOG.info("TEST_SKIP_LOCALSTACK_START is set, not starting localstack")
         return
 
-    if is_aws_cloud() and not is_env_true("TEST_FORCE_LOCALSTACK_START"):
-        LOG.info("Test running against aws, not starting localstack")
-        return
+    if is_aws_cloud():
+        if not is_env_true("TEST_FORCE_LOCALSTACK_START"):
+            LOG.info("Test running against aws, not starting localstack")
+            return
+        LOG.info("TEST_FORCE_LOCALSTACK_START is set, a Localstack instance will be created.")
 
     from localstack.utils.common import safe_requests
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

To enable testing for the replicator, we need a mechanism by which we can start a localstack instance when running test against AWS. This change will allow us to spawn an instance while respecting the devs configuration without having to re:invent the wheel.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Look at env `TEST_FORCE_LOCALSTACK_START` to create instance even if `is_aws_cloud()` is true

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
