### PR TITLE
StepFunctions: Ensure Service Integrations Assume State Machine Role Credentials

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/credentials.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/credentials.py
@@ -1,4 +1,5 @@
-from typing import Final, Optional
+from dataclasses import dataclass
+from typing import Final
 
 from localstack.services.stepfunctions.asl.component.common.string.string_expression import (
     StringExpression,
@@ -6,8 +7,10 @@ from localstack.services.stepfunctions.asl.component.common.string.string_expres
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 
-_CREDENTIALS_ROLE_ARN_KEY: Final[str] = "RoleArn"
-ComputedCredentials = dict
+
+@dataclass
+class StateCredentials:
+    role_arn: str
 
 
 class RoleArn(EvalComponent):
@@ -26,12 +29,8 @@ class Credentials(EvalComponent):
     def __init__(self, role_arn: RoleArn):
         self.role_arn = role_arn
 
-    @staticmethod
-    def get_role_arn_from(computed_credentials: ComputedCredentials) -> Optional[str]:
-        return computed_credentials.get(_CREDENTIALS_ROLE_ARN_KEY)
-
     def _eval_body(self, env: Environment) -> None:
         self.role_arn.eval(env=env)
         role_arn = env.stack.pop()
-        computes_credentials: ComputedCredentials = {_CREDENTIALS_ROLE_ARN_KEY: role_arn}
+        computes_credentials = StateCredentials(role_arn=role_arn)
         env.stack.append(computes_credentials)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/lambda_eval_utils.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/lambda_eval_utils.py
@@ -4,7 +4,7 @@ from typing import IO, Any, Final, Optional, Union
 
 from localstack.aws.api.lambda_ import InvocationResponse
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    ComputedCredentials,
+    StateCredentials,
 )
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.utils.boto_client import boto_client_for
@@ -39,10 +39,10 @@ def _from_payload(payload_streaming_body: IO[bytes]) -> Union[json, str]:
 
 
 def exec_lambda_function(
-    env: Environment, parameters: dict, region: str, account: str, credentials: ComputedCredentials
+    env: Environment, parameters: dict, region: str, state_credentials: StateCredentials
 ) -> None:
     lambda_client = boto_client_for(
-        region=region, account=account, service="lambda", credentials=credentials
+        service="lambda", region=region, state_credentials=state_credentials
     )
 
     invocation_resp: InvocationResponse = lambda_client.invoke(**parameters)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_api_gateway.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_api_gateway.py
@@ -24,7 +24,7 @@ from localstack.services.stepfunctions.asl.component.common.error_name.failure_e
     FailureEvent,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    ComputedCredentials,
+    StateCredentials,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     ResourceCondition,
@@ -294,7 +294,7 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ):
         # TODO: add support for task credentials
 

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
@@ -15,7 +15,7 @@ from localstack.services.stepfunctions.asl.component.common.error_name.states_er
     StatesErrorNameType,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    ComputedCredentials,
+    StateCredentials,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     ResourceCondition,
@@ -128,15 +128,14 @@ class StateTaskServiceAwsSdk(StateTaskServiceCallback):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ):
         service_name = self._get_boto_service_name()
         api_action = self._get_boto_service_action()
         api_client = boto_client_for(
-            region=resource_runtime_part.region,
-            account=resource_runtime_part.account,
             service=service_name,
-            credentials=task_credentials,
+            region=resource_runtime_part.region,
+            state_credentials=state_credentials,
         )
         response = getattr(api_client, api_action)(**normalised_parameters) or dict()
         if response:

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_callback.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_callback.py
@@ -17,7 +17,7 @@ from localstack.services.stepfunctions.asl.component.common.error_name.failure_e
     FailureEvent,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    ComputedCredentials,
+    StateCredentials,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     ResourceCondition,
@@ -66,7 +66,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ) -> Callable[[], Optional[Any]]:
         raise RuntimeError(
             f"Unsupported .sync callback procedure in resource {self.resource.resource_arn}"
@@ -77,7 +77,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ) -> Callable[[], Optional[Any]]:
         raise RuntimeError(
             f"Unsupported .sync2 callback procedure in resource {self.resource.resource_arn}"
@@ -149,7 +149,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ) -> None:
         task_output = env.stack.pop()
 
@@ -190,7 +190,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
                         env=env,
                         resource_runtime_part=resource_runtime_part,
                         normalised_parameters=normalised_parameters,
-                        task_credentials=task_credentials,
+                        state_credentials=state_credentials,
                     )
                 else:
                     # The condition checks about the resource's condition is exhaustive leaving
@@ -199,7 +199,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
                         env=env,
                         resource_runtime_part=resource_runtime_part,
                         normalised_parameters=normalised_parameters,
-                        task_credentials=task_credentials,
+                        state_credentials=state_credentials,
                     )
 
                 outcome = self._eval_sync(
@@ -326,7 +326,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ) -> None:
         if self._is_integration_pattern():
             output = env.stack[-1]
@@ -346,12 +346,12 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
                 env=env,
                 resource_runtime_part=resource_runtime_part,
                 normalised_parameters=normalised_parameters,
