### PR TITLE
bump minimum version of cbor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ base-runtime = [
     # pinned / updated by ASF update action
     "botocore==1.35.81",
     "awscrt>=0.13.14",
-    "cbor2>=5.2.0",
+    "cbor2>=5.5.0",
     "dnspython>=1.16.0",
     "docker>=6.1.1",
     "jsonpatch>=1.24",


### PR DESCRIPTION
## Motivation
Fixes https://github.com/localstack/localstack/issues/11703.
As described in the issue, we should update the minimum requirement for the `cbor` library, as we depend on some code which was introduced with `cbor2==5.5.0`.

## Changes
- Update the minimum version for `cbor`. No other changes are necessary, since in our dependency lock files we already pin the latest version (`5.6.5`).