### PR TITLE
Bump moto-ext to 5.0.22.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.20.post1",
+    "moto-ext[all]==5.0.22.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -256,7 +256,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.20.post1
+moto-ext==5.0.22.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -190,7 +190,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.20.post1
+moto-ext==5.0.22.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -260,7 +260,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.20.post1
+moto-ext==5.0.22.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.0.22.post1

Contains:

- https://github.com/getmoto/moto/pull/8338
- https://github.com/getmoto/moto/pull/8335 
  closes: https://github.com/localstack/localstack/issues/11635

## To do

- [x] Ext compatibility ([Ext integration tests](https://github.com/localstack/localstack-ext/actions/runs/12270701575))
- [x] Multi-account/region compatibility ([Randomised credentials test run](https://app.circleci.com/pipelines/github/localstack/localstack/30183/workflows/202d1981-9c88-4b0c-b423-870911923700))