-                task_credentials=task_credentials,
+                state_credentials=state_credentials,
             )
 
         super()._after_eval_execution(
             env=env,
             resource_runtime_part=resource_runtime_part,
             normalised_parameters=normalised_parameters,
-            task_credentials=task_credentials,
+            state_credentials=state_credentials,
         )

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_dynamodb.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_dynamodb.py
@@ -10,7 +10,7 @@ from localstack.services.stepfunctions.asl.component.common.error_name.failure_e
     FailureEvent,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    ComputedCredentials,
+    StateCredentials,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     ResourceRuntimePart,
@@ -133,15 +133,14 @@ class StateTaskServiceDynamoDB(StateTaskService):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ):
         service_name = self._get_boto_service_name()
         api_action = self._get_boto_service_action()
         dynamodb_client = boto_client_for(
-            region=resource_runtime_part.region,
-            account=resource_runtime_part.account,
             service=service_name,
-            credentials=task_credentials,
+            region=resource_runtime_part.region,
+            state_credentials=state_credentials,
         )
         response = getattr(dynamodb_client, api_action)(**normalised_parameters)
         response.pop("ResponseMetadata", None)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_events.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_events.py
@@ -10,7 +10,7 @@ from localstack.services.stepfunctions.asl.component.common.error_name.failure_e
     FailureEvent,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    ComputedCredentials,
+    StateCredentials,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     ResourceCondition,
@@ -87,16 +87,15 @@ class StateTaskServiceEvents(StateTaskServiceCallback):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ):
         self._normalised_request_parameters(env=env, parameters=normalised_parameters)
         service_name = self._get_boto_service_name()
         api_action = self._get_boto_service_action()
         events_client = boto_client_for(
-            region=resource_runtime_part.region,
-            account=resource_runtime_part.account,
             service=service_name,
-            credentials=task_credentials,
+            region=resource_runtime_part.region,
+            state_credentials=state_credentials,
         )
         response = getattr(events_client, api_action)(**normalised_parameters)
         response.pop("ResponseMetadata", None)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_lambda.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_lambda.py
@@ -15,7 +15,7 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.state
     lambda_eval_utils,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    ComputedCredentials,
+    StateCredentials,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     ResourceCondition,
@@ -122,12 +122,11 @@ class StateTaskServiceLambda(StateTaskServiceCallback):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ):
         lambda_eval_utils.exec_lambda_function(
             env=env,
             parameters=normalised_parameters,
             region=resource_runtime_part.region,
-            account=resource_runtime_part.account,
-            credentials=task_credentials,
+            state_credentials=state_credentials,
         )

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sfn.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sfn.py
@@ -23,7 +23,7 @@ from localstack.services.stepfunctions.asl.component.common.error_name.states_er
     StatesErrorNameType,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    ComputedCredentials,
+    StateCredentials,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     ResourceCondition,
@@ -114,13 +114,12 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ) -> Callable[[], Optional[Any]]:
         sfn_client = boto_client_for(
-            region=resource_runtime_part.region,
-            account=resource_runtime_part.account,
             service="stepfunctions",
-            credentials=task_credentials,
+            region=resource_runtime_part.region,
+            state_credentials=state_credentials,
         )
         submission_output: dict = env.stack.pop()
         execution_arn: str = submission_output["ExecutionArn"]
@@ -176,13 +175,12 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ) -> Callable[[], Optional[Any]]:
         sfn_client = boto_client_for(
             region=resource_runtime_part.region,
-            account=resource_runtime_part.account,
             service="stepfunctions",
-            credentials=task_credentials,
+            state_credentials=state_credentials,
         )
         submission_output: dict = env.stack.pop()
         execution_arn: str = submission_output["ExecutionArn"]
@@ -227,15 +225,14 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ):
         service_name = self._get_boto_service_name()
         api_action = self._get_boto_service_action()
         sfn_client = boto_client_for(
             region=resource_runtime_part.region,
-            account=resource_runtime_part.account,
             service=service_name,
-            credentials=task_credentials,
+            state_credentials=state_credentials,
         )
         response = getattr(sfn_client, api_action)(**normalised_parameters)
         response.pop("ResponseMetadata", None)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sns.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sns.py
@@ -10,7 +10,7 @@ from localstack.services.stepfunctions.asl.component.common.error_name.failure_e
     FailureEvent,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    ComputedCredentials,
+    StateCredentials,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     ResourceCondition,
@@ -90,15 +90,14 @@ class StateTaskServiceSns(StateTaskServiceCallback):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ):
         service_name = self._get_boto_service_name()
         api_action = self._get_boto_service_action()
         sns_client = boto_client_for(
-            region=resource_runtime_part.region,
-            account=resource_runtime_part.account,
             service=service_name,
-            credentials=task_credentials,
+            region=resource_runtime_part.region,
+            state_credentials=state_credentials,
         )
 
         # Optimised integration automatically stringifies

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sqs.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sqs.py
@@ -10,7 +10,7 @@ from localstack.services.stepfunctions.asl.component.common.error_name.failure_e
     FailureEvent,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    ComputedCredentials,
