### PR TITLE
DDB: parity fix for JS clients

### DIFF
--- a/localstack-core/localstack/services/dynamodb/provider.py
+++ b/localstack-core/localstack/services/dynamodb/provider.py
@@ -1313,7 +1313,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         # We found out that 'Parameters' can be an empty list when the request comes from the AWS JS client.
         if execute_statement_input.get("Parameters", None) == []:  # noqa
             raise ValidationException(
-                "Value '[]' at 'parameters' failed to satisfy constraint: Member must have length greater than or equal to 1"
+                "1 validation error detected: Value '[]' at 'parameters' failed to satisfy constraint: Member must have length greater than or equal to 1"
             )
         table_name = extract_table_name_from_partiql_update(statement)
         existing_items = None

--- a/localstack-core/localstack/services/dynamodb/provider.py
+++ b/localstack-core/localstack/services/dynamodb/provider.py
@@ -1310,6 +1310,11 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         #  find a way to make it better, same way as the other operations, by using returnvalues
         # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html
         statement = execute_statement_input["Statement"]
+        # We found out that 'Parameters' can be an empty list when the request comes from the AWS JS client.
+        if execute_statement_input.get("Parameters", None) == []:  # noqa
+            raise ValidationException(
+                "Value '[]' at 'parameters' failed to satisfy constraint: Member must have length greater than or equal to 1"
+            )
         table_name = extract_table_name_from_partiql_update(statement)
         existing_items = None
         stream_type = table_name and get_table_stream_type(

--- a/localstack-core/localstack/services/dynamodb/v2/provider.py
+++ b/localstack-core/localstack/services/dynamodb/v2/provider.py
@@ -889,6 +889,12 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         # TODO: this operation is still really slow with streams enabled
         #  find a way to make it better, same way as the other operations, by using returnvalues
         # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html
+
+        # We found out that 'Parameters' can be an empty list when the request comes from the AWS JS client.
+        if execute_statement_input.get("Parameters", None) == []:  # noqa
+            raise ValidationException(
+                "Value '[]' at 'parameters' failed to satisfy constraint: Member must have length greater than or equal to 1"
+            )
         return self.forward_request(context)
 
     #

--- a/localstack-core/localstack/services/dynamodb/v2/provider.py
+++ b/localstack-core/localstack/services/dynamodb/v2/provider.py
@@ -893,7 +893,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         # We found out that 'Parameters' can be an empty list when the request comes from the AWS JS client.
         if execute_statement_input.get("Parameters", None) == []:  # noqa
             raise ValidationException(
-                "Value '[]' at 'parameters' failed to satisfy constraint: Member must have length greater than or equal to 1"
+                "1 validation error detected: Value '[]' at 'parameters' failed to satisfy constraint: Member must have length greater than or equal to 1"
             )
         return self.forward_request(context)
 

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1458,9 +1458,18 @@
     }
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_execute_statement_empy_parameter": {
-    "recorded-date": "31-12-2024, 07:50:00",
+    "recorded-date": "03-01-2025, 09:24:27",
     "recorded-content": {
-      "invalid-param-error": "Parameter validation failed:\nInvalid length for parameter Parameters, value: 0, valid min length: 1"
+      "invalid-param-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '[]' at 'parameters' failed to satisfy constraint: Member must have length greater than or equal to 1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   }
 }

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1456,5 +1456,11 @@
         "Status": "ENABLED"
       }
     }
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_execute_statement_empy_parameter": {
+    "recorded-date": "31-12-2024, 07:50:00",
+    "recorded-content": {
+      "invalid-param-error": "Parameter validation failed:\nInvalid length for parameter Parameters, value: 0, valid min length: 1"
+    }
   }
 }

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -30,7 +30,7 @@
     "last_validated_date": "2024-01-10T12:59:50+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_execute_statement_empy_parameter": {
-    "last_validated_date": "2024-12-31T07:50:00+00:00"
+    "last_validated_date": "2025-01-03T09:24:27+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_execute_transaction": {
     "last_validated_date": "2023-08-23T14:32:44+00:00"

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -29,6 +29,9 @@
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_create_table_with_partial_sse_specification": {
     "last_validated_date": "2024-01-10T12:59:50+00:00"
   },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_execute_statement_empy_parameter": {
+    "last_validated_date": "2024-12-31T07:50:00+00:00"
+  },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_execute_transaction": {
     "last_validated_date": "2023-08-23T14:32:44+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We got a report from a customer mentioning that an empty parameter list in an execute statement command does not raise any error against LocalStack when using the JS client.

For instance, the following snippet would raise a `ValidationException` error against AWS, but not against LocalStack.

```js
const params = {
  Statement: "SELECT * FROM Table", 
  Parameters: []
};
const command = new ExecuteStatementCommand(params);
await client.send(command)
```

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Adding a check for an empty parameter list;
- Adding a snapshot test.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
