### PR TITLE
remove references to the discuss forum

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,13 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: 💡 Feature request
-    url: https://discuss.localstack.cloud/
-  - name: ❓ Question
-    url: https://discuss.localstack.cloud
-    about: Ask a question about LocalStack
   - name: 📖  LocalStack Documentation
     url: https://localstack.cloud/docs/getting-started/overview/
     about: The LocalStack documentation may answer your questions!
   - name: 💬  LocalStack Community Support (Slack)
-    url: https://localstack-community.slack.com
+    url: https://localstack.cloud/slack
     about: Please ask and answer questions here.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -132,7 +132,6 @@ We do push a set of different image tags for the LocalStack Docker images. When 
 Get in touch with the LocalStack Team to report 🐞 [issues](https://github.com/localstack/localstack/issues/new/choose),upvote 👍 [feature requests](https://github.com/localstack/localstack/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+),🙋🏽 ask [support questions](https://docs.localstack.cloud/getting-started/help-and-support/),or 🗣️ discuss local cloud development:
 
 - [LocalStack Slack Community](https://localstack.cloud/contact/)
-- [LocalStack Discussion Page](https://discuss.localstack.cloud/)
 - [LocalStack GitHub Issue tracker](https://github.com/localstack/localstack/issues)
 - [Getting Started - FAQ](https://docs.localstack.cloud/getting-started/faq/)
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ To use LocalStack with a graphical user interface, you can use the following UI 
 
 ## Releases
 
-Please refer to [GitHub releases](https://github.com/localstack/localstack/releases) to see the complete list of changes for each release. For extended release notes, please refer to the [LocalStack Discuss](https://discuss.localstack.cloud/c/announcement/5).
+Please refer to [GitHub releases](https://github.com/localstack/localstack/releases) to see the complete list of changes for each release. For extended release notes, please refer to the [changelog](https://docs.localstack.cloud/references/changelog/).
 
 ## Contributing
 
@@ -179,7 +179,6 @@ upvote 👍 [feature requests](https://github.com/localstack/localstack/issues?q
 or 🗣️ discuss local cloud development:
 
 - [LocalStack Slack Community](https://localstack.cloud/contact/)
-- [LocalStack Discussion Page](https://discuss.localstack.cloud/)
 - [LocalStack GitHub Issue tracker](https://github.com/localstack/localstack/issues)
 
 ### Contributors


### PR DESCRIPTION
## Motivation

The Discuss forum is being deprecated.

## Changes

Removes references to the Discuss forum and redirects the users to the changelog documentation.

