### PR TITLE
fix `echo_http_server_post` returning double slash path

### DIFF
--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -2137,7 +2137,7 @@ def echo_http_server_post(echo_http_server):
     if is_aws_cloud():
         return f"{PUBLIC_HTTP_ECHO_SERVER_URL}/post"
 
-    return f"{echo_http_server}/post"
+    return f"{echo_http_server}post"
 
 
 def create_policy_doc(effect: str, actions: List, resource=None) -> Dict:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The `echo_http_server_post` has different behavior between AWS and LocalStack (where it will direct the request against `https://httpbin.org/post` in AWS and a local http server in LocalStack, but at this url: `http://localhost:<port>//post`).

This PR fixes the format for them to both return the `/post` path. 

I'll run a downstream test on this to verify everything is right. 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- don't add a slash when there's already one returned by `http server.url_for("/")`. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
