### PR TITLE
fix readme run integration individual tests cmd

### DIFF
--- a/docs/testing/integration-tests/README.md
+++ b/docs/testing/integration-tests/README.md
@@ -94,7 +94,7 @@ python -m pytest --log-cli-level=INFO tests/integration
 You can further specify the file and test class you want to run in the test path:
 
 ```bash
-TEST_PATH="tests/integration/docker/test_docker.py::TestDockerClient" make test
+TEST_PATH="tests/integration/docker_utils/test_docker.py::TestDockerClient" make test
 ```
 
 ### Test against a running LocalStack instance


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While reading the [Integration tests README](https://github.com/localstack/localstack/blob/master/docs/testing/integration-tests/README.md) file and testing the example command `TEST_PATH="tests/integration/docker/test_docker.py::TestDockerClient" make test` locally I found out that it fails because the path is not correct.

https://github.com/localstack/localstack/blob/master/docs/testing/integration-tests/README.md#running-individual-tests

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Updated the integration individual tests example command with the corrected path to run the test.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
