### PR TITLE
lambda layer enable deterministic layer version creation

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -201,6 +201,7 @@ from localstack.services.lambda_.invocation.runtime_executor import get_runtime_
 from localstack.services.lambda_.lambda_utils import HINT_LOG
 from localstack.services.lambda_.layerfetcher.layer_fetcher import LayerFetcher
 from localstack.services.lambda_.provider_utils import (
+    LambdaLayerVersionIdentifier,
     get_function_version,
     get_function_version_from_arn,
 )
@@ -3524,8 +3525,10 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
 
         layer = state.layers[layer_name]
         with layer.next_version_lock:
-            next_version = layer.next_version
-            layer.next_version += 1
+            next_version = LambdaLayerVersionIdentifier(
+                account_id=account, region=region, layer_name=layer_name
+            ).generate(next_version=layer.next_version)
+            layer.next_version = max(next_version, layer.next_version) + 1
 
         # creating a new layer
         if content.get("ZipFile"):

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -3528,7 +3528,13 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             next_version = LambdaLayerVersionIdentifier(
                 account_id=account, region=region, layer_name=layer_name
             ).generate(next_version=layer.next_version)
-            layer.next_version = max(next_version, layer.next_version) + 1
+            # When creating a layer with user defined layer version, it is possible that we
+            # create layer versions out of order.
+            # ie. a user could replicate layer v2 then layer v1. It is important to always keep the maximum possible
+            # value for next layer to avoid overwriting existing versions
+            if layer.next_version <= next_version:
+                # We don't need to update layer.next_version if the created version is lower than the "next in line"
+                layer.next_version = max(next_version, layer.next_version) + 1
 
         # creating a new layer
         if content.get("ZipFile"):

--- a/localstack-core/localstack/services/lambda_/provider_utils.py
+++ b/localstack-core/localstack/services/lambda_/provider_utils.py
@@ -9,6 +9,7 @@ from localstack.services.lambda_.api_utils import (
     unqualified_lambda_arn,
 )
 from localstack.services.lambda_.invocation.models import lambda_stores
+from localstack.utils.id_generator import ExistingIds, ResourceIdentifier, Tags, localstack_id
 
 if TYPE_CHECKING:
     from localstack.services.lambda_.invocation.lambda_models import (
@@ -66,3 +67,26 @@ def get_function_version(
         )
     # TODO what if version is missing?
     return version
+
+
+class LambdaLayerVersionIdentifier(ResourceIdentifier):
+    service = "lambda"
+    resource = "layer-version"
+
+    def __init__(self, account_id: str, region: str, layer_name: str):
+        super(LambdaLayerVersionIdentifier, self).__init__(account_id, region, layer_name)
+
+    def generate(
+        self, existing_ids: ExistingIds = None, tags: Tags = None, next_version: int = None
+    ) -> int:
+        return int(generate_layer_version(self, next_version=next_version))
+
+
+@localstack_id
+def generate_layer_version(
+    resource_identifier: ResourceIdentifier,
+    existing_ids: ExistingIds = None,
+    tags: Tags = None,
+    next_version: int = 0,
+):
+    return next_version

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -6627,6 +6627,10 @@ class TestLambdaLayer:
     def test_layer_deterministic_version(
         self, dummylayer, cleanups, aws_client, account_id, region_name, set_resource_custom_id
     ):
+        """
+        Test deterministic layer version generation.
+        Ensuring we can control the version of the layer created through the LocalstackIdManager
+        """
         layer_name = f"testlayer-{short_uid()}"
         layer_version = randint(1, 10)
 

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -17,6 +17,7 @@ import re
 import threading
 from hashlib import sha256
 from io import BytesIO
+from random import randint
 from typing import Callable
 
 import pytest
@@ -33,6 +34,7 @@ from localstack.aws.api.lambda_ import (
 )
 from localstack.services.lambda_.api_utils import ARCHITECTURES
 from localstack.services.lambda_.provider import TAG_KEY_CUSTOM_URL
+from localstack.services.lambda_.provider_utils import LambdaLayerVersionIdentifier
 from localstack.services.lambda_.runtimes import (
     ALL_RUNTIMES,
     DEPRECATED_RUNTIMES,
@@ -6620,6 +6622,33 @@ class TestLambdaLayer:
         snapshot.match(
             "get_layer_version_policy_postdeletes2", get_layer_version_policy_postdeletes2
         )
+
+    @markers.aws.only_localstack(reason="Deterministic id generation is LS only")
+    def test_layer_deterministic_version(
+        self, dummylayer, cleanups, aws_client, account_id, region_name, set_resource_custom_id
+    ):
+        layer_name = f"testlayer-{short_uid()}"
+        layer_version = randint(1, 10)
+
+        layer_version_identifier = LambdaLayerVersionIdentifier(
+            account_id=account_id, region=region_name, layer_name=layer_name
+        )
+        set_resource_custom_id(layer_version_identifier, layer_version)
+        publish_result = aws_client.lambda_.publish_layer_version(
+            LayerName=layer_name,
+            CompatibleRuntimes=[Runtime.python3_12],
+            Content={"ZipFile": dummylayer},
+            CompatibleArchitectures=[Architecture.x86_64],
+        )
+        cleanups.append(
+            lambda: aws_client.lambda_.delete_layer_version(
+                LayerName=layer_name, VersionNumber=publish_result["Version"]
+            )
+        )
+        assert publish_result["Version"] == layer_version
+
+        # Try to get the layer version. it will raise an error if it can't be found
+        aws_client.lambda_.get_layer_version(LayerName=layer_name, VersionNumber=layer_version)
 
 
 class TestLambdaSnapStart:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

As we are making progress with the replicator, we need to implement deterministic id generation for lambda layers in order to control the created version.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- When defining the next version for a lambda layer, we will first verify if a static version was set. Defaulting to standard behavior
- added test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
