### PR TITLE
Add s3 as ESM failure destination for Kinesis and DynamoDB stream sources

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
@@ -180,6 +180,7 @@ class EsmWorkerFactory:
                 ),
             )
             poller = DynamoDBPoller(
+                esm_config=self.esm_config,
                 source_arn=source_arn,
                 source_parameters=source_parameters,
                 source_client=source_client,

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
@@ -152,6 +152,7 @@ class EsmWorkerFactory:
                 ),
             )
             poller = KinesisPoller(
+                esm_config=self.esm_config,
                 source_arn=source_arn,
                 source_parameters=source_parameters,
                 source_client=source_client,

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
@@ -152,7 +152,7 @@ class EsmWorkerFactory:
                 ),
             )
             poller = KinesisPoller(
-                esm_config=self.esm_config,
+                esm_uuid=self.esm_config["UUID"],
                 source_arn=source_arn,
                 source_parameters=source_parameters,
                 source_client=source_client,
@@ -180,7 +180,7 @@ class EsmWorkerFactory:
                 ),
             )
             poller = DynamoDBPoller(
-                esm_config=self.esm_config,
+                esm_uuid=self.esm_config["UUID"],
                 source_arn=source_arn,
                 source_parameters=source_parameters,
                 source_client=source_client,

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/dynamodb_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/dynamodb_poller.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from botocore.client import BaseClient
 
 from localstack.aws.api.dynamodbstreams import StreamStatus
+from localstack.aws.api.lambda_ import EventSourceMappingConfiguration
 from localstack.services.lambda_.event_source_mapping.event_processor import (
     EventProcessor,
 )
@@ -20,12 +21,14 @@ class DynamoDBPoller(StreamPoller):
         source_client: BaseClient | None = None,
         processor: EventProcessor | None = None,
         partner_resource_arn: str | None = None,
+        esm_config: EventSourceMappingConfiguration | None = None,
     ):
         super().__init__(
             source_arn,
             source_parameters,
             source_client,
             processor,
+            esm_config=esm_config,
             partner_resource_arn=partner_resource_arn,
         )
 

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/dynamodb_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/dynamodb_poller.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from botocore.client import BaseClient
 
 from localstack.aws.api.dynamodbstreams import StreamStatus
-from localstack.aws.api.lambda_ import EventSourceMappingConfiguration
 from localstack.services.lambda_.event_source_mapping.event_processor import (
     EventProcessor,
 )
@@ -21,14 +20,14 @@ class DynamoDBPoller(StreamPoller):
         source_client: BaseClient | None = None,
         processor: EventProcessor | None = None,
         partner_resource_arn: str | None = None,
-        esm_config: EventSourceMappingConfiguration | None = None,
+        esm_uuid: str | None = None,
     ):
         super().__init__(
             source_arn,
             source_parameters,
             source_client,
             processor,
-            esm_config=esm_config,
+            esm_uuid=esm_uuid,
             partner_resource_arn=partner_resource_arn,
         )
 

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/kinesis_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/kinesis_poller.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from botocore.client import BaseClient
 
 from localstack.aws.api.kinesis import StreamStatus
+from localstack.aws.api.lambda_ import EventSourceMappingConfiguration
 from localstack.aws.api.pipes import (
     KinesisStreamStartPosition,
 )
@@ -30,6 +31,7 @@ class KinesisPoller(StreamPoller):
     def __init__(
         self,
         source_arn: str,
+        esm_config: EventSourceMappingConfiguration,
         source_parameters: dict | None = None,
         source_client: BaseClient | None = None,
         processor: EventProcessor | None = None,
@@ -39,6 +41,7 @@ class KinesisPoller(StreamPoller):
     ):
         super().__init__(
             source_arn,
+            esm_config,
             source_parameters,
             source_client,
             processor,

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/kinesis_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/kinesis_poller.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from botocore.client import BaseClient
 
 from localstack.aws.api.kinesis import StreamStatus
-from localstack.aws.api.lambda_ import EventSourceMappingConfiguration
 from localstack.aws.api.pipes import (
     KinesisStreamStartPosition,
 )
@@ -37,14 +36,14 @@ class KinesisPoller(StreamPoller):
         partner_resource_arn: str | None = None,
         invoke_identity_arn: str | None = None,
         kinesis_namespace: bool = False,
-        esm_config: EventSourceMappingConfiguration | None = None,
+        esm_uuid: str | None = None,
     ):
         super().__init__(
             source_arn,
             source_parameters,
             source_client,
             processor,
-            esm_config=esm_config,
+            esm_uuid=esm_uuid,
             partner_resource_arn=partner_resource_arn,
         )
         self.invoke_identity_arn = invoke_identity_arn

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/kinesis_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/kinesis_poller.py
@@ -31,20 +31,20 @@ class KinesisPoller(StreamPoller):
     def __init__(
         self,
         source_arn: str,
-        esm_config: EventSourceMappingConfiguration,
         source_parameters: dict | None = None,
         source_client: BaseClient | None = None,
         processor: EventProcessor | None = None,
         partner_resource_arn: str | None = None,
         invoke_identity_arn: str | None = None,
         kinesis_namespace: bool = False,
+        esm_config: EventSourceMappingConfiguration | None = None,
     ):
         super().__init__(
             source_arn,
-            esm_config,
             source_parameters,
             source_client,
             processor,
+            esm_config=esm_config,
             partner_resource_arn=partner_resource_arn,
         )
         self.invoke_identity_arn = invoke_identity_arn

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -342,7 +342,7 @@ class StreamPoller(Poller):
                         self.esm_config["UUID"], shard_id, failure_timstamp
                     ),
                     Body=json.dumps(dlq_event_with_payload),
