### PR TITLE
Upgrade npm in docker image to mitigate cross-spawn CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && tar -xJf "$LATEST_VERSION_FILENAME.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
   && rm "$LATEST_VERSION_FILENAME.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  # upgrade npm to the latest version
+  && npm upgrade -g npm \
   # smoke tests
   && node --version \
   && npm --version \


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes the detected vulnerability [CVE-2024-21538](https://nvd.nist.gov/vuln/detail/CVE-2024-21538) in our docker image.
`cross-spawn` is bundled with `npm`, therefore we need to upgrade `npm` to upgrade `cross-spawn`.

Npm ships with the updated dependency with `10.9.1` (or later) or `9.9.4` (or later) (see https://github.com/npm/cli/issues/7902#issuecomment-2492429448).
The per-default bundled npm version in our nodejs installation is `10.8.2`, and there is currently no npm `18.x` version with a newer bundled npm version:

```bash
curl https://nodejs.org/dist/index.json | jq '[.[] | select(.version | startswith("v18."))] | first | .npm'
```

The only nodejs version currently shipping with a sufficiently new `npm` version would be `v23.4.0`, which is quite the upgrade and not an LTS version.

In order to still mitigate this CVE, we can just upgrade the `npm` version in docker right after installing nodejs.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Upgraded `npm` to version `10.9.2` in our LocalStack docker image


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
