### PR TITLE
[SFN] Correctly record failed EventsBridge PUT requests

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_events.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_events.py
@@ -99,11 +99,11 @@ class StateTaskServiceEvents(StateTaskServiceCallback):
 
         # If the response from PutEvents contains a non-zero FailedEntryCount then the
         #  Task state fails with the error EventBridge.FailedEntry.
-        if self.resource.api_action == "putevents":
+        if self.resource.api_action == "putEvents":
             failed_entry_count = response.get("FailedEntryCount", 0)
             if failed_entry_count > 0:
                 # TODO: pipe events' cause in the exception object. At them moment
                 #  LS events does not update this field.
-                raise SfnFailedEntryCountException(cause={"Cause": "Unsupported"})
+                raise SfnFailedEntryCountException(cause=response)
 
         env.stack.append(response)

--- a/tests/aws/services/stepfunctions/v2/services/test_events_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_events_task_service.py
@@ -1,6 +1,5 @@
 import json
 
-import pytest
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
 from localstack.testing.pytest import markers
@@ -70,9 +69,6 @@ class TestTaskServiceEvents:
         )
         record_sqs_events(aws_client, queue_url, sfn_snapshot, len(entries))
 
-    @pytest.mark.skip(
-        reason="LS EventsBridge does not recognise the incorrect formation of the detail field"
-    )
     @markers.aws.validated
     def test_put_events_malformed_detail(
         self,
@@ -107,11 +103,7 @@ class TestTaskServiceEvents:
             definition,
             exec_input,
         )
-        record_sqs_events(aws_client, queue_url, sfn_snapshot, len(entries))
 
-    @pytest.mark.skip(
-        reason="LS EventsBridge does not update the FailedEntryCount object as expected."
-    )
     @markers.aws.validated
     def test_put_events_no_source(
         self,
@@ -151,3 +143,44 @@ class TestTaskServiceEvents:
             exec_input,
         )
         record_sqs_events(aws_client, queue_url, sfn_snapshot, len(entries))
+
+    @markers.aws.validated
+    def test_put_events_mixed_malformed_detail(
+        self,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        events_to_sqs_queue,
+        aws_client,
+        sfn_snapshot,
+    ):
+        detail_type = f"detail_type_{short_uid()}"
+        event_pattern = {"detail-type": [detail_type]}
+        queue_url = events_to_sqs_queue(event_pattern)
+        sfn_snapshot.add_transformer(RegexTransformer(detail_type, "<detail-type>"))
+        sfn_snapshot.add_transformer(RegexTransformer(queue_url, "<sqs_queue_url>"))
+
+        template = ST.load_sfn_template(ST.EVENTS_PUT_EVENTS)
+        definition = json.dumps(template)
+
+        entries = [
+            {
+                "Detail": json.dumps({"Message": "HelloWorld0"}),
+                "DetailType": detail_type,
+                "Source": "some.source",
+            },
+            {
+                "Detail": json.dumps("jsonstring"),
+                "DetailType": detail_type,
+                "Source": "some.source",
+            },
+        ]
+        exec_input = json.dumps({"Entries": entries})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+        record_sqs_events(aws_client, queue_url, sfn_snapshot, 1)

--- a/tests/aws/services/stepfunctions/v2/services/test_events_task_service.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_events_task_service.snapshot.json
@@ -574,5 +574,167 @@
         }
       ]
     }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_events_task_service.py::TestTaskServiceEvents::test_put_events_mixed_malformed_detail": {
+    "recorded-date": "05-12-2024, 13:56:38",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Entries": [
+                  {
+                    "Detail": "{\"Message\": \"HelloWorld0\"}",
+                    "DetailType": "<detail-type>",
+                    "Source": "some.source"
+                  },
+                  {
+                    "Detail": "\"jsonstring\"",
+                    "DetailType": "<detail-type>",
+                    "Source": "some.source"
+                  }
+                ]
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Entries": [
+                  {
+                    "Detail": "{\"Message\": \"HelloWorld0\"}",
+                    "DetailType": "<detail-type>",
+                    "Source": "some.source"
+                  },
+                  {
+                    "Detail": "\"jsonstring\"",
+                    "DetailType": "<detail-type>",
+                    "Source": "some.source"
+                  }
+                ]
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "PutEvents"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Entries": [
+                  {
+                    "Detail": "{\"Message\": \"HelloWorld0\"}",
+                    "DetailType": "<detail-type>",
+                    "Source": "some.source"
+                  },
+                  {
+                    "Detail": "\"jsonstring\"",
+                    "DetailType": "<detail-type>",
+                    "Source": "some.source"
+                  }
+                ]
+              },
+              "region": "<region>",
+              "resource": "putEvents",
+              "resourceType": "events"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "putEvents",
+              "resourceType": "events"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskFailedEventDetails": {
+              "cause": {
+                "Entries": [
+                  {
+                    "EventId": "<uuid:1>"
+                  },
+                  {
+                    "ErrorCode": "MalformedDetail",
+                    "ErrorMessage": "Detail is malformed."
+                  }
+                ],
+                "FailedEntryCount": 1
+              },
+              "error": "EventBridge.FailedEntry",
+              "resource": "putEvents",
+              "resourceType": "events"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": {
+                "Entries": [
+                  {
+                    "EventId": "<uuid:1>"
+                  },
+                  {
+                    "ErrorCode": "MalformedDetail",
+                    "ErrorMessage": "Detail is malformed."
+                  }
+                ],
+                "FailedEntryCount": 1
+              },
+              "error": "EventBridge.FailedEntry"
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stepfunctions_events": [
+        {
+          "version": "0",
+          "id": "<uuid:1>",
+          "detail-type": "<detail-type>",
+          "source": "some.source",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [
+            "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "arn:<partition>:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>"
+          ],
+          "detail": {
+            "Message": "HelloWorld0"
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/services/test_events_task_service.validation.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_events_task_service.validation.json
@@ -3,7 +3,10 @@
     "last_validated_date": "2023-09-12T08:45:20+00:00"
   },
   "tests/aws/services/stepfunctions/v2/services/test_events_task_service.py::TestTaskServiceEvents::test_put_events_malformed_detail": {
-    "last_validated_date": "2023-09-12T08:51:57+00:00"
+    "last_validated_date": "2024-12-05T11:30:19+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_events_task_service.py::TestTaskServiceEvents::test_put_events_mixed_malformed_detail": {
+    "last_validated_date": "2024-12-05T13:56:38+00:00"
   },
   "tests/aws/services/stepfunctions/v2/services/test_events_task_service.py::TestTaskServiceEvents::test_put_events_no_source": {
     "last_validated_date": "2023-09-12T11:17:16+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes the construction of EventsBridge PUT failures -- as well as recording them to the execution history. Relies on changes in https://github.com/localstack/localstack/pull/11990

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Remove skips on events tests.
- Adds another test to ensure we can handle the mixed case where some entries are malformed and some are valid.
- Pass the PUT response as the cause of the failure event when constructing failed events. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