-                )  # TODO include payload and check other specifics for S3
+                )
             else:
                 LOG.warning("Unsupported DLQ service %s", service)
 
@@ -416,4 +416,4 @@ def get_failure_s3_object_key(esm_uuid: str, shard_id: str, failure_datetime: da
     timestamp = failure_datetime.strftime("%Y-%m-%dT%H.%M.%S")
     year_month_day = failure_datetime.strftime("%Y/%m/%d")
     random_uuid = long_uid()
-    return f"aws/lambda/{esm_uuid}/{shard_id}/{year_month_day}/{timestamp}-{random_uuid}"  # TODO finish according to spec
+    return f"aws/lambda/{esm_uuid}/{shard_id}/{year_month_day}/{timestamp}-{random_uuid}"

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -51,15 +51,15 @@ class StreamPoller(Poller):
     def __init__(
         self,
         source_arn: str,
-        esm_config: EventSourceMappingConfiguration,
         source_parameters: dict | None = None,
         source_client: BaseClient | None = None,
         processor: EventProcessor | None = None,
         partner_resource_arn: str | None = None,
+        esm_config: EventSourceMappingConfiguration | None = None,
     ):
         super().__init__(source_arn, source_parameters, source_client, processor)
-        self.esm_config = esm_config
         self.partner_resource_arn = partner_resource_arn
+        self.esm_config = esm_config
         self.shards = {}
         self.iterator_over_shards = None
 

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -376,8 +376,12 @@ class StreamPoller(Poller):
         }
 
     def add_payload_to_dlq_event(self, dlq_event: dict, events) -> dict:
-        # TODO add payload from the original event
-        return dlq_event
+        return {
+            **dlq_event,
+            "payload": {
+                "Records": events,
+            },
+        }
 
     def max_retries_exceeded(self, attempts: int) -> bool:
         maximum_retry_attempts = self.stream_parameters.get("MaximumRetryAttempts", -1)

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -7,7 +7,6 @@ from typing import Iterator
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 
-from localstack.aws.api.lambda_ import EventSourceMappingConfiguration
 from localstack.aws.api.pipes import (
     OnPartialBatchItemFailureStreams,
 )
@@ -43,7 +42,7 @@ class StreamPoller(Poller):
     # This is a workaround for not handling shards in parallel.
     iterator_over_shards: Iterator[tuple[str, str]] | None
     # data from ESM configuration is needed in failure processing
-    esm_config: EventSourceMappingConfiguration
+    esm_uuid: str | None
 
     # The ARN of the processor (e.g., Pipe ARN)
     partner_resource_arn: str | None

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -41,7 +41,7 @@ class StreamPoller(Poller):
     # Iterator for round-robin polling from different shards because a batch cannot contain events from different shards
     # This is a workaround for not handling shards in parallel.
     iterator_over_shards: Iterator[tuple[str, str]] | None
-    # data from ESM configuration is needed in failure processing
+    # ESM UUID is needed in failure processing to form s3 failure destination object key
     esm_uuid: str | None
 
     # The ARN of the processor (e.g., Pipe ARN)

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -55,11 +55,11 @@ class StreamPoller(Poller):
         source_client: BaseClient | None = None,
         processor: EventProcessor | None = None,
         partner_resource_arn: str | None = None,
-        esm_config: EventSourceMappingConfiguration | None = None,
+        esm_uuid: str | None = None,
     ):
         super().__init__(source_arn, source_parameters, source_client, processor)
         self.partner_resource_arn = partner_resource_arn
-        self.esm_config = esm_config
+        self.esm_uuid = esm_uuid
         self.shards = {}
         self.iterator_over_shards = None
 
@@ -338,9 +338,7 @@ class StreamPoller(Poller):
                 dlq_event_with_payload = self.add_payload_to_dlq_event(dlq_event, events)
                 s3_client.put_object(
                     Bucket=s3_bucket_name(dlq_arn),
-                    Key=get_failure_s3_object_key(
-                        self.esm_config["UUID"], shard_id, failure_timstamp
-                    ),
+                    Key=get_failure_s3_object_key(self.esm_uuid, shard_id, failure_timstamp),
                     Body=json.dumps(dlq_event_with_payload),
                 )
             else:

--- a/localstack-core/localstack/testing/aws/lambda_utils.py
+++ b/localstack-core/localstack/testing/aws/lambda_utils.py
@@ -276,7 +276,7 @@ lambda_role = {
         }
     ],
 }
