### PR TITLE
StepFunctions: Fix Boto Request Encoding

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service.py
@@ -106,8 +106,7 @@ class StateTaskService(StateTask, abc.ABC):
         elif isinstance(value_shape, StringShape) and not isinstance(request_value, str):
             boto_request_value = to_json_str(request_value)
         elif value_shape.type_name == "blob" and not isinstance(boto_request_value, bytes):
-            if not isinstance(boto_request_value, str):
-                boto_request_value = to_json_str(request_value, separators=(":", ","))
+            boto_request_value = to_json_str(request_value, separators=(",", ":"))
             boto_request_value = to_bytes(boto_request_value)
         return boto_request_value
 

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.snapshot.json
@@ -2348,7 +2348,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[str]": {
-    "recorded-date": "11-06-2024, 07:42:53",
+    "recorded-date": "13-12-2024, 15:20:04",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -2465,11 +2465,12 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      }
+      },
+      "s3-object-content-body": "\"text data\""
     }
   },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[dict]": {
-    "recorded-date": "11-06-2024, 07:43:09",
+    "recorded-date": "13-12-2024, 15:20:52",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -2592,11 +2593,14 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "s3-object-content-body": {
+        "Dict": "Value"
       }
     }
   },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[list]": {
-    "recorded-date": "11-06-2024, 07:43:26",
+    "recorded-date": "13-12-2024, 15:21:44",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -2722,11 +2726,12 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      }
+      },
+      "s3-object-content-body": "[\"List\",\"Data\"]"
     }
   },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[bool]": {
-    "recorded-date": "11-06-2024, 07:43:42",
+    "recorded-date": "13-12-2024, 15:22:31",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -2843,11 +2848,12 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      }
+      },
+      "s3-object-content-body": "false"
     }
   },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[num]": {
-    "recorded-date": "11-06-2024, 07:43:58",
+    "recorded-date": "13-12-2024, 15:23:18",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -2964,7 +2970,8 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      }
+      },
+      "s3-object-content-body": "0"
     }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.validation.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.validation.json
@@ -27,19 +27,19 @@
     "last_validated_date": "2024-05-23T19:11:47+00:00"
   },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[bool]": {
-    "last_validated_date": "2024-06-11T07:43:42+00:00"
+    "last_validated_date": "2024-12-13T15:22:31+00:00"
   },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[dict]": {
-    "last_validated_date": "2024-06-11T07:43:09+00:00"
+    "last_validated_date": "2024-12-13T15:20:52+00:00"
   },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[list]": {
-    "last_validated_date": "2024-06-11T07:43:26+00:00"
+    "last_validated_date": "2024-12-13T15:21:44+00:00"
   },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[num]": {
-    "last_validated_date": "2024-06-11T07:43:58+00:00"
+    "last_validated_date": "2024-12-13T15:23:18+00:00"
   },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_put_object[str]": {
-    "last_validated_date": "2024-06-11T07:42:53+00:00"
+    "last_validated_date": "2024-12-13T15:20:04+00:00"
   },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_outcome_with_no_such_token[state_machine_template0]": {
     "last_validated_date": "2024-04-10T18:55:26+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The SFN v2 interpreter incorporates custom logic to convert SFN request parameter objects to ensure compatibility with boto requests, and vice versa. However, this logic currently misencodes JSON strings, occasionally resulting in corrupted JSON objects being sent to the target service https://github.com/localstack/localstack/issues/12030. These changes rectify this issue.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Fix json object encoding separators and ensure strings are also converted to json string literals
- Updated s3 service integration tests to sample the resulting value for multiple json types

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
