### PR TITLE
Fix swagger endpoint from ephemeral instance

### DIFF
--- a/localstack-core/localstack/http/resources/swagger/endpoints.py
+++ b/localstack-core/localstack/http/resources/swagger/endpoints.py
@@ -7,10 +7,17 @@ from localstack.config import external_service_url
 from localstack.http import Response
 
 
+def _get_service_url(request: Request) -> str:
+    # special case for ephemeral instances
+    if "sandbox.localstack.cloud" in request.host:
+        return external_service_url(protocol="https", port=443)
+    return external_service_url(protocol=request.scheme)
+
+
 class SwaggerUIApi:
     @route("/_localstack/swagger", methods=["GET"])
     def server_swagger_ui(self, request: Request) -> Response:
-        init_path = f"{external_service_url(protocol=request.scheme)}/openapi.yaml"
+        init_path = f"{_get_service_url(request)}/openapi.yaml"
         oas_path = os.path.join(os.path.dirname(__file__), "templates")
         env = Environment(loader=FileSystemLoader(oas_path))
         template = env.get_template("index.html")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The swagger endpoint is not functioning properly when used from an ephemeral instance (see [#1573](https://github.com/localstack/localstack-web/pull/1573) for more context).
We are relying on the `external_service_url` function to compute the path for the `openapi.yaml` file. This function uses the default 4566 port, leading to a fetch error.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Consider the special case of ephemeral instances when building the `openapi.yaml` path.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