-s3_lambda_permission = {
+esm_lambda_permission = {
     "Version": "2012-10-17",
     "Statement": [
         {
@@ -298,6 +298,8 @@ s3_lambda_permission = {
                 "logs:CreateLogGroup",
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
+                "s3:ListBucket",
+                "s3:PutObject",
             ],
             "Resource": ["*"],
         }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -548,6 +548,12 @@ class TestDynamoDBEventSourceMapping:
         messages = retry(verify_failure_received, retries=15, sleep=sleep, sleep_before=5)
         snapshot.match("destination_queue_messages", messages)
 
+    # FIXME UpdateTable is not returning a WarmThroughput property
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..TableDescription.WarmThroughput",
+        ],
+    )
     @markers.aws.validated
     def test_dynamodb_event_source_mapping_with_s3_on_failure_destination(
         self,

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -347,7 +347,7 @@ class TestDynamoDBEventSourceMapping:
         list_esm = aws_client.lambda_.list_event_source_mappings(EventSourceArn=latest_stream_arn)
         snapshot.match("list_event_source_mapping_result", list_esm)
 
-    # FIXME UpdateTable is not returning a TableID
+    # TODO re-record snapshot, now TableId is returned but new WarmThroughput property is not
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..TableDescription.TableId",
@@ -462,7 +462,7 @@ class TestDynamoDBEventSourceMapping:
 
         snapshot.match("failure_sns_message", failure_sns_message)
 
-    # FIXME UpdateTable is not returning a TableID
+    # TODO re-record snapshot, now TableId is returned but new WarmThroughput property is not
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..TableDescription.TableId",

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -552,6 +552,7 @@ class TestDynamoDBEventSourceMapping:
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..TableDescription.WarmThroughput",
+            "$..requestContext.requestId",  # TODO there is an extra uuid in the snapshot when run in CI on itest-ddb-v2-provider step, need to look why
         ],
     )
     @markers.aws.validated

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -12,8 +12,8 @@ from localstack.testing.aws.lambda_utils import (
     _await_dynamodb_table_active,
     _await_event_source_mapping_enabled,
     _get_lambda_invocation_events,
+    esm_lambda_permission,
     lambda_role,
-    s3_lambda_permission,
 )
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
@@ -113,7 +113,7 @@ class TestDynamoDBEventSourceMapping:
             RoleName=role,
             PolicyName=policy_name,
             RoleDefinition=lambda_role,
