### PR TITLE
Cfn support layer version read list

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -3606,7 +3606,12 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             )
 
         store = lambda_stores[account_id][region_name]
-        layer_version = store.layers.get(layer_name, {}).layer_versions.get(layer_version)
+        if not (layers := store.layers.get(layer_name)):
+            raise ResourceNotFoundException(
+                "The resource you requested does not exist.", Type="User"
+            )
+
+        layer_version = layers.layer_versions.get(layer_version)
 
         if not layer_version:
             raise ResourceNotFoundException(

--- a/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_layerversion.schema.json
+++ b/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_layerversion.schema.json
@@ -1,50 +1,22 @@
 {
   "typeName": "AWS::Lambda::LayerVersion",
   "description": "Resource Type definition for AWS::Lambda::LayerVersion",
-  "additionalProperties": false,
-  "properties": {
-    "CompatibleRuntimes": {
-      "type": "array",
-      "uniqueItems": false,
-      "items": {
-        "type": "string"
-      }
-    },
-    "LicenseInfo": {
-      "type": "string"
-    },
-    "Description": {
-      "type": "string"
-    },
-    "LayerName": {
-      "type": "string"
-    },
-    "Content": {
-      "$ref": "#/definitions/Content"
-    },
-    "Id": {
-      "type": "string"
-    },
-    "CompatibleArchitectures": {
-      "type": "array",
-      "uniqueItems": false,
-      "items": {
-        "type": "string"
-      }
-    }
-  },
+  "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-lambda.git",
   "definitions": {
     "Content": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "S3ObjectVersion": {
+          "description": "For versioned objects, the version of the layer archive object to use.",
           "type": "string"
         },
         "S3Bucket": {
+          "description": "The Amazon S3 bucket of the layer archive.",
           "type": "string"
         },
         "S3Key": {
+          "description": "The Amazon S3 key of the layer archive.",
           "type": "string"
         }
       },
@@ -54,6 +26,46 @@
       ]
     }
   },
+  "properties": {
+    "CompatibleRuntimes": {
+      "description": "A list of compatible function runtimes. Used for filtering with ListLayers and ListLayerVersions.",
+      "type": "array",
+      "insertionOrder": false,
+      "uniqueItems": false,
+      "items": {
+        "type": "string"
+      }
+    },
+    "LicenseInfo": {
+      "description": "The layer's software license.",
+      "type": "string"
+    },
+    "Description": {
+      "description": "The description of the version.",
+      "type": "string"
+    },
+    "LayerName": {
+      "description": "The name or Amazon Resource Name (ARN) of the layer.",
+      "type": "string"
+    },
+    "Content": {
+      "description": "The function layer archive.",
+      "$ref": "#/definitions/Content"
+    },
+    "LayerVersionArn": {
+      "type": "string"
+    },
+    "CompatibleArchitectures": {
+      "description": "A list of compatible instruction set architectures.",
+      "type": "array",
+      "insertionOrder": false,
+      "uniqueItems": false,
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false,
   "required": [
     "Content"
   ],
@@ -65,10 +77,44 @@
     "/properties/Description",
     "/properties/Content"
   ],
-  "primaryIdentifier": [
-    "/properties/Id"
-  ],
   "readOnlyProperties": [
-    "/properties/Id"
-  ]
+    "/properties/LayerVersionArn"
+  ],
+  "writeOnlyProperties": [
+    "/properties/Content"
+  ],
+  "primaryIdentifier": [
+    "/properties/LayerVersionArn"
+  ],
+  "tagging": {
+    "taggable": false,
+    "tagOnCreate": false,
+    "tagUpdatable": false,
+    "cloudFormationSystemTags": false
+  },
+  "handlers": {
+    "create": {
+      "permissions": [
+        "lambda:PublishLayerVersion",
+        "s3:GetObject",
+        "s3:GetObjectVersion"
+      ]
+    },
+    "read": {
+      "permissions": [
+        "lambda:GetLayerVersion"
+      ]
+    },
+    "delete": {
+      "permissions": [
+        "lambda:GetLayerVersion",
+        "lambda:DeleteLayerVersion"
+      ]
+    },
+    "list": {
+      "permissions": [
+        "lambda:ListLayerVersions"
+      ]
+    }
+  }
 }

--- a/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
@@ -1594,5 +1594,17 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_layer_crud": {
+    "recorded-date": "20-12-2024, 18:23:31",
+    "recorded-content": {
+      "layer-name": "<layer-name:1>",
+      "cfn-output": {
+        "LambdaArn": "arn:<partition>:lambda:<region>:111111111111:function:<lambda-name:1>",
+        "LambdaName": "<lambda-name:1>",
+        "LayerVersionArn": "arn:<partition>:lambda:<region>:111111111111:layer:<layer-name:1>:1",
+        "LayerVersionRef": "arn:<partition>:lambda:<region>:111111111111:layer:<layer-name:1>:1"
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -38,6 +38,9 @@
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_function_tags": {
     "last_validated_date": "2024-10-01T12:52:51+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_layer_crud": {
+    "last_validated_date": "2024-12-20T18:23:31+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_version": {
     "last_validated_date": "2024-04-09T07:21:37+00:00"
   },

--- a/tests/aws/templates/lambda_layer_version.yml
+++ b/tests/aws/templates/lambda_layer_version.yml
@@ -1,0 +1,71 @@
+Parameters:
+  LayerBucket:
+    Type: String
+  LayerName:
+    Type: String
+Resources:
+  FunctionServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  Layer:
+    Type: AWS::Lambda::LayerVersion
+    Properties:
+      LayerName: !Ref LayerName
+      CompatibleArchitectures:
+        - arm64
+      CompatibleRuntimes:
+        - python3.11
+        - python3.12
+      Content:
+        S3Bucket: !Ref LayerBucket
+        S3Key: layer.zip
+      Description: "layer to test cfn"
+  Function:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: "function to test lambda layer"
+      Layers:
+        - !Ref Layer
+      Code:
+        ZipFile: |
+          def handler(event, *args, **kwargs):
+              return "CRUD test"
+      Role:
+        Fn::GetAtt:
+          - FunctionServiceRole
+          - Arn
+      Handler: index.handler
+      Runtime: python3.12
+
+    DependsOn:
+      - FunctionServiceRole
+Outputs:
+  LambdaName:
+    Value:
+      Ref: Function
+  LambdaArn:
+    Value:
+      Fn::GetAtt:
+        - Function
+        - Arn
+  LayerVersionRef:
+    Value:
+      Ref: Layer
+  LayerVersionArn:
+    Value:
+      Fn::GetAtt:
+        - Layer
+        - LayerVersionArn


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Implementation of the `read` and `list` operations for lambda layer versions.

The cloudformation schema were out of date so they were also updated as part of this pr.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Fix a bug in `get_layer_versions` where `store.layers.get(layer_name, {}).layer_versions.get(layer_version)` would fail when the lambda layer did not exists
- Updated the Primary Identifier from `Id` to `LayerVersionArn` with a validated test
- Implementation of `read` and `list`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
