### PR TITLE
Bugfix/eventbridge/transformer issue with nested key

### DIFF
--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -16,6 +16,7 @@ from localstack.aws.connect import connect_to
 from localstack.services.events.models import FormattedEvent, TransformedEvent, ValidationException
 from localstack.services.events.target_helper import send_event_to_api_destination
 from localstack.services.events.utils import (
+    dict_to_simple_string,
     event_time_to_time_string,
     get_trace_header_encoded_region_account,
     is_nested_in_string,
@@ -91,6 +92,8 @@ def replace_template_placeholders(
                 return to_json_str(value)
         if isinstance(value, datetime.datetime):
             return event_time_to_time_string(value)
+        if isinstance(value, dict):
+            return dict_to_simple_string(value)
         return value
 
     formatted_template = TRANSFORMER_PLACEHOLDER_PATTERN.sub(replace_placeholder, template)

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -83,7 +83,7 @@ def replace_template_placeholders(
 
     def replace_placeholder(match):
         key = match.group(1)
-        value = replacements.get(key, match.group(0))  # handle non defined placeholders
+        value = replacements.get(key, "")  # handle non defined placeholders
         if isinstance(value, datetime.datetime):
             return event_time_to_time_string(value)
         if isinstance(value, dict):
@@ -97,11 +97,13 @@ def replace_template_placeholders(
             return f"[{','.join(value)}]"
         if is_nested_in_string(template, match):
             return value
-        return json.dumps(value)
+        if is_json_template:
+            return json.dumps(value)
+        return value
 
     formatted_template = (
         TRANSFORMER_PLACEHOLDER_PATTERN.sub(replace_placeholder, template)
-        .replace('""', '"')
+        # .replace('""', '"')
         .replace("\\n", "\n")
     )
 

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -101,14 +101,11 @@ def replace_template_placeholders(
             return json.dumps(value)
         return value
 
-    formatted_template = (
-        TRANSFORMER_PLACEHOLDER_PATTERN.sub(replace_placeholder, template)
-        # .replace('""', '"')
-        .replace("\\n", "\n")
+    formatted_template = TRANSFORMER_PLACEHOLDER_PATTERN.sub(replace_placeholder, template).replace(
+        "\\n", "\n"
     )
 
     if is_json_template:
-        # fixed_formatted_template = fix_json_string(formatted_template)
         try:
             loaded_json_template = json.loads(formatted_template)
             return loaded_json_template

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -87,7 +87,7 @@ def replace_template_placeholders(
         if isinstance(value, datetime.datetime):
             return event_time_to_time_string(value)
         if isinstance(value, dict):
-            json_str = to_json_str(value)
+            json_str = to_json_str(value).replace('\\"', '"')
             if is_json_template:
                 return json_str
             return json_str.replace('"', "")
@@ -182,7 +182,10 @@ class TargetSender(ABC):
                 event = transform_event_with_target_input_path(input_path, event)
             if input_transformer := self.target.get("InputTransformer"):
                 event = self.transform_event_with_target_input_transformer(input_transformer, event)
-        self.send_event(event)
+        if event:
+            self.send_event(event)
+        else:
+            LOG.info("No event to send to target %s", self.target.get("Id"))
 
     def transform_event_with_target_input_transformer(
         self, input_transformer: InputTransformer, event: FormattedEvent

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -59,17 +59,6 @@ def to_json_str(obj: Any, separators: Optional[tuple[str, str]] = (",", ":")) ->
     return json_str.replace('\\"', '"')
 
 
-def fix_json_string(s):
-    try:
-        json.loads(s)
-        return s
-    except json.JSONDecodeError:
-        # Find unquoted values and quote them
-        pattern = r'(?:[:,{[]]\s*)([^",\{\}\[\]\s][^,\}\]]*)'
-        fixed = re.sub(pattern, r': "\1"', s)
-        return fixed
-
-
 def extract_region_and_account_id(
     name_or_arn: EventBusNameOrArn, context: RequestContext
 ) -> tuple[str, str]:

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -264,7 +264,7 @@ def get_trace_header_encoded_region_account(
             return json.dumps({"original_account": source_account_id})
 
 
-def is_nested_in_string(template, match) -> bool:
+def is_nested_in_string(template: str, match: re.Match[str]) -> bool:
     """
     Determines if a match (string) is nested within a larger string value in the given template.
 

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -266,11 +266,13 @@ def get_trace_header_encoded_region_account(
 
 def is_nested_in_string(template: str, match: re.Match[str]) -> bool:
     """
-    Determines if a match (string) is nested within a larger string value in the given template.
+    Determines if a match (string) is within quotes in the given template.
 
-    This function checks if there are quotes surrounding the larger string that contains the placeholder.
-    True for "users-service/users/<userId>"
-    False for "<userId>"
+    Examples:
+    True for "users-service/users/<userId>"  # nested within larger string
+    True for "<userId>"                      # simple quoted placeholder
+    True for "Hello <name>"                  # nested within larger string
+    False for {"id": <userId>}               # not in quotes at all
     """
     start = match.start()
     end = match.end()
@@ -280,7 +282,7 @@ def is_nested_in_string(template: str, match: re.Match[str]) -> bool:
     next_comma = template.find(",", end)
     next_brace = template.find("}", end)
 
-    # Nested if there's no right quote or comma or brace comes before the right quote,
+    # If no right quote, or if comma/brace comes before right quote, not nested
     if (
         right_quote == -1
         or (next_comma != -1 and next_comma < right_quote)
@@ -288,4 +290,4 @@ def is_nested_in_string(template: str, match: re.Match[str]) -> bool:
     ):
         return False
 
-    return left_quote != -1 and template[left_quote + 1 : right_quote].strip() != match.group(0)
+    return left_quote != -1

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -248,3 +248,28 @@ def get_trace_header_encoded_region_account(
             return json.dumps({"original_id": original_id, "original_account": source_account_id})
         else:
             return json.dumps({"original_account": source_account_id})
+
+
+def is_nested_in_string(template, match) -> bool:
+    """
+    Check if the placeholder is nested within a larger string value.
+    This checks if there are quotes surrounding the larger string containing the placeholder.
+    e.g. "users-service/users/<userId>" with "<*?>" as match.
+    """
+    start = match.start()
+    end = match.end()
+
+    left_quote = template.rfind('"', 0, start)
+    right_quote = template.find('"', end)
+    next_comma = template.find(",", end)
+    next_brace = template.find("}", end)
+
+    # Nested if there's no right quote or comma or brace comes before the right quote,
+    if (
+        right_quote == -1
+        or (next_comma != -1 and next_comma < right_quote)
+        or (next_brace != -1 and next_brace < right_quote)
+    ):
+        return False
+
+    return left_quote != -1 and template[left_quote + 1 : right_quote].strip() != match.group(0)

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -273,3 +273,7 @@ def is_nested_in_string(template, match) -> bool:
         return False
 
     return left_quote != -1 and template[left_quote + 1 : right_quote].strip() != match.group(0)
+
+
+def dict_to_simple_string(d):
+    return "{" + ",".join(f"{k}:{v}" for k, v in d.items()) + "}"

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -266,9 +266,11 @@ def get_trace_header_encoded_region_account(
 
 def is_nested_in_string(template, match) -> bool:
     """
-    Check if the placeholder is nested within a larger string value.
-    This checks if there are quotes surrounding the larger string containing the placeholder.
-    e.g. "users-service/users/<userId>" with "<*?>" as match.
+    Determines if a match (string) is nested within a larger string value in the given template.
+
+    This function checks if there are quotes surrounding the larger string that contains the placeholder.
+    True for "users-service/users/<userId>"
+    False for "<userId>"
     """
     start = match.start()
     end = match.end()

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -52,11 +52,8 @@ class EventJSONEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
-def to_json_str(obj: Any, separators: Optional[tuple[str, str]] = (",", ":")) -> str | None:
-    if not obj:
-        return None
-    json_str = json.dumps(obj, cls=EventJSONEncoder, separators=separators)
-    return json_str.replace('\\"', '"')
+def to_json_str(obj: Any, separators: Optional[tuple[str, str]] = (",", ":")) -> str:
+    return json.dumps(obj, cls=EventJSONEncoder, separators=separators)
 
 
 def extract_region_and_account_id(

--- a/tests/aws/services/events/helper_functions.py
+++ b/tests/aws/services/events/helper_functions.py
@@ -73,7 +73,10 @@ def put_entries_assert_results_sqs(
     messages = retry(get_message, retries=5, queue_url=queue_url)
 
     if should_match:
-        actual_event = json.loads(messages[0]["Body"])
+        try:
+            actual_event = json.loads(messages[0]["Body"])
+        except json.JSONDecodeError:
+            actual_event = messages[0]["Body"]
         if isinstance(actual_event, dict) and "detail" in actual_event:
             assert_valid_event(actual_event)
         return messages

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -29,6 +29,12 @@ from tests.aws.services.events.helper_functions import (
 )
 
 EVENT_DETAIL = {"command": "update-account", "payload": {"acc_id": "0a787ecb-4015", "sf_id": "baz"}}
+SPECIAL_EVENT_DETAIL = {
+    "command": "update-account",
+    "payload": {"acc_id": "0a787ecb-4015", "sf_id": "baz"},
+    "listsingle": ["HIGH"],
+    "listmulti": ["ACTIVE", "INACTIVE"],
+}
 
 TEST_EVENT_PATTERN = {
     "source": ["core.update-account-command"],

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -483,6 +483,7 @@ class TestInputTransformer:
             '"Payload of <payload> with path users-service/users/<userId>"',
             '{"method": "PUT", "path": "users-service/users/<userId>", "bod": "<userId>"}',
             '{"method": "PUT", "path": "users-service/users/<userId>", "bod": [<userId>, "hardcoded"]}',
+            '{"method": "PUT", "nested": {"level1": {"level2": {"level3": "users-service/users/<userId>"} } }, "bod": "<userId>"}',
             '"<listsingle> single list item"\n"<listmulti> multiple list items"\n"<systemstring> system account id"\n"<payload> payload"\n"<userId> user id"',
         ],
     )

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -488,6 +488,7 @@ class TestInputTransformer:
             '{"method": "PUT", "path": "users-service/users/<userId>", "bod": <payload>}',
             '"Payload of <payload> with path users-service/users/<userId> and <userId>"',
             '{"id" : <userId>}',
+            '{"id" : "<userId>"}',
             '{"method": "PUT", "path": "users-service/users/<userId>", "id": <userId>, "body": <payload>}',
             '{"method": "PUT", "path": "users-service/users/<userId>", "bod": [<userId>, "hardcoded"]}',
             '{"method": "PUT", "nested": {"level1": {"level2": {"level3": "users-service/users/<userId>"} } }, "bod": "<userId>"}',

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -392,6 +392,12 @@ class TestInputTransformer:
         snapshot.add_transformer(snapshot.transform.regex(target_id, "<target-id>"))
         snapshot.match("missing-key-exception-error", exception)
 
+    # TODO test wrong input template
+    # '{"userId": "users/<userId>/profile/<type>"}',
+    # ("prefix_<userId>_suffix",)
+    # ("multi_replacement/users/<userId>/second/<userId>",)
+    # "abc:  <userId>",
+
     @markers.aws.validated
     @pytest.mark.skipif(
         is_old_provider(),
@@ -489,6 +495,7 @@ class TestInputTransformer:
             '"<listmulti> multiple list items"',
             '{"singlelistitem": <listsingle>}',
             '"<listsingle> single list item <listmulti> multiple list items <systemstring> system account id <payload> payload <userId> user id"',
+            '{"multi_replacement": "users/<userId>/second/<userId>"}',
             # TODO known limitation due to sqs message handling sting with new line
             # '"<listsingle> single list item\n<listmulti> multiple list items"',
         ],

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -468,8 +468,16 @@ class TestInputTransformer:
         is_old_provider(),
         reason="V1 provider does not support this feature",
     )
+    @pytest.mark.parametrize(
+        "input_template",
+        [
+            '{"method": "PUT", "path": "users-service/users/<userId>", "bod": <payload>}',
+            '"Payload of <payload> with path users-service/users/<userId>"',
+        ],
+    )
     def test_input_transformer_nested_keys_replacement(
         self,
+        input_template,
         put_events_with_filter_to_sqs,
         snapshot,
     ):
@@ -490,9 +498,6 @@ class TestInputTransformer:
             "userId": "$.detail.payload.acc_id",
             "payload": "$.detail.payload",
         }
-        input_template = (
-            '{"method": "PUT", "path": "users-service/users/<userId>", "bod": <payload>}'
-        )
         input_transformer = {
             "InputPathsMap": input_path_map,
             "InputTemplate": input_template,

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -267,8 +267,8 @@
       ]
     }
   },
-  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement": {
-    "recorded-date": "06-12-2024, 11:07:17",
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": <payload>}]": {
+    "recorded-date": "06-12-2024, 12:10:34",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -283,6 +283,19 @@
               "sf_id": "baz"
             }
           }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId>\"]": {
+    "recorded-date": "06-12-2024, 12:13:58",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"Payload of {acc_id:0a787ecb-4015,sf_id:baz} with path users-service/users/0a787ecb-4015\""
         }
       ]
     }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -268,7 +268,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": <payload>}]": {
-    "recorded-date": "06-12-2024, 12:10:34",
+    "recorded-date": "13-12-2024, 12:23:34",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -288,7 +288,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId>\"]": {
-    "recorded-date": "06-12-2024, 12:13:58",
+    "recorded-date": "13-12-2024, 12:23:37",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -296,6 +296,56 @@
           "ReceiptHandle": "<receipt-handle:1>",
           "MD5OfBody": "<m-d5-of-body:1>",
           "Body": "\"Payload of {acc_id:0a787ecb-4015,sf_id:baz} with path users-service/users/0a787ecb-4015\""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": \"<userId>\"}]": {
+    "recorded-date": "13-12-2024, 12:23:39",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "method": "PUT",
+            "path": "users-service/users/0a787ecb-4015",
+            "bod": "0a787ecb-4015"
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": [<userId>, \"hardcoded\"]}]": {
+    "recorded-date": "13-12-2024, 12:23:41",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "method": "PUT",
+            "path": "users-service/users/0a787ecb-4015",
+            "bod": [
+              "0a787ecb-4015",
+              "hardcoded"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item\"\\n\"<listmulti> multiple list items\"\\n\"<systemstring> system account id\"\\n\"<payload> payload\"\\n\"<userId> user id\"]": {
+    "recorded-date": "13-12-2024, 12:23:43",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"[HIGH] single list item\"\n\"[ACTIVE,INACTIVE] multiple list items\"\n\" system account id\"\n\"{acc_id:0a787ecb-4015,sf_id:baz} payload\"\n\"0a787ecb-4015 user id\""
         }
       ]
     }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -268,7 +268,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": <payload>}]": {
-    "recorded-date": "13-12-2024, 12:23:34",
+    "recorded-date": "13-12-2024, 13:20:27",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -288,7 +288,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId>\"]": {
-    "recorded-date": "13-12-2024, 12:23:37",
+    "recorded-date": "13-12-2024, 13:20:30",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -301,7 +301,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": \"<userId>\"}]": {
-    "recorded-date": "13-12-2024, 12:23:39",
+    "recorded-date": "13-12-2024, 13:20:32",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -318,7 +318,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": [<userId>, \"hardcoded\"]}]": {
-    "recorded-date": "13-12-2024, 12:23:41",
+    "recorded-date": "13-12-2024, 13:20:34",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -338,7 +338,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item\"\\n\"<listmulti> multiple list items\"\\n\"<systemstring> system account id\"\\n\"<payload> payload\"\\n\"<userId> user id\"]": {
-    "recorded-date": "13-12-2024, 12:23:43",
+    "recorded-date": "13-12-2024, 13:20:39",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -346,6 +346,29 @@
           "ReceiptHandle": "<receipt-handle:1>",
           "MD5OfBody": "<m-d5-of-body:1>",
           "Body": "\"[HIGH] single list item\"\n\"[ACTIVE,INACTIVE] multiple list items\"\n\" system account id\"\n\"{acc_id:0a787ecb-4015,sf_id:baz} payload\"\n\"0a787ecb-4015 user id\""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"nested\": {\"level1\": {\"level2\": {\"level3\": \"users-service/users/<userId>\"} } }, \"bod\": \"<userId>\"}]": {
+    "recorded-date": "13-12-2024, 13:20:37",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "method": "PUT",
+            "nested": {
+              "level1": {
+                "level2": {
+                  "level3": "users-service/users/0a787ecb-4015"
+                }
+              }
+            },
+            "bod": "0a787ecb-4015"
+          }
         }
       ]
     }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -478,5 +478,20 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"id\" : \"<userId>\"}]": {
+    "recorded-date": "16-12-2024, 12:26:02",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "id": "0a787ecb-4015"
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -268,7 +268,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": <payload>}]": {
-    "recorded-date": "13-12-2024, 17:27:29",
+    "recorded-date": "13-12-2024, 18:03:12",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -288,7 +288,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId> and <userId>\"]": {
-    "recorded-date": "13-12-2024, 17:27:32",
+    "recorded-date": "13-12-2024, 18:03:14",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -301,7 +301,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"id\": <userId>, \"body\": <payload>}]": {
-    "recorded-date": "13-12-2024, 17:27:36",
+    "recorded-date": "13-12-2024, 18:03:18",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -322,7 +322,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": [<userId>, \"hardcoded\"]}]": {
-    "recorded-date": "13-12-2024, 17:27:39",
+    "recorded-date": "13-12-2024, 18:03:21",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -342,7 +342,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"nested\": {\"level1\": {\"level2\": {\"level3\": \"users-service/users/<userId>\"} } }, \"bod\": \"<userId>\"}]": {
-    "recorded-date": "13-12-2024, 17:27:41",
+    "recorded-date": "13-12-2024, 18:03:23",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -378,7 +378,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"id\" : <userId>}]": {
-    "recorded-date": "13-12-2024, 17:27:34",
+    "recorded-date": "13-12-2024, 18:03:16",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -401,7 +401,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item\"]": {
-    "recorded-date": "13-12-2024, 17:27:43",
+    "recorded-date": "13-12-2024, 18:03:25",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -414,7 +414,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listmulti> multiple list items\"]": {
-    "recorded-date": "13-12-2024, 17:27:46",
+    "recorded-date": "13-12-2024, 18:03:28",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -435,7 +435,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"singlelistitem\": <listsingle>}]": {
-    "recorded-date": "13-12-2024, 17:27:48",
+    "recorded-date": "13-12-2024, 18:03:30",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -452,7 +452,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item <listmulti> multiple list items <systemstring> system account id <payload> payload <userId> user id\"]": {
-    "recorded-date": "13-12-2024, 17:40:06",
+    "recorded-date": "13-12-2024, 18:03:32",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -460,6 +460,21 @@
           "ReceiptHandle": "<receipt-handle:1>",
           "MD5OfBody": "<m-d5-of-body:1>",
           "Body": "\"[HIGH] single list item [ACTIVE,INACTIVE] multiple list items  system account id {acc_id:0a787ecb-4015,sf_id:baz} payload 0a787ecb-4015 user id\""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"multi_replacement\": \"users/<userId>/second/<userId>\"}]": {
+    "recorded-date": "13-12-2024, 18:03:35",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "multi_replacement": "users/0a787ecb-4015/second/0a787ecb-4015"
+          }
         }
       ]
     }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -266,5 +266,25 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement": {
+    "recorded-date": "06-12-2024, 11:07:17",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "method": "PUT",
+            "path": "users-service/users/0a787ecb-4015",
+            "bod": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -268,7 +268,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": <payload>}]": {
-    "recorded-date": "13-12-2024, 13:20:27",
+    "recorded-date": "13-12-2024, 17:27:29",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -287,21 +287,21 @@
       ]
     }
   },
-  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId>\"]": {
-    "recorded-date": "13-12-2024, 13:20:30",
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId> and <userId>\"]": {
+    "recorded-date": "13-12-2024, 17:27:32",
     "recorded-content": {
       "input-transformed-messages": [
         {
           "MessageId": "<uuid:1>",
           "ReceiptHandle": "<receipt-handle:1>",
           "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": "\"Payload of {acc_id:0a787ecb-4015,sf_id:baz} with path users-service/users/0a787ecb-4015\""
+          "Body": "\"Payload of {acc_id:0a787ecb-4015,sf_id:baz} with path users-service/users/0a787ecb-4015 and 0a787ecb-4015\""
         }
       ]
     }
   },
-  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": \"<userId>\"}]": {
-    "recorded-date": "13-12-2024, 13:20:32",
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"id\": <userId>, \"body\": <payload>}]": {
+    "recorded-date": "13-12-2024, 17:27:36",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -311,14 +311,18 @@
           "Body": {
             "method": "PUT",
             "path": "users-service/users/0a787ecb-4015",
-            "bod": "0a787ecb-4015"
+            "id": "0a787ecb-4015",
+            "body": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
           }
         }
       ]
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": [<userId>, \"hardcoded\"]}]": {
-    "recorded-date": "13-12-2024, 13:20:34",
+    "recorded-date": "13-12-2024, 17:27:39",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -337,21 +341,8 @@
       ]
     }
   },
-  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item\"\\n\"<listmulti> multiple list items\"\\n\"<systemstring> system account id\"\\n\"<payload> payload\"\\n\"<userId> user id\"]": {
-    "recorded-date": "13-12-2024, 13:20:39",
-    "recorded-content": {
-      "input-transformed-messages": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": "\"[HIGH] single list item\"\n\"[ACTIVE,INACTIVE] multiple list items\"\n\" system account id\"\n\"{acc_id:0a787ecb-4015,sf_id:baz} payload\"\n\"0a787ecb-4015 user id\""
-        }
-      ]
-    }
-  },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"nested\": {\"level1\": {\"level2\": {\"level3\": \"users-service/users/<userId>\"} } }, \"bod\": \"<userId>\"}]": {
-    "recorded-date": "13-12-2024, 13:20:37",
+    "recorded-date": "13-12-2024, 17:27:41",
     "recorded-content": {
       "input-transformed-messages": [
         {
@@ -369,6 +360,106 @@
             },
             "bod": "0a787ecb-4015"
           }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item\"\\n\"<listmulti> multiple list items\"\\n\"<systemstring> system account id\"\\n\"<payload> payload\"\\n\"<userId> user id\"]": {
+    "recorded-date": "13-12-2024, 17:27:50",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"[HIGH] single list item\"\n\"[ACTIVE,INACTIVE] multiple list items\"\n\" system account id\"\n\"{acc_id:0a787ecb-4015,sf_id:baz} payload\"\n\"0a787ecb-4015 user id\""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"id\" : <userId>}]": {
+    "recorded-date": "13-12-2024, 17:27:34",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "id": "0a787ecb-4015"
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[<listsingle> single list item]": {
+    "recorded-date": "13-12-2024, 17:13:22",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[<listmulti> multiple list items]": {
+    "recorded-date": "13-12-2024, 17:13:36",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item\"]": {
+    "recorded-date": "13-12-2024, 17:27:43",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"[HIGH] single list item\""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listmulti> multiple list items\"]": {
+    "recorded-date": "13-12-2024, 17:27:46",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"[ACTIVE,INACTIVE] multiple list items\""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"singlelistitem\": \"<listsingle>\", \"multiplelistitems\": \"<listmulti>\"}]": {
+    "recorded-date": "13-12-2024, 17:15:23",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"singlelistitem\": \"<listsingle>\"}]": {
+    "recorded-date": "13-12-2024, 17:16:48",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"singlelistitem\": <listsingle>}]": {
+    "recorded-date": "13-12-2024, 17:27:48",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "singlelistitem": [
+              "HIGH"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item <listmulti> multiple list items <systemstring> system account id <payload> payload <userId> user id\"]": {
+    "recorded-date": "13-12-2024, 17:40:06",
+    "recorded-content": {
+      "input-transformed-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"[HIGH] single list item [ACTIVE,INACTIVE] multiple list items  system account id {acc_id:0a787ecb-4015,sf_id:baz} payload 0a787ecb-4015 user id\""
         }
       ]
     }

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -14,6 +14,9 @@
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail1]": {
     "last_validated_date": "2024-05-13T12:27:11+00:00"
   },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement": {
+    "last_validated_date": "2024-12-06T11:07:17+00:00"
+  },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
     "last_validated_date": "2024-06-11T08:33:10+00:00"
   },

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -17,6 +17,12 @@
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement": {
     "last_validated_date": "2024-12-06T11:07:17+00:00"
   },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId>\"]": {
+    "last_validated_date": "2024-12-06T12:13:58+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": <payload>}]": {
+    "last_validated_date": "2024-12-06T12:10:34+00:00"
+  },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
     "last_validated_date": "2024-06-11T08:33:10+00:00"
   },

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -17,23 +17,59 @@
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement": {
     "last_validated_date": "2024-12-06T11:07:17+00:00"
   },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listmulti> multiple list items\"]": {
+    "last_validated_date": "2024-12-13T17:27:46+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item <listmulti> multiple list items <systemstring> system account id <payload> payload <userId> user id\"]": {
+    "last_validated_date": "2024-12-13T17:40:06+00:00"
+  },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item\"\\n\"<listmulti> multiple list items\"\\n\"<systemstring> system account id\"\\n\"<payload> payload\"\\n\"<userId> user id\"]": {
-    "last_validated_date": "2024-12-13T13:20:39+00:00"
+    "last_validated_date": "2024-12-13T17:27:50+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item\"]": {
+    "last_validated_date": "2024-12-13T17:27:43+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId> and <userId>\"]": {
+    "last_validated_date": "2024-12-13T17:27:32+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId>\"]": {
     "last_validated_date": "2024-12-13T13:20:30+00:00"
   },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"id\" : <userId>}]": {
+    "last_validated_date": "2024-12-13T17:27:34+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"id\": <userId>}]": {
+    "last_validated_date": "2024-12-13T14:56:24+00:00"
+  },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"nested\": {\"level1\": {\"level2\": {\"level3\": \"users-service/users/<userId>\"} } }, \"bod\": \"<userId>\"}]": {
-    "last_validated_date": "2024-12-13T13:20:37+00:00"
+    "last_validated_date": "2024-12-13T17:27:41+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": \"<userId>\"}]": {
     "last_validated_date": "2024-12-13T13:20:32+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": <payload>}]": {
-    "last_validated_date": "2024-12-13T13:20:27+00:00"
+    "last_validated_date": "2024-12-13T17:27:29+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": [<userId>, \"hardcoded\"]}]": {
-    "last_validated_date": "2024-12-13T13:20:34+00:00"
+    "last_validated_date": "2024-12-13T17:27:39+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"id\": \"<userId>\", \"body\": <payload>}]": {
+    "last_validated_date": "2024-12-13T14:54:39+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"id\": <userId>, \"body\": <payload>}]": {
+    "last_validated_date": "2024-12-13T17:27:36+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"singlelistitem\": <listsingle>}]": {
+    "last_validated_date": "2024-12-13T17:27:48+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement_not_valid[{\"not_valid\": \"users-service/users/<payload>\", \"bod\": <payload>}]": {
+    "last_validated_date": "2024-12-13T14:55:05+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement_not_valid[{\"payload\": \"<payload>\"}]": {
+    "last_validated_date": "2024-12-13T14:55:13+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement_not_valid[{\"singlelistitem\": \"<listsingle>\"}]": {
+    "last_validated_date": "2024-12-13T17:19:20+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
     "last_validated_date": "2024-06-11T08:33:10+00:00"

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -18,49 +18,52 @@
     "last_validated_date": "2024-12-06T11:07:17+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listmulti> multiple list items\"]": {
-    "last_validated_date": "2024-12-13T17:27:46+00:00"
+    "last_validated_date": "2024-12-13T18:03:28+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item <listmulti> multiple list items <systemstring> system account id <payload> payload <userId> user id\"]": {
-    "last_validated_date": "2024-12-13T17:40:06+00:00"
+    "last_validated_date": "2024-12-13T18:03:32+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item\"\\n\"<listmulti> multiple list items\"\\n\"<systemstring> system account id\"\\n\"<payload> payload\"\\n\"<userId> user id\"]": {
     "last_validated_date": "2024-12-13T17:27:50+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item\"]": {
-    "last_validated_date": "2024-12-13T17:27:43+00:00"
+    "last_validated_date": "2024-12-13T18:03:25+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId> and <userId>\"]": {
-    "last_validated_date": "2024-12-13T17:27:32+00:00"
+    "last_validated_date": "2024-12-13T18:03:14+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId>\"]": {
     "last_validated_date": "2024-12-13T13:20:30+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"id\" : <userId>}]": {
-    "last_validated_date": "2024-12-13T17:27:34+00:00"
+    "last_validated_date": "2024-12-13T18:03:16+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"id\": <userId>}]": {
     "last_validated_date": "2024-12-13T14:56:24+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"nested\": {\"level1\": {\"level2\": {\"level3\": \"users-service/users/<userId>\"} } }, \"bod\": \"<userId>\"}]": {
-    "last_validated_date": "2024-12-13T17:27:41+00:00"
+    "last_validated_date": "2024-12-13T18:03:23+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": \"<userId>\"}]": {
     "last_validated_date": "2024-12-13T13:20:32+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": <payload>}]": {
-    "last_validated_date": "2024-12-13T17:27:29+00:00"
+    "last_validated_date": "2024-12-13T18:03:12+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": [<userId>, \"hardcoded\"]}]": {
-    "last_validated_date": "2024-12-13T17:27:39+00:00"
+    "last_validated_date": "2024-12-13T18:03:21+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"id\": \"<userId>\", \"body\": <payload>}]": {
     "last_validated_date": "2024-12-13T14:54:39+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"id\": <userId>, \"body\": <payload>}]": {
-    "last_validated_date": "2024-12-13T17:27:36+00:00"
+    "last_validated_date": "2024-12-13T18:03:18+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"multi_replacement\": \"users/<userId>/second/<userId>\"}]": {
+    "last_validated_date": "2024-12-13T18:03:35+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"singlelistitem\": <listsingle>}]": {
-    "last_validated_date": "2024-12-13T17:27:48+00:00"
+    "last_validated_date": "2024-12-13T18:03:30+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement_not_valid[{\"not_valid\": \"users-service/users/<payload>\", \"bod\": <payload>}]": {
     "last_validated_date": "2024-12-13T14:55:05+00:00"

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -17,11 +17,20 @@
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement": {
     "last_validated_date": "2024-12-06T11:07:17+00:00"
   },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item\"\\n\"<listmulti> multiple list items\"\\n\"<systemstring> system account id\"\\n\"<payload> payload\"\\n\"<userId> user id\"]": {
+    "last_validated_date": "2024-12-13T12:23:43+00:00"
+  },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId>\"]": {
-    "last_validated_date": "2024-12-06T12:13:58+00:00"
+    "last_validated_date": "2024-12-13T12:23:37+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": \"<userId>\"}]": {
+    "last_validated_date": "2024-12-13T12:23:39+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": <payload>}]": {
-    "last_validated_date": "2024-12-06T12:10:34+00:00"
+    "last_validated_date": "2024-12-13T12:23:34+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": [<userId>, \"hardcoded\"]}]": {
+    "last_validated_date": "2024-12-13T12:23:41+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
     "last_validated_date": "2024-06-11T08:33:10+00:00"

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -18,19 +18,22 @@
     "last_validated_date": "2024-12-06T11:07:17+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"<listsingle> single list item\"\\n\"<listmulti> multiple list items\"\\n\"<systemstring> system account id\"\\n\"<payload> payload\"\\n\"<userId> user id\"]": {
-    "last_validated_date": "2024-12-13T12:23:43+00:00"
+    "last_validated_date": "2024-12-13T13:20:39+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId>\"]": {
-    "last_validated_date": "2024-12-13T12:23:37+00:00"
+    "last_validated_date": "2024-12-13T13:20:30+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"nested\": {\"level1\": {\"level2\": {\"level3\": \"users-service/users/<userId>\"} } }, \"bod\": \"<userId>\"}]": {
+    "last_validated_date": "2024-12-13T13:20:37+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": \"<userId>\"}]": {
-    "last_validated_date": "2024-12-13T12:23:39+00:00"
+    "last_validated_date": "2024-12-13T13:20:32+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": <payload>}]": {
-    "last_validated_date": "2024-12-13T12:23:34+00:00"
+    "last_validated_date": "2024-12-13T13:20:27+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"method\": \"PUT\", \"path\": \"users-service/users/<userId>\", \"bod\": [<userId>, \"hardcoded\"]}]": {
-    "last_validated_date": "2024-12-13T12:23:41+00:00"
+    "last_validated_date": "2024-12-13T13:20:34+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
     "last_validated_date": "2024-06-11T08:33:10+00:00"

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -35,6 +35,9 @@
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[\"Payload of <payload> with path users-service/users/<userId>\"]": {
     "last_validated_date": "2024-12-13T13:20:30+00:00"
   },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"id\" : \"<userId>\"}]": {
+    "last_validated_date": "2024-12-16T12:26:02+00:00"
+  },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement[{\"id\" : <userId>}]": {
     "last_validated_date": "2024-12-13T18:03:16+00:00"
   },

--- a/tests/unit/services/events/test_utils.py
+++ b/tests/unit/services/events/test_utils.py
@@ -6,23 +6,22 @@ from localstack.services.events.utils import is_nested_in_string
 
 
 @pytest.mark.parametrize(
-    "template, match, expected",
+    "template, expected",
     [
         # Basic cases
-        ('"users-service/users/<userId>"', "<userId>", True),
-        ("<userId>", "<userId>", False),
+        ('"users-service/users/<userId>"', True),
+        ("<userId>", False),
         # Edge cases with commas and braces
-        ('{"path": "users/<userId>", "id": <userId>}', "<userId>", True),
-        ('{"id": <userId>}', "<userId>", False),
+        ('{"path": "users/<userId>", "id": <userId>}', True),
+        ('{"id": <userId>}', False),
         # Multiple placeholders
-        ('"users/<userId>/profile/<type>"', "<userId>", True),
-        ('"users/<userId>/profile/<type>"', "<type>", True),
+        ('"users/<userId>/profile/<type>"', True),
         # Nested JSON structures
-        ('{"data": {"path": "users/<userId>"}}', "<userId>", True),
-        ('{"data": <userId>}', "<userId>", False),
+        ('{"data": {"path": "users/<userId>"}}', True),
+        ('{"data": <userId>}', False),
     ],
 )
-def test_is_nested_in_string(template, match, expected):
+def test_is_nested_in_string(template, expected):
     pattern = re.compile(r"<.*?>")
-    match = pattern.search(template, match)
+    match = pattern.search(template)
     assert is_nested_in_string(template, match) == expected

--- a/tests/unit/services/events/test_utils.py
+++ b/tests/unit/services/events/test_utils.py
@@ -1,0 +1,28 @@
+import re
+
+import pytest
+
+from localstack.services.events.utils import is_nested_in_string
+
+
+@pytest.mark.parametrize(
+    "template, match, expected",
+    [
+        # Basic cases
+        ('"users-service/users/<userId>"', "<userId>", True),
+        ("<userId>", "<userId>", False),
+        # Edge cases with commas and braces
+        ('{"path": "users/<userId>", "id": <userId>}', "<userId>", True),
+        ('{"id": <userId>}', "<userId>", False),
+        # Multiple placeholders
+        ('"users/<userId>/profile/<type>"', "<userId>", True),
+        ('"users/<userId>/profile/<type>"', "<type>", True),
+        # Nested JSON structures
+        ('{"data": {"path": "users/<userId>"}}', "<userId>", True),
+        ('{"data": <userId>}', "<userId>", False),
+    ],
+)
+def test_is_nested_in_string(template, match, expected):
+    pattern = re.compile(r"<.*?>")
+    match = pattern.search(template, match)
+    assert is_nested_in_string(template, match) == expected

--- a/tests/unit/services/events/test_utils.py
+++ b/tests/unit/services/events/test_utils.py
@@ -10,7 +10,7 @@ from localstack.services.events.utils import is_nested_in_string
     [
         # Basic cases
         ('"users-service/users/<userId>"', True),
-        ("<userId>", False),
+        ('"<userId>"', True),
         # Edge cases with commas and braces
         ('{"path": "users/<userId>", "id": <userId>}', True),
         ('{"id": <userId>}', False),
@@ -19,6 +19,7 @@ from localstack.services.events.utils import is_nested_in_string
         # Nested JSON structures
         ('{"data": {"path": "users/<userId>"}}', True),
         ('{"data": <userId>}', False),
+        ('{"data": "<userId>"}', True),
     ],
 )
 def test_is_nested_in_string(template, expected):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
InputTransformer map values from the event to keys defined in InputPathMap and these can then be used in InputTemplate to replace placeholders.
These placeholders can also be in a continuous string "string/<placeholder>" this was failing in localstack as raised here https://github.com/localstack/localstack/issues/11126



<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add support for string nested placeholders in json input templates
- add support for string nested placeholders in string input templates


<!-- Optional section: How to test these changes? -->
<!--
## Testing
`tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_nested_keys_replacement`