-            PolicyDefinition=s3_lambda_permission,
+            PolicyDefinition=esm_lambda_permission,
         )
 
         create_lambda_function(
@@ -401,7 +401,7 @@ class TestDynamoDBEventSourceMapping:
             RoleName=role,
             PolicyName=policy_name,
             RoleDefinition=lambda_role,
-            PolicyDefinition=s3_lambda_permission,
+            PolicyDefinition=esm_lambda_permission,
         )
 
         create_lambda_function(
@@ -493,7 +493,7 @@ class TestDynamoDBEventSourceMapping:
             RoleName=role,
             PolicyName=policy_name,
             RoleDefinition=lambda_role,
-            PolicyDefinition=s3_lambda_permission,
+            PolicyDefinition=esm_lambda_permission,
         )
 
         create_lambda_function(
@@ -841,7 +841,7 @@ class TestDynamoDBEventSourceMapping:
             RoleName=role,
             PolicyName=policy_name,
             RoleDefinition=lambda_role,
-            PolicyDefinition=s3_lambda_permission,
+            PolicyDefinition=esm_lambda_permission,
         )
 
         create_lambda_function(

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py
@@ -1,6 +1,7 @@
 import json
 import math
 import time
+from datetime import datetime
 
 import pytest
 from botocore.exceptions import ClientError
@@ -17,6 +18,7 @@ from localstack.testing.aws.lambda_utils import (
 )
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
+from localstack.utils.aws.arns import s3_bucket_arn
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
 from localstack.utils.testutil import check_expected_lambda_log_events_length, get_lambda_log_events
@@ -545,6 +547,114 @@ class TestDynamoDBEventSourceMapping:
         sleep = 15 if is_aws_cloud() else 5
         messages = retry(verify_failure_received, retries=15, sleep=sleep, sleep_before=5)
         snapshot.match("destination_queue_messages", messages)
+
+    @markers.aws.validated
+    def test_dynamodb_event_source_mapping_with_s3_on_failure_destination(
+        self,
+        s3_bucket,
+        create_lambda_function,
+        aws_client,
+        cleanups,
+        dynamodb_create_table,
+        create_iam_role_with_policy,
+        region_name,
+        snapshot,
+    ):
+        # set up s3, lambda, dynamdodb
+
+        function_name = f"lambda_func-{short_uid()}"
+        role = f"test-lambda-role-{short_uid()}"
+        policy_name = f"test-lambda-policy-{short_uid()}"
+        table_name = f"test-table-{short_uid()}"
+        partition_key = "my_partition_key"
+        item = {partition_key: {"S": "hello world"}}
+
+        bucket_name = s3_bucket
+        bucket_arn = s3_bucket_arn(bucket_name, region=region_name)
+
+        role_arn = create_iam_role_with_policy(
+            RoleName=role,
+            PolicyName=policy_name,
+            RoleDefinition=lambda_role,
+            PolicyDefinition=esm_lambda_permission,
+        )
+
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_UNHANDLED_ERROR,
+            func_name=function_name,
+            runtime=Runtime.python3_12,
+            role=role_arn,
+        )
+
+        create_table_response = dynamodb_create_table(
+            table_name=table_name, partition_key=partition_key
+        )
+        _await_dynamodb_table_active(aws_client.dynamodb, table_name)
+        snapshot.match("create_table_response", create_table_response)
+
+        update_table_response = aws_client.dynamodb.update_table(
+            TableName=table_name,
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "NEW_IMAGE"},
+        )
+        snapshot.match("update_table_response", update_table_response)
+        stream_arn = update_table_response["TableDescription"]["LatestStreamArn"]
+
+        # create event source mapping
+
+        destination_config = {"OnFailure": {"Destination": bucket_arn}}
+
+        create_event_source_mapping_response = aws_client.lambda_.create_event_source_mapping(
+            FunctionName=function_name,
+            BatchSize=1,
+            StartingPosition="TRIM_HORIZON",
+            EventSourceArn=stream_arn,
+            MaximumBatchingWindowInSeconds=1,
+            MaximumRetryAttempts=1,
+            DestinationConfig=destination_config,
+        )
+        cleanups.append(
+            lambda: aws_client.lambda_.delete_event_source_mapping(UUID=event_source_mapping_uuid)
+        )
+        snapshot.match("create_event_source_mapping_response", create_event_source_mapping_response)
+        event_source_mapping_uuid = create_event_source_mapping_response["UUID"]
+        _await_event_source_mapping_enabled(aws_client.lambda_, event_source_mapping_uuid)
+
+        # trigger ESM source
+
+        aws_client.dynamodb.put_item(TableName=table_name, Item=item)
+
+        # add snapshot transformers
+
+        snapshot.add_transformer(snapshot.transform.regex(r"shardId-.*", "<dynamodb-shard-id>"))
+
+        # verify failure record data
+
+        def get_invocation_record():
+            list_objects_response = aws_client.s3.list_objects_v2(Bucket=bucket_name)
+            bucket_objects = list_objects_response["Contents"]
+            assert len(bucket_objects) == 1
+            object_key = bucket_objects[0]["Key"]
+
+            invocation_record = aws_client.s3.get_object(
+                Bucket=bucket_name,
+                Key=object_key,
+            )
+            return invocation_record, object_key
+
+        sleep = 15 if is_aws_cloud() else 5
+        s3_invocation_record, s3_object_key = retry(
+            get_invocation_record, retries=15, sleep=sleep, sleep_before=5
+        )
+
+        record_body = json.loads(s3_invocation_record["Body"].read().decode("utf-8"))
+        snapshot.match("record_body", record_body)
+
+        failure_datetime = datetime.fromisoformat(record_body["timestamp"])
+        timestamp = failure_datetime.strftime("%Y-%m-%dT%H.%M.%S")
+        year_month_day = failure_datetime.strftime("%Y/%m/%d")
+        assert s3_object_key.startswith(
+            f'aws/lambda/{event_source_mapping_uuid}/{record_body["DDBStreamBatchInfo"]["shardId"]}/{year_month_day}/{timestamp}'
+        )  # there is a random UUID at the end of object key, checking that the key starts with deterministic values
 
     # TODO: consider re-designing this test case because it currently does negative testing for the second event,
     #  which can be unreliable due to undetermined waiting times (i.e., retries). For reliable testing, we need

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.snapshot.json
@@ -4290,5 +4290,174 @@
         }
       ]
     }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_s3_on_failure_destination": {
