### PR TITLE
Unskip fixed event filtering tests

### DIFF
--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -580,6 +580,7 @@ class TestDynamoDBEventSourceMapping:
                 {"eventName": ["INSERT"], "eventSource": ["aws:dynamodb"]},
                 1,
                 id="content_multiple_filters",
+                marks=pytest.skip(reason="Broken, needs investigation"),
             ),
             # Test content filter using the DynamoDB data type "S"
             pytest.param(

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -672,8 +672,6 @@ class TestDynamoDBEventSourceMapping:
         Test assumption: The first item MUST always match the filter and the second item CAN match the filter.
         => This enables two-step testing (i.e., snapshots between inserts) but is unreliable and should be revised.
         """
-        if filter == {"eventName": ["INSERT"], "eventSource": ["aws:dynamodb"]}:
-            pytest.skip(reason="content_multiple_filters failing for ESM v2 (needs investigation)")
         function_name = f"lambda_func-{short_uid()}"
         table_name = f"test-table-{short_uid()}"
         max_retries = 50

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -599,36 +599,34 @@ class TestDynamoDBEventSourceMapping:
                 1,
                 id="exists_filter_type",
             ),
-            # TODO: Fix native LocalStack implementation for exists
-            # pytest.param(
-            #     {"id": {"S": "id_value_1"}},
-            #     {"id": {"S": "id_value_2"}, "presentKey": {"S": "presentValue"}},
-            #     {"dynamodb": {"NewImage": {"presentKey": [{"exists": False}]}}},
-            #     2,
-            #     id="exists_false_filter",
-            # ),
+            pytest.param(
+                {"id": {"S": "id_value_1"}},
+                {"id": {"S": "id_value_2"}, "presentKey": {"S": "presentValue"}},
+                {"dynamodb": {"NewImage": {"presentKey": [{"exists": False}]}}},
+                2,
+                id="exists_false_filter",
+            ),
             # numeric filter
             # NOTE: numeric filters do not work with DynamoDB because all values are represented as string
             # and not converted to numbers for filtering.
             # The following AWS tutorial has a note about numeric filtering, which does not apply to DynamoDB strings:
             # https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.Lambda.Tutorial2.html
-            # TODO: Fix native LocalStack implementation for anything-but
-            # pytest.param(
-            #     {"id": {"S": "id_value_1"}, "numericFilter": {"N": "42"}},
-            #     {"id": {"S": "id_value_2"}, "numericFilter": {"N": "101"}},
-            #     {
-            #         "dynamodb": {
-            #             "NewImage": {
-            #                 "numericFilter": {
-            #                     # Filtering passes if at least one of the filter conditions matches
-            #                     "N": [{"numeric": [">", 100]}, {"anything-but": "101"}]
-            #                 }
-            #             }
-            #         }
-            #     },
-            #     1,
-            #     id="numeric_filter",
-            # ),
+            pytest.param(
+                {"id": {"S": "id_value_1"}, "numericFilter": {"N": "42"}},
+                {"id": {"S": "id_value_2"}, "numericFilter": {"N": "101"}},
+                {
+                    "dynamodb": {
+                        "NewImage": {
+                            "numericFilter": {
+                                # Filtering passes if at least one of the filter conditions matches
+                                "N": [{"numeric": [">", 100]}, {"anything-but": "101"}]
+                            }
+                        }
+                    }
+                },
+                1,
+                id="numeric_filter",
+            ),
             # Prefix
             pytest.param(
                 {"id": {"S": "id_value_1"}, "prefix": {"S": "us-1-other-suffix"}},

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -580,7 +580,7 @@ class TestDynamoDBEventSourceMapping:
                 {"eventName": ["INSERT"], "eventSource": ["aws:dynamodb"]},
                 1,
                 id="content_multiple_filters",
-                marks=pytest.skip(reason="Broken, needs investigation"),
+                marks=pytest.mark.skip(reason="Broken, needs investigation"),
             ),
             # Test content filter using the DynamoDB data type "S"
             pytest.param(

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.snapshot.json
@@ -1326,7 +1326,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[exists_false_filter]": {
-    "recorded-date": "11-04-2024, 20:56:31",
+    "recorded-date": "05-12-2024, 15:58:42",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -1339,7 +1339,7 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
           "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
@@ -1371,6 +1371,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1390,7 +1391,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,
@@ -1500,7 +1501,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[numeric_filter]": {
-    "recorded-date": "11-04-2024, 20:57:39",
+    "recorded-date": "05-12-2024, 16:01:14",
     "recorded-content": {
       "table_creation_response": {
         "TableDescription": {
@@ -1513,7 +1514,7 @@
           "BillingModeSummary": {
             "BillingMode": "PAY_PER_REQUEST"
           },
-          "CreationDateTime": "datetime",
+          "CreationDateTime": "<datetime>",
           "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
@@ -1545,6 +1546,7 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
         "FilterCriteria": {
           "Filters": [
             {
@@ -1572,7 +1574,7 @@
         },
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 1,
         "MaximumRecordAgeInSeconds": -1,

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.validation.json
@@ -21,7 +21,7 @@
     "last_validated_date": "2024-10-12T11:19:06+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[exists_false_filter]": {
-    "last_validated_date": "2024-04-11T20:56:30+00:00"
+    "last_validated_date": "2024-12-05T15:58:41+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[exists_filter_type]": {
     "last_validated_date": "2024-10-12T11:10:04+00:00"
@@ -30,7 +30,7 @@
     "last_validated_date": "2024-10-12T11:03:06+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[numeric_filter]": {
-    "last_validated_date": "2024-04-11T20:57:38+00:00"
+    "last_validated_date": "2024-12-05T16:01:13+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[prefix_filter]": {
     "last_validated_date": "2024-10-12T11:11:04+00:00"

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.snapshot.json
@@ -3688,5 +3688,876 @@
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_batching_behaviour[100]": {
     "recorded-date": "26-11-2024, 14:23:08",
     "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[single-filter]": {
+    "recorded-date": "10-12-2024, 17:35:40",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "testItem": [
+                    "test24"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "testItem": "test24"
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[or-filter]": {
+    "recorded-date": "10-12-2024, 17:36:20",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "testItem": [
+                    "test24",
+                    "test45"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "testItem": "test45"
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[and-filter]": {
+    "recorded-date": "10-12-2024, 17:37:03",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "testItem": [
+                    "test24",
+                    "test45"
+                  ],
+                  "test2": [
+                    "go"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "testItem": "test45",
+                "test2": "go"
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[exists-filter]": {
+    "recorded-date": "10-12-2024, 17:37:41",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "test2": [
+                    {
+                      "exists": true
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "test2": "7411"
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[numeric-bigger]": {
+    "recorded-date": "10-12-2024, 19:37:10",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "my-number": [
+                    {
+                      "numeric": [
+                        ">",
+                        100
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "my-number": 101
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[numeric-smaller]": {
+    "recorded-date": "10-12-2024, 19:37:55",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "my-number": [
+                    {
+                      "numeric": [
+                        "<",
+                        100
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "my-number": 99
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[numeric-range]": {
+    "recorded-date": "10-12-2024, 19:38:28",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "my-number": [
+                    {
+                      "numeric": [
+                        ">=",
+                        100,
+                        "<",
+                        200
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "my-number": 100
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[numeric-prefix]": {
+    "recorded-date": "10-12-2024, 17:40:33",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "test2": [
+                    {
+                      "prefix": "us-1"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "test2": "us-1-48454"
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[single]": {
+    "recorded-date": "10-12-2024, 19:34:32",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "my-key": [
+                    "my-value"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "my-key": "my-value"
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[or]": {
+    "recorded-date": "10-12-2024, 19:35:19",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "my-key": [
+                    "my-value-one",
+                    "my-value-two"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "my-key": "my-value-two"
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[and]": {
+    "recorded-date": "10-12-2024, 19:35:54",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "my-key-one": [
+                    "other-filter",
+                    "my-value-one"
+                  ],
+                  "my-key-two": [
+                    "my-value-two"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "my-key-one": "my-value-one",
+                "my-key-two": "my-value-two"
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[exists]": {
+    "recorded-date": "10-12-2024, 19:36:24",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "my-key": [
+                    {
+                      "exists": true
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "my-key": "any-value-one"
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[plain-string-matching]": {
+    "recorded-date": "10-12-2024, 19:47:26",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[plain-string-filter]": {
+    "recorded-date": "10-12-2024, 19:47:31",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[valid-json-filter]": {
+    "recorded-date": "10-12-2024, 19:40:28",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "my-key": [
+                    "my-value"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "my-key": "my-value"
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[prefix]": {
+    "recorded-date": "10-12-2024, 19:47:22",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": {
+                "body": {
+                  "my-key": [
+                    {
+                      "prefix": "yes"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "invocation_events": [
+        {
+          "Records": [
+            {
+              "messageId": "<uuid:2>",
+              "receiptHandle": "<receipt-handle:1>",
+              "body": {
+                "my-key": "yes-value"
+              },
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "sent-timestamp",
+                "SenderId": "sender-id",
+                "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
+              },
+              "messageAttributes": {},
+              "md5OfMessageAttributes": null,
+              "md5OfBody": "<md5-of-body:1>",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
+              "awsRegion": "<region>"
+            }
+          ]
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.validation.json
@@ -5,6 +5,18 @@
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_event_source_mapping_default_batch_size": {
     "last_validated_date": "2024-10-12T13:37:18+00:00"
   },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[and-filter]": {
+    "last_validated_date": "2024-12-10T17:37:02+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[and]": {
+    "last_validated_date": "2024-12-10T19:35:53+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[exists-filter]": {
+    "last_validated_date": "2024-12-10T17:37:40+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[exists]": {
+    "last_validated_date": "2024-12-10T19:36:23+00:00"
+  },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter0-item_matching0-item_not_matching0]": {
     "last_validated_date": "2024-10-12T13:38:37+00:00"
   },
@@ -28,6 +40,36 @@
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter7-item_matching7-item_not_matching7]": {
     "last_validated_date": "2024-10-12T13:43:31+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[numeric-bigger]": {
+    "last_validated_date": "2024-12-10T19:37:09+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[numeric-prefix]": {
+    "last_validated_date": "2024-12-10T17:40:32+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[numeric-range]": {
+    "last_validated_date": "2024-12-10T19:38:27+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[numeric-smaller]": {
+    "last_validated_date": "2024-12-10T19:37:54+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[or-filter]": {
+    "last_validated_date": "2024-12-10T17:36:19+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[or]": {
+    "last_validated_date": "2024-12-10T19:35:18+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[prefix]": {
+    "last_validated_date": "2024-12-10T19:47:21+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[single-filter]": {
+    "last_validated_date": "2024-12-10T17:35:39+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[single]": {
+    "last_validated_date": "2024-12-10T19:34:31+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[valid-json-filter]": {
+    "last_validated_date": "2024-12-10T19:40:27+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping": {
     "last_validated_date": "2024-11-25T15:46:54+00:00"


### PR DESCRIPTION
## Motivation

With @bentsku's new Python-based event filtering engine, we should be able to unskip tests that previously relied on the Java engine but were skipped to avoid JPype conflicts with StepFunctions JSONata.

## Changes

* Unskip event filtering ESM tests

## TODO

- [x] test_dynamodb_event_filter[numeric_filter] is fixed by https://github.com/localstack/localstack/pull/11994
- [x] Invalid filter detection for ESM should be fixed with a WIP PR by @gregfurman 
- [ ] test_dynamodb_event_filter[content_multiple_filters] is an ESM issue (as the skip comment says) and needs investigation -> SKIPPED for now, needs more investigation in a follow up
- [x] NICE-TO-HAVE: migrate `test_sqs_event_filter` to use `pytest.param` (Example in `aws.services.lambda_.event_source_mapping.test_lambda_integration_dynamodbstreams.TestDynamoDBEventSourceMapping.test_dynamodb_event_filter`) because it makes selective test execution and reporting so much easier and clearer.