### PR TITLE
fix client factory for bypassing DNS server

### DIFF
--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -660,7 +660,11 @@ def resolve_dns_from_upstream(hostname: str) -> str:
     if len(response.answer) == 0:
         raise ValueError(f"No DNS response found for hostname '{hostname}'")
 
-    ip_addresses = list(response.answer[0].items.keys())
+    ip_addresses = []
+    for answer in response.answer:
+        if answer.match(dns.rdataclass.IN, dns.rdatatype.A, dns.rdatatype.TYPE0):
+            ip_addresses.extend(answer.items.keys())
+
     return choice(ip_addresses).address
 
 

--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -665,6 +665,9 @@ def resolve_dns_from_upstream(hostname: str) -> str:
         if answer.match(dns.rdataclass.IN, dns.rdatatype.A, dns.rdatatype.TYPE0):
             ip_addresses.extend(answer.items.keys())
 
+    if not ip_addresses:
+        raise ValueError(f"No DNS records of type 'A' found for hostname '{hostname}'")
+
     return choice(ip_addresses).address
 
 

--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -662,7 +662,7 @@ def resolve_dns_from_upstream(hostname: str) -> str:
 
     ip_addresses = []
     for answer in response.answer:
-        if answer.match(dns.rdataclass.IN, dns.rdatatype.A, dns.rdatatype.TYPE0):
+        if answer.match(dns.rdataclass.IN, dns.rdatatype.A, dns.rdatatype.NONE):
             ip_addresses.extend(answer.items.keys())
 
     if not ip_addresses:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
It seems our tests broke due to maybe some change in how AWS was returning their DNS records, and it seems we return the full chain of resolution.

When doing the following request:
`request = dns.message.make_query(hostname, "A")`
We would get a full answer containing `CNAME` records:
`[<DNS sts.amazonaws.com. IN CNAME RRset: [<reg.sts-ge.amazonaws.com.>]>, <DNS reg.sts-ge.amazonaws.com. IN CNAME RRset: [<use1-default-r.sts-ge.amazonaws.com.>]>, <DNS use1-default-r.sts-ge.amazonaws.com. IN CNAME RRset: [<sts-global-default.us-east-1.amazonaws.com.>]>, <DNS sts-global-default.us-east-1.amazonaws.com. IN A RRset: [<209.54.177.164>]>]`

Which then lead to an issue when trying to access the `address` field:
`AttributeError: 'CNAME' object has no attribute 'address'`

I've introduced a filter step to make sure we're only trying to get `A` records before choosing. However, I'm not quite sure if this is expected behavior, I believe that might be a change in how AWS returns their DNS and introducing a few resolving steps in between. I don't know if we make the query better? Should we only get the last answer instead of filtering? Something like `list(response.answer[-1].items.keys())` instead? My knowledge of DNS stops here 😄 

Manual run for bootstraps tests: #/12434395225

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- filter the returned `list[RRSet]` to only contains `A` type before trying to access the `address` field.  

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