+    "recorded-date": "03-01-2025, 16:42:26",
+    "recorded-content": {
+      "create_table_response": {
+        "TableDescription": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "my_partition_key",
+              "AttributeType": "S"
+            }
+          ],
+          "BillingModeSummary": {
+            "BillingMode": "PAY_PER_REQUEST"
+          },
+          "CreationDateTime": "<datetime>",
+          "DeletionProtectionEnabled": false,
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "my_partition_key",
+              "KeyType": "HASH"
+            }
+          ],
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 0,
+            "WriteCapacityUnits": 0
+          },
+          "TableArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<resource:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update_table_response": {
+        "TableDescription": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "my_partition_key",
+              "AttributeType": "S"
+            }
+          ],
+          "BillingModeSummary": {
+            "BillingMode": "PAY_PER_REQUEST",
+            "LastUpdateToPayPerRequestDateTime": "<datetime>"
+          },
+          "CreationDateTime": "<datetime>",
+          "DeletionProtectionEnabled": false,
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "my_partition_key",
+              "KeyType": "HASH"
+            }
+          ],
+          "LatestStreamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+          "LatestStreamLabel": "<resource:2>",
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 0,
+            "WriteCapacityUnits": 0
+          },
+          "StreamSpecification": {
+            "StreamEnabled": true,
+            "StreamViewType": "NEW_IMAGE"
+          },
+          "TableArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<resource:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "UPDATING",
+          "WarmThroughput": {
+            "ReadUnitsPerSecond": 12000,
+            "Status": "ACTIVE",
+            "WriteUnitsPerSecond": 4000
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_event_source_mapping_response": {
+        "BatchSize": 1,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {
+            "Destination": "arn:<partition>:s3:::<resource:3>"
+          }
+        },
+        "EventSourceArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:2>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:4>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumRecordAgeInSeconds": -1,
+        "MaximumRetryAttempts": 1,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "record_body": {
+        "DDBStreamBatchInfo": {
+          "approximateArrivalOfFirstRecord": "<timestamp:2022-07-13T13:48:01Z>",
+          "approximateArrivalOfLastRecord": "<timestamp:2022-07-13T13:48:01Z>",
+          "batchSize": 1,
+          "endSequenceNumber": "<sequence-number:1>",
+          "shardId": "<shard-id:1>",
+          "startSequenceNumber": "<sequence-number:1>",
+          "streamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>"
+        },
+        "payload": {
+          "Records": [
+            {
+              "eventID": "<event-i-d:1>",
+              "eventName": "INSERT",
+              "eventVersion": "1.1",
+              "eventSource": "aws:dynamodb",
+              "awsRegion": "<region>",
+              "dynamodb": {
+                "ApproximateCreationDateTime": "<approximate-creation-datetime>",
+                "Keys": {
+                  "my_partition_key": {
+                    "S": "hello world"
+                  }
+                },
+                "NewImage": {
+                  "my_partition_key": {
+                    "S": "hello world"
+                  }
+                },
+                "SequenceNumber": "<sequence-number:1>",
+                "SizeBytes": 54,
+                "StreamViewType": "NEW_IMAGE"
+              },
+              "eventSourceARN": "arn:<partition>:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>"
+            }
+          ]
+        },
+        "requestContext": {
+          "approximateInvokeCount": 2,
+          "condition": "RetryAttemptsExhausted",
+          "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:4>",
+          "requestId": "<uuid:3>"
+        },
+        "responseContext": {
+          "executedVersion": "$LATEST",
+          "functionError": "Unhandled",
+          "statusCode": 200
+        },
+        "timestamp": "<timestamp:2022-07-13T13:48:01.000Z>",
+        "version": "1.0"
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.validation.json
@@ -41,6 +41,9 @@
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_on_failure_destination_config": {
     "last_validated_date": "2024-10-12T11:01:14+00:00"
   },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_s3_on_failure_destination": {
+    "last_validated_date": "2025-01-03T16:42:22+00:00"
+  },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_sns_on_failure_destination_config": {
     "last_validated_date": "2024-10-12T10:59:07+00:00"
   },

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -924,13 +924,16 @@ class TestKinesisSource:
                 Bucket=bucket_name,
                 Key=object_key,
             )
-            return result
+            result_body = json.loads(result["Body"].read().decode("utf-8"))
+            payload = json.loads(result_body["payload"])
+            return result, payload
 
         sleep = 15 if is_aws_cloud() else 5
-        s3_invocation_record = retry(
+        s3_invocation_record, record_payload = retry(
             verify_failure_received, retries=15, sleep=sleep, sleep_before=5
         )
         snapshot.match("s3_invocation_record", s3_invocation_record)
+        snapshot.match("record_payload", record_payload)
 
     @markers.aws.validated
     @pytest.mark.parametrize(

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -11,9 +11,9 @@ from localstack.testing.aws.lambda_utils import (
     _await_event_source_mapping_enabled,
     _await_event_source_mapping_state,
     _get_lambda_invocation_events,
+    esm_lambda_permission,
     get_lambda_log_events,
     lambda_role,
-    s3_lambda_permission,
 )
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
@@ -478,7 +478,7 @@ class TestKinesisSource:
             RoleName=role,
             PolicyName=policy_name,
             RoleDefinition=lambda_role,
-            PolicyDefinition=s3_lambda_permission,
+            PolicyDefinition=esm_lambda_permission,
         )
 
         create_lambda_function(
@@ -565,7 +565,7 @@ class TestKinesisSource:
             RoleName=role,
             PolicyName=policy_name,
             RoleDefinition=lambda_role,
-            PolicyDefinition=s3_lambda_permission,
+            PolicyDefinition=esm_lambda_permission,
         )
 
         create_lambda_function(
@@ -755,7 +755,7 @@ class TestKinesisSource:
             RoleName=role,
             PolicyName=policy_name,
             RoleDefinition=lambda_role,
-            PolicyDefinition=s3_lambda_permission,
+            PolicyDefinition=esm_lambda_permission,
         )
 
         # create topic and queue
@@ -861,7 +861,7 @@ class TestKinesisSource:
             RoleName=role,
             PolicyName=policy_name,
             RoleDefinition=lambda_role,
-            PolicyDefinition=s3_lambda_permission,  # why it is called s3_lambda_permission?
+            PolicyDefinition=esm_lambda_permission,
         )
 
         create_lambda_function(
@@ -1113,7 +1113,7 @@ class TestKinesisEventFiltering:
             RoleName=role,
             PolicyName=policy_name,
             RoleDefinition=lambda_role,
-            PolicyDefinition=s3_lambda_permission,
+            PolicyDefinition=esm_lambda_permission,
         )
 
         create_lambda_function(

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -915,6 +915,7 @@ class TestKinesisSource:
         # add snapshot transformers
 
         snapshot.add_transformer(snapshot.transform.key_value("ETag"))
+        snapshot.add_transformer(snapshot.transform.regex(r"shardId-\d+", "<kinesis-shard-id>"))
 
         # verify failure record data
 

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -936,7 +936,6 @@ class TestKinesisSource:
         s3_invocation_record, s3_object_key = retry(
             get_invocation_record, retries=15, sleep=sleep, sleep_before=5
         )
-        snapshot.match("s3_invocation_record", s3_invocation_record)
 
         record_body = json.loads(s3_invocation_record["Body"].read().decode("utf-8"))
         snapshot.match("record_body", record_body)

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -915,14 +915,15 @@ class TestKinesisSource:
         # verify failure
 
         def verify_failure_received():
+            list_objects_response = aws_client.s3.list_objects_v2(Bucket=bucket_name)
+            bucket_objects = list_objects_response["Contents"]
+            assert len(bucket_objects) == 1
+            object_key = bucket_objects[0]["Key"]
+
             result = aws_client.s3.get_object(
                 Bucket=bucket_name,
-                Key="""
-            aws/lambda/<ESM-UUID>/<shardID>/YYYY/MM/DD/YYYY-MM-DDTHH.MM.SS-<Random UUID>
-            https://docs.aws.amazon.com/lambda/latest/dg/kinesis-on-failure-destination.html
-            """,
+                Key=object_key,
             )
-            # TODO assert result
             return result
 
         sleep = 15 if is_aws_cloud() else 5

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -912,7 +912,11 @@ class TestKinesisSource:
             StreamName=kinesis_name, Data=to_bytes(json.dumps(message)), PartitionKey="custom"
         )
 
