### PR TITLE
DynamoDB: Fix empty replicas list in response

### DIFF
--- a/localstack-core/localstack/services/dynamodb/provider.py
+++ b/localstack-core/localstack/services/dynamodb/provider.py
@@ -752,7 +752,8 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             if replica_region != context.region:
                 replica_description_list.append(replica_description)
 
-        table_description.update({"Replicas": replica_description_list})
+        if replica_description_list:
+            table_description.update({"Replicas": replica_description_list})
 
         # update only TableId and SSEDescription if present
         if table_definitions := store.table_definitions.get(table_name):

--- a/localstack-core/localstack/services/dynamodb/v2/provider.py
+++ b/localstack-core/localstack/services/dynamodb/v2/provider.py
@@ -590,7 +590,8 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             if replica_region != context.region:
                 replica_description_list.append(replica_description)
 
-        table_description.update({"Replicas": replica_description_list})
+        if replica_description_list:
+            table_description.update({"Replicas": replica_description_list})
 
         # update only TableId and SSEDescription if present
         if table_definitions := store.table_definitions.get(table_name):

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -1099,7 +1099,7 @@ class TestDynamoDB:
             TableName=table_name, ReplicaUpdates=[{"Delete": {"RegionName": "us-east-1"}}]
         )
         response = dynamodb_ap_south_1.describe_table(TableName=table_name)
-        assert len(response["Table"]["Replicas"]) == 0
+        assert "Replicas" not in response["Table"]
 
     @markers.aws.only_localstack
     def test_global_tables(self, aws_client, ddb_test_table):

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -1669,18 +1669,16 @@ class TestDynamoDB:
             SSESpecification=sse_specification,
             Tags=TEST_DDB_TAGS,
         )
-        snapshot.match("SSEDescription", result["TableDescription"]["SSEDescription"])
+        snapshot.match("create_table_sse_description", result["TableDescription"]["SSEDescription"])
 
         kms_master_key_arn = result["TableDescription"]["SSEDescription"]["KMSMasterKeyArn"]
         result = aws_client.kms.describe_key(KeyId=kms_master_key_arn)
-        snapshot.match("KMSDescription", result)
+        snapshot.match("describe_kms_key", result)
 
         result = aws_client.dynamodb.update_table(
             TableName=table_name, BillingMode="PAY_PER_REQUEST"
         )
-        snapshot.match(
-            "update-table-unchanged-sse-spec", result["TableDescription"]["SSEDescription"]
-        )
+        snapshot.match("update_table_sse_description", result["TableDescription"]["SSEDescription"])
 
         # Verify that SSEDescription exists and remains unchanged after update_table
         assert result["TableDescription"]["SSEDescription"]["Status"] == "ENABLED"

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1419,14 +1419,14 @@
     }
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_update_table_without_sse_specification_change": {
-    "recorded-date": "09-12-2024, 16:09:53",
+    "recorded-date": "17-12-2024, 10:40:03",
     "recorded-content": {
-      "SSEDescription": {
+      "create_table_sse_description": {
         "KMSMasterKeyArn": "arn:<partition>:kms:<region>:111111111111:key/<uuid:1>",
         "SSEType": "KMS",
         "Status": "ENABLED"
       },
-      "KMSDescription": {
+      "describe_kms_key": {
         "KeyMetadata": {
           "AWSAccountId": "111111111111",
           "Arn": "arn:<partition>:kms:<region>:111111111111:key/<uuid:1>",
@@ -1450,7 +1450,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "update-table-unchanged-sse-spec": {
+      "update_table_sse_description": {
         "KMSMasterKeyArn": "arn:<partition>:kms:<region>:111111111111:key/<uuid:1>",
         "SSEType": "KMS",
         "Status": "ENABLED"

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -54,7 +54,7 @@
     "last_validated_date": "2023-10-22T20:27:28+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_update_table_without_sse_specification_change": {
-    "last_validated_date": "2024-12-09T16:09:21+00:00"
+    "last_validated_date": "2024-12-17T10:39:19+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_empty_and_binary_values": {
     "last_validated_date": "2023-08-23T14:32:29+00:00"


### PR DESCRIPTION
## Changes

This PR fixes a regression caused by https://github.com/localstack/localstack/pull/11938 which would cause an empty list to be returned when no replicas are configured ([reference test run](https://app.circleci.com/pipelines/github/localstack/localstack/30313/workflows/a3d53cf9-5726-4dbb-8fee-5b90a7b60cf5/jobs/268546/tests)). The behaviour is AWS validated by the tests in the reference run.

## Tests

Randomised MA/MR tests: https://app.circleci.com/pipelines/github/localstack/localstack/30321/workflows/ade8da0d-d52a-453e-8c4f-efc418e5d8c3