### PR TITLE
WIP - create Firehose streams without name

### DIFF
--- a/localstack-core/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack-core/localstack/services/cloudformation/deployment_utils.py
@@ -172,14 +172,14 @@ def select_parameters(*param_names):
 def is_none_or_empty_value(value):
     return not value or value == PLACEHOLDER_AWS_NO_VALUE
 
-
+# TODO: almost the same logic is in provider_utils.generate_default_name
 def generate_default_name(stack_name: str, logical_resource_id: str):
     random_id_part = short_uid()
     resource_id_part = logical_resource_id[:24]
     stack_name_part = stack_name[: 63 - 2 - (len(random_id_part) + len(resource_id_part))]
     return f"{stack_name_part}-{resource_id_part}-{random_id_part}"
 
-
+# TODO: almost the same logic is in provider_utils.generate_default_name_without_stack
 def generate_default_name_without_stack(logical_resource_id: str):
     random_id_part = short_uid()
     resource_id_part = logical_resource_id[: 63 - 1 - len(random_id_part)]

--- a/localstack-core/localstack/services/cloudformation/provider_utils.py
+++ b/localstack-core/localstack/services/cloudformation/provider_utils.py
@@ -17,14 +17,12 @@ from botocore.model import Shape, StructureShape
 
 
 def generate_default_name(stack_name: str, logical_resource_id: str):
-    random_id_part = str(uuid.uuid4())[0:8]
-    resource_id_part = logical_resource_id[:24]
-    stack_name_part = stack_name[: 63 - 2 - (len(random_id_part) + len(resource_id_part))]
-    return f"{stack_name_part}-{resource_id_part}-{random_id_part}"
+    random_id_part = str(uuid.uuid4())[0:8].upper()
+    return f"{stack_name}-{logical_resource_id}-{random_id_part}"
 
 
 def generate_default_name_without_stack(logical_resource_id: str):
-    random_id_part = str(uuid.uuid4())[0:8]
+    random_id_part = str(uuid.uuid4())[0:8].upper()
     resource_id_part = logical_resource_id[: 63 - 1 - len(random_id_part)]
     return f"{resource_id_part}-{random_id_part}"
 

--- a/localstack-core/localstack/services/kinesisfirehose/resource_providers/aws_kinesisfirehose_deliverystream.py
+++ b/localstack-core/localstack/services/kinesisfirehose/resource_providers/aws_kinesisfirehose_deliverystream.py
@@ -412,8 +412,10 @@ class KinesisFirehoseDeliveryStreamProvider(
                 resource_model=model,
                 custom_context=request.custom_context,
             )
+        else:
+            print(f'REPEATED_INVOCATION for {attrs["DeliveryStreamName"]}')
         # TODO add handler for CREATE FAILED state
-        stream = firehose.describe_delivery_stream(DeliveryStreamName=model["DeliveryStreamName"])
+        stream = firehose.describe_delivery_stream(DeliveryStreamName=attrs["DeliveryStreamName"])
         if stream["DeliveryStreamDescription"]["DeliveryStreamStatus"] != "ACTIVE":
             return ProgressEvent(
                 status=OperationStatus.IN_PROGRESS,

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -111,6 +111,7 @@ class TestKinesis:
             else config.internal_service_url()
         )
 
+    # TODO should not fail without the name
     @markers.aws.validated
     def test_create_stream_without_stream_name_raises(self, aws_client_factory):
         boto_config = BotoConfig(parameter_validation=False)


### PR DESCRIPTION
## Motivation
Create Firehose streams without names with CloudFormation
It solves [this issue](https://github.com/localstack/localstack/issues/12066) 

## Changes
This is a work in progress to show a possible solution. 
- `provider_utils.generate_default_name()` - do not cut the name of the resource to be able to find it later
- add a few TODOs to raise a concern
- try to guess the stream name during REPEATED_INVOCATION (@Morijarti @alexrashed)
- use **addr** instead of `model`
`stream = firehose.describe_delivery_stream(DeliveryStreamName=`**attrs**`["DeliveryStreamName"])`
`stream = firehose.describe_delivery_stream(DeliveryStreamName=`**model**`["DeliveryStreamName"])`

## Testing
Unfortunately, I couls not run any tests. Neither with `make tests` nor within docker container
Any help is greatly appreciated!

## TODO
To finish the implementation to be able to create firehose streams wihout a name with CloudFormation (when the name is generated with stack name, name of the resorce and a random part)