-        # verify failure
+        # add snapshot transformers
+
+        snapshot.add_transformer(snapshot.transform.key_value("ETag"))
+
+        # verify failure record data
 
         def verify_failure_received():
             list_objects_response = aws_client.s3.list_objects_v2(Bucket=bucket_name)

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
@@ -3081,7 +3081,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
-    "recorded-date": "27-12-2024, 17:11:15",
+    "recorded-date": "27-12-2024, 17:21:48",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -3131,7 +3131,7 @@
           "approximateArrivalOfLastRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
           "batchSize": 1,
           "endSequenceNumber": "<sequence-number:1>",
-          "shardId": "shardId-000000000000",
+          "shardId": "<kinesis-shard-id>",
           "startSequenceNumber": "<sequence-number:1>",
           "streamArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
         },
@@ -3147,7 +3147,7 @@
               },
               "eventSource": "aws:kinesis",
               "eventVersion": "1.0",
-              "eventID": "shardId-000000000000:<sequence-number:1>",
+              "eventID": "<kinesis-shard-id>:<sequence-number:1>",
               "eventName": "aws:kinesis:record",
               "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:4>",
               "awsRegion": "<region>",

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
@@ -3081,7 +3081,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
-    "recorded-date": "27-12-2024, 17:21:48",
+    "recorded-date": "03-01-2025, 14:50:27",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -3109,20 +3109,6 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 202
-        }
-      },
-      "s3_invocation_record": {
-        "AcceptRanges": "bytes",
-        "Body": "",
-        "ContentLength": 1508,
-        "ContentType": "application/octet-stream",
-        "ETag": "<e-tag:1>",
-        "LastModified": "<datetime>",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
         }
       },
       "record_body": {

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
@@ -3079,5 +3079,76 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
+    "recorded-date": "26-12-2024, 18:06:42",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 1,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {
+            "Destination": "arn:<partition>:s3:::<resource:1>"
+          }
+        },
+        "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumRecordAgeInSeconds": -1,
+        "MaximumRetryAttempts": 1,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "s3_invocation_record": {
+        "AcceptRanges": "bytes",
+        "Body": {
+          "requestContext": {
+            "requestId": "<uuid:2>",
+            "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
+            "condition": "RetryAttemptsExhausted",
+            "approximateInvokeCount": 2
+          },
+          "responseContext": {
+            "statusCode": 200,
+            "executedVersion": "$LATEST",
+            "functionError": "Unhandled"
+          },
+          "version": "1.0",
+          "payload": "{\"Records\":[{\"kinesis\":{\"kinesisSchemaVersion\":\"1.0\",\"partitionKey\":\"custom\",\"sequenceNumber\":\"49659010315856526710810015429194486176186859345735057410\",\"data\":\"eyJpbnB1dCI6ICJoZWxsbyIsICJ2YWx1ZSI6ICJ3b3JsZCIsICJyYWlzZV9lcnJvciI6IDF9\",\"approximateArrivalTimestamp\":1.735236331572E9},\"eventSource\":\"aws:kinesis\",\"eventVersion\":\"1.0\",\"eventID\":\"shardId-000000000000:49659010315856526710810015429194486176186859345735057410\",\"eventName\":\"aws:kinesis:record\",\"invokeIdentityArn\":\"arn:<partition>:iam::111111111111:role/test-lambda-role-bf05eead\",\"awsRegion\":\"<region>\",\"eventSourceARN\":\"arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>\"}]}",
+          "timestamp": "<timestamp:2022-07-13T13:48:01.000Z>",
+          "KinesisBatchInfo": {
+            "shardId": "shardId-000000000000",
+            "startSequenceNumber": "49659010315856526710810015429194486176186859345735057410",
+            "endSequenceNumber": "49659010315856526710810015429194486176186859345735057410",
+            "approximateArrivalOfFirstRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
+            "approximateArrivalOfLastRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
+            "batchSize": 1,
+            "streamArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
+          }
+        },
+        "ContentLength": 1508,
+        "ContentType": "application/octet-stream",
+        "ETag": "\"af5c92b4209fa09486d6dde7dbd7464e\"",
+        "LastModified": "<datetime>",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
@@ -3081,7 +3081,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
-    "recorded-date": "26-12-2024, 18:06:42",
+    "recorded-date": "27-12-2024, 12:53:37",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -3113,34 +3113,10 @@
       },
       "s3_invocation_record": {
         "AcceptRanges": "bytes",
-        "Body": {
-          "requestContext": {
-            "requestId": "<uuid:2>",
-            "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
-            "condition": "RetryAttemptsExhausted",
-            "approximateInvokeCount": 2
-          },
-          "responseContext": {
-            "statusCode": 200,
-            "executedVersion": "$LATEST",
-            "functionError": "Unhandled"
-          },
-          "version": "1.0",
-          "payload": "{\"Records\":[{\"kinesis\":{\"kinesisSchemaVersion\":\"1.0\",\"partitionKey\":\"custom\",\"sequenceNumber\":\"49659010315856526710810015429194486176186859345735057410\",\"data\":\"eyJpbnB1dCI6ICJoZWxsbyIsICJ2YWx1ZSI6ICJ3b3JsZCIsICJyYWlzZV9lcnJvciI6IDF9\",\"approximateArrivalTimestamp\":1.735236331572E9},\"eventSource\":\"aws:kinesis\",\"eventVersion\":\"1.0\",\"eventID\":\"shardId-000000000000:49659010315856526710810015429194486176186859345735057410\",\"eventName\":\"aws:kinesis:record\",\"invokeIdentityArn\":\"arn:<partition>:iam::111111111111:role/test-lambda-role-bf05eead\",\"awsRegion\":\"<region>\",\"eventSourceARN\":\"arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>\"}]}",
-          "timestamp": "<timestamp:2022-07-13T13:48:01.000Z>",
-          "KinesisBatchInfo": {
-            "shardId": "shardId-000000000000",
-            "startSequenceNumber": "49659010315856526710810015429194486176186859345735057410",
-            "endSequenceNumber": "49659010315856526710810015429194486176186859345735057410",
-            "approximateArrivalOfFirstRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
-            "approximateArrivalOfLastRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
-            "batchSize": 1,
-            "streamArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
-          }
-        },
+        "Body": "",
         "ContentLength": 1508,
         "ContentType": "application/octet-stream",
-        "ETag": "\"af5c92b4209fa09486d6dde7dbd7464e\"",
+        "ETag": "\"c60df69791d6f056ea15f16103c9f65d\"",
         "LastModified": "<datetime>",
         "Metadata": {},
         "ServerSideEncryption": "AES256",
@@ -3148,6 +3124,26 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "record_payload": {
+        "Records": [
+          {
+            "awsRegion": "<region>",
+            "eventID": "shardId-000000000000:<sequence-number:1>",
+            "eventName": "aws:kinesis:record",
+            "eventSource": "aws:kinesis",
+            "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+            "eventVersion": "1.0",
+            "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:4>",
+            "kinesis": {
+              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
+              "data": "eyJpbnB1dCI6ICJoZWxsbyIsICJ2YWx1ZSI6ICJ3b3JsZCIsICJyYWlzZV9lcnJvciI6IDF9",
+              "kinesisSchemaVersion": "1.0",
+              "partitionKey": "custom",
+              "sequenceNumber": "<sequence-number:1>"
+            }
+          }
+        ]
       }
     }
   }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
