### PR TITLE
Ship StepFunction JSONata dependency by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,6 +153,7 @@ RUN --mount=type=cache,target=/root/.cache \
     source .venv/bin/activate && \
     python -m localstack.cli.lpm install \
       lambda-runtime \
+      jpype-jsonata \
       dynamodb-local && \
     chown -R localstack:localstack /usr/lib/localstack && \
     chmod -R 777 /usr/lib/localstack

--- a/localstack-core/localstack/dev/run/__main__.py
+++ b/localstack-core/localstack/dev/run/__main__.py
@@ -36,7 +36,7 @@ from .paths import HOST_PATH_MAPPINGS, HostPaths
     type=str,
     required=False,
     help="Overwrite the container image to be used (defaults to localstack/localstack or "
-    "localstack/localstack-pro.",
+    "localstack/localstack-pro).",
 )
 @click.option(
     "--volume-dir",
@@ -66,7 +66,7 @@ from .paths import HOST_PATH_MAPPINGS, HostPaths
     "--mount-source/--no-mount-source",
     is_flag=True,
     default=True,
-    help="Mount source files from localstack, localstack-ext, and moto into the container.",
+    help="Mount source files from localstack and localstack-ext. Use --local-packages for optional dependencies such as moto.",
 )
 @click.option(
     "--mount-dependencies/--no-mount-dependencies",

--- a/localstack-core/localstack/services/stepfunctions/asl/jsonata/jsonata.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/jsonata/jsonata.py
@@ -8,8 +8,8 @@ from typing import Any, Callable, Final, Optional
 import jpype
 import jpype.imports
 
-from localstack.services.stepfunctions.asl.jsonata.packages import jsonata_package
 from localstack.services.stepfunctions.asl.utils.encoding import to_json_str
+from localstack.services.stepfunctions.packages import jpype_jsonata_package
 from localstack.utils.objects import singleton_factory
 
 JSONataExpression = str
@@ -40,17 +40,19 @@ class _JSONataJVMBridge:
     _java_JSONATA: "com.dashjoin.jsonata.Jsonata.jsonata"  # noqa
 
     def __init__(self):
-        installer = jsonata_package.get_installer()
+        installer = jpype_jsonata_package.get_installer()
         installer.install()
 
         from jpype import config as jpype_config
 
         jpype_config.destroy_jvm = False
 
+        # Limitation: We can only start one JVM instance within LocalStack and using JPype for another purpose
+        # (e.g., event-ruler) fails unless we change the way we load/reload the classpath.
         jvm_path = installer.get_java_lib_path()
         jsonata_libs_path = Path(installer.get_installed_dir())
-        event_ruler_libs_pattern = jsonata_libs_path.joinpath("*")
-        jpype.startJVM(jvm_path, classpath=[event_ruler_libs_pattern], interrupt=False)
+        jsonata_libs_pattern = jsonata_libs_path.joinpath("*")
+        jpype.startJVM(jvm_path, classpath=[jsonata_libs_pattern], interrupt=False)
 
         from com.fasterxml.jackson.databind import ObjectMapper  # noqa
         from com.dashjoin.jsonata.Jsonata import jsonata  # noqa

--- a/localstack-core/localstack/services/stepfunctions/packages.py
+++ b/localstack-core/localstack/services/stepfunctions/packages.py
@@ -3,17 +3,11 @@ from localstack.packages.core import MavenPackageInstaller
 from localstack.packages.java import JavaInstallerMixin
 
 JSONATA_DEFAULT_VERSION = "0.9.7"
-JACKSON_DEFAULT_VERSION = "2.16.2"
-
-JSONATA_JACKSON_VERSION_STORE = {JSONATA_DEFAULT_VERSION: JACKSON_DEFAULT_VERSION}
 
 
 class JSONataPackage(Package):
     def __init__(self):
         super().__init__("JSONataLibs", JSONATA_DEFAULT_VERSION)
-
-    def get_versions(self) -> list[str]:
-        return list(JSONATA_JACKSON_VERSION_STORE.keys())
 
     def _get_installer(self, version: str) -> PackageInstaller:
         return JSONataPackageInstaller(version)
@@ -21,13 +15,9 @@ class JSONataPackage(Package):
 
 class JSONataPackageInstaller(JavaInstallerMixin, MavenPackageInstaller):
     def __init__(self, version: str):
-        jackson_version = JSONATA_JACKSON_VERSION_STORE[version]
         super().__init__(
             f"pkg:maven/com.dashjoin/jsonata@{version}",
-            f"pkg:maven/com.fasterxml.jackson.core/jackson-core@{jackson_version}",
-            f"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@{jackson_version}",
-            f"pkg:maven/com.fasterxml.jackson.core/jackson-databind@{jackson_version}",
         )
 
 
-jsonata_package = JSONataPackage()
+jpype_jsonata_package = JSONataPackage()

--- a/localstack-core/localstack/services/stepfunctions/plugins.py
+++ b/localstack-core/localstack/services/stepfunctions/plugins.py
@@ -1,0 +1,9 @@
+from localstack.packages import Package, package
+
+
+@package(name="jpype-jsonata")
+def jpype_jsonata_package() -> Package:
+    """The Java-based jsonata library uses JPype and depends on a JVM installation."""
+    from localstack.services.stepfunctions.packages import jpype_jsonata_package
+
+    return jpype_jsonata_package


### PR DESCRIPTION
## Motivation

A support case raised the issue that StepFunctions failed with an SSL error when downloading the JVM 11 dependency used by the JSONata feature. This blocks usage of the JSONata feature for customers behind a proxy in the default configuration.

Alternatively, we need to provide comprehensive documentation on configuring proxies with all possible LocalStack URLs downloaded dynamically.

## Changes

* Create an installable package plugin `jpype-jsonata` to make the JSONata package installable via lpm
* Remove unnecessary Jackson dependency (side effect from copying the event-ruler installer). Tested locally with the LocalStack dev run script and the SFN test `test_base_map_from_input`
* ATTEMPT 🚧 Change JRE version to unify with dynamodb-local
* Move the package installer to the top-level directory for easy discovery following our convention
* Fix some typos and document JPype limitation
* sneaky: clarify dev run help as a follow-up to https://github.com/localstack/localstack/pull/12092 (cc @simonrw )

## Implications

Shipping `jpype-jsonata` increases the size of the LocalStack image by ~60MB (477MB+60MB => +12%) because of the following dependencies:
* jsonata jar: 166kb
* JRE 11: 60MB. JPype depends on Java and the default JRE 11 is not re-using the same JRE 21 already shipped with dynamodb local (which depends on JRE 17+)

@viren-nadkarni @alexrashed @dominikschubert What do you think? Should we unify the JRE versions or live with the +60MB?
* JPype should work with JRE 21 based on my testing with JRE 23
* We could add `self.java_version = "21"` (🚧 implicit alignment) or change the default version (bigger blast radius)