### PR TITLE
fix APIGW transformers to not do value replacement on port

### DIFF
--- a/localstack-core/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack-core/localstack/testing/snapshots/transformer_utility.py
@@ -217,7 +217,11 @@ class TransformerUtility:
             ),
             TransformerUtility.key_value("X-Amzn-Apigateway-Api-Id"),
             TransformerUtility.key_value("X-Forwarded-For"),
-            TransformerUtility.key_value("X-Forwarded-Port"),
+            TransformerUtility.key_value(
+                "X-Forwarded-Port",
+                value_replacement="<X-Forwarded-Port>",
+                reference_replacement=False,
+            ),
             TransformerUtility.key_value(
                 "X-Forwarded-Proto",
                 value_replacement="<X-Forwarded-Proto>",

--- a/tests/aws/services/apigateway/test_apigateway_integrations.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.snapshot.json
@@ -436,7 +436,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::TestApiGatewayHeaderRemapping::test_apigateway_header_remapping_http[HTTP]": {
-    "recorded-date": "17-07-2024, 18:34:51",
+    "recorded-date": "11-12-2024, 15:28:47",
     "recorded-content": {
       "apigw-id": "<apigw-id:1>",
       "no-param-integration": {
@@ -451,7 +451,7 @@
         },
         "response-headers": {
           "Connection": "close",
-          "Content-Length": "463",
+          "Content-Length": "462",
           "Content-Type": "application/json",
           "Date": "<Date>",
           "X-Amzn-Trace-Id": "<X-Amzn-Trace-Id>",
@@ -521,7 +521,7 @@
           "Age": "response_param_Age",
           "Connection": "close",
           "Content-Encoding": "response_param_Content-Encoding",
-          "Content-Length": "2740",
+          "Content-Length": "2739",
           "Content-Type": "response_param_Content-Type",
           "Date": "<Date>",
           "Pragma": "response_param_Pragma",
@@ -580,7 +580,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::TestApiGatewayHeaderRemapping::test_apigateway_header_remapping_http[HTTP_PROXY]": {
-    "recorded-date": "17-07-2024, 18:35:02",
+    "recorded-date": "11-12-2024, 15:29:02",
     "recorded-content": {
       "apigw-id": "<apigw-id:1>",
       "no-param-integration": {
@@ -607,12 +607,12 @@
           "Access-Control-Allow-Credentials": "true",
           "Access-Control-Allow-Origin": "*",
           "Connection": "close",
-          "Content-Length": "791",
+          "Content-Length": "790",
           "Content-Type": "application/json",
           "Date": "<Date>",
           "x-amz-apigw-id": "<x-amz-apigw-id>",
           "x-amzn-Remapped-Connection": "keep-alive",
-          "x-amzn-Remapped-Content-Length": "791",
+          "x-amzn-Remapped-Content-Length": "790",
           "x-amzn-Remapped-Date": "<x-amzn-Remapped-Date>",
           "x-amzn-Remapped-Server": "gunicorn/19.9.0",
           "x-amzn-RequestId": "<uuid:1>"
@@ -649,12 +649,12 @@
           "Access-Control-Allow-Credentials": "true",
           "Access-Control-Allow-Origin": "*",
           "Connection": "close",
-          "Content-Length": "1189",
+          "Content-Length": "1188",
           "Content-Type": "application/json",
           "Date": "<Date>",
           "x-amz-apigw-id": "<x-amz-apigw-id>",
           "x-amzn-Remapped-Connection": "keep-alive",
-          "x-amzn-Remapped-Content-Length": "1189",
+          "x-amzn-Remapped-Content-Length": "1188",
           "x-amzn-Remapped-Date": "<x-amzn-Remapped-Date>",
           "x-amzn-Remapped-Server": "gunicorn/19.9.0",
           "x-amzn-RequestId": "<uuid:2>"
@@ -691,7 +691,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::TestApiGatewayHeaderRemapping::test_apigateway_header_remapping_aws[AWS]": {
-    "recorded-date": "18-07-2024, 23:22:48",
+    "recorded-date": "11-12-2024, 15:29:40",
     "recorded-content": {
       "apigw-id": "<apigw-id:1>",
       "no-param-integration": {
@@ -874,7 +874,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::TestApiGatewayHeaderRemapping::test_apigateway_header_remapping_aws[AWS_PROXY]": {
-    "recorded-date": "18-07-2024, 23:23:10",
+    "recorded-date": "11-12-2024, 15:29:56",
     "recorded-content": {
       "apigw-id": "<apigw-id:1>",
       "no-param-integration": {
@@ -897,12 +897,12 @@
           "Warn": "299 localStack/0.0",
           "X-Amzn-Trace-Id": "<X-Amzn-Trace-Id>",
           "X-Forwarded-For": "<x--forwarded--for:1>",
-          "X-Forwarded-Port": "<x--forwarded--port:1>",
+          "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>"
         },
         "response-headers": {
           "Connection": "close",
-          "Content-Length": "2339",
+          "Content-Length": "2336",
           "Content-Type": "application/json",
           "Date": "<Date>",
           "X-Amzn-Trace-Id": "<X-Amzn-Trace-Id>",
@@ -930,12 +930,12 @@
           "Warn": "299 localStack/0.0",
           "X-Amzn-Trace-Id": "<X-Amzn-Trace-Id>",
           "X-Forwarded-For": "<x--forwarded--for:1>",
-          "X-Forwarded-Port": "<x--forwarded--port:1>",
+          "X-Forwarded-Port": "<X-Forwarded-Port>",
           "X-Forwarded-Proto": "<X-Forwarded-Proto>"
         },
         "response-headers": {
           "Connection": "close",
-          "Content-Length": "2323",
+          "Content-Length": "2320",
           "Content-Type": "application/json",
           "Date": "<Date>",
           "X-Amzn-Trace-Id": "<X-Amzn-Trace-Id>",

--- a/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
@@ -1,15 +1,15 @@
 {
   "tests/aws/services/apigateway/test_apigateway_integrations.py::TestApiGatewayHeaderRemapping::test_apigateway_header_remapping_aws[AWS]": {
-    "last_validated_date": "2024-07-18T23:22:46+00:00"
+    "last_validated_date": "2024-12-11T15:29:38+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::TestApiGatewayHeaderRemapping::test_apigateway_header_remapping_aws[AWS_PROXY]": {
-    "last_validated_date": "2024-07-18T23:23:04+00:00"
+    "last_validated_date": "2024-12-11T15:29:54+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::TestApiGatewayHeaderRemapping::test_apigateway_header_remapping_http[HTTP]": {
-    "last_validated_date": "2024-07-17T18:34:51+00:00"
+    "last_validated_date": "2024-12-11T15:28:46+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::TestApiGatewayHeaderRemapping::test_apigateway_header_remapping_http[HTTP_PROXY]": {
-    "last_validated_date": "2024-07-17T18:34:56+00:00"
+    "last_validated_date": "2024-12-11T15:28:54+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_create_execute_api_vpc_endpoint": {
     "last_validated_date": "2024-04-15T23:07:07+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

@dfangl encountered a flake in an APIGW test which was quite unlikely, due to a port field (usually `443`) being present in a UUID and breaking the snapshot replacement. 

https://app.circleci.com/pipelines/github/localstack/localstack/30209/workflows/d7b445e5-43ba-4686-8d83-73a0c370d721/jobs/267451/tests

side-note: the content length changing between snapshots might mean we should transform it, it runs against AWS again when run but might change over time. We can always look into it in a follow up

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- do not reference replace the forwarded port field as it is not really important to do so, and update the snapshots that are concerned

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
