### PR TITLE
Bugfix/eventbridge/process to all matching rules

### DIFF
--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -167,8 +167,8 @@ class TargetSender(ABC):
     @property
     def unique_id(self):
         """Necessary to distinguish between targets with the same ARN but for different rules.
-        The unique_id is a combination of the ARN and the rule ARN.
-        This is necessary nice input path and input transformer can be different for the same target ARN,
+        The unique_id is a combination of the rule ARN and the Target Id.
+        This is necessary since input path and input transformer can be different for the same target ARN,
         attached to different rules."""
         return f"{self.rule_arn}-{self.target_id}"
 

--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -161,6 +161,18 @@ class TargetSender(ABC):
         return self.target["Arn"]
 
     @property
+    def target_id(self):
+        return self.target["Id"]
+
+    @property
+    def unique_id(self):
+        """Necessary to distinguish between targets with the same ARN but for different rules.
+        The unique_id is a combination of the ARN and the rule ARN.
+        This is necessary nice input path and input transformer can be different for the same target ARN,
+        attached to different rules."""
+        return f"{self.rule_arn}-{self.target_id}"
+
+    @property
     def client(self):
         """Lazy initialization of internal botoclient factory."""
         if self._client is None:
@@ -263,7 +275,7 @@ class TargetSender(ABC):
         return predefined_template_replacements
 
 
-TargetSenderDict = dict[Arn, TargetSender]
+TargetSenderDict = dict[str, TargetSender]  # rule_arn-target_id as global unique id
 
 # Target Senders are ordered alphabetically by service name
 

--- a/tests/aws/services/events/test_archive_and_replay.py
+++ b/tests/aws/services/events/test_archive_and_replay.py
@@ -13,7 +13,7 @@ from tests.aws.services.events.helper_functions import (
     wait_for_replay_in_state,
 )
 from tests.aws.services.events.test_events import (
-    EVENT_DETAIL,
+    TEST_EVENT_DETAIL,
     TEST_EVENT_PATTERN,
     TEST_EVENT_PATTERN_NO_DETAIL,
 )
@@ -219,7 +219,7 @@ class TestArchive:
             entry = {
                 "Source": TEST_EVENT_PATTERN["source"][0],
                 "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                "Detail": json.dumps(EVENT_DETAIL),
+                "Detail": json.dumps(TEST_EVENT_DETAIL),
             }
             entries.append(entry)
 
@@ -412,7 +412,7 @@ class TestReplay:
             entry = {
                 "Source": TEST_EVENT_PATTERN["source"][0],
                 "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                "Detail": json.dumps(EVENT_DETAIL),
+                "Detail": json.dumps(TEST_EVENT_DETAIL),
                 "EventBusName": event_bus_name,
             }
             entries.append(entry)

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -1635,6 +1635,10 @@ class TestEventRule:
             snapshot.match(f"events-{source}", events)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        is_old_provider(),
+        reason="V1 provider does not support this feature",
+    )
     def test_process_pattern_to_single_matching_rules_single_target(
         self,
         create_lambda_function,

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -1414,7 +1414,7 @@ class TestEventRule:
         events_put_rule,
         aws_client,
     ):
-        """two rules with each two sqs targets, all 4 ques should receive the event"""
+        """two rules with each two sqs targets, all 4 queues should receive the event"""
 
         custom_bus_name = f"test-bus-{short_uid()}"
         events_create_event_bus(Name=custom_bus_name)

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -2003,6 +2003,12 @@ class TestEventTarget:
             ],
         )
 
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.regex(target_id, "target-id"),
+                snapshot.transform.regex(queue_arn, "target-arn"),
+            ]
+        )
         response = aws_client.events.list_targets_by_rule(Rule=rule_name)
         snapshot.match("list-targets", response)
 
@@ -2042,6 +2048,13 @@ class TestEventTarget:
             ],
         )
 
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.regex(target_id, "target-id"),
+                snapshot.transform.regex(queue_arn, "target-arn"),
+            ]
+        )
+
         response = aws_client.events.list_targets_by_rule(Rule=rule_one_name)
         snapshot.match("list-targets-rule-one", response)
 
