### PR TITLE
[ESM] Handle DynamoDB-local Invalid ShardID exception

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/dynamodb_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/dynamodb_poller.py
@@ -74,18 +74,6 @@ class DynamoDBPoller(StreamPoller):
             "eventVersion": "1.1",
         }
 
-    def get_records(self, shard_iterator: str) -> dict:
-        try:
-            return super().get_records(shard_iterator)
-        except self.source_client.exceptions.TrimmedDataAccessException as e:
-            LOG.debug(
-                "Attempted to iterate over trimmed record or expired shard iterator %s for stream %s, re-initializing shards",
-                shard_iterator,
-                self.source_arn,
-            )
-            self.shards = self.initialize_shards()
-            raise e
-
     def transform_into_events(self, records: list[dict], shard_id) -> list[dict]:
         events = []
         for record in records:

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/dynamodb_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/dynamodb_poller.py
@@ -74,6 +74,18 @@ class DynamoDBPoller(StreamPoller):
             "eventVersion": "1.1",
         }
 
+    def get_records(self, shard_iterator: str) -> dict:
+        try:
+            return super().get_records(shard_iterator)
+        except self.source_client.exceptions.TrimmedDataAccessException as e:
+            LOG.debug(
+                "Attempted to iterate over trimmed record or expired shard iterator %s for stream %s, re-initializing shards",
+                shard_iterator,
+                self.source_arn,
+            )
+            self.shards = self.initialize_shards()
+            raise e
+
     def transform_into_events(self, records: list[dict], shard_id) -> list[dict]:
         events = []
         for record in records:

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -264,10 +264,7 @@ class StreamPoller(Poller):
             )
             return get_records_response
         # TODO: test iterator expired with conditional error scenario (requires failure destinations)
-        except (
-            self.source_client.exceptions.ExpiredIteratorException,
-            self.source_client.exceptions.TrimmedDataAccessException,
-        ) as e:
+        except self.source_client.exceptions.ExpiredIteratorExceptionas as e:
             LOG.debug(
                 "Shard iterator %s expired for stream %s, re-initializing shards",
                 shard_iterator,

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -264,7 +264,10 @@ class StreamPoller(Poller):
             )
             return get_records_response
         # TODO: test iterator expired with conditional error scenario (requires failure destinations)
-        except self.source_client.exceptions.ExpiredIteratorException as e:
+        except (
+            self.source_client.exceptions.ExpiredIteratorException,
+            self.source_client.exceptions.TrimmedDataAccessException,
+        ) as e:
             LOG.debug(
                 "Shard iterator %s expired for stream %s, re-initializing shards",
                 shard_iterator,

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -264,7 +264,7 @@ class StreamPoller(Poller):
             )
             return get_records_response
         # TODO: test iterator expired with conditional error scenario (requires failure destinations)
-        except self.source_client.exceptions.ExpiredIteratorExceptionas as e:
+        except self.source_client.exceptions.ExpiredIteratorException as e:
             LOG.debug(
                 "Shard iterator %s expired for stream %s, re-initializing shards",
                 shard_iterator,

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -284,7 +284,6 @@ class StreamPoller(Poller):
                 raise CustomerInvocationError from e
             elif "ResourceNotFoundException" in str(e):
                 # FIXME: The 'Invalid ShardId in ShardIterator' error is returned by DynamoDB-local. Unsure when/why this is returned.
-                #
                 if "Invalid ShardId in ShardIterator" in str(e):
                     LOG.warning(
                         "Invalid ShardId in ShardIterator for %s. Re-initializing shards.",

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -298,6 +298,13 @@ class StreamPoller(Poller):
                         e,
                     )
                     raise CustomerInvocationError from e
+            elif "TrimmedDataAccessException" in str(e):
+                LOG.debug(
+                    "Attempted to iterate over trimmed record or expired shard iterator %s for stream %s, re-initializing shards",
+                    shard_iterator,
+                    self.source_arn,
+                )
+                self.initialize_shards()
             else:
                 LOG.debug("ClientError during get_records for stream %s: %s", self.source_arn, e)
                 raise PipeInternalError from e


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Doing a `GetRecords` operation against DynamoDB-local can raise an (undocumented) `Invalid ShardId in ShardIterator` exception. Since we poll a stream in ESM, encountering this sharding issue should necessitate a re-initialise of the shards we are polling.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Check whether ResourceNotFound exception is of type `Invalid ShardId in ShardIterator`, and trigger a re-sharding if encountered.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
