### PR TITLE
LDR: selectable local mounts

### DIFF
--- a/localstack-core/localstack/dev/run/__main__.py
+++ b/localstack-core/localstack/dev/run/__main__.py
@@ -20,6 +20,7 @@ from localstack.utils.run import run_interactive
 from localstack.utils.strings import short_uid
 
 from .configurators import (
+    HOST_PATH_MAPPINGS,
     ConfigEnvironmentConfigurator,
     DependencyMountConfigurator,
     EntryPointMountConfigurator,
@@ -119,6 +120,7 @@ from .paths import HostPaths
     "-l",
     multiple=True,
     required=False,
+    type=click.Choice(HOST_PATH_MAPPINGS.keys(), case_sensitive=False),
     help="Mount specified packages into the container",
 )
 @click.argument("command", nargs=-1, required=False)
@@ -306,6 +308,7 @@ def run(
                 SourceVolumeMountConfigurator(
                     host_paths=host_paths,
                     pro=pro,
+                    chosen_packages=local_packages,
                 )
             )
         if mount_entrypoints:

--- a/localstack-core/localstack/dev/run/__main__.py
+++ b/localstack-core/localstack/dev/run/__main__.py
@@ -20,7 +20,6 @@ from localstack.utils.run import run_interactive
 from localstack.utils.strings import short_uid
 
 from .configurators import (
-    HOST_PATH_MAPPINGS,
     ConfigEnvironmentConfigurator,
     DependencyMountConfigurator,
     EntryPointMountConfigurator,
@@ -28,7 +27,7 @@ from .configurators import (
     PortConfigurator,
     SourceVolumeMountConfigurator,
 )
-from .paths import HostPaths
+from .paths import HOST_PATH_MAPPINGS, HostPaths
 
 
 @click.command("run")

--- a/localstack-core/localstack/dev/run/__main__.py
+++ b/localstack-core/localstack/dev/run/__main__.py
@@ -114,6 +114,13 @@ from .paths import HostPaths
     required=False,
     help="Docker network to start the container in",
 )
