### PR TITLE
apigw fix openapi request parameters

### DIFF
--- a/tests/aws/files/openapi-basepath-url.yaml
+++ b/tests/aws/files/openapi-basepath-url.yaml
@@ -27,6 +27,8 @@ paths:
               method.response.header.Access-Control-Allow-Origin: "'*'"
         requestParameters:
           integration.request.header.X-Amz-Invocation-Type: "'Event'"
+          integration.request.header.double-single: "'True'"
+          integration.request.header.nothing: true
         requestTemplates:
           application/json: '{"statusCode": 200}'
         passthroughBehavior: when_no_match

--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -480,7 +480,6 @@ class TestApiGatewayImportRestApi:
         apigw_create_rest_api,
         aws_client,
         snapshot,
-        apigateway_placeholder_authorizer_lambda_invocation_arn,
         apigw_snapshot_imported_resources,
         apigw_deploy_rest_api,
     ):

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -2537,7 +2537,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api_with_base_path_oas30[prepend]": {
-    "recorded-date": "15-04-2024, 21:36:04",
+    "recorded-date": "12-12-2024, 22:45:00",
     "recorded-content": {
       "put-rest-api-oas30-srv-var": {
         "apiKeySource": "HEADER",
@@ -2790,6 +2790,9 @@
         "rootResourceId": "<id:2>",
         "tags": {},
         "version": "2.0",
+        "warnings": [
+          "Invalid format for 'requestParameters'. Expected type string for property 'integration.request.header.nothing' of resource '/base-url/part/test' and method 'GET' but got 'true'"
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2846,7 +2849,8 @@
           },
           "passthroughBehavior": "WHEN_NO_MATCH",
           "requestParameters": {
-            "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+            "integration.request.header.X-Amz-Invocation-Type": "'Event'",
+            "integration.request.header.double-single": "'True'"
           },
           "requestTemplates": {
             "application/json": {
@@ -2898,7 +2902,8 @@
         },
         "passthroughBehavior": "WHEN_NO_MATCH",
         "requestParameters": {
-          "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+          "integration.request.header.X-Amz-Invocation-Type": "'Event'",
+          "integration.request.header.double-single": "'True'"
         },
         "requestTemplates": {
           "application/json": {
@@ -3022,7 +3027,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api_with_base_path_oas30[split]": {
-    "recorded-date": "15-04-2024, 21:36:26",
+    "recorded-date": "12-12-2024, 22:45:36",
     "recorded-content": {
       "put-rest-api-oas30-srv-var": {
         "apiKeySource": "HEADER",
@@ -3269,6 +3274,9 @@
         "rootResourceId": "<id:2>",
         "tags": {},
         "version": "2.0",
+        "warnings": [
+          "Invalid format for 'requestParameters'. Expected type string for property 'integration.request.header.nothing' of resource '/part/test' and method 'GET' but got 'true'"
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3319,7 +3327,8 @@
           },
           "passthroughBehavior": "WHEN_NO_MATCH",
           "requestParameters": {
-            "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+            "integration.request.header.X-Amz-Invocation-Type": "'Event'",
+            "integration.request.header.double-single": "'True'"
           },
           "requestTemplates": {
             "application/json": {
@@ -3371,7 +3380,8 @@
         },
         "passthroughBehavior": "WHEN_NO_MATCH",
         "requestParameters": {
-          "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+          "integration.request.header.X-Amz-Invocation-Type": "'Event'",
+          "integration.request.header.double-single": "'True'"
         },
         "requestTemplates": {
           "application/json": {
@@ -3495,7 +3505,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api_with_base_path_oas30[ignore]": {
-    "recorded-date": "15-04-2024, 21:35:47",
+    "recorded-date": "12-12-2024, 22:44:26",
     "recorded-content": {
       "put-rest-api-oas30-srv-var": {
         "apiKeySource": "HEADER",
@@ -3742,6 +3752,9 @@
         "rootResourceId": "<id:2>",
         "tags": {},
         "version": "2.0",
+        "warnings": [
+          "Invalid format for 'requestParameters'. Expected type string for property 'integration.request.header.nothing' of resource '/test' and method 'GET' but got 'true'"
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3786,7 +3799,8 @@
           },
           "passthroughBehavior": "WHEN_NO_MATCH",
           "requestParameters": {
-            "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+            "integration.request.header.X-Amz-Invocation-Type": "'Event'",
+            "integration.request.header.double-single": "'True'"
           },
           "requestTemplates": {
             "application/json": {
@@ -3838,7 +3852,8 @@
         },
         "passthroughBehavior": "WHEN_NO_MATCH",
         "requestParameters": {
-          "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+          "integration.request.header.X-Amz-Invocation-Type": "'Event'",
+          "integration.request.header.double-single": "'True'"
         },
         "requestTemplates": {
           "application/json": {

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -9,13 +9,13 @@
     "last_validated_date": "2024-04-15T21:30:20+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api_with_base_path_oas30[ignore]": {
-    "last_validated_date": "2024-04-15T21:35:08+00:00"
+    "last_validated_date": "2024-12-12T22:44:26+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api_with_base_path_oas30[prepend]": {
-    "last_validated_date": "2024-04-15T21:36:02+00:00"
+    "last_validated_date": "2024-12-12T22:44:40+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api_with_base_path_oas30[split]": {
-    "last_validated_date": "2024-04-15T21:36:22+00:00"
+    "last_validated_date": "2024-12-12T22:45:20+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[ignore]": {
     "last_validated_date": "2024-04-15T21:32:25+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

As reported by a user, if a YAML OpenApi specs passes a Boolean value for request parameter mapping, we would fail the invocation for that integration. 

While the value is invalid, AWS doesn't fail and instead just ignores the parameter when importing the api and adds a warning to the response.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Make sure that a boolean value cannot be added as an integration request parameters mapping
- adds warnings to the response of the import.


## Notes

If the flags `failsOnWarning` is provided, we should instead revert the changes when encountering a warning. But this is something we will need to tackle in a follow up as it would require much bigger changes to the import and put endpoints and the helpers method

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
