### PR TITLE
upgrade cryptography and amazon-kclpy

### DIFF
--- a/localstack-core/localstack/utils/kinesis/kclipy_helper.py
+++ b/localstack-core/localstack/utils/kinesis/kclipy_helper.py
@@ -95,11 +95,13 @@ def create_config_file(
 ):
     if not credentialsProvider:
         credentialsProvider = "DefaultCredentialsProvider"
+    # TODO properly migrate to v3 of KCL and remove the clientVersionConfig
     content = f"""
         executableName = {executableName}
         streamName = {streamName}
         applicationName = {applicationName}
         AWSCredentialsProvider = {credentialsProvider}
+        clientVersionConfig = CLIENT_VERSION_CONFIG_COMPATIBLE_WITH_2x
         kinesisCredentialsProvider = {credentialsProvider}
         dynamoDBCredentialsProvider = {credentialsProvider}
         cloudWatchCredentialsProvider = {credentialsProvider}

--- a/localstack-core/localstack/utils/kinesis/kclipy_helper.py
+++ b/localstack-core/localstack/utils/kinesis/kclipy_helper.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import sys
 from glob import glob
 
 from amazon_kclpy import kcl
@@ -99,11 +100,10 @@ def create_config_file(
         streamName = {streamName}
         applicationName = {applicationName}
         AWSCredentialsProvider = {credentialsProvider}
-        clientVersionConfig = CLIENT_VERSION_CONFIG_COMPATIBLE_WITH_2x
         kinesisCredentialsProvider = {credentialsProvider}
         dynamoDBCredentialsProvider = {credentialsProvider}
         cloudWatchCredentialsProvider = {credentialsProvider}
-        processingLanguage = python/3.11
+        processingLanguage = python/{sys.version_info.major}.{sys.version_info.minor}
         shardSyncIntervalMillis = 2000
         parentShardPollIntervalMillis = 2000
         idleTimeBetweenReadsInMillis = 1000

--- a/localstack-core/localstack/utils/kinesis/kclipy_helper.py
+++ b/localstack-core/localstack/utils/kinesis/kclipy_helper.py
@@ -93,16 +93,17 @@ def create_config_file(
     **kwargs,
 ):
     if not credentialsProvider:
-        credentialsProvider = "DefaultAWSCredentialsProviderChain"
+        credentialsProvider = "DefaultCredentialsProvider"
     content = f"""
         executableName = {executableName}
         streamName = {streamName}
         applicationName = {applicationName}
         AWSCredentialsProvider = {credentialsProvider}
+        clientVersionConfig = CLIENT_VERSION_CONFIG_COMPATIBLE_WITH_2x
         kinesisCredentialsProvider = {credentialsProvider}
         dynamoDBCredentialsProvider = {credentialsProvider}
         cloudWatchCredentialsProvider = {credentialsProvider}
