### PR TITLE
APIGW: ParameterMapping skip if invalid input

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py
@@ -52,6 +52,15 @@ class ParametersMapper:
         case_sensitive_headers = build_multi_value_headers(invocation_request["headers"])
 
         for integration_mapping, request_mapping in request_parameters.items():
+            # TODO: remove this once the validation has been added to the provider, to avoid breaking
+            if not isinstance(integration_mapping, str) or not isinstance(request_mapping, str):
+                LOG.warning(
+                    "Wrong parameter mapping value type: %s: %s. They should both be string. Skipping this mapping.",
+                    integration_mapping,
+                    request_mapping,
+                )
+                continue
+
             integration_param_location, param_name = integration_mapping.removeprefix(
                 "integration.request."
             ).split(".")

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -3556,5 +3556,53 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_put_integration_request_parameter_bool_type": {
+    "recorded-date": "12-12-2024, 10:46:41",
+    "recorded-content": {
+      "bool-method": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "GET",
+        "requestParameters": {
+          "method.request.path.testPath": true
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-method-request-param-wrong-type": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid mapping expression specified: Validation Result: warnings : [], errors : [Invalid mapping expression specified: true]"
+        },
+        "message": "Invalid mapping expression specified: Validation Result: warnings : [], errors : [Invalid mapping expression specified: true]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-integration-request-param-wrong-type": {
+        "Error": {
+          "Code": "SerializationException",
+          "Message": "class java.lang.Boolean can not be converted to an String"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-integration-request-param-bool-value": {
+        "Error": {
+          "Code": "SerializationException",
+          "Message": "class java.lang.Boolean can not be converted to an String"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -128,6 +128,9 @@
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_update_gateway_response": {
     "last_validated_date": "2024-04-15T20:47:11+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_put_integration_request_parameter_bool_type": {
+    "last_validated_date": "2024-12-12T10:46:41+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_put_integration_response_validation": {
     "last_validated_date": "2024-08-21T15:09:28+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've got a report from a user with this stack trace:
```python
2024-12-11 15:56:52   File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/apigateway/next_gen/execute_api/parameters_mapping.py", line 59, in map_integration_request

2024-12-11 15:56:52     if request_mapping.startswith("method.request."):

2024-12-11 15:56:52        ^^^^^^^^^^^^^^^^^^^^^^^^^^

2024-12-11 15:56:52 AttributeError: 'bool' object has no attribute 'startswith'
```

However, it seems the only way we can get to those conditions is by specifying an invalid `requestParameters` object with boolean values. It seems AWS does not accept that, but as we are lacking way to reproduce and to be sure we are not going too far with provider validation, this PR only skips the error for now. 

We need as a follow up to implement proper Parameter Mapping validation like we have done for HTTP APIs. 

I've already added a test for the AWS validation, but we need to implement the validation in a follow up. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a skipped test to verify that we cannot have any else than strings in the parameter mappings
- skip the parameter mapping if the values aren't string, to avoid non-caught exceptions

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->

## TODO

What's left to do:

- [ ] in a follow-up, add the provider validation so that it's not possible to get in those conditions in the invocation layer

