### PR TITLE
DynamoDB: Disable Scalable Vector Extensions in JRE

### DIFF
--- a/localstack-core/localstack/services/dynamodb/server.py
+++ b/localstack-core/localstack/services/dynamodb/server.py
@@ -1,5 +1,7 @@
+import contextlib
 import logging
 import os
+import subprocess
 import threading
 
 from localstack import config
@@ -142,10 +144,29 @@ class DynamodbServer(Server):
     def library_path(self) -> str:
         return f"{dynamodblocal_package.get_installed_dir()}/DynamoDBLocal_lib"
 
+    def _get_java_vm_options(self) -> list[str]:
+        dynamodblocal_installer = dynamodblocal_package.get_installer()
+
+        # Workaround for JVM SIGILL crash on Apple Silicon M4
+        # See https://bugs.openjdk.org/browse/JDK-8345296
+        # To be removed after Java is bumped to 17.0.15+ and 21.0.7+
+
+        # This command returns all supported JVM options
+        with contextlib.suppress(subprocess.CalledProcessError):
+            stdout = run(
+                cmd=["java", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintFlagsFinal", "-version"],
+                env_vars=dynamodblocal_installer.get_java_env_vars(),
+                print_error=True,
+            )
+            # Check if Scalable Vector Extensions are support on this JVM and CPU. If so, disable it
+            if "UseSVE" in stdout:
+                return ["-XX:UseSVE=0"]
+        return []
+
     def _create_shell_command(self) -> list[str]:
         cmd = [
             "java",
-            "-XX:UseSVE=0",  # See https://bugs.openjdk.org/browse/JDK-8345296
+            *self._get_java_vm_options(),
             "-Xmx%s" % self.heap_size,
             f"-javaagent:{dynamodblocal_package.get_installer().get_ddb_agent_jar_path()}",
             f"-Djava.library.path={self.library_path}",

--- a/localstack-core/localstack/services/dynamodb/server.py
+++ b/localstack-core/localstack/services/dynamodb/server.py
@@ -145,6 +145,7 @@ class DynamodbServer(Server):
     def _create_shell_command(self) -> list[str]:
         cmd = [
             "java",
+            "-XX:UseSVE=0",  # See https://bugs.openjdk.org/browse/JDK-8345296
             "-Xmx%s" % self.heap_size,
             f"-javaagent:{dynamodblocal_package.get_installer().get_ddb_agent_jar_path()}",
             f"-Djava.library.path={self.library_path}",


### PR DESCRIPTION
## Background

There have been several reports of JRE crashing with SIGILL on Apple Silicon M4. This crash is specific to JRE 17+ when running in a Docker container (i.e. when [prctl](https://manpages.ubuntu.com/manpages/jammy/en/man2/prctl.2.html) is not available) on aarch64.

In LocalStack, the bug affects DynamoDB Local.

## Changes

This PR adds the suggested workaround of disabling Scalable Vector Extensions (SVE) in JRE.

SVE disable option is passed to the JVM only when supported, otherwise it complains about unsupported VM option and exits.

## Tests

Due to lack of an M4 machine, it is not tested whether this resolves the issue.

## Related

See https://bugs.openjdk.org/browse/JDK-8345296

Might close - https://github.com/localstack/localstack/issues/12054