-        processingLanguage = python/3.10
+        processingLanguage = python/3.11
         shardSyncIntervalMillis = 2000
         parentShardPollIntervalMillis = 2000
         idleTimeBetweenReadsInMillis = 1000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ runtime = [
     # pinned / updated by ASF update action
     "awscli>=1.32.117",
     "airspeed-ext>=0.6.3",
-    "amazon_kclpy>=2.0.6,!=2.1.0,!=2.1.4",
+    "amazon_kclpy>=3.0.0",
     # antlr4-python3-runtime: exact pin because antlr4 runtime is tightly coupled to the generated parser code
     "antlr4-python3-runtime==4.13.2",
     "apispec>=5.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,15 +80,13 @@ runtime = [
     # pinned / updated by ASF update action
     "awscli>=1.32.117",
     "airspeed-ext>=0.6.3",
-    # TODO upgrade to kclpy 3+
-    "amazon_kclpy>=2.0.6,!=2.1.0,!=2.1.4,<3.0.0",
+    "amazon_kclpy>=2.0.6,!=2.1.0,!=2.1.4",
     # antlr4-python3-runtime: exact pin because antlr4 runtime is tightly coupled to the generated parser code
     "antlr4-python3-runtime==4.13.2",
     "apispec>=5.1.1",
     "aws-sam-translator>=1.15.1",
     "crontab>=0.22.6",
-    # TODO remove upper limit once https://github.com/getmoto/moto/pull/7876 is in our moto-ext version
-    "cryptography>=41.0.5,<43.0.0",
+    "cryptography>=41.0.5",
     # allow Python programs full access to Java class libraries. Used for opt-in event ruler.
     "jpype1-ext>=0.0.1",
     "json5>=0.9.11",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 airspeed-ext==0.6.7
     # via localstack-core
-amazon-kclpy==2.1.5
+amazon-kclpy==3.0.1
     # via localstack-core
 annotated-types==0.7.0
     # via pydantic
@@ -107,7 +107,7 @@ coveralls==4.0.1
     # via localstack-core (pyproject.toml)
 crontab==1.0.1
     # via localstack-core
-cryptography==42.0.8
+cryptography==44.0.0
     # via
     #   joserfc
     #   localstack-core

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -6,7 +6,7 @@
 #
 airspeed-ext==0.6.7
     # via localstack-core (pyproject.toml)
-amazon-kclpy==2.1.5
+amazon-kclpy==3.0.1
     # via localstack-core (pyproject.toml)
 annotated-types==0.7.0
     # via pydantic
@@ -78,7 +78,7 @@ constantly==23.10.4
     # via localstack-twisted
 crontab==1.0.1
     # via localstack-core (pyproject.toml)
-cryptography==42.0.8
+cryptography==44.0.0
     # via
     #   joserfc
     #   localstack-core

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,7 +6,7 @@
 #
 airspeed-ext==0.6.7
     # via localstack-core
-amazon-kclpy==2.1.5
+amazon-kclpy==3.0.1
     # via localstack-core
 annotated-types==0.7.0
     # via pydantic
@@ -101,7 +101,7 @@ coverage==7.6.9
     # via localstack-core (pyproject.toml)
 crontab==1.0.1
     # via localstack-core
-cryptography==42.0.8
+cryptography==44.0.0
     # via
     #   joserfc
     #   localstack-core

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -6,7 +6,7 @@
 #
 airspeed-ext==0.6.7
     # via localstack-core
-amazon-kclpy==2.1.5
+amazon-kclpy==3.0.1
     # via localstack-core
 annotated-types==0.7.0
     # via pydantic
@@ -111,7 +111,7 @@ coveralls==4.0.1
     # via localstack-core
 crontab==1.0.1
     # via localstack-core
-cryptography==42.0.8
+cryptography==44.0.0
     # via
     #   joserfc
     #   localstack-core

--- a/tests/aws/test_integration.py
+++ b/tests/aws/test_integration.py
@@ -188,7 +188,7 @@ class TestIntegration:
             )
             assert stream_info["DeliveryStreamDescription"]["DeliveryStreamStatus"] == "ACTIVE"
 
-        retry(_assert_active, sleep=1, retries=30)
+        retry(_assert_active, sleep=1, retries=60)
 
         # create target S3 bucket
         s3_create_bucket(Bucket=TEST_BUCKET_NAME)


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/11829 and https://github.com/localstack/localstack/pull/11245 we introduced some dependency limits which we need to remove to get up-to-date again.

## Changes
- Remove the pin on `cryptography` and `amazon_kclpy`.
- Upgrade the client config for `amazon_kclpy` to enable "v2 compatibility mode" (to minimize the amount of necessary changes in this PR while fixing the failing tests).
- Extend the timeout for `test_firehose_kinesis_to_s3` as it was already flaky before.

## TODO
- [x] Fix failing tests:
  - [x] `test_firehose_kinesis_to_s3`
  - [x] `test_lambda_streams_batch_and_transactions`
  - [x] `test_firehose_stack_with_kinesis_as_source`
  - [x] `test_run_kcl`

## TODO in a follow-up
- Migrate the usage of KCL to v3 (since this PR just enables the v2 compat mode).