### PR TITLE
fix APIGW test with hardcoded region

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -868,6 +868,13 @@ class TestApiGatewayImportRestApi:
                 ),
             ]
         )
+        snapshot.add_transformer(
+            snapshot.transform.regex(
+                regex="petstore.execute-api.us-west-1",
+                replacement="<external-aws-endpoint>",
+            ),
+            priority=-10,
+        )
         spec_file = load_file(TEST_OPENAPI_COGNITO_AUTH)
         # the authorizer does not need to exist in AWS
         spec_file = spec_file.replace(

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -4810,7 +4810,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_cognito_auth_identity_source": {
-    "recorded-date": "26-11-2024, 21:33:17",
+    "recorded-date": "11-12-2024, 13:10:45",
     "recorded-content": {
       "import-swagger": {
         "apiKeySource": "HEADER",
@@ -5113,7 +5113,7 @@
           "passthroughBehavior": "WHEN_NO_MATCH",
           "timeoutInMillis": 29000,
           "type": "HTTP_PROXY",
-          "uri": "http://petstore.execute-api.us-west-1.amazonaws.com/petstore/pets"
+          "uri": "http://<external-aws-endpoint>.amazonaws.com/petstore/pets"
         },
         "methodResponses": {
           "200": {
@@ -5157,7 +5157,7 @@
         "passthroughBehavior": "WHEN_NO_MATCH",
         "timeoutInMillis": 29000,
         "type": "HTTP_PROXY",
-        "uri": "http://petstore.execute-api.us-west-1.amazonaws.com/petstore/pets",
+        "uri": "http://<external-aws-endpoint>.amazonaws.com/petstore/pets",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -36,7 +36,7 @@
     "last_validated_date": "2024-04-15T21:37:44+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_cognito_auth_identity_source": {
-    "last_validated_date": "2024-11-26T21:33:17+00:00"
+    "last_validated_date": "2024-12-11T13:10:15+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_global_api_key_authorizer": {
     "last_validated_date": "2024-04-15T21:36:29+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by our pipeline here: https://app.circleci.com/pipelines/github/localstack/localstack/30176/workflows/23745dcd-aaf8-4add-84f5-ae041d88e5a0

We had a failure when the run was using the `us-west-1` region, and the automatic snapshot replacement would replace that value with the `<region>` placeholder. 

However, this hardcoded can be kept as is, because it is an actual available endpoint in AWS, and we can't be sure it's available in all regions. The workaround for this is to transform the value with a higher priority that the regular `<region>` transformer, to be sure we always replace the value in the snapshots. 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a transformer with higher priority of the external AWS APIGW endpoint 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
