### PR TITLE
Bugfix/eventbridge/step functions target id input key

### DIFF
--- a/localstack-core/localstack/services/events/target.py
+++ b/localstack-core/localstack/services/events/target.py
@@ -168,11 +168,14 @@ class TargetSender(ABC):
         return self._client
 
     @abstractmethod
-    def send_event(self, event: FormattedEvent | TransformedEvent):
+    def send_event(
+        self, event: FormattedEvent | TransformedEvent, input_event: FormattedEvent | None = None
+    ):
         pass
 
     def process_event(self, event: FormattedEvent):
         """Processes the event and send it to the target."""
+        input_event = event.copy()
         if input_ := self.target.get("Input"):
             event = json.loads(input_)
         if isinstance(event, dict):
@@ -183,7 +186,7 @@ class TargetSender(ABC):
             if input_transformer := self.target.get("InputTransformer"):
                 event = self.transform_event_with_target_input_transformer(input_transformer, event)
         if event:
-            self.send_event(event)
+            self.send_event(event, input_event)
         else:
             LOG.info("No event to send to target %s", self.target.get("Id"))
 
@@ -474,14 +477,14 @@ class FirehoseTargetSender(TargetSender):
 
 
 class KinesisTargetSender(TargetSender):
-    def send_event(self, event):
+    def send_event(self, event, input_event):
         partition_key_path = collections.get_safe(
             self.target,
             "$.KinesisParameters.PartitionKeyPath",
             default_value="$.id",
         )
         stream_name = self.target["Arn"].split("/")[-1]
-        partition_key = collections.get_safe(event, partition_key_path, event["id"])
+        partition_key = collections.get_safe(input_event, partition_key_path, input_event["id"])
         self.client.put_record(
             StreamName=stream_name,
             Data=to_bytes(to_json_str(event)),
@@ -559,10 +562,10 @@ class SqsTargetSender(TargetSender):
 class StatesTargetSender(TargetSender):
     """Step Functions Target Sender"""
 
-    def send_event(self, event):
+    def send_event(self, event, input_event):
         self.service = "stepfunctions"
         self.client.start_execution(
-            stateMachineArn=self.target["Arn"], name=event["id"], input=to_json_str(event)
+            stateMachineArn=self.target["Arn"], name=input_event["id"], input=to_json_str(event)
         )
 
     def _validate_input(self, target: Target):

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -813,9 +813,11 @@ class TestEventsTargetFirehose:
 
 
 class TestEventsTargetKinesis:
+    @pytest.mark.parametrize("with_input_transformer", [True, False])
     @markers.aws.validated
     def test_put_events_with_target_kinesis(
         self,
+        with_input_transformer,
         kinesis_create_stream,
         wait_for_stream_ready,
         create_iam_role_with_policy,
@@ -870,6 +872,11 @@ class TestEventsTargetKinesis:
             EventPattern=json.dumps(TEST_EVENT_PATTERN),
         )
 
+        input_transformer = {
+            "InputPathsMap": {"payload": "$.detail.payload"},
+            "InputTemplate": '{"payload": <payload>}',
+        }
+        kwargs = {"InputTransformer": input_transformer} if with_input_transformer else {}
         target_id = f"target-{short_uid()}"
         aws_client.events.put_targets(
             Rule=rule_name,
@@ -880,6 +887,7 @@ class TestEventsTargetKinesis:
                     "Arn": stream_arn,
                     "RoleArn": event_bridge_bus_to_kinesis_role_arn,
                     "KinesisParameters": {"PartitionKeyPath": "$.detail-type"},
+                    **kwargs,
                 }
             ],
         )

--- a/tests/aws/services/events/test_events_targets.snapshot.json
+++ b/tests/aws/services/events/test_events_targets.snapshot.json
@@ -899,5 +899,38 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events_targets.py::TestEventsTargetKinesis::test_put_events_with_target_kinesis[True]": {
+    "recorded-date": "03-01-2025, 15:02:29",
+    "recorded-content": {
+      "response": {
+        "payload": {
+          "acc_id": "0a787ecb-4015",
+          "sf_id": "baz"
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_targets.py::TestEventsTargetKinesis::test_put_events_with_target_kinesis[False]": {
+    "recorded-date": "03-01-2025, 15:03:08",
+    "recorded-content": {
+      "response": {
+        "version": "0",
+        "id": "<uuid:1>",
+        "detail-type": "core.update-account-command",
+        "source": "core.update-account-command",
+        "account": "111111111111",
+        "time": "date",
+        "region": "<region>",
+        "resources": [],
+        "detail": {
+          "command": "update-account",
+          "payload": {
+            "acc_id": "0a787ecb-4015",
+            "sf_id": "baz"
+          }
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events_targets.validation.json
+++ b/tests/aws/services/events/test_events_targets.validation.json
@@ -20,6 +20,12 @@
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetKinesis::test_put_events_with_target_kinesis": {
     "last_validated_date": "2024-07-11T09:04:25+00:00"
   },
+  "tests/aws/services/events/test_events_targets.py::TestEventsTargetKinesis::test_put_events_with_target_kinesis[False]": {
+    "last_validated_date": "2025-01-03T15:03:08+00:00"
+  },
+  "tests/aws/services/events/test_events_targets.py::TestEventsTargetKinesis::test_put_events_with_target_kinesis[True]": {
+    "last_validated_date": "2025-01-03T15:02:29+00:00"
+  },
   "tests/aws/services/events/test_events_targets.py::TestEventsTargetLambda::test_put_events_with_target_lambda": {
     "last_validated_date": "2024-07-11T09:04:48+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Some target senders rely on specific fields from the event e.g. the event id, if an input transformer or input path is applied to the event, these keys could be removed, and the sending of the event will fail.

This PR fixes the problem addresses in this github bug report: https://github.com/localstack/localstack/issues/11970

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Optionally supply the input_event (no input transformer or input path applied for transformation) to the respective send_event method of Kinesis sender and Step Functions sender.

## Testing
Add test send event to target kinesis with input transformer enabled
Add test send event to target step functions with input transformer enabled
