### PR TITLE
Events: fix `numeric` operator string handling and provider validation for TestEventPattern

### DIFF
--- a/localstack-core/localstack/services/events/event_rule_engine.py
+++ b/localstack-core/localstack/services/events/event_rule_engine.py
@@ -148,6 +148,8 @@ class EventRuleEngine:
 
     @staticmethod
     def _evaluate_numeric_condition(conditions, value) -> bool:
+        if not isinstance(value, (int, float)):
+            return False
         try:
             # try if the value is numeric
             value = float(value)

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -1209,6 +1209,25 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         """Test event pattern uses EventBridge event pattern matching:
         https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html
         """
+        try:
+            json_event = json.loads(event)
+        except json.JSONDecodeError:
+            raise ValidationException("Parameter Event is not valid.")
+
+        mandatory_fields = {
+            "id",
+            "account",
+            "source",
+            "time",
+            "region",
+            "detail-type",
+        }
+        # https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_TestEventPattern.html
+        # the documentation says that `resources` is mandatory, but it is not in reality
+
+        if not mandatory_fields.issubset(json_event):
+            raise ValidationException("Parameter Event is not valid.")
+
         result = matches_event(event_pattern, event)
         return TestEventPatternResponse(Result=result)
 

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -1225,7 +1225,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         # https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_TestEventPattern.html
         # the documentation says that `resources` is mandatory, but it is not in reality
 
-        if not mandatory_fields.issubset(json_event):
+        if not isinstance(json_event, dict) or not mandatory_fields.issubset(json_event):
             raise ValidationException("Parameter Event is not valid.")
 
         result = matches_event(event_pattern, event)