@@ -3081,7 +3081,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
-    "recorded-date": "27-12-2024, 12:53:37",
+    "recorded-date": "27-12-2024, 16:33:41",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -3116,7 +3116,7 @@
         "Body": "",
         "ContentLength": 1508,
         "ContentType": "application/octet-stream",
-        "ETag": "\"c60df69791d6f056ea15f16103c9f65d\"",
+        "ETag": "<e-tag:1>",
         "LastModified": "<datetime>",
         "Metadata": {},
         "ServerSideEncryption": "AES256",

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
@@ -3081,7 +3081,7 @@
     }
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
-    "recorded-date": "27-12-2024, 16:33:41",
+    "recorded-date": "27-12-2024, 17:11:15",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -3125,25 +3125,49 @@
           "HTTPStatusCode": 200
         }
       },
-      "record_payload": {
-        "Records": [
-          {
-            "awsRegion": "<region>",
-            "eventID": "shardId-000000000000:<sequence-number:1>",
-            "eventName": "aws:kinesis:record",
-            "eventSource": "aws:kinesis",
-            "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
-            "eventVersion": "1.0",
-            "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:4>",
-            "kinesis": {
-              "approximateArrivalTimestamp": "<approximate-arrival-timestamp>",
-              "data": "eyJpbnB1dCI6ICJoZWxsbyIsICJ2YWx1ZSI6ICJ3b3JsZCIsICJyYWlzZV9lcnJvciI6IDF9",
-              "kinesisSchemaVersion": "1.0",
-              "partitionKey": "custom",
-              "sequenceNumber": "<sequence-number:1>"
+      "record_body": {
+        "KinesisBatchInfo": {
+          "approximateArrivalOfFirstRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
+          "approximateArrivalOfLastRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
+          "batchSize": 1,
+          "endSequenceNumber": "<sequence-number:1>",
+          "shardId": "shardId-000000000000",
+          "startSequenceNumber": "<sequence-number:1>",
+          "streamArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
+        },
+        "payload": {
+          "Records": [
+            {
+              "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "custom",
+                "sequenceNumber": "<sequence-number:1>",
+                "data": "eyJpbnB1dCI6ICJoZWxsbyIsICJ2YWx1ZSI6ICJ3b3JsZCIsICJyYWlzZV9lcnJvciI6IDF9",
+                "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+              },
+              "eventSource": "aws:kinesis",
+              "eventVersion": "1.0",
+              "eventID": "shardId-000000000000:<sequence-number:1>",
+              "eventName": "aws:kinesis:record",
+              "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:4>",
+              "awsRegion": "<region>",
+              "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
             }
-          }
-        ]
+          ]
+        },
+        "requestContext": {
+          "approximateInvokeCount": 2,
+          "condition": "RetryAttemptsExhausted",
+          "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
+          "requestId": "<uuid:2>"
+        },
+        "responseContext": {
+          "executedVersion": "$LATEST",
+          "functionError": "Unhandled",
+          "statusCode": 200
+        },
+        "timestamp": "<timestamp:2022-07-13T13:48:01.000Z>",
+        "version": "1.0"
       }
     }
   }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -21,7 +21,7 @@
     "last_validated_date": "2024-12-13T14:04:46+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
