### PR TITLE
make SNS `SigningCertURL` configurable even if not resolvable

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1125,6 +1125,8 @@ LEGACY_SNS_GCM_PUBLISHING = is_env_true("LEGACY_SNS_GCM_PUBLISHING")
 
 SNS_SES_SENDER_ADDRESS = os.environ.get("SNS_SES_SENDER_ADDRESS", "").strip()
 
+SNS_CERT_URL_HOST = os.environ.get("SNS_CERT_URL_HOST", "").strip()
+
 # Whether the Next Gen APIGW invocation logic is enabled (on by default)
 APIGW_NEXT_GEN_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_APIGATEWAY", "") in ("next_gen", "")
 

--- a/localstack-core/localstack/services/sns/publisher.py
+++ b/localstack-core/localstack/services/sns/publisher.py
@@ -237,7 +237,7 @@ class LambdaTopicPublisher(TopicPublisher):
         :param subscriber: the SNS subscription
         :return: an SNS message body formatted as a lambda Event in a JSON string
         """
-        external_url = external_service_url().rstrip("/")
+        external_url = get_cert_base_url()
         unsubscribe_url = create_unsubscribe_url(external_url, subscriber["SubscriptionArn"])
         message_attributes = prepare_message_attributes(message_context.message_attributes)
 
@@ -958,7 +958,7 @@ def create_sns_message_body(
     if message_type == "Notification" and is_raw_message_delivery(subscriber):
         return message_content
 
-    external_url = external_service_url().rstrip("/")
+    external_url = get_cert_base_url()
 
     data = {
         "Type": message_type,
@@ -1127,6 +1127,13 @@ def store_delivery_log(
     return store_cloudwatch_logs(
         logs_client, log_group_name, log_stream_name, log_output, invocation_time
     )
+
+
+def get_cert_base_url() -> str:
+    if config.SNS_CERT_URL_HOST:
+        return f"https://{config.SNS_CERT_URL_HOST}"
+
+    return external_service_url().rstrip("/")
 
 
 def create_subscribe_url(external_url, topic_arn, subscription_token):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #11850, some SDK will verify the `SigningCertURL` field host part even if not validating the messages. 

This PR introduces a config flag to allow the user to set the host of the `SigningCertURL` to pass those regex pattern, even if the host is then non-resolvable, it should at least unblock the user, as they confirmed this would be sufficient for their use case. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a config flag `SNS_CERT_URL_HOST` to allow the user the set the host to an arbitrary value
- create a test to validate SNS is properly using that value

_fixes #11850_

## TODO

What's left to do:

- [ ] create the docs PR to document this new config flag
