### PR TITLE
Add tests to source package exclusions in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
+exclude tests/**
+exclude .test_durations
 include Makefile
 include LICENSE.txt
-include VERSION
-recursive-include localstack/ext *.java
-recursive-include localstack/ext pom.xml
-recursive-include localstack/utils/kinesis *.java
-recursive-include localstack/utils/kinesis *.py
+recursive-include localstack-core/localstack/utils/kinesis *.java
+recursive-include localstack-core/localstack/utils/kinesis *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,3 @@ exclude tests/**
 exclude .test_durations
 include Makefile
 include LICENSE.txt
-recursive-include localstack-core/localstack/utils/kinesis *.java
-recursive-include localstack-core/localstack/utils/kinesis *.py


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The source package currently includes all tests, which makes it quite big (10MB). This happens because its inclusions/exclusions are not managed in `pyproject.toml` but in the older `MANIFEST.in`. 
Our `MANIFEST.in` also contains some outdated paths in there.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Add exclusions for the tests in the source distribution
- Update/Remove outdated paths in MANIFEST.in


## Testing

```
drwxr-xr-x@    - silvio staff  7 Jan 12:17 localstack_core-4.0.4.dev85
.rw-r--r--@ 2.4M silvio staff  7 Jan 12:18 localstack_core-4.0.4.dev85-py3-none-any.whl
.rw-r--r--@  10M silvio staff  7 Jan 12:17 localstack_core-4.0.4.dev85.tar.gz
drwxr-xr-x@    - silvio staff  7 Jan 12:20 localstack_core-4.0.4.dev86
.rw-r--r--@ 2.4M silvio staff  7 Jan 12:20 localstack_core-4.0.4.dev86-py3-none-any.whl
.rw-r--r--@ 4.3M silvio staff  7 Jan 12:20 localstack_core-4.0.4.dev86.tar.gz
```

The size of the source distribution reduces by 57%.
Checking the contents shows that tests are not included anymore.

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
