### PR TITLE
Bump moto-ext to 5.0.26.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.22.post1",
+    "moto-ext[all]==5.0.25.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.25.post1",
+    "moto-ext[all]==5.0.26.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -12,7 +12,7 @@ certifi==2024.12.14
     # via requests
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via localstack-core (pyproject.toml)

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -38,7 +38,7 @@ psutil==6.1.1
     # via localstack-core (pyproject.toml)
 pycparser==2.22
     # via cffi
-pygments==2.18.0
+pygments==2.19.0
     # via rich
 pyproject-hooks==1.2.0
     # via build

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -254,7 +254,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.25.post1
+moto-ext==5.0.26.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -210,8 +210,6 @@ jsii==1.106.0
     #   constructs
 json5==0.10.0
     # via localstack-core
-jsondiff==2.2.1
-    # via moto-ext
 jsonpatch==1.33
     # via
     #   cfn-lint
@@ -256,7 +254,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.22.post1
+moto-ext==5.0.25.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy
@@ -332,7 +330,7 @@ publication==0.0.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-py-partiql-parser==0.5.6
+py-partiql-parser==0.6.1
     # via moto-ext
 pyasn1==0.6.1
     # via rsa
@@ -384,7 +382,6 @@ pyyaml==6.0.2
     # via
     #   awscli
     #   cfn-lint
-    #   jsondiff
     #   jsonschema-path
     #   localstack-core
     #   localstack-core (pyproject.toml)

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.25.post1
+moto-ext==5.0.26.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -147,8 +147,6 @@ jpype1-ext==0.0.2
     # via localstack-core (pyproject.toml)
 json5==0.10.0
     # via localstack-core (pyproject.toml)
-jsondiff==2.2.1
-    # via moto-ext
 jsonpatch==1.33
     # via
     #   cfn-lint
@@ -190,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.22.post1
+moto-ext==5.0.25.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy
@@ -235,7 +233,7 @@ psutil==6.1.1
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
-py-partiql-parser==0.5.6
+py-partiql-parser==0.6.1
     # via moto-ext
 pyasn1==0.6.1
     # via rsa
@@ -271,7 +269,6 @@ pyyaml==6.0.2
     # via
     #   awscli
     #   cfn-lint
-    #   jsondiff
     #   jsonschema-path
     #   localstack-core
     #   localstack-core (pyproject.toml)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -238,7 +238,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.25.post1
+moto-ext==5.0.26.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -194,8 +194,6 @@ jsii==1.106.0
     #   constructs
 json5==0.10.0
     # via localstack-core
-jsondiff==2.2.1
-    # via moto-ext
 jsonpatch==1.33
     # via
     #   cfn-lint
@@ -240,7 +238,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.22.post1
+moto-ext==5.0.25.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy
@@ -302,7 +300,7 @@ publication==0.0.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-py-partiql-parser==0.5.6
+py-partiql-parser==0.6.1
     # via moto-ext
 pyasn1==0.6.1
     # via rsa
@@ -352,7 +350,6 @@ pyyaml==6.0.2
     # via
     #   awscli
     #   cfn-lint
-    #   jsondiff
     #   jsonschema-path
     #   localstack-core
     #   localstack-core (pyproject.toml)

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -214,8 +214,6 @@ jsii==1.106.0
     #   constructs
 json5==0.10.0
     # via localstack-core
-jsondiff==2.2.1
-    # via moto-ext
 jsonpatch==1.33
     # via
     #   cfn-lint
@@ -260,7 +258,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.22.post1
+moto-ext==5.0.25.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy
@@ -530,7 +528,7 @@ publication==0.0.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-py-partiql-parser==0.5.6
+py-partiql-parser==0.6.1
     # via moto-ext
 pyasn1==0.6.1
     # via rsa
@@ -582,7 +580,6 @@ pyyaml==6.0.2
     # via
     #   awscli
     #   cfn-lint
-    #   jsondiff
     #   jsonschema-path
     #   localstack-core
     #   localstack-core (pyproject.toml)

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -258,7 +258,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.25.post1
+moto-ext==5.0.26.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.snapshot.json
+++ b/tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.snapshot.json
@@ -224,7 +224,7 @@
     }
   },
   "tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.py::test_deploy_security_group_with_tags": {
-    "recorded-date": "16-08-2024, 19:09:00",
+    "recorded-date": "02-01-2025, 10:30:57",
     "recorded-content": {
       "security-group": {
         "Description": "Security Group",
@@ -245,6 +245,7 @@
           }
         ],
         "OwnerId": "111111111111",
+        "SecurityGroupArn": "arn:<partition>:ec2:<region>:111111111111:security-group/<group-id:1>",
         "Tags": [
           {
             "Key": "aws:cloudformation:logical-id",

--- a/tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.validation.json
+++ b/tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.validation.json
@@ -6,7 +6,7 @@
     "last_validated_date": "2024-04-26T16:18:18+00:00"
   },
   "tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.py::test_deploy_security_group_with_tags": {
-    "last_validated_date": "2024-08-16T19:09:00+00:00"
+    "last_validated_date": "2025-01-02T10:30:57+00:00"
   },
   "tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.py::test_deploy_vpc_endpoint": {
     "last_validated_date": "2024-04-30T20:01:19+00:00"


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.0.26.post1

Contains:

- https://github.com/getmoto/moto/pull/8393
- https://github.com/getmoto/moto/pull/8295

## To do

- [x] Ext compatibility (Ext integration tests # 2554)
- [x] Multi-account/region compatibility ([Randomised credentials test run](https://app.circleci.com/pipelines/github/localstack/localstack/30527/workflows/088ef2ba-f15a-4eba-9c07-66842df450ec))