### PR TITLE
Unskip supported Lambda and ESM tests

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -51,6 +51,13 @@ def test_lambda_w_dynamodb_event_filter(deploy_cfn_template, aws_client):
     retry(_assert_single_lambda_call, retries=30)
 
 
+@markers.snapshot.skip_snapshot_verify(
+    [
+        # TODO: Fix flaky ESM state mismatch upon update in LocalStack (expected Enabled, actual Disabled)
+        #  This might be a parity issue if AWS does rolling updates (i.e., never disables the ESM upon update).
+        "$..EventSourceMappings..State",
+    ]
+)
 @markers.aws.validated
 def test_lambda_w_dynamodb_event_filter_update(deploy_cfn_template, snapshot, aws_client):
     snapshot.add_transformer(snapshot.transform.dynamodb_api())

--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -19,8 +19,6 @@ from localstack.utils.sync import retry, wait_until
 from localstack.utils.testutil import create_lambda_archive, get_lambda_log_events
 
 
-# TODO: Fix for new Lambda provider (was tested for old provider)
-@pytest.mark.skip(reason="not implemented yet in new provider")
 @markers.aws.validated
 def test_lambda_w_dynamodb_event_filter(deploy_cfn_template, aws_client):
     function_name = f"test-fn-{short_uid()}"
@@ -53,15 +51,6 @@ def test_lambda_w_dynamodb_event_filter(deploy_cfn_template, aws_client):
     retry(_assert_single_lambda_call, retries=30)
 
 
-# TODO make a test simular to one above but for updated filtering
-
-
-@markers.snapshot.skip_snapshot_verify(
-    [
-        "$..EventSourceMappings..FunctionArn",
-        "$..EventSourceMappings..LastProcessingResult",
-    ]
-)
 @markers.aws.validated
 def test_lambda_w_dynamodb_event_filter_update(deploy_cfn_template, snapshot, aws_client):
     snapshot.add_transformer(snapshot.transform.dynamodb_api())
@@ -261,7 +250,6 @@ def test_lambda_alias(deploy_cfn_template, snapshot, aws_client):
     not in_default_partition(), reason="Test not applicable in non-default partitions"
 )
 @markers.aws.validated
-@markers.snapshot.skip_snapshot_verify(paths=["$..DestinationConfig"])
 def test_lambda_code_signing_config(deploy_cfn_template, snapshot, account_id, aws_client):
     snapshot.add_transformer(snapshot.transform.cloudformation_api())
     snapshot.add_transformer(snapshot.transform.lambda_api())
@@ -305,7 +293,12 @@ def test_event_invoke_config(deploy_cfn_template, snapshot, aws_client):
     snapshot.match("event_invoke_config", event_invoke_config)
 
 
-@markers.snapshot.skip_snapshot_verify(paths=["$..CodeSize"])
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        # Lambda ZIP flaky in CI
+        "$..CodeSize",
+    ]
+)
 @markers.aws.validated
 def test_lambda_version(deploy_cfn_template, snapshot, aws_client):
     snapshot.add_transformer(snapshot.transform.cloudformation_api())
@@ -462,7 +455,6 @@ def test_lambda_vpc(deploy_cfn_template, aws_client):
     aws_client.lambda_.invoke(FunctionName=fn_name, LogType="Tail", Payload=b"{}")
 
 
