### PR TITLE
[ESM] Raise exception when setting DestinationConfig.OnSuccess

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1889,6 +1889,13 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         # TODO: test whether stream ARNs are valid sources for Pipes or ESM or whether only DynamoDB table ARNs work
         is_create_esm_request = context.operation.name == self.create_event_source_mapping.operation
 
+        if destination_config := request.get("DestinationConfig"):
+            if "OnSuccess" in destination_config:
+                raise InvalidParameterValueException(
+                    "Unsupported DestinationConfig parameter for given event source mapping type.",
+                    Type="User",
+                )
+
         service = None
         if "SelfManagedEventSource" in request:
             service = "kafka"

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -5337,6 +5337,19 @@ class TestLambdaEventSourceMappings:
                 EventSourceArn="arn:aws:sqs:us-east-1:111111111111:somequeue",
             )
         snapshot.match("create_unknown_params", e.value.response)
+
+        with pytest.raises(aws_client.lambda_.exceptions.InvalidParameterValueException) as e:
+            aws_client.lambda_.create_event_source_mapping(
+                FunctionName="doesnotexist",
+                EventSourceArn="arn:aws:sqs:us-east-1:111111111111:somequeue",
+                DestinationConfig={
+                    "OnSuccess": {
+                        "Destination": "arn:aws:sqs:us-east-1:111111111111:someotherqueue"
+                    }
+                },
+            )
+        snapshot.match("destination_config_failure", e.value.response)
+
         # TODO: add test for event source arn == failure destination
         # TODO: add test for adding success destination
         # TODO: add test_multiple_esm_conflict: create an event source mapping for a combination of function + target ARN that already exists

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -5791,7 +5791,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_event_source_mapping_exceptions": {
-    "recorded-date": "10-04-2024, 09:19:37",
+    "recorded-date": "05-12-2024, 10:52:30",
     "recorded-content": {
       "get_unknown_uuid": {
         "Error": {
@@ -5848,6 +5848,18 @@
         },
         "Type": "User",
         "message": "Function does not exist",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "destination_config_failure": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Unsupported DestinationConfig parameter for given event source mapping type."
+        },
+        "Type": "User",
+        "message": "Unsupported DestinationConfig parameter for given event source mapping type.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -42,7 +42,7 @@
     "last_validated_date": "2024-04-10T09:21:59+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_event_source_mapping_exceptions": {
-    "last_validated_date": "2024-04-10T09:19:37+00:00"
+    "last_validated_date": "2024-12-05T10:52:30+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_event_source_mapping_lifecycle": {
     "last_validated_date": "2024-10-14T12:36:54+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Although the AWS docs indicates we can use a [`DestinationConfig` object's `OnSuccess`](https://docs.aws.amazon.com/lambda/latest/api/API_DestinationConfig.html#lambda-Type-DestinationConfig-OnSuccess) in ESM, this is actually not supported. This PR adds a parity test and raises an exception for the aforementioned case.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added parity test with raised exception
- Raise exception in LS on ESM validation

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