--- a/tests/aws/services/events/event_pattern_templates/numeric-int-float.json5
+++ b/tests/aws/services/events/event_pattern_templates/numeric-int-float.json5
@@ -1,0 +1,15 @@
+// Based on "Considerations when creating event patterns" from https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "number": 101.0
+  },
+  "EventPattern": {
+    "number": [{"numeric": [">", 100]}]
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/numeric-null_NEG.json5
+++ b/tests/aws/services/events/event_pattern_templates/numeric-null_NEG.json5
@@ -1,0 +1,15 @@
+// Based on "Considerations when creating event patterns" from https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "number": null
+  },
+  "EventPattern": {
+    "number": [{"numeric": [">", 100]}]
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/numeric-string_NEG.json5
+++ b/tests/aws/services/events/event_pattern_templates/numeric-string_NEG.json5
@@ -1,0 +1,15 @@
+// Based on "Considerations when creating event patterns" from https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "number": "300"
+  },
+  "EventPattern": {
+    "number": [{"numeric": [">", 100]}]
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/or-numeric-anything-but.json5
+++ b/tests/aws/services/events/event_pattern_templates/or-numeric-anything-but.json5
@@ -1,0 +1,38 @@
+{
+  "Event": {
+    "id": "1",
+    "source": "order",
+    "detail-type": "Test",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "dynamodb": {
+      "ApproximateCreationDateTime": 1733418659.0,
+      "Keys": {
+        "id": {
+          "S": "id_value_1"
+        }
+      },
+      "NewImage": {
+        "id": {
+          "S": "id_value_1"
+        },
+        "numericFilter": {
+          "N": "42"
+        }
+      },
+      "SequenceNumber": "49658361752382621885697088319781165717078428243510427650",
+      "SizeBytes": 52,
+      "StreamViewType": "NEW_AND_OLD_IMAGES"
+    }
+  },
+  "EventPattern": {
+    "dynamodb": {
+      "NewImage": {
+        "numericFilter": {
+          "N": [{"numeric": [">", 100]}, {"anything-but": "101"}]
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/events/event_pattern_templates/or-numeric-anything-but_NEG.json5
+++ b/tests/aws/services/events/event_pattern_templates/or-numeric-anything-but_NEG.json5
@@ -1,0 +1,38 @@
+{
+  "Event": {
+    "id": "1",
+    "source": "order",
+    "detail-type": "Test",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "dynamodb": {
+      "ApproximateCreationDateTime": 1733418659.0,
+      "Keys": {
+        "id": {
+          "S": "id_value_1"
+        }
+      },
+      "NewImage": {
+        "id": {
+          "S": "id_value_1"
+        },
+        "numericFilter": {
+          "N": "101"
+        }
+      },
+      "SequenceNumber": "49658361752382621885697088319781165717078428243510427650",
+      "SizeBytes": 52,
+      "StreamViewType": "NEW_AND_OLD_IMAGES"
+    }
+  },
+  "EventPattern": {
+    "dynamodb": {
+      "NewImage": {
+        "numericFilter": {
+          "N": [{"numeric": [">", 100]}, {"anything-but": "101"}]
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/events/test_events_patterns.py
+++ b/tests/aws/services/events/test_events_patterns.py
@@ -251,7 +251,7 @@ class TestEventPattern:
         reason="V1 provider does not properly validate",
     )
     def test_invalid_event_payload(self, aws_client, snapshot):
-        # following fields are mandatory: `id`, `account`, `source`, `time`, `region`, `resources`, `detail-type`
+        # following fields are mandatory: `id`, `account`, `source`, `time`, `region`, `detail-type`
         event = {"testEvent": "value"}
         pattern = {"body": {"test2": [{"numeric": [">", 100]}]}}
 

--- a/tests/aws/services/events/test_events_patterns.py
+++ b/tests/aws/services/events/test_events_patterns.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError
 from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
 from tests.aws.services.events.helper_functions import (
+    is_old_provider,
     sqs_collect_messages,
 )
 
@@ -213,6 +214,10 @@ class TestEventPattern:
         snapshot.match("invalid-pattern", e.value.response)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        is_old_provider(),
+        reason="V1 provider does not properly validate",
+    )
     def test_plain_string_payload(self, aws_client, snapshot):
         event = "plain string"
         pattern = {"body": {"test2": [{"numeric": [">", 100]}]}}
@@ -225,6 +230,10 @@ class TestEventPattern:
         snapshot.match("plain-string-payload-exc", e.value.response)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        is_old_provider(),
+        reason="V1 provider does not properly validate",
+    )
     def test_invalid_event_payload(self, aws_client, snapshot):
         # following fields are mandatory: `id`, `account`, `source`, `time`, `region`, `resources`, `detail-type`
         event = {"testEvent": "value"}

--- a/tests/aws/services/events/test_events_patterns.py
+++ b/tests/aws/services/events/test_events_patterns.py
@@ -212,6 +212,31 @@ class TestEventPattern:
             )
         snapshot.match("invalid-pattern", e.value.response)
 
+    @markers.aws.validated
+    def test_plain_string_payload(self, aws_client, snapshot):
+        event = "plain string"
+        pattern = {"body": {"test2": [{"numeric": [">", 100]}]}}
+
+        with pytest.raises(ClientError) as e:
+            aws_client.events.test_event_pattern(
+                Event=event,
+                EventPattern=json.dumps(pattern),
+            )
+        snapshot.match("plain-string-payload-exc", e.value.response)
+
+    @markers.aws.validated
+    def test_invalid_event_payload(self, aws_client, snapshot):
+        # following fields are mandatory: `id`, `account`, `source`, `time`, `region`, `resources`, `detail-type`
+        event = {"testEvent": "value"}
+        pattern = {"body": {"test2": [{"numeric": [">", 100]}]}}
+
+        with pytest.raises(ClientError) as e:
+            aws_client.events.test_event_pattern(
+                Event=json.dumps(event),
+                EventPattern=json.dumps(pattern),
+            )
+        snapshot.match("plain-string-payload-exc", e.value.response)
+
 
 class TestRuleWithPattern:
     @markers.aws.validated

--- a/tests/aws/services/events/test_events_patterns.py
+++ b/tests/aws/services/events/test_events_patterns.py
@@ -234,6 +234,22 @@ class TestEventPattern:
         is_old_provider(),
         reason="V1 provider does not properly validate",
     )
+    def test_array_event_payload(self, aws_client, snapshot):
+        event = ["plain string"]
+        pattern = {"body": {"test2": [{"numeric": [">", 100]}]}}
+
+        with pytest.raises(ClientError) as e:
+            aws_client.events.test_event_pattern(
+                Event=json.dumps(event),
+                EventPattern=json.dumps(pattern),
+            )
+        snapshot.match("array-event-payload-exc", e.value.response)
+
+    @markers.aws.validated
+    @pytest.mark.skipif(
+        is_old_provider(),
+        reason="V1 provider does not properly validate",
+    )
     def test_invalid_event_payload(self, aws_client, snapshot):
         # following fields are mandatory: `id`, `account`, `source`, `time`, `region`, `resources`, `detail-type`
         event = {"testEvent": "value"}

--- a/tests/aws/services/events/test_events_patterns.snapshot.json
+++ b/tests/aws/services/events/test_events_patterns.snapshot.json
@@ -1,22 +1,22 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "recorded-date": "05-12-2024, 17:44:30",
+    "recorded-date": "05-12-2024, 17:58:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "recorded-date": "05-12-2024, 17:44:30",
+    "recorded-date": "05-12-2024, 17:58:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:30",
+    "recorded-date": "05-12-2024, 17:58:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "recorded-date": "05-12-2024, 17:44:31",
+    "recorded-date": "05-12-2024, 17:58:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:31",
+    "recorded-date": "05-12-2024, 17:58:59",
     "recorded-content": {
       "int_nolist_EXC": {
         "exception_message": {
@@ -35,39 +35,39 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "recorded-date": "05-12-2024, 17:44:32",
+    "recorded-date": "05-12-2024, 17:59:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:33",
+    "recorded-date": "05-12-2024, 17:59:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:33",
+    "recorded-date": "05-12-2024, 17:59:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "recorded-date": "05-12-2024, 17:44:33",
+    "recorded-date": "05-12-2024, 17:59:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "recorded-date": "05-12-2024, 17:44:33",
+    "recorded-date": "05-12-2024, 17:59:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "recorded-date": "05-12-2024, 17:44:33",
+    "recorded-date": "05-12-2024, 17:59:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:34",
+    "recorded-date": "05-12-2024, 17:59:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "recorded-date": "05-12-2024, 17:44:34",
+    "recorded-date": "05-12-2024, 17:59:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:34",
+    "recorded-date": "05-12-2024, 17:59:02",
     "recorded-content": {
       "content_numeric_operatorcasing_EXC": {
         "exception_message": {
@@ -86,19 +86,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:35",
+    "recorded-date": "05-12-2024, 17:59:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "recorded-date": "05-12-2024, 17:44:35",
+    "recorded-date": "05-12-2024, 17:59:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:35",
+    "recorded-date": "05-12-2024, 17:59:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:35",
+    "recorded-date": "05-12-2024, 17:59:04",
     "recorded-content": {
       "string_nolist_EXC": {
         "exception_message": {
@@ -117,27 +117,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:36",
+    "recorded-date": "05-12-2024, 17:59:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:36",
+    "recorded-date": "05-12-2024, 17:59:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:36",
+    "recorded-date": "05-12-2024, 17:59:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "recorded-date": "05-12-2024, 17:44:36",
+    "recorded-date": "05-12-2024, 17:59:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "recorded-date": "05-12-2024, 17:44:36",
+    "recorded-date": "05-12-2024, 17:59:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:37",
+    "recorded-date": "05-12-2024, 17:59:05",
     "recorded-content": {
       "arrays_empty_EXC": {
         "exception_message": {
@@ -156,55 +156,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:37",
+    "recorded-date": "05-12-2024, 17:59:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "recorded-date": "05-12-2024, 17:44:37",
+    "recorded-date": "05-12-2024, 17:59:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "recorded-date": "05-12-2024, 17:44:37",
+    "recorded-date": "05-12-2024, 17:59:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "recorded-date": "05-12-2024, 17:44:37",
+    "recorded-date": "05-12-2024, 17:59:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "recorded-date": "05-12-2024, 17:44:38",
+    "recorded-date": "05-12-2024, 17:59:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "recorded-date": "05-12-2024, 17:44:38",
+    "recorded-date": "05-12-2024, 17:59:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "recorded-date": "05-12-2024, 17:44:38",
+    "recorded-date": "05-12-2024, 17:59:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "recorded-date": "05-12-2024, 17:44:38",
+    "recorded-date": "05-12-2024, 17:59:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "recorded-date": "05-12-2024, 17:44:38",
+    "recorded-date": "05-12-2024, 17:59:07",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "recorded-date": "05-12-2024, 17:44:39",
+    "recorded-date": "05-12-2024, 17:59:07",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:39",
+    "recorded-date": "05-12-2024, 17:59:07",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:39",
+    "recorded-date": "05-12-2024, 17:59:07",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:40",
+    "recorded-date": "05-12-2024, 17:59:08",
     "recorded-content": {
       "operator_case_sensitive_EXC": {
         "exception_message": {
@@ -223,15 +223,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "recorded-date": "05-12-2024, 17:44:40",
+    "recorded-date": "05-12-2024, 17:59:08",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:40",
+    "recorded-date": "05-12-2024, 17:59:08",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:41",
+    "recorded-date": "05-12-2024, 17:59:09",
     "recorded-content": {
       "content_numeric_EXC": {
         "exception_message": {
@@ -250,87 +250,87 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:41",
+    "recorded-date": "05-12-2024, 17:59:09",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "recorded-date": "05-12-2024, 17:44:41",
+    "recorded-date": "05-12-2024, 17:59:09",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:42",
+    "recorded-date": "05-12-2024, 17:59:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "recorded-date": "05-12-2024, 17:44:42",
+    "recorded-date": "05-12-2024, 17:59:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:42",
+    "recorded-date": "05-12-2024, 17:59:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "recorded-date": "05-12-2024, 17:44:42",
+    "recorded-date": "05-12-2024, 17:59:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "recorded-date": "05-12-2024, 17:44:42",
+    "recorded-date": "05-12-2024, 17:59:10",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:43",
+    "recorded-date": "05-12-2024, 17:59:11",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:43",
+    "recorded-date": "05-12-2024, 17:59:11",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "recorded-date": "05-12-2024, 17:44:43",
+    "recorded-date": "05-12-2024, 17:59:11",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "recorded-date": "05-12-2024, 17:44:43",
+    "recorded-date": "05-12-2024, 17:59:11",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:43",
+    "recorded-date": "05-12-2024, 17:59:11",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:43",
+    "recorded-date": "05-12-2024, 17:59:12",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "recorded-date": "05-12-2024, 17:44:44",
+    "recorded-date": "05-12-2024, 17:59:12",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "recorded-date": "05-12-2024, 17:44:44",
+    "recorded-date": "05-12-2024, 17:59:12",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "recorded-date": "05-12-2024, 17:44:45",
+    "recorded-date": "05-12-2024, 17:59:13",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:45",
+    "recorded-date": "05-12-2024, 17:59:13",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "recorded-date": "05-12-2024, 17:44:45",
+    "recorded-date": "05-12-2024, 17:59:13",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:45",
+    "recorded-date": "05-12-2024, 17:59:13",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:46",
+    "recorded-date": "05-12-2024, 17:59:14",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:46",
+    "recorded-date": "05-12-2024, 17:59:14",
     "recorded-content": {
       "content_wildcard_complex_EXC": {
         "exception_message": {
@@ -349,55 +349,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:47",
+    "recorded-date": "05-12-2024, 17:59:16",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "recorded-date": "05-12-2024, 17:44:48",
+    "recorded-date": "05-12-2024, 17:59:16",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:48",
+    "recorded-date": "05-12-2024, 17:59:16",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "recorded-date": "05-12-2024, 17:44:48",
+    "recorded-date": "05-12-2024, 17:59:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "recorded-date": "05-12-2024, 17:44:50",
+    "recorded-date": "05-12-2024, 17:59:18",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "recorded-date": "05-12-2024, 17:44:50",
+    "recorded-date": "05-12-2024, 17:59:19",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:51",
+    "recorded-date": "05-12-2024, 17:59:19",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "recorded-date": "05-12-2024, 17:44:51",
+    "recorded-date": "05-12-2024, 17:59:19",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:52",
+    "recorded-date": "05-12-2024, 17:59:20",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "recorded-date": "05-12-2024, 17:44:52",
+    "recorded-date": "05-12-2024, 17:59:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:52",
+    "recorded-date": "05-12-2024, 17:59:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:53",
+    "recorded-date": "05-12-2024, 17:59:21",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:53",
+    "recorded-date": "05-12-2024, 17:59:21",
     "recorded-content": {
       "content_numeric_syntax_EXC": {
         "exception_message": {
@@ -416,19 +416,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "recorded-date": "05-12-2024, 17:44:53",
+    "recorded-date": "05-12-2024, 17:59:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "recorded-date": "05-12-2024, 17:44:53",
+    "recorded-date": "05-12-2024, 17:59:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "recorded-date": "05-12-2024, 17:44:53",
+    "recorded-date": "05-12-2024, 17:59:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "recorded-date": "05-12-2024, 17:44:53",
+    "recorded-date": "05-12-2024, 17:59:22",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
@@ -580,7 +580,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:33",
+    "recorded-date": "05-12-2024, 17:59:01",
     "recorded-content": {
       "content_wildcard_repeating_star_EXC": {
         "exception_message": {
@@ -599,7 +599,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:39",
+    "recorded-date": "05-12-2024, 17:59:07",
     "recorded-content": {
       "content_ignorecase_EXC": {
         "exception_message": {
@@ -618,7 +618,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:49",
+    "recorded-date": "05-12-2024, 17:59:18",
     "recorded-content": {
       "content_ip_address_EXC": {
         "exception_message": {
@@ -637,7 +637,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:40",
+    "recorded-date": "05-12-2024, 17:59:08",
     "recorded-content": {
       "content_anything_but_ignorecase_EXC": {
         "exception_message": {
@@ -656,7 +656,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:44",
+    "recorded-date": "05-12-2024, 17:59:12",
     "recorded-content": {
       "content_anything_but_ignorecase_list_EXC": {
         "exception_message": {
@@ -675,7 +675,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:47",
+    "recorded-date": "05-12-2024, 17:59:15",
     "recorded-content": {
       "content_ignorecase_list_EXC": {
         "exception_message": {
@@ -754,27 +754,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
-    "recorded-date": "05-12-2024, 17:44:41",
+    "recorded-date": "05-12-2024, 17:59:09",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:33",
+    "recorded-date": "05-12-2024, 17:59:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list]": {
-    "recorded-date": "05-12-2024, 17:44:34",
+    "recorded-date": "05-12-2024, 17:59:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:39",
+    "recorded-date": "05-12-2024, 17:59:07",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard]": {
-    "recorded-date": "05-12-2024, 17:44:49",
+    "recorded-date": "05-12-2024, 17:59:18",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_int_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:49",
+    "recorded-date": "05-12-2024, 17:59:17",
     "recorded-content": {
       "content_wildcard_int_EXC": {
         "exception_message": {
@@ -793,7 +793,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_list_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:51",
+    "recorded-date": "05-12-2024, 17:59:20",
     "recorded-content": {
       "content_wildcard_list_EXC": {
         "exception_message": {
@@ -812,7 +812,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_type_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:32",
+    "recorded-date": "05-12-2024, 17:59:00",
     "recorded-content": {
       "content_anything_wildcard_list_type_EXC": {
         "exception_message": {
@@ -831,7 +831,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_type_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:48",
+    "recorded-date": "05-12-2024, 17:59:16",
     "recorded-content": {
       "content_anything_wildcard_type_EXC": {
         "exception_message": {
@@ -850,7 +850,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_type_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:30",
+    "recorded-date": "05-12-2024, 17:58:58",
     "recorded-content": {
       "content_anything_suffix_list_type_EXC": {
         "exception_message": {
@@ -869,15 +869,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list]": {
-    "recorded-date": "05-12-2024, 17:44:33",
+    "recorded-date": "05-12-2024, 17:59:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:33",
+    "recorded-date": "05-12-2024, 17:59:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_int_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:38",
+    "recorded-date": "05-12-2024, 17:59:06",
     "recorded-content": {
       "content_anything_suffix_int_EXC": {
         "exception_message": {
@@ -896,15 +896,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list]": {
-    "recorded-date": "05-12-2024, 17:44:43",
+    "recorded-date": "05-12-2024, 17:59:11",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:46",
+    "recorded-date": "05-12-2024, 17:59:15",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_type_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:48",
+    "recorded-date": "05-12-2024, 17:59:17",
     "recorded-content": {
       "content_anything_prefix_list_type_EXC": {
         "exception_message": {
@@ -923,7 +923,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_int_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:51",
+    "recorded-date": "05-12-2024, 17:59:20",
     "recorded-content": {
       "content_anything_prefix_int_EXC": {
         "exception_message": {
@@ -942,7 +942,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_list_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:35",
+    "recorded-date": "05-12-2024, 17:59:03",
     "recorded-content": {
       "content_prefix_list_EXC": {
         "exception_message": {
@@ -961,7 +961,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_int_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:42",
+    "recorded-date": "05-12-2024, 17:59:10",
     "recorded-content": {
       "content_prefix_int_EXC": {
         "exception_message": {
@@ -980,7 +980,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_int_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:46",
+    "recorded-date": "05-12-2024, 17:59:14",
     "recorded-content": {
       "content_suffix_int_EXC": {
         "exception_message": {
@@ -999,7 +999,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_list_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:50",
+    "recorded-date": "05-12-2024, 17:59:18",
     "recorded-content": {
       "content_suffix_list_EXC": {
         "exception_message": {
@@ -1018,7 +1018,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_ignorecase_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:45",
+    "recorded-date": "05-12-2024, 17:59:13",
     "recorded-content": {
       "content_anything_prefix_ignorecase_EXC": {
         "exception_message": {
@@ -1037,7 +1037,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_ignorecase_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:47",
+    "recorded-date": "05-12-2024, 17:59:15",
     "recorded-content": {
       "content_anything_suffix_ignorecase_EXC": {
         "exception_message": {
@@ -1056,7 +1056,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_mask_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:31",
+    "recorded-date": "05-12-2024, 17:58:59",
     "recorded-content": {
       "content_ip_address_bad_mask_EXC": {
         "exception_message": {
@@ -1075,15 +1075,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:36",
+    "recorded-date": "05-12-2024, 17:59:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6]": {
-    "recorded-date": "05-12-2024, 17:44:37",
+    "recorded-date": "05-12-2024, 17:59:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_ip_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:43",
+    "recorded-date": "05-12-2024, 17:59:12",
     "recorded-content": {
       "content_ip_address_bad_ip_EXC": {
         "exception_message": {
@@ -1102,7 +1102,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_type_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:50",
+    "recorded-date": "05-12-2024, 17:59:19",
     "recorded-content": {
       "content_ip_address_type_EXC": {
         "exception_message": {
@@ -1121,7 +1121,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_bad_ip_EXC]": {
-    "recorded-date": "05-12-2024, 17:44:52",
+    "recorded-date": "05-12-2024, 17:59:20",
     "recorded-content": {
       "content_ip_address_v6_bad_ip_EXC": {
         "exception_message": {
@@ -1144,7 +1144,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_list_empty_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:32",
+    "recorded-date": "05-12-2024, 17:59:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_plain_string_payload": {
@@ -1163,15 +1163,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-numeric-anything-but_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:35",
+    "recorded-date": "05-12-2024, 17:59:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-numeric-anything-but]": {
-    "recorded-date": "05-12-2024, 17:44:48",
+    "recorded-date": "05-12-2024, 17:59:17",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-string_NEG]": {
-    "recorded-date": "05-12-2024, 17:44:41",
+    "recorded-date": "05-12-2024, 17:59:09",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_event_payload": {
@@ -1188,5 +1188,9 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-null_NEG]": {
+    "recorded-date": "05-12-2024, 17:59:15",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/events/test_events_patterns.snapshot.json
+++ b/tests/aws/services/events/test_events_patterns.snapshot.json
@@ -1,22 +1,22 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "recorded-date": "05-12-2024, 17:58:58",
+    "recorded-date": "05-12-2024, 18:00:39",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "recorded-date": "05-12-2024, 17:58:58",
+    "recorded-date": "05-12-2024, 18:00:39",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "recorded-date": "05-12-2024, 17:58:58",
+    "recorded-date": "05-12-2024, 18:00:39",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "recorded-date": "05-12-2024, 17:58:59",
+    "recorded-date": "05-12-2024, 18:00:40",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "recorded-date": "05-12-2024, 17:58:59",
+    "recorded-date": "05-12-2024, 18:00:40",
     "recorded-content": {
       "int_nolist_EXC": {
         "exception_message": {
@@ -35,39 +35,39 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "recorded-date": "05-12-2024, 17:59:00",
+    "recorded-date": "05-12-2024, 18:00:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:01",
+    "recorded-date": "05-12-2024, 18:00:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:01",
+    "recorded-date": "05-12-2024, 18:00:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "recorded-date": "05-12-2024, 17:59:01",
+    "recorded-date": "05-12-2024, 18:00:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "recorded-date": "05-12-2024, 17:59:01",
+    "recorded-date": "05-12-2024, 18:00:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "recorded-date": "05-12-2024, 17:59:01",
+    "recorded-date": "05-12-2024, 18:00:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:02",
+    "recorded-date": "05-12-2024, 18:00:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "recorded-date": "05-12-2024, 17:59:02",
+    "recorded-date": "05-12-2024, 18:00:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:02",
+    "recorded-date": "05-12-2024, 18:00:43",
     "recorded-content": {
       "content_numeric_operatorcasing_EXC": {
         "exception_message": {
@@ -86,19 +86,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:03",
+    "recorded-date": "05-12-2024, 18:00:44",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "recorded-date": "05-12-2024, 17:59:03",
+    "recorded-date": "05-12-2024, 18:00:44",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:04",
+    "recorded-date": "05-12-2024, 18:00:45",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:04",
+    "recorded-date": "05-12-2024, 18:00:45",
     "recorded-content": {
       "string_nolist_EXC": {
         "exception_message": {
@@ -117,27 +117,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:04",
+    "recorded-date": "05-12-2024, 18:00:45",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:04",
+    "recorded-date": "05-12-2024, 18:00:45",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:04",
+    "recorded-date": "05-12-2024, 18:00:46",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "recorded-date": "05-12-2024, 17:59:05",
+    "recorded-date": "05-12-2024, 18:00:46",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "recorded-date": "05-12-2024, 17:59:05",
+    "recorded-date": "05-12-2024, 18:00:46",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:05",
+    "recorded-date": "05-12-2024, 18:00:46",
     "recorded-content": {
       "arrays_empty_EXC": {
         "exception_message": {
@@ -156,55 +156,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:05",
+    "recorded-date": "05-12-2024, 18:00:46",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "recorded-date": "05-12-2024, 17:59:05",
+    "recorded-date": "05-12-2024, 18:00:46",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "recorded-date": "05-12-2024, 17:59:05",
+    "recorded-date": "05-12-2024, 18:00:47",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "recorded-date": "05-12-2024, 17:59:06",
+    "recorded-date": "05-12-2024, 18:00:47",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "recorded-date": "05-12-2024, 17:59:06",
+    "recorded-date": "05-12-2024, 18:00:47",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "recorded-date": "05-12-2024, 17:59:06",
+    "recorded-date": "05-12-2024, 18:00:47",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "recorded-date": "05-12-2024, 17:59:06",
+    "recorded-date": "05-12-2024, 18:00:47",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "recorded-date": "05-12-2024, 17:59:06",
+    "recorded-date": "05-12-2024, 18:00:47",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "recorded-date": "05-12-2024, 17:59:07",
+    "recorded-date": "05-12-2024, 18:00:48",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "recorded-date": "05-12-2024, 17:59:07",
+    "recorded-date": "05-12-2024, 18:00:48",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:07",
+    "recorded-date": "05-12-2024, 18:00:49",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:07",
+    "recorded-date": "05-12-2024, 18:00:49",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:08",
+    "recorded-date": "05-12-2024, 18:00:49",
     "recorded-content": {
       "operator_case_sensitive_EXC": {
         "exception_message": {
@@ -223,15 +223,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "recorded-date": "05-12-2024, 17:59:08",
+    "recorded-date": "05-12-2024, 18:00:49",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:08",
+    "recorded-date": "05-12-2024, 18:00:50",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:09",
+    "recorded-date": "05-12-2024, 18:00:50",
     "recorded-content": {
       "content_numeric_EXC": {
         "exception_message": {
@@ -250,87 +250,87 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:09",
+    "recorded-date": "05-12-2024, 18:00:51",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "recorded-date": "05-12-2024, 17:59:09",
+    "recorded-date": "05-12-2024, 18:00:51",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:10",
+    "recorded-date": "05-12-2024, 18:00:52",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "recorded-date": "05-12-2024, 17:59:10",
+    "recorded-date": "05-12-2024, 18:00:52",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:10",
+    "recorded-date": "05-12-2024, 18:00:52",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "recorded-date": "05-12-2024, 17:59:10",
+    "recorded-date": "05-12-2024, 18:00:52",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "recorded-date": "05-12-2024, 17:59:10",
+    "recorded-date": "05-12-2024, 18:00:52",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:11",
+    "recorded-date": "05-12-2024, 18:00:52",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:11",
+    "recorded-date": "05-12-2024, 18:00:53",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "recorded-date": "05-12-2024, 17:59:11",
+    "recorded-date": "05-12-2024, 18:00:53",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "recorded-date": "05-12-2024, 17:59:11",
+    "recorded-date": "05-12-2024, 18:00:53",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:11",
+    "recorded-date": "05-12-2024, 18:00:53",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:12",
+    "recorded-date": "05-12-2024, 18:00:53",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "recorded-date": "05-12-2024, 17:59:12",
+    "recorded-date": "05-12-2024, 18:00:54",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "recorded-date": "05-12-2024, 17:59:12",
+    "recorded-date": "05-12-2024, 18:00:54",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "recorded-date": "05-12-2024, 17:59:13",
+    "recorded-date": "05-12-2024, 18:00:54",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:13",
+    "recorded-date": "05-12-2024, 18:00:54",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "recorded-date": "05-12-2024, 17:59:13",
+    "recorded-date": "05-12-2024, 18:00:54",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:13",
+    "recorded-date": "05-12-2024, 18:00:55",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:14",
+    "recorded-date": "05-12-2024, 18:00:55",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:14",
+    "recorded-date": "05-12-2024, 18:00:56",
     "recorded-content": {
       "content_wildcard_complex_EXC": {
         "exception_message": {
@@ -349,55 +349,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:16",
+    "recorded-date": "05-12-2024, 18:00:57",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "recorded-date": "05-12-2024, 17:59:16",
+    "recorded-date": "05-12-2024, 18:00:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:16",
+    "recorded-date": "05-12-2024, 18:00:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "recorded-date": "05-12-2024, 17:59:17",
+    "recorded-date": "05-12-2024, 18:00:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "recorded-date": "05-12-2024, 17:59:18",
+    "recorded-date": "05-12-2024, 18:01:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "recorded-date": "05-12-2024, 17:59:19",
+    "recorded-date": "05-12-2024, 18:01:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:19",
+    "recorded-date": "05-12-2024, 18:01:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "recorded-date": "05-12-2024, 17:59:19",
+    "recorded-date": "05-12-2024, 18:01:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:20",
+    "recorded-date": "05-12-2024, 18:01:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "recorded-date": "05-12-2024, 17:59:21",
+    "recorded-date": "05-12-2024, 18:01:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:21",
+    "recorded-date": "05-12-2024, 18:01:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:21",
+    "recorded-date": "05-12-2024, 18:01:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:21",
+    "recorded-date": "05-12-2024, 18:01:03",
     "recorded-content": {
       "content_numeric_syntax_EXC": {
         "exception_message": {
@@ -416,19 +416,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "recorded-date": "05-12-2024, 17:59:22",
+    "recorded-date": "05-12-2024, 18:01:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "recorded-date": "05-12-2024, 17:59:22",
+    "recorded-date": "05-12-2024, 18:01:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "recorded-date": "05-12-2024, 17:59:22",
+    "recorded-date": "05-12-2024, 18:01:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "recorded-date": "05-12-2024, 17:59:22",
+    "recorded-date": "05-12-2024, 18:01:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
@@ -580,7 +580,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:01",
+    "recorded-date": "05-12-2024, 18:00:43",
     "recorded-content": {
       "content_wildcard_repeating_star_EXC": {
         "exception_message": {
@@ -599,7 +599,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:07",
+    "recorded-date": "05-12-2024, 18:00:48",
     "recorded-content": {
       "content_ignorecase_EXC": {
         "exception_message": {
@@ -618,7 +618,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:18",
+    "recorded-date": "05-12-2024, 18:00:59",
     "recorded-content": {
       "content_ip_address_EXC": {
         "exception_message": {
@@ -637,7 +637,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:08",
+    "recorded-date": "05-12-2024, 18:00:50",
     "recorded-content": {
       "content_anything_but_ignorecase_EXC": {
         "exception_message": {
@@ -656,7 +656,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:12",
+    "recorded-date": "05-12-2024, 18:00:54",
     "recorded-content": {
       "content_anything_but_ignorecase_list_EXC": {
         "exception_message": {
@@ -675,7 +675,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:15",
+    "recorded-date": "05-12-2024, 18:00:56",
     "recorded-content": {
       "content_ignorecase_list_EXC": {
         "exception_message": {
@@ -754,27 +754,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
-    "recorded-date": "05-12-2024, 17:59:09",
+    "recorded-date": "05-12-2024, 18:00:50",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:01",
+    "recorded-date": "05-12-2024, 18:00:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list]": {
-    "recorded-date": "05-12-2024, 17:59:02",
+    "recorded-date": "05-12-2024, 18:00:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:07",
+    "recorded-date": "05-12-2024, 18:00:48",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard]": {
-    "recorded-date": "05-12-2024, 17:59:18",
+    "recorded-date": "05-12-2024, 18:00:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_int_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:17",
+    "recorded-date": "05-12-2024, 18:00:59",
     "recorded-content": {
       "content_wildcard_int_EXC": {
         "exception_message": {
@@ -793,7 +793,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_list_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:20",
+    "recorded-date": "05-12-2024, 18:01:01",
     "recorded-content": {
       "content_wildcard_list_EXC": {
         "exception_message": {
@@ -812,7 +812,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_type_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:00",
+    "recorded-date": "05-12-2024, 18:00:41",
     "recorded-content": {
       "content_anything_wildcard_list_type_EXC": {
         "exception_message": {
@@ -831,7 +831,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_type_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:16",
+    "recorded-date": "05-12-2024, 18:00:57",
     "recorded-content": {
       "content_anything_wildcard_type_EXC": {
         "exception_message": {
@@ -850,7 +850,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_type_EXC]": {
-    "recorded-date": "05-12-2024, 17:58:58",
+    "recorded-date": "05-12-2024, 18:00:40",
     "recorded-content": {
       "content_anything_suffix_list_type_EXC": {
         "exception_message": {
@@ -869,15 +869,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list]": {
-    "recorded-date": "05-12-2024, 17:59:01",
+    "recorded-date": "05-12-2024, 18:00:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:01",
+    "recorded-date": "05-12-2024, 18:00:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_int_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:06",
+    "recorded-date": "05-12-2024, 18:00:47",
     "recorded-content": {
       "content_anything_suffix_int_EXC": {
         "exception_message": {
@@ -896,15 +896,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list]": {
-    "recorded-date": "05-12-2024, 17:59:11",
+    "recorded-date": "05-12-2024, 18:00:52",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:15",
+    "recorded-date": "05-12-2024, 18:00:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_type_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:17",
+    "recorded-date": "05-12-2024, 18:00:58",
     "recorded-content": {
       "content_anything_prefix_list_type_EXC": {
         "exception_message": {
@@ -923,7 +923,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_int_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:20",
+    "recorded-date": "05-12-2024, 18:01:01",
     "recorded-content": {
       "content_anything_prefix_int_EXC": {
         "exception_message": {
@@ -942,7 +942,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_list_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:03",
+    "recorded-date": "05-12-2024, 18:00:44",
     "recorded-content": {
       "content_prefix_list_EXC": {
         "exception_message": {
@@ -961,7 +961,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_int_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:10",
+    "recorded-date": "05-12-2024, 18:00:51",
     "recorded-content": {
       "content_prefix_int_EXC": {
         "exception_message": {
@@ -980,7 +980,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_int_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:14",
+    "recorded-date": "05-12-2024, 18:00:55",
     "recorded-content": {
       "content_suffix_int_EXC": {
         "exception_message": {
@@ -999,7 +999,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_list_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:18",
+    "recorded-date": "05-12-2024, 18:01:00",
     "recorded-content": {
       "content_suffix_list_EXC": {
         "exception_message": {
@@ -1018,7 +1018,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_ignorecase_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:13",
+    "recorded-date": "05-12-2024, 18:00:55",
     "recorded-content": {
       "content_anything_prefix_ignorecase_EXC": {
         "exception_message": {
@@ -1037,7 +1037,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_ignorecase_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:15",
+    "recorded-date": "05-12-2024, 18:00:57",
     "recorded-content": {
       "content_anything_suffix_ignorecase_EXC": {
         "exception_message": {
@@ -1056,7 +1056,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_mask_EXC]": {
-    "recorded-date": "05-12-2024, 17:58:59",
+    "recorded-date": "05-12-2024, 18:00:41",
     "recorded-content": {
       "content_ip_address_bad_mask_EXC": {
         "exception_message": {
@@ -1075,15 +1075,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:04",
+    "recorded-date": "05-12-2024, 18:00:45",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6]": {
-    "recorded-date": "05-12-2024, 17:59:05",
+    "recorded-date": "05-12-2024, 18:00:47",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_ip_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:12",
+    "recorded-date": "05-12-2024, 18:00:53",
     "recorded-content": {
       "content_ip_address_bad_ip_EXC": {
         "exception_message": {
@@ -1102,7 +1102,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_type_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:19",
+    "recorded-date": "05-12-2024, 18:01:00",
     "recorded-content": {
       "content_ip_address_type_EXC": {
         "exception_message": {
@@ -1121,7 +1121,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_bad_ip_EXC]": {
-    "recorded-date": "05-12-2024, 17:59:20",
+    "recorded-date": "05-12-2024, 18:01:02",
     "recorded-content": {
       "content_ip_address_v6_bad_ip_EXC": {
         "exception_message": {
@@ -1144,7 +1144,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_list_empty_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:00",
+    "recorded-date": "05-12-2024, 18:00:41",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_plain_string_payload": {
@@ -1163,15 +1163,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-numeric-anything-but_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:03",
+    "recorded-date": "05-12-2024, 18:00:44",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-numeric-anything-but]": {
-    "recorded-date": "05-12-2024, 17:59:17",
+    "recorded-date": "05-12-2024, 18:00:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-string_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:09",
+    "recorded-date": "05-12-2024, 18:00:50",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_event_payload": {
@@ -1190,7 +1190,11 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-null_NEG]": {
-    "recorded-date": "05-12-2024, 17:59:15",
+    "recorded-date": "05-12-2024, 18:00:57",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-int-float]": {
+    "recorded-date": "05-12-2024, 18:00:51",
     "recorded-content": {}
   }
 }

--- a/tests/aws/services/events/test_events_patterns.snapshot.json
+++ b/tests/aws/services/events/test_events_patterns.snapshot.json
@@ -1,22 +1,22 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "recorded-date": "03-12-2024, 22:27:17",
+    "recorded-date": "05-12-2024, 17:44:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "recorded-date": "03-12-2024, 22:27:17",
+    "recorded-date": "05-12-2024, 17:44:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:17",
+    "recorded-date": "05-12-2024, 17:44:30",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "recorded-date": "03-12-2024, 22:27:18",
+    "recorded-date": "05-12-2024, 17:44:31",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:18",
+    "recorded-date": "05-12-2024, 17:44:31",
     "recorded-content": {
       "int_nolist_EXC": {
         "exception_message": {
@@ -35,39 +35,39 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "recorded-date": "03-12-2024, 22:27:19",
+    "recorded-date": "05-12-2024, 17:44:32",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:19",
+    "recorded-date": "05-12-2024, 17:44:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:19",
+    "recorded-date": "05-12-2024, 17:44:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "recorded-date": "03-12-2024, 22:27:20",
+    "recorded-date": "05-12-2024, 17:44:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "recorded-date": "03-12-2024, 22:27:20",
+    "recorded-date": "05-12-2024, 17:44:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "recorded-date": "03-12-2024, 22:27:20",
+    "recorded-date": "05-12-2024, 17:44:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:21",
+    "recorded-date": "05-12-2024, 17:44:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "recorded-date": "03-12-2024, 22:27:21",
+    "recorded-date": "05-12-2024, 17:44:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:21",
+    "recorded-date": "05-12-2024, 17:44:34",
     "recorded-content": {
       "content_numeric_operatorcasing_EXC": {
         "exception_message": {
@@ -86,19 +86,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:21",
+    "recorded-date": "05-12-2024, 17:44:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "recorded-date": "03-12-2024, 22:27:22",
+    "recorded-date": "05-12-2024, 17:44:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:22",
+    "recorded-date": "05-12-2024, 17:44:35",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:22",
+    "recorded-date": "05-12-2024, 17:44:35",
     "recorded-content": {
       "string_nolist_EXC": {
         "exception_message": {
@@ -117,27 +117,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:23",
+    "recorded-date": "05-12-2024, 17:44:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:23",
+    "recorded-date": "05-12-2024, 17:44:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:23",
+    "recorded-date": "05-12-2024, 17:44:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "recorded-date": "03-12-2024, 22:27:23",
+    "recorded-date": "05-12-2024, 17:44:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "recorded-date": "03-12-2024, 22:27:23",
+    "recorded-date": "05-12-2024, 17:44:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:23",
+    "recorded-date": "05-12-2024, 17:44:37",
     "recorded-content": {
       "arrays_empty_EXC": {
         "exception_message": {
@@ -156,55 +156,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:23",
+    "recorded-date": "05-12-2024, 17:44:37",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "recorded-date": "03-12-2024, 22:27:24",
+    "recorded-date": "05-12-2024, 17:44:37",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "recorded-date": "03-12-2024, 22:27:24",
+    "recorded-date": "05-12-2024, 17:44:37",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "recorded-date": "03-12-2024, 22:27:24",
+    "recorded-date": "05-12-2024, 17:44:37",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "recorded-date": "03-12-2024, 22:27:24",
+    "recorded-date": "05-12-2024, 17:44:38",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "recorded-date": "03-12-2024, 22:27:24",
+    "recorded-date": "05-12-2024, 17:44:38",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "recorded-date": "03-12-2024, 22:27:24",
+    "recorded-date": "05-12-2024, 17:44:38",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "recorded-date": "03-12-2024, 22:27:25",
+    "recorded-date": "05-12-2024, 17:44:38",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "recorded-date": "03-12-2024, 22:27:25",
+    "recorded-date": "05-12-2024, 17:44:38",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "recorded-date": "03-12-2024, 22:27:25",
+    "recorded-date": "05-12-2024, 17:44:39",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:26",
+    "recorded-date": "05-12-2024, 17:44:39",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:26",
+    "recorded-date": "05-12-2024, 17:44:39",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:26",
+    "recorded-date": "05-12-2024, 17:44:40",
     "recorded-content": {
       "operator_case_sensitive_EXC": {
         "exception_message": {
@@ -223,15 +223,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "recorded-date": "03-12-2024, 22:27:27",
+    "recorded-date": "05-12-2024, 17:44:40",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:27",
+    "recorded-date": "05-12-2024, 17:44:40",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:28",
+    "recorded-date": "05-12-2024, 17:44:41",
     "recorded-content": {
       "content_numeric_EXC": {
         "exception_message": {
@@ -250,87 +250,87 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:28",
+    "recorded-date": "05-12-2024, 17:44:41",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "recorded-date": "03-12-2024, 22:27:28",
+    "recorded-date": "05-12-2024, 17:44:41",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:29",
+    "recorded-date": "05-12-2024, 17:44:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "recorded-date": "03-12-2024, 22:27:29",
+    "recorded-date": "05-12-2024, 17:44:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:29",
+    "recorded-date": "05-12-2024, 17:44:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "recorded-date": "03-12-2024, 22:27:29",
+    "recorded-date": "05-12-2024, 17:44:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "recorded-date": "03-12-2024, 22:27:29",
+    "recorded-date": "05-12-2024, 17:44:42",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:29",
+    "recorded-date": "05-12-2024, 17:44:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:29",
+    "recorded-date": "05-12-2024, 17:44:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "recorded-date": "03-12-2024, 22:27:29",
+    "recorded-date": "05-12-2024, 17:44:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "recorded-date": "03-12-2024, 22:27:30",
+    "recorded-date": "05-12-2024, 17:44:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:30",
+    "recorded-date": "05-12-2024, 17:44:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:30",
+    "recorded-date": "05-12-2024, 17:44:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "recorded-date": "03-12-2024, 22:27:30",
+    "recorded-date": "05-12-2024, 17:44:44",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "recorded-date": "03-12-2024, 22:27:31",
+    "recorded-date": "05-12-2024, 17:44:44",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "recorded-date": "03-12-2024, 22:27:31",
+    "recorded-date": "05-12-2024, 17:44:45",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:31",
+    "recorded-date": "05-12-2024, 17:44:45",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "recorded-date": "03-12-2024, 22:27:31",
+    "recorded-date": "05-12-2024, 17:44:45",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:31",
+    "recorded-date": "05-12-2024, 17:44:45",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:32",
+    "recorded-date": "05-12-2024, 17:44:46",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:32",
+    "recorded-date": "05-12-2024, 17:44:46",
     "recorded-content": {
       "content_wildcard_complex_EXC": {
         "exception_message": {
@@ -349,55 +349,55 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:34",
+    "recorded-date": "05-12-2024, 17:44:47",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "recorded-date": "03-12-2024, 22:27:35",
+    "recorded-date": "05-12-2024, 17:44:48",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:35",
+    "recorded-date": "05-12-2024, 17:44:48",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "recorded-date": "03-12-2024, 22:27:35",
+    "recorded-date": "05-12-2024, 17:44:48",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "recorded-date": "03-12-2024, 22:27:36",
+    "recorded-date": "05-12-2024, 17:44:50",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "recorded-date": "03-12-2024, 22:27:37",
+    "recorded-date": "05-12-2024, 17:44:50",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:37",
+    "recorded-date": "05-12-2024, 17:44:51",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "recorded-date": "03-12-2024, 22:27:37",
+    "recorded-date": "05-12-2024, 17:44:51",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:39",
+    "recorded-date": "05-12-2024, 17:44:52",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "recorded-date": "03-12-2024, 22:27:39",
+    "recorded-date": "05-12-2024, 17:44:52",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:39",
+    "recorded-date": "05-12-2024, 17:44:52",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:39",
+    "recorded-date": "05-12-2024, 17:44:53",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:39",
+    "recorded-date": "05-12-2024, 17:44:53",
     "recorded-content": {
       "content_numeric_syntax_EXC": {
         "exception_message": {
@@ -416,19 +416,19 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "recorded-date": "03-12-2024, 22:27:40",
+    "recorded-date": "05-12-2024, 17:44:53",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "recorded-date": "03-12-2024, 22:27:40",
+    "recorded-date": "05-12-2024, 17:44:53",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "recorded-date": "03-12-2024, 22:27:40",
+    "recorded-date": "05-12-2024, 17:44:53",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "recorded-date": "03-12-2024, 22:27:40",
+    "recorded-date": "05-12-2024, 17:44:53",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
@@ -580,7 +580,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:20",
+    "recorded-date": "05-12-2024, 17:44:33",
     "recorded-content": {
       "content_wildcard_repeating_star_EXC": {
         "exception_message": {
@@ -599,7 +599,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:25",
+    "recorded-date": "05-12-2024, 17:44:39",
     "recorded-content": {
       "content_ignorecase_EXC": {
         "exception_message": {
@@ -618,7 +618,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:36",
+    "recorded-date": "05-12-2024, 17:44:49",
     "recorded-content": {
       "content_ip_address_EXC": {
         "exception_message": {
@@ -637,7 +637,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:27",
+    "recorded-date": "05-12-2024, 17:44:40",
     "recorded-content": {
       "content_anything_but_ignorecase_EXC": {
         "exception_message": {
@@ -656,7 +656,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:31",
+    "recorded-date": "05-12-2024, 17:44:44",
     "recorded-content": {
       "content_anything_but_ignorecase_list_EXC": {
         "exception_message": {
@@ -675,7 +675,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:33",
+    "recorded-date": "05-12-2024, 17:44:47",
     "recorded-content": {
       "content_ignorecase_list_EXC": {
         "exception_message": {
@@ -754,27 +754,27 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
-    "recorded-date": "03-12-2024, 22:27:27",
+    "recorded-date": "05-12-2024, 17:44:41",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:19",
+    "recorded-date": "05-12-2024, 17:44:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list]": {
-    "recorded-date": "03-12-2024, 22:27:21",
+    "recorded-date": "05-12-2024, 17:44:34",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:25",
+    "recorded-date": "05-12-2024, 17:44:39",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard]": {
-    "recorded-date": "03-12-2024, 22:27:36",
+    "recorded-date": "05-12-2024, 17:44:49",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_int_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:35",
+    "recorded-date": "05-12-2024, 17:44:49",
     "recorded-content": {
       "content_wildcard_int_EXC": {
         "exception_message": {
@@ -793,7 +793,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_list_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:38",
+    "recorded-date": "05-12-2024, 17:44:51",
     "recorded-content": {
       "content_wildcard_list_EXC": {
         "exception_message": {
@@ -812,7 +812,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_type_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:19",
+    "recorded-date": "05-12-2024, 17:44:32",
     "recorded-content": {
       "content_anything_wildcard_list_type_EXC": {
         "exception_message": {
@@ -831,7 +831,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_type_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:34",
+    "recorded-date": "05-12-2024, 17:44:48",
     "recorded-content": {
       "content_anything_wildcard_type_EXC": {
         "exception_message": {
@@ -850,7 +850,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_type_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:17",
+    "recorded-date": "05-12-2024, 17:44:30",
     "recorded-content": {
       "content_anything_suffix_list_type_EXC": {
         "exception_message": {
@@ -869,15 +869,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list]": {
-    "recorded-date": "03-12-2024, 22:27:20",
+    "recorded-date": "05-12-2024, 17:44:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:20",
+    "recorded-date": "05-12-2024, 17:44:33",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_int_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:25",
+    "recorded-date": "05-12-2024, 17:44:38",
     "recorded-content": {
       "content_anything_suffix_int_EXC": {
         "exception_message": {
@@ -896,15 +896,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list]": {
-    "recorded-date": "03-12-2024, 22:27:29",
+    "recorded-date": "05-12-2024, 17:44:43",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:33",
+    "recorded-date": "05-12-2024, 17:44:46",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_type_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:35",
+    "recorded-date": "05-12-2024, 17:44:48",
     "recorded-content": {
       "content_anything_prefix_list_type_EXC": {
         "exception_message": {
@@ -923,7 +923,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_int_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:38",
+    "recorded-date": "05-12-2024, 17:44:51",
     "recorded-content": {
       "content_anything_prefix_int_EXC": {
         "exception_message": {
@@ -942,7 +942,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_list_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:21",
+    "recorded-date": "05-12-2024, 17:44:35",
     "recorded-content": {
       "content_prefix_list_EXC": {
         "exception_message": {
@@ -961,7 +961,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_int_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:28",
+    "recorded-date": "05-12-2024, 17:44:42",
     "recorded-content": {
       "content_prefix_int_EXC": {
         "exception_message": {
@@ -980,7 +980,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_int_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:32",
+    "recorded-date": "05-12-2024, 17:44:46",
     "recorded-content": {
       "content_suffix_int_EXC": {
         "exception_message": {
@@ -999,7 +999,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_list_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:36",
+    "recorded-date": "05-12-2024, 17:44:50",
     "recorded-content": {
       "content_suffix_list_EXC": {
         "exception_message": {
@@ -1018,7 +1018,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_ignorecase_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:32",
+    "recorded-date": "05-12-2024, 17:44:45",
     "recorded-content": {
       "content_anything_prefix_ignorecase_EXC": {
         "exception_message": {
@@ -1037,7 +1037,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_ignorecase_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:33",
+    "recorded-date": "05-12-2024, 17:44:47",
     "recorded-content": {
       "content_anything_suffix_ignorecase_EXC": {
         "exception_message": {
@@ -1056,7 +1056,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_mask_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:18",
+    "recorded-date": "05-12-2024, 17:44:31",
     "recorded-content": {
       "content_ip_address_bad_mask_EXC": {
         "exception_message": {
@@ -1075,15 +1075,15 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_NEG]": {
-    "recorded-date": "03-12-2024, 22:27:22",
+    "recorded-date": "05-12-2024, 17:44:36",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6]": {
-    "recorded-date": "03-12-2024, 22:27:24",
+    "recorded-date": "05-12-2024, 17:44:37",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_ip_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:30",
+    "recorded-date": "05-12-2024, 17:44:43",
     "recorded-content": {
       "content_ip_address_bad_ip_EXC": {
         "exception_message": {
@@ -1102,7 +1102,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_type_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:37",
+    "recorded-date": "05-12-2024, 17:44:50",
     "recorded-content": {
       "content_ip_address_type_EXC": {
         "exception_message": {
@@ -1121,7 +1121,7 @@
     }
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_bad_ip_EXC]": {
-    "recorded-date": "03-12-2024, 22:27:39",
+    "recorded-date": "05-12-2024, 17:44:52",
     "recorded-content": {
       "content_ip_address_v6_bad_ip_EXC": {
         "exception_message": {
@@ -1144,7 +1144,49 @@
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_list_empty_NEG]": {
-    "recorded-date": "29-11-2024, 21:46:55",
+    "recorded-date": "05-12-2024, 17:44:32",
     "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_plain_string_payload": {
+    "recorded-date": "05-12-2024, 16:59:10",
+    "recorded-content": {
+      "plain-string-payload-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Parameter Event is not valid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-numeric-anything-but_NEG]": {
+    "recorded-date": "05-12-2024, 17:44:35",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-numeric-anything-but]": {
+    "recorded-date": "05-12-2024, 17:44:48",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-string_NEG]": {
+    "recorded-date": "05-12-2024, 17:44:41",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_event_payload": {
+    "recorded-date": "05-12-2024, 17:44:17",
+    "recorded-content": {
+      "plain-string-payload-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Parameter Event is not valid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events_patterns.snapshot.json
+++ b/tests/aws/services/events/test_events_patterns.snapshot.json
@@ -1196,5 +1196,20 @@
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-int-float]": {
     "recorded-date": "05-12-2024, 18:00:51",
     "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_array_event_payload": {
+    "recorded-date": "06-12-2024, 09:49:56",
+    "recorded-content": {
+      "array-event-payload-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Parameter Event is not valid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events_patterns.validation.json
+++ b/tests/aws/services/events/test_events_patterns.validation.json
@@ -1,342 +1,354 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "last_validated_date": "2024-12-03T22:27:19+00:00"
+    "last_validated_date": "2024-12-05T17:44:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:39+00:00"
+    "last_validated_date": "2024-12-05T17:44:52+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:23+00:00"
+    "last_validated_date": "2024-12-05T17:44:37+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:31+00:00"
+    "last_validated_date": "2024-12-05T17:44:45+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "last_validated_date": "2024-12-03T22:27:40+00:00"
+    "last_validated_date": "2024-12-05T17:44:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:23+00:00"
+    "last_validated_date": "2024-12-05T17:44:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "last_validated_date": "2024-12-03T22:27:25+00:00"
+    "last_validated_date": "2024-12-05T17:44:38+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "last_validated_date": "2024-12-03T22:27:18+00:00"
+    "last_validated_date": "2024-12-05T17:44:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:21+00:00"
+    "last_validated_date": "2024-12-05T17:44:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "last_validated_date": "2024-12-03T22:27:28+00:00"
+    "last_validated_date": "2024-12-05T17:44:41+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:28+00:00"
+    "last_validated_date": "2024-12-05T17:44:41+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "last_validated_date": "2024-12-03T22:27:24+00:00"
+    "last_validated_date": "2024-12-05T17:44:38+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:27+00:00"
+    "last_validated_date": "2024-12-05T17:44:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:37+00:00"
+    "last_validated_date": "2024-12-05T17:44:51+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "last_validated_date": "2024-12-03T22:27:31+00:00"
+    "last_validated_date": "2024-12-05T17:44:45+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:31+00:00"
+    "last_validated_date": "2024-12-05T17:44:44+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:19+00:00"
+    "last_validated_date": "2024-12-05T17:44:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "last_validated_date": "2024-12-03T22:27:40+00:00"
+    "last_validated_date": "2024-12-05T17:44:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:26+00:00"
+    "last_validated_date": "2024-12-05T17:44:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "last_validated_date": "2024-12-03T22:27:25+00:00"
+    "last_validated_date": "2024-12-05T17:44:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:21+00:00"
+    "last_validated_date": "2024-12-05T17:44:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "last_validated_date": "2024-12-03T22:27:21+00:00"
+    "last_validated_date": "2024-12-05T17:44:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:23+00:00"
+    "last_validated_date": "2024-12-05T17:44:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "last_validated_date": "2024-12-03T22:27:24+00:00"
+    "last_validated_date": "2024-12-05T17:44:37+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:34+00:00"
+    "last_validated_date": "2024-12-05T17:44:47+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
-    "last_validated_date": "2024-12-03T22:27:27+00:00"
+    "last_validated_date": "2024-12-05T17:44:41+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "last_validated_date": "2024-12-03T22:27:29+00:00"
+    "last_validated_date": "2024-12-05T17:44:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:22+00:00"
+    "last_validated_date": "2024-12-05T17:44:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_ignorecase_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:32+00:00"
+    "last_validated_date": "2024-12-05T17:44:45+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_int_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:38+00:00"
+    "last_validated_date": "2024-12-05T17:44:51+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list]": {
-    "last_validated_date": "2024-12-03T22:27:20+00:00"
+    "last_validated_date": "2024-12-05T17:44:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:20+00:00"
+    "last_validated_date": "2024-12-05T17:44:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_type_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:35+00:00"
+    "last_validated_date": "2024-12-05T17:44:48+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "last_validated_date": "2024-12-03T22:27:31+00:00"
+    "last_validated_date": "2024-12-05T17:44:44+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:29+00:00"
+    "last_validated_date": "2024-12-05T17:44:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_ignorecase_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:33+00:00"
+    "last_validated_date": "2024-12-05T17:44:47+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_int_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:25+00:00"
+    "last_validated_date": "2024-12-05T17:44:38+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list]": {
-    "last_validated_date": "2024-12-03T22:27:29+00:00"
+    "last_validated_date": "2024-12-05T17:44:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:33+00:00"
+    "last_validated_date": "2024-12-05T17:44:46+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_type_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:17+00:00"
+    "last_validated_date": "2024-12-05T17:44:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard]": {
-    "last_validated_date": "2024-12-03T22:27:36+00:00"
+    "last_validated_date": "2024-12-05T17:44:49+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:19+00:00"
+    "last_validated_date": "2024-12-05T17:44:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list]": {
-    "last_validated_date": "2024-12-03T22:27:21+00:00"
+    "last_validated_date": "2024-12-05T17:44:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:25+00:00"
+    "last_validated_date": "2024-12-05T17:44:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_type_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:19+00:00"
+    "last_validated_date": "2024-12-05T17:44:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_type_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:34+00:00"
+    "last_validated_date": "2024-12-05T17:44:48+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "last_validated_date": "2024-12-03T22:27:27+00:00"
+    "last_validated_date": "2024-12-05T17:44:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:39+00:00"
+    "last_validated_date": "2024-12-05T17:44:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "last_validated_date": "2024-12-03T22:27:36+00:00"
+    "last_validated_date": "2024-12-05T17:44:50+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:39+00:00"
+    "last_validated_date": "2024-12-05T17:44:52+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "last_validated_date": "2024-12-03T22:27:39+00:00"
+    "last_validated_date": "2024-12-05T17:44:52+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:25+00:00"
+    "last_validated_date": "2024-12-05T17:44:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:35+00:00"
+    "last_validated_date": "2024-12-05T17:44:48+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:33+00:00"
+    "last_validated_date": "2024-12-05T17:44:47+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "last_validated_date": "2024-12-03T22:27:22+00:00"
+    "last_validated_date": "2024-12-05T17:44:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:36+00:00"
+    "last_validated_date": "2024-12-05T17:44:49+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:27+00:00"
+    "last_validated_date": "2024-12-05T17:44:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_ip_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:30+00:00"
+    "last_validated_date": "2024-12-05T17:44:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_mask_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:18+00:00"
+    "last_validated_date": "2024-12-05T17:44:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_type_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:37+00:00"
+    "last_validated_date": "2024-12-05T17:44:50+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6]": {
-    "last_validated_date": "2024-12-03T22:27:24+00:00"
+    "last_validated_date": "2024-12-05T17:44:37+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:22+00:00"
+    "last_validated_date": "2024-12-05T17:44:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_bad_ip_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:39+00:00"
+    "last_validated_date": "2024-12-05T17:44:52+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:28+00:00"
+    "last_validated_date": "2024-12-05T17:44:41+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "last_validated_date": "2024-12-03T22:27:40+00:00"
+    "last_validated_date": "2024-12-05T17:44:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:29+00:00"
+    "last_validated_date": "2024-12-05T17:44:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:21+00:00"
+    "last_validated_date": "2024-12-05T17:44:34+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:39+00:00"
+    "last_validated_date": "2024-12-05T17:44:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "last_validated_date": "2024-12-03T22:27:35+00:00"
+    "last_validated_date": "2024-12-05T17:44:48+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:31+00:00"
+    "last_validated_date": "2024-12-05T17:44:45+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "last_validated_date": "2024-12-03T22:27:29+00:00"
+    "last_validated_date": "2024-12-05T17:44:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_int_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:28+00:00"
+    "last_validated_date": "2024-12-05T17:44:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_list_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:21+00:00"
+    "last_validated_date": "2024-12-05T17:44:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "last_validated_date": "2024-12-03T22:27:37+00:00"
+    "last_validated_date": "2024-12-05T17:44:51+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:17+00:00"
+    "last_validated_date": "2024-12-05T17:44:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "last_validated_date": "2024-12-03T22:27:29+00:00"
+    "last_validated_date": "2024-12-05T17:44:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:32+00:00"
+    "last_validated_date": "2024-12-05T17:44:46+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_int_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:32+00:00"
+    "last_validated_date": "2024-12-05T17:44:46+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_list_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:36+00:00"
+    "last_validated_date": "2024-12-05T17:44:50+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:32+00:00"
+    "last_validated_date": "2024-12-05T17:44:46+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_int_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:35+00:00"
+    "last_validated_date": "2024-12-05T17:44:49+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_list_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:38+00:00"
+    "last_validated_date": "2024-12-05T17:44:51+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "last_validated_date": "2024-12-03T22:27:20+00:00"
+    "last_validated_date": "2024-12-05T17:44:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:26+00:00"
+    "last_validated_date": "2024-12-05T17:44:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "last_validated_date": "2024-12-03T22:27:17+00:00"
+    "last_validated_date": "2024-12-05T17:44:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:19+00:00"
+    "last_validated_date": "2024-12-05T17:44:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:20+00:00"
+    "last_validated_date": "2024-12-05T17:44:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "last_validated_date": "2024-12-03T22:27:20+00:00"
+    "last_validated_date": "2024-12-05T17:44:33+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "last_validated_date": "2024-12-03T22:27:29+00:00"
+    "last_validated_date": "2024-12-05T17:44:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:30+00:00"
+    "last_validated_date": "2024-12-05T17:44:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "last_validated_date": "2024-12-03T22:27:24+00:00"
+    "last_validated_date": "2024-12-05T17:44:37+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:29+00:00"
+    "last_validated_date": "2024-12-05T17:44:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "last_validated_date": "2024-12-03T22:27:24+00:00"
+    "last_validated_date": "2024-12-05T17:44:38+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "last_validated_date": "2024-12-03T22:27:23+00:00"
+    "last_validated_date": "2024-12-05T17:44:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:23+00:00"
+    "last_validated_date": "2024-12-05T17:44:36+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_list_empty_NEG]": {
+    "last_validated_date": "2024-12-05T17:44:32+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:18+00:00"
+    "last_validated_date": "2024-12-05T17:44:31+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:30+00:00"
+    "last_validated_date": "2024-12-05T17:44:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "last_validated_date": "2024-12-03T22:27:17+00:00"
+    "last_validated_date": "2024-12-05T17:44:30+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "last_validated_date": "2024-12-03T22:27:35+00:00"
+    "last_validated_date": "2024-12-05T17:44:48+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:23+00:00"
+    "last_validated_date": "2024-12-05T17:44:37+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "last_validated_date": "2024-12-03T22:27:25+00:00"
+    "last_validated_date": "2024-12-05T17:44:38+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "last_validated_date": "2024-12-03T22:27:29+00:00"
+    "last_validated_date": "2024-12-05T17:44:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "last_validated_date": "2024-12-03T22:27:37+00:00"
+    "last_validated_date": "2024-12-05T17:44:50+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-string_NEG]": {
+    "last_validated_date": "2024-12-05T17:44:41+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:26+00:00"
+    "last_validated_date": "2024-12-05T17:44:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "last_validated_date": "2024-12-03T22:27:24+00:00"
+    "last_validated_date": "2024-12-05T17:44:37+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "last_validated_date": "2024-12-03T22:27:40+00:00"
+    "last_validated_date": "2024-12-05T17:44:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "last_validated_date": "2024-12-03T22:27:23+00:00"
+    "last_validated_date": "2024-12-05T17:44:36+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "last_validated_date": "2024-12-03T22:27:20+00:00"
+    "last_validated_date": "2024-12-05T17:44:33+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-numeric-anything-but]": {
+    "last_validated_date": "2024-12-05T17:44:48+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-numeric-anything-but_NEG]": {
+    "last_validated_date": "2024-12-05T17:44:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "last_validated_date": "2024-12-03T22:27:30+00:00"
+    "last_validated_date": "2024-12-05T17:44:44+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "last_validated_date": "2024-12-03T22:27:30+00:00"
+    "last_validated_date": "2024-12-05T17:44:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "last_validated_date": "2024-12-03T22:27:31+00:00"
+    "last_validated_date": "2024-12-05T17:44:45+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "last_validated_date": "2024-12-03T22:27:24+00:00"
+    "last_validated_date": "2024-12-05T17:44:38+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "last_validated_date": "2024-12-03T22:27:22+00:00"
+    "last_validated_date": "2024-12-05T17:44:35+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
     "last_validated_date": "2024-07-11T13:55:39+00:00"
@@ -346,6 +358,9 @@
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_with_multi_key": {
     "last_validated_date": "2024-07-11T13:55:38+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_event_payload": {
+    "last_validated_date": "2024-12-05T17:44:17+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_json_event_pattern[[\"not\", \"a\", \"dict\", \"but valid json\"]]": {
     "last_validated_date": "2024-11-29T00:19:33+00:00"
@@ -358,6 +373,9 @@
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_invalid_json_event_pattern[{'bad': 'quotation'}]": {
     "last_validated_date": "2024-11-29T00:19:32+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_plain_string_payload": {
+    "last_validated_date": "2024-12-05T16:59:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestRuleWithPattern::test_put_event_with_content_base_rule_in_pattern": {
     "last_validated_date": "2024-07-11T14:14:42+00:00"

--- a/tests/aws/services/events/test_events_patterns.validation.json
+++ b/tests/aws/services/events/test_events_patterns.validation.json
@@ -1,357 +1,360 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "last_validated_date": "2024-12-05T17:59:00+00:00"
+    "last_validated_date": "2024-12-05T18:00:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:20+00:00"
+    "last_validated_date": "2024-12-05T18:01:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:05+00:00"
+    "last_validated_date": "2024-12-05T18:00:46+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:13+00:00"
+    "last_validated_date": "2024-12-05T18:00:55+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "last_validated_date": "2024-12-05T17:59:22+00:00"
+    "last_validated_date": "2024-12-05T18:01:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:04+00:00"
+    "last_validated_date": "2024-12-05T18:00:46+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "last_validated_date": "2024-12-05T17:59:06+00:00"
+    "last_validated_date": "2024-12-05T18:00:47+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "last_validated_date": "2024-12-05T17:58:59+00:00"
+    "last_validated_date": "2024-12-05T18:00:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:02+00:00"
+    "last_validated_date": "2024-12-05T18:00:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "last_validated_date": "2024-12-05T17:59:09+00:00"
+    "last_validated_date": "2024-12-05T18:00:51+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:09+00:00"
+    "last_validated_date": "2024-12-05T18:00:51+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "last_validated_date": "2024-12-05T17:59:06+00:00"
+    "last_validated_date": "2024-12-05T18:00:47+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:08+00:00"
+    "last_validated_date": "2024-12-05T18:00:50+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:19+00:00"
+    "last_validated_date": "2024-12-05T18:01:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "last_validated_date": "2024-12-05T17:59:13+00:00"
+    "last_validated_date": "2024-12-05T18:00:54+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:12+00:00"
+    "last_validated_date": "2024-12-05T18:00:54+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:01+00:00"
+    "last_validated_date": "2024-12-05T18:00:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "last_validated_date": "2024-12-05T17:59:22+00:00"
+    "last_validated_date": "2024-12-05T18:01:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:07+00:00"
+    "last_validated_date": "2024-12-05T18:00:49+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "last_validated_date": "2024-12-05T17:59:07+00:00"
+    "last_validated_date": "2024-12-05T18:00:48+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:03+00:00"
+    "last_validated_date": "2024-12-05T18:00:44+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "last_validated_date": "2024-12-05T17:59:02+00:00"
+    "last_validated_date": "2024-12-05T18:00:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:04+00:00"
+    "last_validated_date": "2024-12-05T18:00:45+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "last_validated_date": "2024-12-05T17:59:06+00:00"
+    "last_validated_date": "2024-12-05T18:00:47+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:16+00:00"
+    "last_validated_date": "2024-12-05T18:00:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
-    "last_validated_date": "2024-12-05T17:59:09+00:00"
+    "last_validated_date": "2024-12-05T18:00:50+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "last_validated_date": "2024-12-05T17:59:11+00:00"
+    "last_validated_date": "2024-12-05T18:00:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:04+00:00"
+    "last_validated_date": "2024-12-05T18:00:45+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_ignorecase_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:13+00:00"
+    "last_validated_date": "2024-12-05T18:00:55+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_int_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:19+00:00"
+    "last_validated_date": "2024-12-05T18:01:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list]": {
-    "last_validated_date": "2024-12-05T17:59:01+00:00"
+    "last_validated_date": "2024-12-05T18:00:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:01+00:00"
+    "last_validated_date": "2024-12-05T18:00:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_type_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:17+00:00"
+    "last_validated_date": "2024-12-05T18:00:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "last_validated_date": "2024-12-05T17:59:12+00:00"
+    "last_validated_date": "2024-12-05T18:00:54+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:10+00:00"
+    "last_validated_date": "2024-12-05T18:00:52+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_ignorecase_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:15+00:00"
+    "last_validated_date": "2024-12-05T18:00:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_int_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:06+00:00"
+    "last_validated_date": "2024-12-05T18:00:47+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list]": {
-    "last_validated_date": "2024-12-05T17:59:11+00:00"
+    "last_validated_date": "2024-12-05T18:00:52+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:15+00:00"
+    "last_validated_date": "2024-12-05T18:00:56+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_type_EXC]": {
-    "last_validated_date": "2024-12-05T17:58:58+00:00"
+    "last_validated_date": "2024-12-05T18:00:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard]": {
-    "last_validated_date": "2024-12-05T17:59:18+00:00"
+    "last_validated_date": "2024-12-05T18:00:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:01+00:00"
+    "last_validated_date": "2024-12-05T18:00:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list]": {
-    "last_validated_date": "2024-12-05T17:59:02+00:00"
+    "last_validated_date": "2024-12-05T18:00:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:07+00:00"
+    "last_validated_date": "2024-12-05T18:00:48+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_type_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:00+00:00"
+    "last_validated_date": "2024-12-05T18:00:41+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_type_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:16+00:00"
+    "last_validated_date": "2024-12-05T18:00:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "last_validated_date": "2024-12-05T17:59:08+00:00"
+    "last_validated_date": "2024-12-05T18:00:49+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:21+00:00"
+    "last_validated_date": "2024-12-05T18:01:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "last_validated_date": "2024-12-05T17:59:18+00:00"
+    "last_validated_date": "2024-12-05T18:01:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:21+00:00"
+    "last_validated_date": "2024-12-05T18:01:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "last_validated_date": "2024-12-05T17:59:21+00:00"
+    "last_validated_date": "2024-12-05T18:01:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:07+00:00"
+    "last_validated_date": "2024-12-05T18:00:48+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:16+00:00"
+    "last_validated_date": "2024-12-05T18:00:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:15+00:00"
+    "last_validated_date": "2024-12-05T18:00:56+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "last_validated_date": "2024-12-05T17:59:03+00:00"
+    "last_validated_date": "2024-12-05T18:00:44+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:18+00:00"
+    "last_validated_date": "2024-12-05T18:00:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:08+00:00"
+    "last_validated_date": "2024-12-05T18:00:50+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_ip_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:12+00:00"
+    "last_validated_date": "2024-12-05T18:00:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_mask_EXC]": {
-    "last_validated_date": "2024-12-05T17:58:59+00:00"
+    "last_validated_date": "2024-12-05T18:00:41+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_type_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:19+00:00"
+    "last_validated_date": "2024-12-05T18:01:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6]": {
-    "last_validated_date": "2024-12-05T17:59:05+00:00"
+    "last_validated_date": "2024-12-05T18:00:47+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:04+00:00"
+    "last_validated_date": "2024-12-05T18:00:45+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_bad_ip_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:20+00:00"
+    "last_validated_date": "2024-12-05T18:01:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:09+00:00"
+    "last_validated_date": "2024-12-05T18:00:50+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "last_validated_date": "2024-12-05T17:59:22+00:00"
+    "last_validated_date": "2024-12-05T18:01:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:10+00:00"
+    "last_validated_date": "2024-12-05T18:00:52+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:02+00:00"
+    "last_validated_date": "2024-12-05T18:00:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:21+00:00"
+    "last_validated_date": "2024-12-05T18:01:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "last_validated_date": "2024-12-05T17:59:16+00:00"
+    "last_validated_date": "2024-12-05T18:00:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:13+00:00"
+    "last_validated_date": "2024-12-05T18:00:54+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "last_validated_date": "2024-12-05T17:59:10+00:00"
+    "last_validated_date": "2024-12-05T18:00:52+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_int_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:10+00:00"
+    "last_validated_date": "2024-12-05T18:00:51+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_list_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:03+00:00"
+    "last_validated_date": "2024-12-05T18:00:44+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "last_validated_date": "2024-12-05T17:59:19+00:00"
+    "last_validated_date": "2024-12-05T18:01:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "last_validated_date": "2024-12-05T17:58:58+00:00"
+    "last_validated_date": "2024-12-05T18:00:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "last_validated_date": "2024-12-05T17:59:10+00:00"
+    "last_validated_date": "2024-12-05T18:00:52+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:14+00:00"
+    "last_validated_date": "2024-12-05T18:00:55+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_int_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:14+00:00"
+    "last_validated_date": "2024-12-05T18:00:55+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_list_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:18+00:00"
+    "last_validated_date": "2024-12-05T18:01:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:14+00:00"
+    "last_validated_date": "2024-12-05T18:00:56+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_int_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:17+00:00"
+    "last_validated_date": "2024-12-05T18:00:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_list_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:20+00:00"
+    "last_validated_date": "2024-12-05T18:01:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "last_validated_date": "2024-12-05T17:59:01+00:00"
+    "last_validated_date": "2024-12-05T18:00:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:07+00:00"
+    "last_validated_date": "2024-12-05T18:00:49+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "last_validated_date": "2024-12-05T17:58:58+00:00"
+    "last_validated_date": "2024-12-05T18:00:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:01+00:00"
+    "last_validated_date": "2024-12-05T18:00:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:01+00:00"
+    "last_validated_date": "2024-12-05T18:00:43+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "last_validated_date": "2024-12-05T17:59:01+00:00"
+    "last_validated_date": "2024-12-05T18:00:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "last_validated_date": "2024-12-05T17:59:10+00:00"
+    "last_validated_date": "2024-12-05T18:00:52+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:12+00:00"
+    "last_validated_date": "2024-12-05T18:00:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "last_validated_date": "2024-12-05T17:59:05+00:00"
+    "last_validated_date": "2024-12-05T18:00:46+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:11+00:00"
+    "last_validated_date": "2024-12-05T18:00:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "last_validated_date": "2024-12-05T17:59:06+00:00"
+    "last_validated_date": "2024-12-05T18:00:47+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "last_validated_date": "2024-12-05T17:59:05+00:00"
+    "last_validated_date": "2024-12-05T18:00:46+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:04+00:00"
+    "last_validated_date": "2024-12-05T18:00:45+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_list_empty_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:00+00:00"
+    "last_validated_date": "2024-12-05T18:00:41+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "last_validated_date": "2024-12-05T17:58:59+00:00"
+    "last_validated_date": "2024-12-05T18:00:40+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:11+00:00"
+    "last_validated_date": "2024-12-05T18:00:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "last_validated_date": "2024-12-05T17:58:58+00:00"
+    "last_validated_date": "2024-12-05T18:00:39+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "last_validated_date": "2024-12-05T17:59:16+00:00"
+    "last_validated_date": "2024-12-05T18:00:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:05+00:00"
+    "last_validated_date": "2024-12-05T18:00:46+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "last_validated_date": "2024-12-05T17:59:07+00:00"
+    "last_validated_date": "2024-12-05T18:00:48+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:11+00:00"
+    "last_validated_date": "2024-12-05T18:00:52+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "last_validated_date": "2024-12-05T17:59:19+00:00"
+    "last_validated_date": "2024-12-05T18:01:00+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-int-float]": {
+    "last_validated_date": "2024-12-05T18:00:51+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-null_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:15+00:00"
+    "last_validated_date": "2024-12-05T18:00:57+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-string_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:09+00:00"
+    "last_validated_date": "2024-12-05T18:00:50+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:08+00:00"
+    "last_validated_date": "2024-12-05T18:00:49+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "last_validated_date": "2024-12-05T17:59:05+00:00"
+    "last_validated_date": "2024-12-05T18:00:47+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "last_validated_date": "2024-12-05T17:59:22+00:00"
+    "last_validated_date": "2024-12-05T18:01:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "last_validated_date": "2024-12-05T17:59:05+00:00"
+    "last_validated_date": "2024-12-05T18:00:46+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "last_validated_date": "2024-12-05T17:59:01+00:00"
+    "last_validated_date": "2024-12-05T18:00:42+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-numeric-anything-but]": {
-    "last_validated_date": "2024-12-05T17:59:17+00:00"
+    "last_validated_date": "2024-12-05T18:00:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-numeric-anything-but_NEG]": {
-    "last_validated_date": "2024-12-05T17:59:03+00:00"
+    "last_validated_date": "2024-12-05T18:00:44+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "last_validated_date": "2024-12-05T17:59:12+00:00"
+    "last_validated_date": "2024-12-05T18:00:54+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "last_validated_date": "2024-12-05T17:59:11+00:00"
+    "last_validated_date": "2024-12-05T18:00:53+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "last_validated_date": "2024-12-05T17:59:13+00:00"
+    "last_validated_date": "2024-12-05T18:00:54+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "last_validated_date": "2024-12-05T17:59:06+00:00"
+    "last_validated_date": "2024-12-05T18:00:47+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "last_validated_date": "2024-12-05T17:59:04+00:00"
+    "last_validated_date": "2024-12-05T18:00:45+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
     "last_validated_date": "2024-07-11T13:55:39+00:00"

--- a/tests/aws/services/events/test_events_patterns.validation.json
+++ b/tests/aws/services/events/test_events_patterns.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_array_event_payload": {
+    "last_validated_date": "2024-12-06T09:49:56+00:00"
+  },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
     "last_validated_date": "2024-12-05T18:00:42+00:00"
   },

--- a/tests/aws/services/events/test_events_patterns.validation.json
+++ b/tests/aws/services/events/test_events_patterns.validation.json
@@ -1,354 +1,357 @@
 {
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays]": {
-    "last_validated_date": "2024-12-05T17:44:32+00:00"
+    "last_validated_date": "2024-12-05T17:59:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:52+00:00"
+    "last_validated_date": "2024-12-05T17:59:20+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:37+00:00"
+    "last_validated_date": "2024-12-05T17:59:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[arrays_empty_null_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:45+00:00"
+    "last_validated_date": "2024-12-05T17:59:13+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean]": {
-    "last_validated_date": "2024-12-05T17:44:53+00:00"
+    "last_validated_date": "2024-12-05T17:59:22+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[boolean_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:36+00:00"
+    "last_validated_date": "2024-12-05T17:59:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_many_rules]": {
-    "last_validated_date": "2024-12-05T17:44:38+00:00"
+    "last_validated_date": "2024-12-05T17:59:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match]": {
-    "last_validated_date": "2024-12-05T17:44:31+00:00"
+    "last_validated_date": "2024-12-05T17:58:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_multi_match_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:34+00:00"
+    "last_validated_date": "2024-12-05T17:59:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or]": {
-    "last_validated_date": "2024-12-05T17:44:41+00:00"
+    "last_validated_date": "2024-12-05T17:59:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[complex_or_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:41+00:00"
+    "last_validated_date": "2024-12-05T17:59:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase]": {
-    "last_validated_date": "2024-12-05T17:44:38+00:00"
+    "last_validated_date": "2024-12-05T17:59:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:40+00:00"
+    "last_validated_date": "2024-12-05T17:59:08+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:51+00:00"
+    "last_validated_date": "2024-12-05T17:59:19+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list]": {
-    "last_validated_date": "2024-12-05T17:44:45+00:00"
+    "last_validated_date": "2024-12-05T17:59:13+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:44+00:00"
+    "last_validated_date": "2024-12-05T17:59:12+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:33+00:00"
+    "last_validated_date": "2024-12-05T17:59:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number]": {
-    "last_validated_date": "2024-12-05T17:44:53+00:00"
+    "last_validated_date": "2024-12-05T17:59:22+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:39+00:00"
+    "last_validated_date": "2024-12-05T17:59:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list]": {
-    "last_validated_date": "2024-12-05T17:44:39+00:00"
+    "last_validated_date": "2024-12-05T17:59:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_number_list_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:35+00:00"
+    "last_validated_date": "2024-12-05T17:59:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string]": {
-    "last_validated_date": "2024-12-05T17:44:34+00:00"
+    "last_validated_date": "2024-12-05T17:59:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:36+00:00"
+    "last_validated_date": "2024-12-05T17:59:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list]": {
-    "last_validated_date": "2024-12-05T17:44:37+00:00"
+    "last_validated_date": "2024-12-05T17:59:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_list_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:47+00:00"
+    "last_validated_date": "2024-12-05T17:59:16+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_but_string_null]": {
-    "last_validated_date": "2024-12-05T17:44:41+00:00"
+    "last_validated_date": "2024-12-05T17:59:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix]": {
-    "last_validated_date": "2024-12-05T17:44:43+00:00"
+    "last_validated_date": "2024-12-05T17:59:11+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:35+00:00"
+    "last_validated_date": "2024-12-05T17:59:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_ignorecase_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:45+00:00"
+    "last_validated_date": "2024-12-05T17:59:13+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_int_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:51+00:00"
+    "last_validated_date": "2024-12-05T17:59:19+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list]": {
-    "last_validated_date": "2024-12-05T17:44:33+00:00"
+    "last_validated_date": "2024-12-05T17:59:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:33+00:00"
+    "last_validated_date": "2024-12-05T17:59:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_prefix_list_type_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:48+00:00"
+    "last_validated_date": "2024-12-05T17:59:17+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix]": {
-    "last_validated_date": "2024-12-05T17:44:44+00:00"
+    "last_validated_date": "2024-12-05T17:59:12+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:42+00:00"
+    "last_validated_date": "2024-12-05T17:59:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_ignorecase_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:47+00:00"
+    "last_validated_date": "2024-12-05T17:59:15+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_int_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:38+00:00"
+    "last_validated_date": "2024-12-05T17:59:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list]": {
-    "last_validated_date": "2024-12-05T17:44:43+00:00"
+    "last_validated_date": "2024-12-05T17:59:11+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:46+00:00"
+    "last_validated_date": "2024-12-05T17:59:15+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_suffix_list_type_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:30+00:00"
+    "last_validated_date": "2024-12-05T17:58:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard]": {
-    "last_validated_date": "2024-12-05T17:44:49+00:00"
+    "last_validated_date": "2024-12-05T17:59:18+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:33+00:00"
+    "last_validated_date": "2024-12-05T17:59:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list]": {
-    "last_validated_date": "2024-12-05T17:44:34+00:00"
+    "last_validated_date": "2024-12-05T17:59:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:39+00:00"
+    "last_validated_date": "2024-12-05T17:59:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_list_type_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:32+00:00"
+    "last_validated_date": "2024-12-05T17:59:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_anything_wildcard_type_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:48+00:00"
+    "last_validated_date": "2024-12-05T17:59:16+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists]": {
-    "last_validated_date": "2024-12-05T17:44:40+00:00"
+    "last_validated_date": "2024-12-05T17:59:08+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:53+00:00"
+    "last_validated_date": "2024-12-05T17:59:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false]": {
-    "last_validated_date": "2024-12-05T17:44:50+00:00"
+    "last_validated_date": "2024-12-05T17:59:18+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_exists_false_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:52+00:00"
+    "last_validated_date": "2024-12-05T17:59:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase]": {
-    "last_validated_date": "2024-12-05T17:44:52+00:00"
+    "last_validated_date": "2024-12-05T17:59:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:39+00:00"
+    "last_validated_date": "2024-12-05T17:59:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:48+00:00"
+    "last_validated_date": "2024-12-05T17:59:16+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ignorecase_list_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:47+00:00"
+    "last_validated_date": "2024-12-05T17:59:15+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address]": {
-    "last_validated_date": "2024-12-05T17:44:35+00:00"
+    "last_validated_date": "2024-12-05T17:59:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:49+00:00"
+    "last_validated_date": "2024-12-05T17:59:18+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:40+00:00"
+    "last_validated_date": "2024-12-05T17:59:08+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_ip_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:43+00:00"
+    "last_validated_date": "2024-12-05T17:59:12+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_bad_mask_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:31+00:00"
+    "last_validated_date": "2024-12-05T17:58:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_type_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:50+00:00"
+    "last_validated_date": "2024-12-05T17:59:19+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6]": {
-    "last_validated_date": "2024-12-05T17:44:37+00:00"
+    "last_validated_date": "2024-12-05T17:59:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:36+00:00"
+    "last_validated_date": "2024-12-05T17:59:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_ip_address_v6_bad_ip_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:52+00:00"
+    "last_validated_date": "2024-12-05T17:59:20+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:41+00:00"
+    "last_validated_date": "2024-12-05T17:59:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and]": {
-    "last_validated_date": "2024-12-05T17:44:53+00:00"
+    "last_validated_date": "2024-12-05T17:59:22+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_and_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:42+00:00"
+    "last_validated_date": "2024-12-05T17:59:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:34+00:00"
+    "last_validated_date": "2024-12-05T17:59:02+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_numeric_syntax_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:53+00:00"
+    "last_validated_date": "2024-12-05T17:59:21+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix]": {
-    "last_validated_date": "2024-12-05T17:44:48+00:00"
+    "last_validated_date": "2024-12-05T17:59:16+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:45+00:00"
+    "last_validated_date": "2024-12-05T17:59:13+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_ignorecase]": {
-    "last_validated_date": "2024-12-05T17:44:42+00:00"
+    "last_validated_date": "2024-12-05T17:59:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_int_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:42+00:00"
+    "last_validated_date": "2024-12-05T17:59:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_prefix_list_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:35+00:00"
+    "last_validated_date": "2024-12-05T17:59:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix]": {
-    "last_validated_date": "2024-12-05T17:44:51+00:00"
+    "last_validated_date": "2024-12-05T17:59:19+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:30+00:00"
+    "last_validated_date": "2024-12-05T17:58:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase]": {
-    "last_validated_date": "2024-12-05T17:44:42+00:00"
+    "last_validated_date": "2024-12-05T17:59:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:46+00:00"
+    "last_validated_date": "2024-12-05T17:59:14+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_int_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:46+00:00"
+    "last_validated_date": "2024-12-05T17:59:14+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_suffix_list_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:50+00:00"
+    "last_validated_date": "2024-12-05T17:59:18+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_complex_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:46+00:00"
+    "last_validated_date": "2024-12-05T17:59:14+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_int_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:49+00:00"
+    "last_validated_date": "2024-12-05T17:59:17+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_list_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:51+00:00"
+    "last_validated_date": "2024-12-05T17:59:20+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating]": {
-    "last_validated_date": "2024-12-05T17:44:33+00:00"
+    "last_validated_date": "2024-12-05T17:59:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:39+00:00"
+    "last_validated_date": "2024-12-05T17:59:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating]": {
-    "last_validated_date": "2024-12-05T17:44:30+00:00"
+    "last_validated_date": "2024-12-05T17:58:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:33+00:00"
+    "last_validated_date": "2024-12-05T17:59:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_repeating_star_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:33+00:00"
+    "last_validated_date": "2024-12-05T17:59:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[content_wildcard_simplified]": {
-    "last_validated_date": "2024-12-05T17:44:33+00:00"
+    "last_validated_date": "2024-12-05T17:59:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event]": {
-    "last_validated_date": "2024-12-05T17:44:42+00:00"
+    "last_validated_date": "2024-12-05T17:59:10+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_event_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:43+00:00"
+    "last_validated_date": "2024-12-05T17:59:12+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern]": {
-    "last_validated_date": "2024-12-05T17:44:37+00:00"
+    "last_validated_date": "2024-12-05T17:59:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dot_joining_pattern_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:43+00:00"
+    "last_validated_date": "2024-12-05T17:59:11+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[dynamodb]": {
-    "last_validated_date": "2024-12-05T17:44:38+00:00"
+    "last_validated_date": "2024-12-05T17:59:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb]": {
-    "last_validated_date": "2024-12-05T17:44:36+00:00"
+    "last_validated_date": "2024-12-05T17:59:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_dynamodb_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:36+00:00"
+    "last_validated_date": "2024-12-05T17:59:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[exists_list_empty_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:32+00:00"
+    "last_validated_date": "2024-12-05T17:59:00+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[int_nolist_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:31+00:00"
+    "last_validated_date": "2024-12-05T17:58:59+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[key_case_sensitive_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:43+00:00"
+    "last_validated_date": "2024-12-05T17:59:11+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[list_within_dict]": {
-    "last_validated_date": "2024-12-05T17:44:30+00:00"
+    "last_validated_date": "2024-12-05T17:58:58+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[minimal]": {
-    "last_validated_date": "2024-12-05T17:44:48+00:00"
+    "last_validated_date": "2024-12-05T17:59:16+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[nested_json_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:37+00:00"
+    "last_validated_date": "2024-12-05T17:59:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value]": {
-    "last_validated_date": "2024-12-05T17:44:38+00:00"
+    "last_validated_date": "2024-12-05T17:59:07+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[null_value_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:43+00:00"
+    "last_validated_date": "2024-12-05T17:59:11+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[number_comparison_float]": {
-    "last_validated_date": "2024-12-05T17:44:50+00:00"
+    "last_validated_date": "2024-12-05T17:59:19+00:00"
+  },
+  "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-null_NEG]": {
+    "last_validated_date": "2024-12-05T17:59:15+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[numeric-string_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:41+00:00"
+    "last_validated_date": "2024-12-05T17:59:09+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_case_sensitive_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:40+00:00"
+    "last_validated_date": "2024-12-05T17:59:08+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[operator_multiple_list]": {
-    "last_validated_date": "2024-12-05T17:44:37+00:00"
+    "last_validated_date": "2024-12-05T17:59:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-anything-but]": {
-    "last_validated_date": "2024-12-05T17:44:53+00:00"
+    "last_validated_date": "2024-12-05T17:59:22+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists-parent]": {
-    "last_validated_date": "2024-12-05T17:44:36+00:00"
+    "last_validated_date": "2024-12-05T17:59:05+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-exists]": {
-    "last_validated_date": "2024-12-05T17:44:33+00:00"
+    "last_validated_date": "2024-12-05T17:59:01+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-numeric-anything-but]": {
-    "last_validated_date": "2024-12-05T17:44:48+00:00"
+    "last_validated_date": "2024-12-05T17:59:17+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[or-numeric-anything-but_NEG]": {
-    "last_validated_date": "2024-12-05T17:44:35+00:00"
+    "last_validated_date": "2024-12-05T17:59:03+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[prefix]": {
-    "last_validated_date": "2024-12-05T17:44:44+00:00"
+    "last_validated_date": "2024-12-05T17:59:12+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[sample1]": {
-    "last_validated_date": "2024-12-05T17:44:43+00:00"
+    "last_validated_date": "2024-12-05T17:59:11+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string]": {
-    "last_validated_date": "2024-12-05T17:44:45+00:00"
+    "last_validated_date": "2024-12-05T17:59:13+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_empty]": {
-    "last_validated_date": "2024-12-05T17:44:38+00:00"
+    "last_validated_date": "2024-12-05T17:59:06+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern[string_nolist_EXC]": {
-    "last_validated_date": "2024-12-05T17:44:35+00:00"
+    "last_validated_date": "2024-12-05T17:59:04+00:00"
   },
   "tests/aws/services/events/test_events_patterns.py::TestEventPattern::test_event_pattern_source": {
     "last_validated_date": "2024-07-11T13:55:39+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #11992, there might have been issue with the new engine rule engine.

I could only reproduce the `test_dynamodb_event_filter[numeric_filter]` failure, which was due to our bad handling of `numeric` logic with string values. 

While validating the fix and the handling of the new EventRuleEngine for `test_sqs_event_filter[this is a test string]`, the behavior was right, but the validation for `TestEventPattern` was wrong. 

I've also validated that `test_dynamodb_event_filter[numeric_filter]` now works with the fix 👍 

Then, when validating the DynamoDB fix, I've tried to copy-paste the input event from ESM, but it failed when calling `TestEventPattern` because the event was not following the right format, so I've added it in the provider to also validate this, as specified by the documentation here: https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_TestEventPattern.html (note, the `resources` field is not mandatory in reality). 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix the handling of `numeric` if the value is a string (or more like the value is not a numeric value)
- fix the validation of the `TestEventPattern` provider operation
- add test cases to cover the `numeric` fix, and the provider validation 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