-    "last_validated_date": "2024-12-26T18:06:38+00:00"
+    "last_validated_date": "2024-12-27T12:53:33+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_sns_on_failure_destination_config": {
     "last_validated_date": "2024-12-13T14:35:43+00:00"

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -20,6 +20,9 @@
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_async_invocation": {
     "last_validated_date": "2024-12-13T14:04:46+00:00"
   },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
+    "last_validated_date": "2024-12-26T18:06:38+00:00"
+  },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_sns_on_failure_destination_config": {
     "last_validated_date": "2024-12-13T14:35:43+00:00"
   },

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -21,7 +21,7 @@
     "last_validated_date": "2024-12-13T14:04:46+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
-    "last_validated_date": "2024-12-27T16:33:37+00:00"
+    "last_validated_date": "2024-12-27T17:11:11+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_sns_on_failure_destination_config": {
     "last_validated_date": "2024-12-13T14:35:43+00:00"

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -21,7 +21,7 @@
     "last_validated_date": "2024-12-13T14:04:46+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
-    "last_validated_date": "2025-01-03T12:49:29+00:00"
+    "last_validated_date": "2025-01-03T14:50:23+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_sns_on_failure_destination_config": {
     "last_validated_date": "2024-12-13T14:35:43+00:00"

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -21,7 +21,7 @@
     "last_validated_date": "2024-12-13T14:04:46+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
-    "last_validated_date": "2024-12-27T17:21:44+00:00"
+    "last_validated_date": "2025-01-02T19:26:57+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_sns_on_failure_destination_config": {
     "last_validated_date": "2024-12-13T14:35:43+00:00"

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -21,7 +21,7 @@
     "last_validated_date": "2024-12-13T14:04:46+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
-    "last_validated_date": "2024-12-27T12:53:33+00:00"
+    "last_validated_date": "2024-12-27T16:33:37+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_sns_on_failure_destination_config": {
     "last_validated_date": "2024-12-13T14:35:43+00:00"

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -21,7 +21,7 @@
     "last_validated_date": "2024-12-13T14:04:46+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
-    "last_validated_date": "2024-12-27T17:11:11+00:00"
+    "last_validated_date": "2024-12-27T17:21:44+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_sns_on_failure_destination_config": {
     "last_validated_date": "2024-12-13T14:35:43+00:00"

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -21,7 +21,7 @@
     "last_validated_date": "2024-12-13T14:04:46+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_s3_on_failure_destination": {
-    "last_validated_date": "2025-01-02T19:26:57+00:00"
+    "last_validated_date": "2025-01-03T12:49:29+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_sns_on_failure_destination_config": {
     "last_validated_date": "2024-12-13T14:35:43+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Currently, LocalStack only supports configuring an Amazon SNS topic or Amazon SQS queue as failure destinations. With [the recent announcement of Amazon S3 as a failed-event destination](https://aws.amazon.com/about-aws/whats-new/2024/11/aws-lambda-s3-failed-event-destination-stream-event-sources/), we should include this additional failure destination.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
