### PR TITLE
StepFunctions: Fix Evaluation of Nested Map Runs

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/job.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/job.py
@@ -50,7 +50,7 @@ class JobPool:
 
         self._jobs_number = len(job_inputs)
         self._open_jobs = [
-            Job(job_index=job_index, job_program=copy.deepcopy(job_program), job_input=job_input)
+            Job(job_index=job_index, job_program=job_program, job_input=job_input)
             for job_index, job_input in enumerate(job_inputs)
         ]
         self._open_jobs.reverse()

--- a/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
+++ b/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
@@ -82,6 +82,9 @@ class ScenariosTemplate(TemplateLoader):
     MAP_STATE_NESTED: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/map_state_nested.json5"
     )
+    MAP_STATE_NESTED_CONFIG_DISTRIBUTED: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/map_state_nested_config_distributed.json5"
+    )
     MAP_STATE_NO_PROCESSOR_CONFIG: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/map_state_no_processor_config.json5"
     )

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_nested_config_distributed.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_nested_config_distributed.json5
@@ -1,0 +1,59 @@
+{
+  "StartAt": "SetupState",
+  "States": {
+    "SetupState": {
+      "Type": "Pass",
+      "Result": {
+        "values": [
+          {
+            "sub-values": [
+              {
+                "num": 1,
+                "str": "A"
+              },
+              {
+                "num": 2,
+                "str": "B"
+              }
+            ]
+          }
+        ]
+      },
+      "Next": "MapState",
+    },
+    "MapState": {
+      "Type": "Map",
+      "MaxConcurrency": 1,
+      "ItemsPath": "$.values",
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "DISTRIBUTED",
+          "ExecutionType": "STANDARD",
+        },
+        "StartAt": "SubMapState",
+        "States": {
+          "SubMapState": {
+            "Type": "Map",
+            "MaxConcurrency": 1,
+            "ItemsPath": "$.sub-values",
+            "ResultPath": "$.result",
+            "ItemProcessor": {
+              "ProcessorConfig": {
+                "Mode": "DISTRIBUTED",
+                "ExecutionType": "STANDARD",
+              },
+              "StartAt": "SubMapStateSuccess",
+              "States": {
+                "SubMapStateSuccess": {
+                  "Type": "Succeed"
+                }
+              },
+            },
+            "End": true,
+          }
+        },
+      },
+      "End": true,
+    },
+  },
+}

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
@@ -1354,6 +1354,28 @@ class TestBaseScenarios:
         )
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..events[8].previousEventId"])
+    def test_map_state_nested_config_distributed(
+        self,
+        aws_client,
+        create_state_machine_iam_role,
+        create_state_machine,
+        sfn_snapshot,
+    ):
+        template = ST.load_sfn_template(ST.MAP_STATE_NESTED_CONFIG_DISTRIBUTED)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({})
+        create_and_record_execution(
+            aws_client,
+            create_state_machine_iam_role,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
     def test_map_state_result_writer(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
@@ -24895,5 +24895,155 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_nested_config_distributed": {
+    "recorded-date": "13-12-2024, 13:38:16",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "SetupState"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "SetupState",
+              "output": {
+                "values": [
+                  {
+                    "sub-values": [
+                      {
+                        "num": 1,
+                        "str": "A"
+                      },
+                      {
+                        "num": 2,
+                        "str": "B"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "values": [
+                  {
+                    "sub-values": [
+                      {
+                        "num": 1,
+                        "str": "A"
+                      },
+                      {
+                        "num": 2,
+                        "str": "B"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapState"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 5,
+            "mapStateStartedEventDetails": {
+              "length": 1
+            },
+            "previousEventId": 4,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "id": 6,
+            "mapRunStartedEventDetails": {
+              "mapRunArn": "arn:<partition>:states:<region>:111111111111:mapRun:<ArnPart_0idx>/<MapRunArnPart0_0idx>:<MapRunArnPart1_0idx>"
+            },
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "MapRunStarted"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "MapRunSucceeded"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "timestamp": "timestamp",
+            "type": "MapStateSucceeded"
+          },
+          {
+            "id": 9,
+            "previousEventId": 6,
+            "stateExitedEventDetails": {
+              "name": "MapState",
+              "output": "[{\"sub-values\":[{\"num\":1,\"str\":\"A\"},{\"num\":2,\"str\":\"B\"}],\"result\":[{\"num\":1,\"str\":\"A\"},{\"num\":2,\"str\":\"B\"}]}]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "[{\"sub-values\":[{\"num\":1,\"str\":\"A\"},{\"num\":2,\"str\":\"B\"}],\"result\":[{\"num\":1,\"str\":\"A\"},{\"num\":2,\"str\":\"B\"}]}]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 10,
+            "previousEventId": 9,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
@@ -278,6 +278,9 @@
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_nested": {
     "last_validated_date": "2024-03-29T16:26:02+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_nested_config_distributed": {
+    "last_validated_date": "2024-12-13T13:38:16+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_no_processor_config": {
     "last_validated_date": "2023-12-15T21:25:27+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, the SFN v2 is unable to evaluate nested MapRun states, resulting in pickling runtime errors https://github.com/localstack/localstack/issues/9809. This was due to an unecessary deep copy of the map run program, which contains unserialisable objects such as locks. The deep copy is not considered necessary as EvalComponents are stateless by design, and can therefore be shared by multiple runtimes. These changes address such issue and add a relevant snapshot test.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- remove unecessary program copy
- added a snapshot test for nested map runs

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