@@ -2069,6 +2082,14 @@ class TestEventTarget:
                 {"Id": target_id_one, "Arn": queue_arn, "InputPath": "$.detail"},
                 {"Id": target_id_two, "Arn": queue_arn, "InputPath": "$.doesnotexist"},
             ],
+        )
+
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.regex(target_id_one, "target-id-one"),
+                snapshot.transform.regex(target_id_two, "target-id-two"),
+                snapshot.transform.regex(queue_arn, "target-arn"),
+            ]
         )
 
         response = aws_client.events.list_targets_by_rule(Rule=rule_name)
@@ -2104,6 +2125,13 @@ class TestEventTarget:
             Targets=[
                 {"Id": target_id, "Arn": queue_arn, "InputPath": "$.doesnotexist"},
             ],
+        )
+
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.regex(target_id, "target-id"),
+                snapshot.transform.regex(queue_arn, "target-arn"),
+            ]
         )
 
         response = aws_client.events.list_targets_by_rule(Rule=rule_one_name)

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1983,8 +1983,49 @@
       }
     }
   },
-  "tests/aws/services/events/test_events.py::TestEventRule::test_process_to_multiple_matching_rules": {
+  "tests/aws/services/events/test_events.py::TestEventRule::test_process_to_multiple_matching_rules_different_targets": {
     "recorded-date": "27-12-2024, 19:02:05",
     "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_process_to_multiple_matching_rules_single_target": {
+    "recorded-date": "02-01-2025, 11:37:47",
+    "recorded-content": {
+      "events": [
+        {
+          "version": "0",
+          "id": "<uuid:1>",
+          "detail-type": "core.update-account-command",
+          "source": "core.update-account-command",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [],
+          "detail": {
+            "command": "update-account",
+            "payload": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        },
+        {
+          "version": "0",
+          "id": "<uuid:1>",
+          "detail-type": "core.update-account-command",
+          "source": "core.update-account-command",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [],
+          "detail": {
+            "command": "update-account",
+            "payload": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2168,5 +2168,54 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_multiple_targets_with_same_id_single_rule": {
+    "recorded-date": "03-01-2025, 12:04:01",
+    "recorded-content": {
+      "list-targets": {
+        "Targets": [
+          {
+            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-4930c31e",
+            "Id": "test-With_valid.Characters-316ebb69",
+            "InputPath": "$.notexisting"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_multiple_targets_with_same_id_across_different_rules": {
+    "recorded-date": "03-01-2025, 12:04:32",
+    "recorded-content": {
+      "list-targets-rule-one": {
+        "Targets": [
+          {
+            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-82897537",
+            "Id": "test-With_valid.Characters-bc4021a0",
+            "InputPath": "$.detail"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-targets-rule-two": {
+        "Targets": [
+          {
+            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-82897537",
+            "Id": "test-With_valid.Characters-bc4021a0",
+            "InputPath": "$.notexisting"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2170,13 +2170,13 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_multiple_targets_with_same_id_single_rule": {
-    "recorded-date": "03-01-2025, 12:04:01",
+    "recorded-date": "03-01-2025, 12:29:52",
     "recorded-content": {
       "list-targets": {
         "Targets": [
           {
-            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-4930c31e",
-            "Id": "test-With_valid.Characters-316ebb69",
+            "Arn": "target-arn",
+            "Id": "target-id",
             "InputPath": "$.notexisting"
           }
         ],
@@ -2188,13 +2188,13 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_multiple_targets_with_same_id_across_different_rules": {
-    "recorded-date": "03-01-2025, 12:04:32",
+    "recorded-date": "03-01-2025, 12:30:57",
     "recorded-content": {
       "list-targets-rule-one": {
         "Targets": [
           {
-            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-82897537",
-            "Id": "test-With_valid.Characters-bc4021a0",
+            "Arn": "target-arn",
+            "Id": "target-id",
             "InputPath": "$.detail"
           }
         ],
@@ -2206,8 +2206,8 @@
       "list-targets-rule-two": {
         "Targets": [
           {
-            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-82897537",
-            "Id": "test-With_valid.Characters-bc4021a0",
+            "Arn": "target-arn",
+            "Id": "target-id",
             "InputPath": "$.notexisting"
           }
         ],
@@ -2219,18 +2219,18 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_multiple_targets_with_same_arn_single_rule": {
-    "recorded-date": "03-01-2025, 12:09:50",
+    "recorded-date": "03-01-2025, 12:32:45",
     "recorded-content": {
       "list-targets": {
         "Targets": [
           {
-            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-77ae0162",
-            "Id": "test-With_valid.Characters-195a2962",
+            "Arn": "target-arn",
+            "Id": "target-id-one",
             "InputPath": "$.detail"
           },
           {
-            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-77ae0162",
-            "Id": "test-With_valid.Characters-7e963a3c",
+            "Arn": "target-arn",
+            "Id": "target-id-two",
             "InputPath": "$.doesnotexist"
           }
         ],
@@ -2242,13 +2242,13 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_multiple_targets_with_same_arn_across_different_rules": {
-    "recorded-date": "03-01-2025, 12:10:07",
+    "recorded-date": "03-01-2025, 12:33:23",
     "recorded-content": {
       "list-targets-rule-one": {
         "Targets": [
           {
-            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-7ff20252",
-            "Id": "test-With_valid.Characters-21b5dd7f",
+            "Arn": "target-arn",
+            "Id": "target-id",
             "InputPath": "$.detail"
           }
         ],
@@ -2260,8 +2260,8 @@
       "list-targets-rule-two": {
         "Targets": [
           {
-            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-7ff20252",
-            "Id": "test-With_valid.Characters-21b5dd7f",
+            "Arn": "target-arn",
+            "Id": "target-id",
             "InputPath": "$.doesnotexist"
           }
         ],

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2217,5 +2217,59 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_multiple_targets_with_same_arn_single_rule": {
+    "recorded-date": "03-01-2025, 12:09:50",
+    "recorded-content": {
+      "list-targets": {
+        "Targets": [
+          {
+            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-77ae0162",
+            "Id": "test-With_valid.Characters-195a2962",
+            "InputPath": "$.detail"
+          },
+          {
+            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-77ae0162",
+            "Id": "test-With_valid.Characters-7e963a3c",
+            "InputPath": "$.doesnotexist"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_multiple_targets_with_same_arn_across_different_rules": {
+    "recorded-date": "03-01-2025, 12:10:07",
+    "recorded-content": {
+      "list-targets-rule-one": {
+        "Targets": [
+          {
+            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-7ff20252",
+            "Id": "test-With_valid.Characters-21b5dd7f",
+            "InputPath": "$.detail"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-targets-rule-two": {
+        "Targets": [
+          {
+            "Arn": "arn:<partition>:sqs:<region>:111111111111:test-queue-7ff20252",
+            "Id": "test-With_valid.Characters-21b5dd7f",
+            "InputPath": "$.doesnotexist"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1982,5 +1982,9 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_process_to_multiple_matching_rules": {
+    "recorded-date": "27-12-2024, 19:02:05",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2140,5 +2140,33 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_process_pattern_to_single_matching_rules_single_target": {
+    "recorded-date": "02-01-2025, 12:47:30",
+    "recorded-content": {
+      "events-1": [
+        {
+          "detail-payload-with-id": {
+            "payload": {
+              "id": "123"
+            }
+          }
+        }
+      ],
+      "events-2": [
+        {
+          "detail-payload-with-id": {
+            "payload": {
+              "id": "123"
+            }
+          }
+        },
+        {
+          "detail-with-id": {
+            "id": "123"
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2027,5 +2027,118 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_process_to_single_matching_rules_single_target": {
+    "recorded-date": "02-01-2025, 12:09:21",
+    "recorded-content": {
+      "events-source-one": [
+        {
+          "version": "0",
+          "id": "<uuid:1>",
+          "detail-type": "core.update-account-command",
+          "source": "source-one",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [],
+          "detail": {
+            "command": "update-account",
+            "payload": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        }
+      ],
+      "events-source-two": [
+        {
+          "version": "0",
+          "id": "<uuid:1>",
+          "detail-type": "core.update-account-command",
+          "source": "source-one",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [],
+          "detail": {
+            "command": "update-account",
+            "payload": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        },
+        {
+          "version": "0",
+          "id": "<uuid:2>",
+          "detail-type": "core.update-account-command",
+          "source": "source-two",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [],
+          "detail": {
+            "command": "update-account",
+            "payload": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        }
+      ],
+      "events-source-three": [
+        {
+          "version": "0",
+          "id": "<uuid:1>",
+          "detail-type": "core.update-account-command",
+          "source": "source-one",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [],
+          "detail": {
+            "command": "update-account",
+            "payload": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        },
+        {
+          "version": "0",
+          "id": "<uuid:2>",
+          "detail-type": "core.update-account-command",
+          "source": "source-two",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [],
+          "detail": {
+            "command": "update-account",
+            "payload": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        },
+        {
+          "version": "0",
+          "id": "<uuid:3>",
+          "detail-type": "core.update-account-command",
+          "source": "source-three",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [],
+          "detail": {
+            "command": "update-account",
+            "payload": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,11 +1,7 @@
 {
-  "tests/aws/services/events/test_events.py::TestEvents::test_create_connection_validations": {
-    "last_validated_date": "2024-12-13T10:54:30+00:00"
+  "tests/aws/services/events/test_events.py::TestEventRule::test_process_to_multiple_matching_rules": {
+    "last_validated_date": "2024-12-27T19:07:55+00:00"
   }
-}
- }
-}
-
 }
 "
   }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,9 +1,9 @@
 {
-  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_multiple_targets_with_same_id_across_different_rules": {
-    "last_validated_date": "2025-01-03T12:04:32+00:00"
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_multiple_targets_with_same_arn_across_different_rules": {
+    "last_validated_date": "2025-01-03T12:10:07+00:00"
   }
 }
-}
+
 "
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,7 +1,10 @@
 {
-  "tests/aws/services/events/test_events.py::TestEventRule::test_process_to_multiple_matching_rules": {
-    "last_validated_date": "2024-12-27T19:07:55+00:00"
+  "tests/aws/services/events/test_events.py::TestEventRule::test_process_to_multiple_matching_rules_single_target": {
+    "last_validated_date": "2025-01-02T11:37:47+00:00"
   }
+}
+
+
 }
 "
   }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,7 +1,8 @@
 {
-  "tests/aws/services/events/test_events.py::TestEventRule::test_process_to_multiple_matching_rules_single_target": {
-    "last_validated_date": "2025-01-02T11:37:47+00:00"
+  "tests/aws/services/events/test_events.py::TestEventRule::test_process_to_single_matching_rules_single_target": {
+    "last_validated_date": "2025-01-02T12:09:21+00:00"
   }
+}
 }
 
 

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_multiple_targets_with_same_arn_across_different_rules": {
-    "last_validated_date": "2025-01-03T12:10:07+00:00"
+    "last_validated_date": "2025-01-03T12:33:23+00:00"
   }
 }
 

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,9 +1,8 @@
 {
-  "tests/aws/services/events/test_events.py::TestEventRule::test_process_pattern_to_single_matching_rules_single_target": {
-    "last_validated_date": "2025-01-02T12:47:30+00:00"
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_multiple_targets_with_same_id_across_different_rules": {
+    "last_validated_date": "2025-01-03T12:04:32+00:00"
   }
 }
-  }
 }
 "
   }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,13 +1,8 @@
 {
-  "tests/aws/services/events/test_events.py::TestEventRule::test_process_to_single_matching_rules_single_target": {
-    "last_validated_date": "2025-01-02T12:09:21+00:00"
+  "tests/aws/services/events/test_events.py::TestEventRule::test_process_pattern_to_single_matching_rules_single_target": {
+    "last_validated_date": "2025-01-02T12:47:30+00:00"
   }
 }
-}
-
-
-}
-"
   }
 }
 "

--- a/tests/aws/services/events/test_events_cross_account_region.py
+++ b/tests/aws/services/events/test_events_cross_account_region.py
@@ -11,7 +11,7 @@ from tests.aws.services.events.helper_functions import (
     sqs_collect_messages,
 )
 from tests.aws.services.events.test_events import (
-    EVENT_DETAIL,
+    TEST_EVENT_DETAIL,
     TEST_EVENT_PATTERN_NO_SOURCE,
 )
 
@@ -231,7 +231,7 @@ def test_event_bus_to_event_bus_cross_account_region(
             {
                 "Source": SOURCE_PRIMARY,
                 "DetailType": TEST_EVENT_PATTERN_NO_SOURCE["detail-type"][0],
-                "Detail": json.dumps(EVENT_DETAIL),
+                "Detail": json.dumps(TEST_EVENT_DETAIL),
                 "EventBusName": event_bus_name_primary,
             }
         ],
@@ -265,7 +265,7 @@ def test_event_bus_to_event_bus_cross_account_region(
             {
                 "Source": SOURCE_SECONDARY,
                 "DetailType": TEST_EVENT_PATTERN_NO_SOURCE["detail-type"][0],
-                "Detail": json.dumps(EVENT_DETAIL),
+                "Detail": json.dumps(TEST_EVENT_DETAIL),
                 "EventBusName": event_bus_name_secondary,
             }
         ],
@@ -424,7 +424,7 @@ class TestEventsCrossAccountRegion:
                 {
                     "Source": SOURCE_PRIMARY,
                     "DetailType": TEST_EVENT_PATTERN_NO_SOURCE["detail-type"][0],
-                    "Detail": json.dumps(EVENT_DETAIL),
+                    "Detail": json.dumps(TEST_EVENT_DETAIL),
                     "EventBusName": event_bus_arn,  # using arn for cross region / cross account
                 }
             ],

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -12,8 +12,8 @@ from tests.aws.services.events.helper_functions import (
     sqs_collect_messages,
 )
 from tests.aws.services.events.test_events import (
-    EVENT_DETAIL,
     SPECIAL_EVENT_DETAIL,
+    TEST_EVENT_DETAIL,
     TEST_EVENT_PATTERN,
 )
 
@@ -82,7 +82,7 @@ class TestInputPath:
             {
                 "Source": TEST_EVENT_PATTERN["source"][0],
                 "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                "Detail": json.dumps(EVENT_DETAIL),
+                "Detail": json.dumps(TEST_EVENT_DETAIL),
             }
         ]
         entries_asserts = [(entries1, True)]
@@ -101,7 +101,7 @@ class TestInputPath:
         snapshot.match("message", messages)
 
     @markers.aws.validated
-    @pytest.mark.parametrize("event_detail", [EVENT_DETAIL, EVENT_DETAIL_DUPLICATED_KEY])
+    @pytest.mark.parametrize("event_detail", [TEST_EVENT_DETAIL, EVENT_DETAIL_DUPLICATED_KEY])
     def test_put_events_with_input_path_nested(
         self, event_detail, put_events_with_filter_to_sqs, snapshot
     ):
@@ -135,7 +135,7 @@ class TestInputPath:
             {
                 "Source": TEST_EVENT_PATTERN["source"][0],
                 "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                "Detail": json.dumps(EVENT_DETAIL),
+                "Detail": json.dumps(TEST_EVENT_DETAIL),
             }
         ]
         entries_asserts = [(entries1, True)]
@@ -193,7 +193,7 @@ class TestInputPath:
                     "EventBusName": bus_name,
                     "Source": TEST_EVENT_PATTERN["source"][0],
                     "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                    "Detail": json.dumps(EVENT_DETAIL),
+                    "Detail": json.dumps(TEST_EVENT_DETAIL),
                 }
             ]
         )
@@ -235,7 +235,7 @@ class TestInputTransformer:
             {
                 "Source": TEST_EVENT_PATTERN["source"][0],
                 "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                "Detail": json.dumps(EVENT_DETAIL),
+                "Detail": json.dumps(TEST_EVENT_DETAIL),
             }
         ]
         entries_asserts = [(entries, True)]
@@ -294,7 +294,7 @@ class TestInputTransformer:
             {
                 "Source": TEST_EVENT_PATTERN["source"][0],
                 "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                "Detail": json.dumps(EVENT_DETAIL),
+                "Detail": json.dumps(TEST_EVENT_DETAIL),
             }
         ]
         entries_asserts = [(entries, True)]
@@ -455,7 +455,7 @@ class TestInputTransformer:
                     "EventBusName": bus_name,
                     "Source": TEST_EVENT_PATTERN["source"][0],
                     "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                    "Detail": json.dumps(EVENT_DETAIL),
+                    "Detail": json.dumps(TEST_EVENT_DETAIL),
                 }
             ]
         )

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -22,7 +22,7 @@ from localstack.utils.testutil import check_expected_lambda_log_events_length
 from tests.aws.scenario.kinesis_firehose.conftest import get_all_expected_messages_from_s3
 from tests.aws.services.events.helper_functions import is_old_provider, sqs_collect_messages
 from tests.aws.services.events.test_api_destinations_and_connection import API_DESTINATION_AUTHS
-from tests.aws.services.events.test_events import EVENT_DETAIL, TEST_EVENT_PATTERN
+from tests.aws.services.events.test_events import TEST_EVENT_DETAIL, TEST_EVENT_PATTERN
 from tests.aws.services.firehose.helper_functions import get_firehose_iam_documents
 from tests.aws.services.kinesis.helper_functions import get_shard_iterator
 from tests.aws.services.lambda_.test_lambda import (
@@ -533,7 +533,7 @@ class TestEventsTargetCloudWatchLogs:
             "EventBusName": event_bus_name,
             "Source": TEST_EVENT_PATTERN["source"][0],
             "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-            "Detail": json.dumps(EVENT_DETAIL),
+            "Detail": json.dumps(TEST_EVENT_DETAIL),
         }
         put_events_response = aws_client.events.put_events(Entries=[event_entry])
         snapshot.match("put_events_response", put_events_response)
@@ -657,7 +657,7 @@ class TestEventsTargetEvents:
                 {
                     "Source": TEST_EVENT_PATTERN["source"][0],
                     "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                    "Detail": json.dumps(EVENT_DETAIL),
+                    "Detail": json.dumps(TEST_EVENT_DETAIL),
                     "EventBusName": event_bus_name_source,
                 }
             ],
@@ -782,7 +782,7 @@ class TestEventsTargetFirehose:
                         "EventBusName": event_bus_name,
                         "Source": TEST_EVENT_PATTERN["source"][0],
                         "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                        "Detail": json.dumps(EVENT_DETAIL),
+                        "Detail": json.dumps(TEST_EVENT_DETAIL),
                     }
                 ]
             )
@@ -895,7 +895,7 @@ class TestEventsTargetKinesis:
                     "EventBusName": event_bus_name,
                     "Source": TEST_EVENT_PATTERN["source"][0],
                     "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                    "Detail": json.dumps(EVENT_DETAIL),
+                    "Detail": json.dumps(TEST_EVENT_DETAIL),
                 }
             ]
         )
@@ -959,7 +959,7 @@ class TestEventsTargetLambda:
                     "EventBusName": bus_name,
                     "Source": TEST_EVENT_PATTERN["source"][0],
                     "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                    "Detail": json.dumps(EVENT_DETAIL),
+                    "Detail": json.dumps(TEST_EVENT_DETAIL),
                 }
             ]
         )
@@ -1247,7 +1247,7 @@ class TestEventsTargetSns:
                     "EventBusName": event_bus_name,
                     "Source": TEST_EVENT_PATTERN["source"][0],
                     "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                    "Detail": json.dumps(EVENT_DETAIL),
+                    "Detail": json.dumps(TEST_EVENT_DETAIL),
                 }
             ]
         )
@@ -1277,7 +1277,7 @@ class TestEventsTargetSqs:
             {
                 "Source": TEST_EVENT_PATTERN["source"][0],
                 "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                "Detail": json.dumps(EVENT_DETAIL),
+                "Detail": json.dumps(TEST_EVENT_DETAIL),
             }
         ]
         message = put_events_with_filter_to_sqs(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Internally target_services are stored in a dictionary _target_servuce_store and identified via the target_arn, this leads to problems since the target_arn is not unique for targets globally and across rules. 
The target_id is unique across targets for a single rule, thus a globally unique id is a combination of rule_arn and target_id

This problem also solves the following github bug report: https://github.com/localstack/localstack/issues/11335

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Changing the key for _target_servuce_store  to `rule_arn-target_id`


## Testing
Adding test for multiple rules with single or multiple patterns invoking the same target.
Adding tests for uniqueness of target_id across targets of single rule and across multiple rules
Adding tests for uniqueness of target_arn across targets of single rule and across multiple rules

