### PR TITLE
Docker client: support lists for entrypoints

### DIFF
--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -450,7 +450,7 @@ class ContainerConfiguration:
     volumes: VolumeMappings = dataclasses.field(default_factory=VolumeMappings)
     ports: PortMappings = dataclasses.field(default_factory=PortMappings)
     exposed_ports: List[str] = dataclasses.field(default_factory=list)
-    entrypoint: Optional[str] = None
+    entrypoint: Optional[Union[List[str], str]] = None
     additional_flags: Optional[str] = None
     command: Optional[List[str]] = None
     env_vars: Dict[str, str] = dataclasses.field(default_factory=dict)
@@ -861,7 +861,7 @@ class ContainerClient(metaclass=ABCMeta):
         image_name: str,
         *,
         name: Optional[str] = None,
-        entrypoint: Optional[str] = None,
+        entrypoint: Optional[Union[List[str], str]] = None,
         remove: bool = False,
         interactive: bool = False,
         tty: bool = False,

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -714,7 +714,7 @@ class CmdDockerClient(ContainerClient):
         image_name: str,
         *,
         name: Optional[str] = None,
-        entrypoint: Optional[str] = None,
+        entrypoint: Optional[Union[List[str], str]] = None,
         remove: bool = False,
         interactive: bool = False,
         tty: bool = False,
@@ -746,7 +746,10 @@ class CmdDockerClient(ContainerClient):
         if name:
             cmd += ["--name", name]
         if entrypoint is not None:  # empty string entrypoint can be intentional
-            cmd += ["--entrypoint", entrypoint]
+            if isinstance(entrypoint, str):
+                cmd += ["--entrypoint", entrypoint]
+            else:
+                cmd += ["--entrypoint", shlex.join(entrypoint)]
         if privileged:
             cmd += ["--privileged"]
         if volumes:

--- a/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
@@ -606,7 +606,7 @@ class SdkDockerClient(ContainerClient):
         image_name: str,
         *,
         name: Optional[str] = None,
-        entrypoint: Optional[str] = None,
+        entrypoint: Optional[Union[List[str], str]] = None,
         remove: bool = False,
         interactive: bool = False,
         tty: bool = False,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The Docker SDK supports passing the container entrypoint as a list, but we currently don't. This does not match the Docker API, nor the ECS API.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Support either the list form as well as the string form.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
