### PR TITLE
add silv-io as default reviewer for upgrade PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
+      - "silv-io"
       - "alexrashed"
     ignore:
       - dependency-name: "python"
@@ -23,6 +24,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
+      - "silv-io"
       - "alexrashed"
     labels:
       - "area: dependencies"

--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -116,4 +116,4 @@ jobs:
           commit-message: "update generated ASF APIs to latest version"
           labels: "area: asf, area: dependencies, semver: patch"
           token: ${{ secrets.PRO_ACCESS_TOKEN }}
-          reviewers: alexrashed
+          reviewers: silv-io,alexrashed


### PR DESCRIPTION
## Motivation
This PR adds @silv-io as default reviewer for PRs created with our ASF Update workflows, as well as for PRs created by Dependabot.

## Changes
- Change config of ASF update action and dependabot to add @silv-io as default-reviewer to all PRs created by these automations.