### PR TITLE
[ESM] Validate filter criteria and unskip tests

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_config_factory.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_config_factory.py
@@ -113,4 +113,6 @@ class EsmConfigFactory:
         #  esm_config
         esm_config.pop("Enabled", "")
         esm_config.pop("FunctionName", "")
+        if not esm_config.get("FilterCriteria", {}).get("Filters", []):
+            esm_config.pop("FilterCriteria", "")
         return esm_config

--- a/localstack-core/localstack/utils/event_matcher.py
+++ b/localstack-core/localstack/utils/event_matcher.py
@@ -2,7 +2,11 @@ import json
 from typing import Any
 
 from localstack import config
-from localstack.services.events.event_rule_engine import EventPatternCompiler, EventRuleEngine
+from localstack.services.events.event_rule_engine import (
+    EventPatternCompiler,
+    EventRuleEngine,
+    InvalidEventPatternException,
+)
 from localstack.services.events.event_ruler import matches_rule
 
 _event_pattern_compiler = EventPatternCompiler()
@@ -58,3 +62,12 @@ def matches_event(event_pattern: dict[str, Any] | str | None, event: dict[str, A
         compiled_event_pattern=compiled_event_pattern,
         event=event,
     )
+
+
+def validate_event_pattern(event_pattern: dict[str, Any] | str | None) -> bool:
+    try:
+        _ = _event_pattern_compiler.compile_event_pattern(event_pattern=event_pattern)
+    except InvalidEventPatternException:
+        return False
+
+    return True

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -756,7 +756,6 @@ class TestDynamoDBEventSourceMapping:
         snapshot.match("lambda-multiple-log-events", events)
 
     @markers.aws.validated
-    @pytest.mark.skip(reason="Invalid filter detection not yet implemented in ESM v2")
     @pytest.mark.parametrize(
         "filter",
         [

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -1026,7 +1026,6 @@ class TestKinesisEventFiltering:
         paths=[
             "$..Messages..Body.KinesisBatchInfo.shardId",
             "$..Messages..Body.KinesisBatchInfo.streamArn",
-            "$..EventSourceMappingArn",
         ],
     )
     @markers.aws.validated

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py
@@ -5,7 +5,6 @@ import pytest
 from botocore.exceptions import ClientError
 from localstack_snapshot.snapshots.transformer import KeyValueBasedTransformer, SortingTransformer
 
-from localstack import config
 from localstack.aws.api.lambda_ import InvalidParameterValueException, Runtime
 from localstack.testing.aws.lambda_utils import _await_event_source_mapping_enabled
 from localstack.testing.aws.util import is_aws_cloud
@@ -1287,11 +1286,6 @@ class TestSQSEventSourceMapping:
         aws_client,
         monkeypatch,
     ):
-        if item_not_matching == "this is a test string" and config.EVENT_RULE_ENGINE != "java":
-            pytest.skip(
-                "String comparison is broken in the Python rule engine for this specific case in ESM v2"
-            )
-
         function_name = f"lambda_func-{short_uid()}"
         queue_name_1 = f"queue-{short_uid()}-1"
         mapping_uuid = None
@@ -1355,7 +1349,6 @@ class TestSQSEventSourceMapping:
         rs = aws_client.sqs.receive_message(QueueUrl=queue_url_1)
         assert rs.get("Messages", []) == []
 
-    @pytest.mark.skip(reason="Invalid filter detection not yet implemented in ESM v2")
     @markers.aws.validated
     @pytest.mark.parametrize(
         "invalid_filter", [None, "simple string", {"eventSource": "aws:sqs"}, {"eventSource": []}]

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -5625,6 +5625,9 @@ class TestLambdaEventSourceMappings:
         )
 
         table_name = f"table-{short_uid()}"
+        # FIXME: Why is this not being automatically transformed?
+        snapshot.add_transformer(snapshot.transform.regex(table_name, "<table-name>"))
+
         dynamodb_create_table(table_name=table_name, partition_key="id")
         _await_dynamodb_table_active(aws_client.dynamodb, table_name)
         update_table_response = aws_client.dynamodb.update_table(

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -5610,6 +5610,64 @@ class TestLambdaEventSourceMappings:
         snapshot.match("error", response)
 
     @markers.aws.validated
+    def test_create_event_filter_criteria_validation(
+        self,
+        create_lambda_function,
+        lambda_su_role,
+        dynamodb_create_table,
+        snapshot,
+        aws_client,
+    ):
+        function_name = f"function-{short_uid()}"
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name,
+            runtime=Runtime.python3_12,
+            role=lambda_su_role,
+        )
+
+        table_name = f"table-{short_uid()}"
+        dynamodb_create_table(table_name=table_name, partition_key="id")
+        _await_dynamodb_table_active(aws_client.dynamodb, table_name)
+        update_table_response = aws_client.dynamodb.update_table(
+            TableName=table_name,
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "NEW_AND_OLD_IMAGES"},
+        )
+        stream_arn = update_table_response["TableDescription"]["LatestStreamArn"]
+
+        response = aws_client.lambda_.create_event_source_mapping(
+            FunctionName=function_name,
+            EventSourceArn=stream_arn,
+            StartingPosition="LATEST",
+            FilterCriteria={"Filters": []},
+        )
+        snapshot.match("response-with-empty-filters", response)
+
+        with pytest.raises(ParamValidationError):
+            aws_client.lambda_.create_event_source_mapping(
+                FunctionName=function_name,
+                EventSourceArn=stream_arn,
+                StartingPosition="LATEST",
+                FilterCriteria={"Filters": [{"Pattern": []}]},
+            )
+
+        with pytest.raises(ParamValidationError):
+            aws_client.lambda_.create_event_source_mapping(
+                FunctionName=function_name,
+                EventSourceArn=stream_arn,
+                StartingPosition="LATEST",
+                FilterCriteria={"wrong": []},
+            )
+
+        with pytest.raises(ParamValidationError):
+            aws_client.lambda_.create_event_source_mapping(
+                FunctionName=function_name,
+                EventSourceArn=stream_arn,
+                StartingPosition="LATEST",
+                FilterCriteria=None,
+            )
+
+    @markers.aws.validated
     @pytest.mark.skip(reason="ESM v2 validation for Kafka poller only works with ext")
     def test_create_event_source_self_managed(
         self,

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -18217,7 +18217,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_filter_criteria_validation": {
-    "recorded-date": "10-12-2024, 16:17:56",
+    "recorded-date": "11-12-2024, 11:29:54",
     "recorded-content": {
       "response-with-empty-filters": {
         "BatchSize": 100,
@@ -18225,7 +18225,7 @@
         "DestinationConfig": {
           "OnFailure": {}
         },
-        "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/table-2e5f8780/stream/<resource:1>",
+        "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table-name>/stream/<resource:1>",
         "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:2>",
         "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -18282,5 +18282,36 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_filter_criteria_validation": {
+    "recorded-date": "10-12-2024, 16:17:56",
+    "recorded-content": {
+      "response-with-empty-filters": {
+        "BatchSize": 100,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {}
+        },
+        "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/table-2e5f8780/stream/<resource:1>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<resource:2>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 0,
+        "MaximumRecordAgeInSeconds": -1,
+        "MaximumRetryAttempts": -1,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "LATEST",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -35,6 +35,9 @@
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventInvokeConfig::test_lambda_eventinvokeconfig_lifecycle": {
     "last_validated_date": "2024-04-10T09:13:20+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_filter_criteria_validation": {
+    "last_validated_date": "2024-12-10T16:17:53+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_self_managed": {
     "last_validated_date": "2024-09-03T20:58:27+00:00"
   },

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -36,7 +36,7 @@
     "last_validated_date": "2024-04-10T09:13:20+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_filter_criteria_validation": {
-    "last_validated_date": "2024-12-10T16:17:53+00:00"
+    "last_validated_date": "2024-12-11T11:29:51+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_self_managed": {
     "last_validated_date": "2024-09-03T20:58:27+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following the introduction of the new python-based filtering engine for events, we can unskip several tests and improve validations of filter criteria when creating/updating ESMs.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Unskips failing filter criteria tests.
- Adds `validate_event_pattern` to `event_matcher.py`.
- Adds `test_create_event_filter_criteria_validation` to ESM lifecycle tests.
- Fixes parity issue that includes an empty filter criteria object in returned ESM config.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