-@pytest.mark.skip(reason="fails/times out with new provider")  # FIXME
 @markers.aws.validated
 def test_update_lambda_permissions(deploy_cfn_template, aws_client):
     stack = deploy_cfn_template(
@@ -619,16 +611,12 @@ class TestCfnLambdaIntegrations:
 
     @markers.snapshot.skip_snapshot_verify(
         paths=[
-            "$..MaximumRetryAttempts",
-            "$..ParallelizationFactor",
-            "$..StateTransitionReason",
             # Lambda
             "$..Tags",
-            "$..Configuration.CodeSize",
-            "$..Configuration.Layers",
+            "$..Configuration.CodeSize",  # Lambda ZIP flaky in CI
             # SQS
             "$..Attributes.SqsManagedSseEnabled",
-            # # IAM
+            # IAM
             "$..PolicyNames",
             "$..PolicyName",
             "$..Role.Description",
@@ -742,12 +730,8 @@ class TestCfnLambdaIntegrations:
         with pytest.raises(aws_client.lambda_.exceptions.ResourceNotFoundException):
             aws_client.lambda_.get_event_source_mapping(UUID=esm_id)
 
-    # TODO: consider moving into the dedicated DynamoDB => Lambda tests
+    # TODO: consider moving into the dedicated DynamoDB => Lambda tests because it tests the filtering functionality rather than CloudFormation (just using CF to deploy resources)
     #  tests.aws.services.lambda_.test_lambda_integration_dynamodbstreams.TestDynamoDBEventSourceMapping.test_dynamodb_event_filter
-    @pytest.mark.skipif(
-        config.EVENT_RULE_ENGINE != "java",
-        reason="Filtering is broken with the Python rule engine for this specific case (exists:false) in ESM v2",
-    )
     @markers.aws.validated
     def test_lambda_dynamodb_event_filter(
         self, dynamodb_wait_for_table_active, deploy_cfn_template, aws_client, monkeypatch
@@ -786,8 +770,7 @@ class TestCfnLambdaIntegrations:
         paths=[
             # Lambda
             "$..Tags",
-            "$..Configuration.CodeSize",
-            "$..Configuration.Layers",
+            "$..Configuration.CodeSize",  # Lambda ZIP flaky in CI
             # IAM
             "$..PolicyNames",
             "$..policies..PolicyName",
@@ -801,12 +784,6 @@ class TestCfnLambdaIntegrations:
             "$..Table.Replicas",
             # stream result
             "$..StreamDescription.CreationRequestDateTime",
-            # event source mapping
-            "$..BisectBatchOnFunctionError",
-            "$..DestinationConfig",
-            "$..LastProcessingResult",
-            "$..MaximumRecordAgeInSeconds",
-            "$..TumblingWindowInSeconds",
         ]
     )
     @markers.aws.validated
@@ -929,16 +906,9 @@ class TestCfnLambdaIntegrations:
         paths=[
             "$..Role.Description",
             "$..Role.MaxSessionDuration",
-            "$..BisectBatchOnFunctionError",
-            "$..DestinationConfig",
-            "$..LastProcessingResult",
-            "$..MaximumRecordAgeInSeconds",
             "$..Configuration.CodeSize",
             "$..Tags",
-            "$..StreamDescription.StreamModeDetails",
-            "$..Configuration.Layers",
-            "$..TumblingWindowInSeconds",
-            # flaky because we currently don't actually wait in cloudformation for it to be active
+            # TODO: wait for ESM to become active in CloudFormation to mitigate these flaky fields
             "$..Configuration.LastUpdateStatus",
             "$..Configuration.State",
             "$..Configuration.StateReason",
@@ -1094,11 +1064,11 @@ class TestCfnLambdaDestinations:
 
     """
 
-    @pytest.mark.skip(reason="not supported atm and test needs further work")
     @pytest.mark.parametrize(
         ["on_success", "on_failure"],
         [
             ("sqs", "sqs"),
+            # TODO: test needs further work
             # ("sns", "sns"),
             # ("lambda", "lambda"),
             # ("eventbridge", "eventbridge")

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -42,7 +42,7 @@
     "last_validated_date": "2024-04-09T07:21:37+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_w_dynamodb_event_filter_update": {
-    "last_validated_date": "2024-10-12T10:42:00+00:00"
+    "last_validated_date": "2024-12-11T09:03:52+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_multiple_lambda_permissions_for_singlefn": {
     "last_validated_date": "2024-04-09T07:25:05+00:00"

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaDestinations::test_generic_destination_routing[sqs-sqs]": {
+    "last_validated_date": "2024-12-10T16:48:04+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_dynamodb_source": {
     "last_validated_date": "2024-10-12T10:46:17+00:00"
   },

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
@@ -195,7 +195,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_async_invocation": {
-    "recorded-date": "27-02-2023, 16:55:08",
+    "recorded-date": "11-12-2024, 09:54:54",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -204,9 +204,10 @@
           "OnFailure": {}
         },
         "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
-        "LastModified": "datetime",
+        "LastModified": "<datetime>",
         "LastProcessingResult": "No records processed",
         "MaximumBatchingWindowInSeconds": 0,
         "MaximumRecordAgeInSeconds": -1,
@@ -233,7 +234,7 @@
                   "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:1>",
                   "data": "eyJyZWNvcmRfaWQiOiAwfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -249,7 +250,7 @@
                   "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:2>",
                   "data": "eyJyZWNvcmRfaWQiOiAxfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -265,7 +266,7 @@
                   "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:3>",
                   "data": "eyJyZWNvcmRfaWQiOiAyfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -281,7 +282,7 @@
                   "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:4>",
                   "data": "eyJyZWNvcmRfaWQiOiAzfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -297,7 +298,7 @@
                   "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:5>",
                   "data": "eyJyZWNvcmRfaWQiOiA0fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -313,7 +314,7 @@
                   "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:6>",
                   "data": "eyJyZWNvcmRfaWQiOiA1fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -329,7 +330,7 @@
                   "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:7>",
                   "data": "eyJyZWNvcmRfaWQiOiA2fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -345,7 +346,7 @@
                   "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:8>",
                   "data": "eyJyZWNvcmRfaWQiOiA3fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -361,7 +362,7 @@
                   "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:9>",
                   "data": "eyJyZWNvcmRfaWQiOiA4fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -377,7 +378,7 @@
                   "partitionKey": "test_0",
                   "sequenceNumber": "<sequence-number:10>",
                   "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -400,7 +401,7 @@
                   "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:11>",
                   "data": "eyJyZWNvcmRfaWQiOiAwfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -416,7 +417,7 @@
                   "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:12>",
                   "data": "eyJyZWNvcmRfaWQiOiAxfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -432,7 +433,7 @@
                   "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:13>",
                   "data": "eyJyZWNvcmRfaWQiOiAyfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -448,7 +449,7 @@
                   "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:14>",
                   "data": "eyJyZWNvcmRfaWQiOiAzfQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -464,7 +465,7 @@
                   "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:15>",
                   "data": "eyJyZWNvcmRfaWQiOiA0fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -480,7 +481,7 @@
                   "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:16>",
                   "data": "eyJyZWNvcmRfaWQiOiA1fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -496,7 +497,7 @@
                   "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:17>",
                   "data": "eyJyZWNvcmRfaWQiOiA2fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -512,7 +513,7 @@
                   "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:18>",
                   "data": "eyJyZWNvcmRfaWQiOiA3fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -528,7 +529,7 @@
                   "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:19>",
                   "data": "eyJyZWNvcmRfaWQiOiA4fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",
@@ -544,7 +545,7 @@
                   "partitionKey": "test_1",
                   "sequenceNumber": "<sequence-number:20>",
                   "data": "eyJyZWNvcmRfaWQiOiA5fQ==",
-                  "approximateArrivalTimestamp": "timestamp"
+                  "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
                 },
                 "eventSource": "aws:kinesis",
                 "eventVersion": "1.0",

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -1,8 +1,9 @@
 {
-  "test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_on_failure_destination_config": {
-    "last_validated_date": "2023-02-27T16:01:08+00:00"
-  },
-  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisEventFiltering::test_kinesis_event_filtering_json_pattern": {
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_async_invocation": {
+    "last_validated_date": "2024-12-11T09:56:46+00:00"
+  }
+}
+source_mapping/test_lambda_integration_kinesis.py::TestKinesisEventFiltering::test_kinesis_event_filtering_json_pattern": {
     "last_validated_date": "2024-10-12T13:31:49+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping": {
@@ -21,7 +22,7 @@
     "last_validated_date": "2024-10-11T11:04:52+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_async_invocation": {
-    "last_validated_date": "2023-02-27T15:55:08+00:00"
+    "last_validated_date": "2024-12-11T09:54:52+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_on_failure_destination_config": {
     "last_validated_date": "2024-10-12T12:27:07+00:00"
@@ -63,13 +64,16 @@
     "last_validated_date": "2024-10-12T13:21:23+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_string_success]": {
-    "last_validated_date": "2024-10-12T13:19:35+00:00"
-  },
-  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_string_success]": {
     "last_validated_date": "2024-10-11T12:38:13+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[null_batch_item_failure_success]": {
     "last_validated_date": "2024-10-12T13:28:03+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[null_success]": {
+    "last_validated_date": "2024-10-12T13:23:12+00:00"
+  }
+}
+"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[null_success]": {
     "last_validated_date": "2024-10-12T13:23:12+00:00"

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -1,81 +1,68 @@
 {
-  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_async_invocation": {
-    "last_validated_date": "2024-12-11T09:56:46+00:00"
-  }
-}
-source_mapping/test_lambda_integration_kinesis.py::TestKinesisEventFiltering::test_kinesis_event_filtering_json_pattern": {
-    "last_validated_date": "2024-10-12T13:31:49+00:00"
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisEventFiltering::test_kinesis_event_filtering_json_pattern": {
+    "last_validated_date": "2024-12-13T14:48:09+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping": {
-    "last_validated_date": "2024-10-12T11:47:14+00:00"
+    "last_validated_date": "2024-12-13T14:01:07+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping_multiple_lambdas_single_kinesis_event_stream": {
-    "last_validated_date": "2024-10-12T13:58:15+00:00"
+    "last_validated_date": "2024-12-13T14:02:48+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_disable_kinesis_event_source_mapping": {
-    "last_validated_date": "2024-10-12T11:54:19+00:00"
+    "last_validated_date": "2024-12-13T14:10:20+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_duplicate_event_source_mappings": {
-    "last_validated_date": "2024-10-12T11:48:44+00:00"
+    "last_validated_date": "2024-12-13T14:03:01+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_empty_provided": {
-    "last_validated_date": "2024-10-11T11:04:52+00:00"
+    "last_validated_date": "2024-12-13T14:45:29+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_async_invocation": {
-    "last_validated_date": "2024-12-11T09:54:52+00:00"
-  },
-  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_on_failure_destination_config": {
-    "last_validated_date": "2024-10-12T12:27:07+00:00"
+    "last_validated_date": "2024-12-13T14:04:46+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_sns_on_failure_destination_config": {
-    "last_validated_date": "2024-10-12T13:17:51+00:00"
+    "last_validated_date": "2024-12-13T14:35:43+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_trim_horizon": {
-    "last_validated_date": "2024-10-12T11:50:50+00:00"
+    "last_validated_date": "2024-12-13T14:06:49+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[empty_string_item_identifier_failure]": {
-    "last_validated_date": "2024-10-12T13:08:07+00:00"
+    "last_validated_date": "2024-12-13T14:23:18+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[invalid_key_foo_failure]": {
-    "last_validated_date": "2024-10-12T13:13:16+00:00"
+    "last_validated_date": "2024-12-13T14:27:36+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[invalid_key_foo_null_value_failure]": {
-    "last_validated_date": "2024-10-12T13:14:10+00:00"
+    "last_validated_date": "2024-12-13T14:31:32+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[item_identifier_not_present_failure]": {
-    "last_validated_date": "2024-10-12T13:06:11+00:00"
+    "last_validated_date": "2024-12-13T14:20:08+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[null_item_identifier_failure]": {
-    "last_validated_date": "2024-10-12T13:10:18+00:00"
+    "last_validated_date": "2024-12-13T14:25:26+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[unhandled_exception_in_function]": {
-    "last_validated_date": "2024-10-14T18:10:14+00:00"
+    "last_validated_date": "2024-12-13T14:34:41+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failures": {
-    "last_validated_date": "2024-10-12T14:17:03+00:00"
+    "last_validated_date": "2024-12-13T14:18:13+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_batch_item_failure_success]": {
-    "last_validated_date": "2024-10-12T13:27:09+00:00"
+    "last_validated_date": "2024-12-13T14:42:49+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_dict_success]": {
-    "last_validated_date": "2024-10-12T13:25:11+00:00"
+    "last_validated_date": "2024-12-13T14:41:30+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_list_success]": {
-    "last_validated_date": "2024-10-12T13:21:23+00:00"
+    "last_validated_date": "2024-12-13T14:38:21+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[empty_string_success]": {
-    "last_validated_date": "2024-10-11T12:38:13+00:00"
+    "last_validated_date": "2024-12-13T14:37:20+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[null_batch_item_failure_success]": {
-    "last_validated_date": "2024-10-12T13:28:03+00:00"
+    "last_validated_date": "2024-12-13T14:44:14+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[null_success]": {
-    "last_validated_date": "2024-10-12T13:23:12+00:00"
-  }
-}
-"
-  },
-  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_success_scenarios[null_success]": {
-    "last_validated_date": "2024-10-12T13:23:12+00:00"
+    "last_validated_date": "2024-12-13T14:39:47+00:00"
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.snapshot.json
@@ -1664,7 +1664,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_batch_size[15]": {
-    "recorded-date": "26-11-2024, 13:43:42",
+    "recorded-date": "11-12-2024, 13:42:57",
     "recorded-content": {
       "create-event-source-mapping-response": {
         "BatchSize": 15,
@@ -1673,7 +1673,7 @@
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
-        "MaximumBatchingWindowInSeconds": 10,
+        "MaximumBatchingWindowInSeconds": "maximum-batching-window-in-seconds",
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
         "UUID": "<uuid:1>",
@@ -1785,8 +1785,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfMessageAttributes": null,
           "md5OfBody": "<md5-of-body:1>",
+          "md5OfMessageAttributes": null,
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -1836,8 +1836,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfMessageAttributes": null,
           "md5OfBody": "<md5-of-body:4>",
+          "md5OfMessageAttributes": null,
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -1904,8 +1904,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfMessageAttributes": null,
           "md5OfBody": "<md5-of-body:8>",
+          "md5OfMessageAttributes": null,
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -2023,8 +2023,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfMessageAttributes": null,
           "md5OfBody": "<md5-of-body:15>",
+          "md5OfMessageAttributes": null,
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -2579,7 +2579,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_batch_size[100]": {
-    "recorded-date": "26-11-2024, 13:44:40",
+    "recorded-date": "11-12-2024, 13:43:49",
     "recorded-content": {
       "create-event-source-mapping-response": {
         "BatchSize": 100,
@@ -2588,7 +2588,7 @@
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
-        "MaximumBatchingWindowInSeconds": 10,
+        "MaximumBatchingWindowInSeconds": "maximum-batching-window-in-seconds",
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
         "UUID": "<uuid:1>",
@@ -2734,8 +2734,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfBody": "<md5-of-body:3>",
           "md5OfMessageAttributes": null,
+          "md5OfBody": "<md5-of-body:3>",
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -2751,8 +2751,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfBody": "<md5-of-body:4>",
           "md5OfMessageAttributes": null,
+          "md5OfBody": "<md5-of-body:4>",
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -2768,8 +2768,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfBody": "<md5-of-body:5>",
           "md5OfMessageAttributes": null,
+          "md5OfBody": "<md5-of-body:5>",
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -2802,8 +2802,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfBody": "<md5-of-body:7>",
           "md5OfMessageAttributes": null,
+          "md5OfBody": "<md5-of-body:7>",
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -2819,8 +2819,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfBody": "<md5-of-body:8>",
           "md5OfMessageAttributes": null,
+          "md5OfBody": "<md5-of-body:8>",
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -2836,8 +2836,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfBody": "<md5-of-body:9>",
           "md5OfMessageAttributes": null,
+          "md5OfBody": "<md5-of-body:9>",
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -2853,8 +2853,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfBody": "<md5-of-body:10>",
           "md5OfMessageAttributes": null,
+          "md5OfBody": "<md5-of-body:10>",
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -2904,8 +2904,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfBody": "<md5-of-body:13>",
           "md5OfMessageAttributes": null,
+          "md5OfBody": "<md5-of-body:13>",
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -2938,8 +2938,8 @@
             "ApproximateFirstReceiveTimestamp": "<approximate-first-receive-timestamp>"
           },
           "messageAttributes": {},
-          "md5OfBody": "<md5-of-body:15>",
           "md5OfMessageAttributes": null,
+          "md5OfBody": "<md5-of-body:15>",
           "eventSource": "aws:sqs",
           "eventSourceARN": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "awsRegion": "<region>"
@@ -2948,7 +2948,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_batch_size[1000]": {
-    "recorded-date": "26-11-2024, 13:45:41",
+    "recorded-date": "11-12-2024, 13:44:40",
     "recorded-content": {
       "create-event-source-mapping-response": {
         "BatchSize": 1000,
@@ -2957,7 +2957,7 @@
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
-        "MaximumBatchingWindowInSeconds": 10,
+        "MaximumBatchingWindowInSeconds": "maximum-batching-window-in-seconds",
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
         "UUID": "<uuid:1>",
@@ -3317,7 +3317,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_batch_size[10000]": {
-    "recorded-date": "26-11-2024, 13:46:48",
+    "recorded-date": "11-12-2024, 13:45:32",
     "recorded-content": {
       "create-event-source-mapping-response": {
         "BatchSize": 10000,
@@ -3326,7 +3326,7 @@
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
         "FunctionResponseTypes": [],
         "LastModified": "<datetime>",
-        "MaximumBatchingWindowInSeconds": 10,
+        "MaximumBatchingWindowInSeconds": "maximum-batching-window-in-seconds",
         "State": "Creating",
         "StateTransitionReason": "USER_INITIATED",
         "UUID": "<uuid:1>",

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.validation.json
@@ -33,16 +33,16 @@
     "last_validated_date": "2024-11-25T15:46:54+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_batch_size[10000]": {
-    "last_validated_date": "2024-11-26T13:46:45+00:00"
+    "last_validated_date": "2024-12-11T13:45:31+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_batch_size[1000]": {
-    "last_validated_date": "2024-11-26T13:45:39+00:00"
+    "last_validated_date": "2024-12-11T13:44:38+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_batch_size[100]": {
-    "last_validated_date": "2024-11-26T13:44:38+00:00"
+    "last_validated_date": "2024-12-11T13:43:48+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_batch_size[15]": {
-    "last_validated_date": "2024-11-26T13:43:39+00:00"
+    "last_validated_date": "2024-12-11T13:42:55+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_batching_reserved_concurrency": {
     "last_validated_date": "2024-11-29T13:29:53+00:00"


### PR DESCRIPTION
## Motivation

With the many Lambda and ESM v2 improvements, we can unskip tests and enable snapshot validations.

## Changes

* Unskip supported Lambda and ESM tests