### PR TITLE
fix KMS DeriveSharedSecret

### DIFF
--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
-from cryptography.exceptions import InvalidSignature
+from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.primitives import serialization as crypto_serialization
@@ -381,7 +381,10 @@ class KmsKey:
                 )
 
         # Deserialize public key from DER encoded data to EllipticCurvePublicKey.
-        pub_key = load_der_public_key(public_key)
+        try:
+            pub_key = load_der_public_key(public_key)
+        except (UnsupportedAlgorithm, ValueError):
+            raise ValidationException("")
         shared_secret = self.crypto_key.key.exchange(ec.ECDH(), pub_key)
         # Perform shared secret derivation.
         return HKDF(

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -1380,6 +1380,13 @@ class TestKMS:
             )
         snapshot.match("response-invalid-key", e.value.response)
 
+        # Call derive shared secret function with invalid public key
+        with pytest.raises(ClientError) as e:
+            aws_client.kms.derive_shared_secret(
+                KeyId=key1["KeyId"], KeyAgreementAlgorithm="ECDH", PublicKey=b"InvalidPublicKey"
+            )
+        snapshot.match("response-invalid-public-key", e.value.response)
+
 
 class TestKMSMultiAccounts:
     @markers.aws.needs_fixing

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -1728,7 +1728,7 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_derive_shared_secret": {
-    "recorded-date": "11-10-2024, 07:07:06",
+    "recorded-date": "24-12-2024, 12:40:21",
     "recorded-content": {
       "response": {
         "KeyAgreementAlgorithm": "ECDH",

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -1728,7 +1728,7 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_derive_shared_secret": {
-    "recorded-date": "24-12-2024, 12:40:21",
+    "recorded-date": "25-12-2024, 14:45:02",
     "recorded-content": {
       "response": {
         "KeyAgreementAlgorithm": "ECDH",
@@ -1777,6 +1777,16 @@
           "Message": "<key-arn> key usage is ENCRYPT_DECRYPT which is not valid for DeriveSharedSecret."
         },
         "message": "<key-arn> key usage is ENCRYPT_DECRYPT which is not valid for DeriveSharedSecret.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "response-invalid-public-key": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": ""
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -30,7 +30,7 @@
     "last_validated_date": "2024-04-11T15:53:40+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_derive_shared_secret": {
-    "last_validated_date": "2024-12-24T12:40:20+00:00"
+    "last_validated_date": "2024-12-25T14:45:00+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_describe_and_list_sign_key": {
     "last_validated_date": "2024-04-11T15:53:27+00:00"

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -30,7 +30,7 @@
     "last_validated_date": "2024-04-11T15:53:40+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_derive_shared_secret": {
-    "last_validated_date": "2024-10-11T07:07:04+00:00"
+    "last_validated_date": "2024-12-24T12:40:20+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_describe_and_list_sign_key": {
     "last_validated_date": "2024-04-11T15:53:27+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

There is an issue https://github.com/localstack/localstack/issues/11905 to address a bug with KMS DerivedSharedSecret that reports that does not work symmetrically.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

`cryptography` library is not correctly used to generate the derive shared secret in the function https://github.com/localstack/localstack/blob/61535b7d970493d9bb6740a03d698d075dd0a3b9/localstack-core/localstack/services/kms/models.py#L368-L388

Currently the HKDF derive function uses directly the public key to generate the derive shared secret. However it is required to add additional steps to fix the bug and get the expected result.

The public key must be transformed from DER encoded data to EllipticCurvePublicKey. A shared secret is then obtained using the exchange function, and finally, the HKDF derive function is used.

Technical documentation: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/kms/derive-shared-secret.html

<!-- Optional section: How to test these changes? -->
## Testing

`test_derive_shared_secret` has been updated to perform a comparison between two generated derive shared secrets to check that are equal and to check validation exception when an invalid public key is received.

**How to test with awscli v1 and v2:**

```
// get the value for ID and export it to FIRST_KEY_ID variable
awslocal kms create-key   --key-spec ECC_NIST_P256   --key-usage KEY_AGREEMENT   --description "ECC NIST P-256 Key Agreement Key"   --region us-east-1

// get the value for ID and export it to SECOND_KEY_ID variable
awslocal kms create-key   --key-spec ECC_NIST_P256   --key-usage KEY_AGREEMENT   --description "ECC NIST P-256 Key Agreement Key 2"   --region us-east-1

// get the value for PublicKey and export it to public_key.der binary file
awslocal kms get-public-key  --key-id $FIRST_KEY_ID --region us-east-1 --output text --query PublicKey | base64 --decode > public_key.der

// get the value for PublicKey and export it to public_key2.der binary file
awslocal kms get-public-key --key-id $SECOND_KEY_ID --region us-east-1 --output text --query PublicKey | base64 --decode > public_key2.der

// the two values for "SharedSecret" from below commands should be the same
awslocal kms derive-shared-secret --key-id $FIRST_KEY_ID --key-agreement-algorithm ECDH --public-key fileb://public_key.der --region us-east-1
awslocal kms derive-shared-secret --key-id $SECOND_KEY_ID --key-agreement-algorithm ECDH --public-key fileb://public_key2.der --region us-east-1
```

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
