### PR TITLE
fix StringSplit regex escape

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/intrinsic/function/statesfunction/string_operations/string_split.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/intrinsic/function/statesfunction/string_operations/string_split.py
@@ -62,10 +62,7 @@ class StringSplit(StatesFunction):
         if not isinstance(del_chars, str):
             raise ValueError(f"Expected string value, but got '{del_chars}'.")
 
-        patterns = []
-        for c in del_chars:
-            patterns.append(f"\\{c}")
-        pattern = "|".join(patterns)
+        pattern = "|".join(re.escape(c) for c in del_chars)
 
         parts = re.split(pattern, string)
         parts_clean = list(filter(bool, parts))

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.py
@@ -20,6 +20,7 @@ class TestStringOperations:
             {"fst": ",,,,", "snd": ","},
             {"fst": "1,2,3,4,5", "snd": ","},
             {"fst": "This.is+a,test=string", "snd": ".+,="},
+            {"fst": "split on T and \nnew line", "snd": "T\n"},
         ]
         create_and_test_on_inputs(
             aws_client.stepfunctions,

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.py::TestStringOperations::test_string_split": {
-    "recorded-date": "28-11-2023, 10:19:26",
+    "recorded-date": "05-12-2024, 20:34:43",
     "recorded-content": {
       "exec_hist_resp_0": {
         "events": [
@@ -463,6 +463,87 @@
                   "a",
                   "test",
                   "string"
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_6": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": "split on T and \nnew line",
+                  "snd": "T\n"
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": "split on T and \nnew line",
+                  "snd": "T\n"
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": [
+                  "split on ",
+                  " and ",
+                  "new line"
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": [
+                  "split on ",
+                  " and ",
+                  "new line"
                 ]
               },
               "outputDetails": {

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.validation.json
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.py::TestStringOperations::test_string_split": {
-    "last_validated_date": "2023-11-28T09:19:26+00:00"
+    "last_validated_date": "2024-12-05T20:34:43+00:00"
   },
   "tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.py::TestStringOperations::test_string_split_context_object": {
     "last_validated_date": "2023-11-28T09:25:42+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The `StringSplit` function allows to split on any of the character provided by the second argument. The current code was manually escaping each character, appending `\\` to it. While allowing for the most common special characters delimiter, the unfortunate side effect is that digits and letters would be incorrectly escaped.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- update the `StringSplit` function to use `re.escape` instead for a safe escaping experience
- perform the `join` directly on the list comprehension for a small performance upgrade

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