+    StateCredentials,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     ResourceCondition,
@@ -92,7 +92,7 @@ class StateTaskServiceSqs(StateTaskServiceCallback):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ):
         # TODO: Stepfunctions automatically dumps to json MessageBody's definitions.
         #  Are these other similar scenarios?
@@ -104,10 +104,9 @@ class StateTaskServiceSqs(StateTaskServiceCallback):
         service_name = self._get_boto_service_name()
         api_action = self._get_boto_service_action()
         sqs_client = boto_client_for(
-            region=resource_runtime_part.region,
-            account=resource_runtime_part.account,
             service=service_name,
-            credentials=task_credentials,
+            region=resource_runtime_part.region,
+            state_credentials=state_credentials,
         )
         response = getattr(sqs_client, api_action)(**normalised_parameters)
         response.pop("ResponseMetadata", None)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_unsupported.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_unsupported.py
@@ -2,7 +2,7 @@ import logging
 from typing import Final
 
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    ComputedCredentials,
+    StateCredentials,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     ResourceCondition,
@@ -42,7 +42,7 @@ class StateTaskServiceUnsupported(StateTaskServiceCallback):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: ComputedCredentials,
+        state_credentials: StateCredentials,
     ):
         # Logs that the evaluation of this optimised service integration is not supported
         # and relays the call to the target service with the computed parameters.
@@ -50,10 +50,9 @@ class StateTaskServiceUnsupported(StateTaskServiceCallback):
         service_name = self._get_boto_service_name()
         boto_action = self._get_boto_service_action()
         boto_client = boto_client_for(
-            region=resource_runtime_part.region,
-            account=resource_runtime_part.account,
             service=service_name,
-            credentials=task_credentials,
+            region=resource_runtime_part.region,
+            state_credentials=state_credentials,
         )
         response = getattr(boto_client, boto_action)(**normalised_parameters)
         response.pop("ResponseMetadata", None)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/state_task.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/state_task.py
@@ -18,8 +18,8 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.execu
     ExecutionState,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    ComputedCredentials,
     Credentials,
+    StateCredentials,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     Resource,
@@ -69,13 +69,13 @@ class StateTask(ExecutionState, abc.ABC):
 
         return parameters
 
-    def _eval_credentials(self, env: Environment) -> ComputedCredentials:
+    def _eval_state_credentials(self, env: Environment) -> StateCredentials:
         if not self.credentials:
-            task_credentials = dict()
+            state_credentials = StateCredentials(role_arn=env.aws_execution_details.role_arn)
         else:
             self.credentials.eval(env=env)
-            task_credentials = env.stack.pop()
-        return task_credentials
+            state_credentials = env.stack.pop()
+        return state_credentials
 
     def _get_timed_out_failure_event(self, env: Environment) -> FailureEvent:
         return FailureEvent(

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/state_task_lambda.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/state_task_lambda.py
@@ -30,9 +30,6 @@ from localstack.services.stepfunctions.asl.component.common.error_name.states_er
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task import (
     lambda_eval_utils,
 )
-from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
-    Credentials,
-)
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
     LambdaResource,
     ResourceRuntimePart,
@@ -134,7 +131,7 @@ class StateTaskLambda(StateTask):
 
     def _eval_execution(self, env: Environment) -> None:
         parameters = self._eval_parameters(env=env)
-        task_credentials = self._eval_credentials(env=env)
+        state_credentials = self._eval_state_credentials(env=env)
         payload = parameters["Payload"]
 
         scheduled_event_details = LambdaFunctionScheduledEventDetails(
@@ -150,7 +147,7 @@ class StateTaskLambda(StateTask):
             scheduled_event_details["timeoutInSeconds"] = timeout_seconds
         if self.credentials:
             scheduled_event_details["taskCredentials"] = TaskCredentials(
-                roleArn=Credentials.get_role_arn_from(computed_credentials=task_credentials)
+                roleArn=state_credentials.role_arn
             )
         env.event_manager.add_event(
             context=env.event_history_context,
@@ -171,8 +168,7 @@ class StateTaskLambda(StateTask):
             env=env,
             parameters=parameters,
             region=resource_runtime_part.region,
-            account=resource_runtime_part.account,
-            credentials=task_credentials,
+            state_credentials=state_credentials,
         )
 
         # In lambda invocations, only payload is passed on as output.


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, the SFN v2 interpreter creates boto clients for service integrations using user credentials if no explicit credentials are provided. This causes IAM policy checks to succeed incorrectly event when `ENFORCE_IAM=1` is set, as the checks were based on the user's permissions rather than those of the state machine's assumed role https://github.com/localstack/localstack/issues/11927. This fix ensures boto clients are created with the assumed role credentials of the state machine.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- In Task states, `Credentials` values are always computed and defaulted to the state machine role arn if not manual override is given
- Boto clients are created through assume role logic, using the role arn in the credentials
- Related minor refactoring to improve readability (mainly around renaming ComputedCredentials -> StateCredentials)

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