+@click.option(
+    "--local-packages",
+    "-l",
+    multiple=True,
+    required=False,
+    help="Mount specified packages into the container",
+)
 @click.argument("command", nargs=-1, required=False)
 def run(
     image: str = None,
@@ -130,6 +137,7 @@ def run(
     publish: Tuple = (),
     entrypoint: str = None,
     network: str = None,
+    local_packages: list[str] | None = None,
     command: str = None,
 ):
     """
@@ -214,6 +222,16 @@ def run(
         │   ├── tests
         │   └── ...
 
+    You can choose which local source repositories are mounted in. For example, if `moto` and `rolo` are
+    both present, only mount `rolo` into the container.
+
+    \b
+        python -m localstack.dev.run --local-packages rolo
+
+    If both `rolo` and `moto` are available and both should be mounted, use the flag twice.
+
+    \b
+        python -m localstack.dev.run --local-packages rolo --local-packages moto
     """
     with console.status("Configuring") as status:
         env_vars = parse_env_vars(env)

--- a/localstack-core/localstack/dev/run/configurators.py
+++ b/localstack-core/localstack/dev/run/configurators.py
@@ -6,7 +6,6 @@ import gzip
 import os
 from pathlib import Path, PurePosixPath
 from tempfile import gettempdir
-from typing import Callable
 
 from localstack import config, constants
 from localstack.utils.bootstrap import ContainerConfigurators
@@ -21,21 +20,13 @@ from localstack.utils.files import get_user_cache_dir
 from localstack.utils.run import run
 from localstack.utils.strings import md5
 
-from .paths import CommunityContainerPaths, ContainerPaths, HostPaths, ProContainerPaths
-
-# Type representing how to extract a specific path from a common root path, typically a lambda function
-PathMappingExtractor = Callable[[HostPaths], Path]
-
-# Declaration of which local packages can be mounted into the container, and their locations on the host
-HOST_PATH_MAPPINGS: dict[
-    str,
-    PathMappingExtractor,
-] = {
-    "moto": lambda paths: paths.moto_project_dir / "moto",
-    "postgresql_proxy": lambda paths: paths.postgresql_proxy / "postgresql_proxy",
-    "rolo": lambda paths: paths.rolo_dir / "rolo",
-    "plux": lambda paths: paths.workspace_dir / "plux" / "plugin",
-}
+from .paths import (
+    HOST_PATH_MAPPINGS,
+    CommunityContainerPaths,
+    ContainerPaths,
+    HostPaths,
+    ProContainerPaths,
+)
 
 
 class ConfigEnvironmentConfigurator:

--- a/localstack-core/localstack/dev/run/configurators.py
+++ b/localstack-core/localstack/dev/run/configurators.py
@@ -23,10 +23,10 @@ from localstack.utils.strings import md5
 
 from .paths import CommunityContainerPaths, ContainerPaths, HostPaths, ProContainerPaths
 
-# TODO: docs
+# Type representing how to extract a specific path from a common root path, typically a lambda function
 PathMappingExtractor = Callable[[HostPaths], Path]
 
-# TODO: docs
+# Declaration of which local packages can be mounted into the container, and their locations on the host
 HOST_PATH_MAPPINGS: dict[
     str,
     PathMappingExtractor,

--- a/localstack-core/localstack/dev/run/configurators.py
+++ b/localstack-core/localstack/dev/run/configurators.py
@@ -160,9 +160,10 @@ class SourceVolumeMountConfigurator:
                 )
 
         # mount local code checkouts if possible
-        for name, path_extractor in HOST_PATH_MAPPINGS.items():
-            if name in self.chosen_packages:
-                self.try_mount_to_site_packages(cfg, path_extractor(self.host_paths))
+        for package_name in self.chosen_packages:
+            # Unconditional lookup because the CLI rejects incorect items
+            extractor = HOST_PATH_MAPPINGS[package_name]
+            self.try_mount_to_site_packages(cfg, extractor(self.host_paths))
 
         # docker entrypoint
         if self.pro:

--- a/localstack-core/localstack/dev/run/paths.py
+++ b/localstack-core/localstack/dev/run/paths.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 
 class HostPaths:
@@ -47,6 +47,21 @@ class HostPaths:
         return (
             self.localstack_pro_project_dir / "localstack-pro-core" / "localstack" / "pro" / "core"
         )
+
+
+# Type representing how to extract a specific path from a common root path, typically a lambda function
+PathMappingExtractor = Callable[[HostPaths], Path]
+
+# Declaration of which local packages can be mounted into the container, and their locations on the host
+HOST_PATH_MAPPINGS: dict[
+    str,
+    PathMappingExtractor,
+] = {
+    "moto": lambda paths: paths.moto_project_dir / "moto",
+    "postgresql_proxy": lambda paths: paths.postgresql_proxy / "postgresql_proxy",
+    "rolo": lambda paths: paths.rolo_dir / "rolo",
+    "plux": lambda paths: paths.workspace_dir / "plux" / "plugin",
+}
 
 
 class ContainerPaths:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When using `python -m localstack.dev.run`, local code checkouts if present are mounted into the container. This may cause confusion if the local project checkout is old and incompatible with the version of LocalStack in the container. 

In particular, we rely heavily on our fork of `moto` which changes semi-frequently. This can cause semi-regular breakages which are difficult to debug.

I think mounting non-core packages should be opt-in to reduce surprises, and should be straightforward and self-documenting to help discoverability.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Add new argument `-l/--local-packages` which can be used to specify which packages are mounted (if found)
* Define which packages are available in a declarative way so additional packages can be easier to add in the future
* Ensure the help string includes the list of packages which can be mounted, as well as validating the user's input to ensure only valid packages can be specified
* Update the example docstring


## Testing

* Check out `rolo` and `moto` in the same parent directory as `localstack` is checked out in, making the following structure:

```
somedir
├── localstack
│   ├── ...
│   ├── localstack-core
│   │   ├── localstack               <- will be mounted into the container
│   │   └── localstack_core.egg-info
│   ├── pyproject.toml
│   ├── tests
│   └── ...
├── moto
│   ├── AUTHORS.md
│   ├── ...
│   ├── moto                         <- will be mounted into the container
│   ├── moto_ext.egg-info
│   ├── pyproject.toml
│   ├── tests
│   └── ...
├── rolo
│   ├── AUTHORS.md
│   ├── ...
│   ├── moto                         <- will be mounted into the container
│   ├── moto_ext.egg-info
│   ├── pyproject.toml
│   ├── tests
│   └── ...
```

* On `master`, run `python -m localstack.dev.run` and note the shown configuration posted at the start of the command contains `rolo` and `moto`, e.g. in the following example see the `volumes` section contains both `localstack/moto/moto` and `localstack/rolo/rolo`

```python
{
    'image_name': 'localstack/localstack',
    'name': 'localstack-main',
    'volumes': [
        '/Users/simon/work/localstack/localstack/localstack-core/.filesystem/var/lib/localstack/cache/machine.json:/var/lib/localstack/cache/machine.json:ro',
        '/Users/simon/Library/Caches/localstack/volume:/var/lib/localstack',
        '/var/run/docker.sock:/var/run/docker.sock',
        '/Users/simon/work/localstack/localstack/localstack-core/localstack:/opt/code/localstack/localstack-core/localstack',
        '/Users/simon/work/localstack/moto/moto:/opt/code/localstack/.venv/lib/python3.11/site-packages/moto:ro',
        '/Users/simon/work/localstack/rolo/rolo:/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo:ro',
        '/Users/simon/work/localstack/localstack/bin/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh:ro'
    ],
    'ports': ['0.0.0.0:4566:4566', '0.0.0.0:443:443', '0.0.0.0:4510-4560:4510-4560'],
    'exposed_ports': [],
    'env_vars': {
        'GATEWAY_LISTEN': '0.0.0.0:4566,0.0.0.0:443',
        'EXTERNAL_SERVICE_PORTS_START': 4510,
        'EXTERNAL_SERVICE_PORTS_END': 4560,
        'DNS_ADDRESS': '127.0.0.1',
        'DEBUG': '1',
        'LOCALSTACK_ROOT_DIR': '/Users/simon/work/localstack',
        'DISABLE_EVENTS': '1',
        'GATEWAY_SERVER': 'twisted',
        'DOCKER_HOST': 'unix:///var/run/docker.sock',
        'IMAGE_NAME': 'localstack/localstack'
    },
    'privileged': False,
    'remove': True,
    'interactive': True,
    'tty': True,
    'detach': False
}
```

* Check out this PR and run the same command and note that the two directories are _not_ present
* Run `python -m localstack.dev.run -l rolo` and note that `rolo` is mounted, but `moto` is not
* Try further combinations

<!-- Optional section: How to test these changes? -->
<!--
-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
