### PR TITLE
Feature/scheduler/extend tests coverage

### DIFF
--- a/tests/aws/services/scheduler/conftest.py
+++ b/tests/aws/services/scheduler/conftest.py
@@ -3,27 +3,45 @@ import logging
 import pytest
 
 from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
 
 LOG = logging.getLogger(__name__)
 
 
 @pytest.fixture
 def events_scheduler_create_schedule_group(aws_client):
-    schedule_group_arns = []
+    schedule_group_names = []
 
     def _events_scheduler_create_schedule_group(name, **kwargs):
         if not name:
             name = f"events-test-schedule-groupe-{short_uid()}"
         response = aws_client.scheduler.create_schedule_group(Name=name, **kwargs)
         schedule_group_arn = response["ScheduleGroupArn"]
-        schedule_group_arns.append(schedule_group_arn)
+        schedule_group_names.append(name)
 
         return schedule_group_arn
 
     yield _events_scheduler_create_schedule_group
 
-    for schedule_group_arn in schedule_group_arns:
+    def _wait_for_schedule_group_deletion(schedule_group_name):
         try:
-            aws_client.scheduler.delete_schedule_group(ScheduleGroupArn=schedule_group_arn)
+            aws_client.scheduler.get_schedule_group(Name=schedule_group_name)
         except Exception:
-            LOG.info("Failed to delete schedule group %s", schedule_group_arn)
+            LOG.info("Schedule group %s deleted", schedule_group_name)
+            return
+
+        raise Exception(f"Schedule group {schedule_group_name} not deleted")
+
+    for schedule_group_name in schedule_group_names:
+        try:
+            aws_client.scheduler.delete_schedule_group(Name=schedule_group_name)
+        except Exception:
+            LOG.info("Failed to delete schedule group %s", schedule_group_name)
+
+        # wait for resource to be deleted
+        retry(
+            _wait_for_schedule_group_deletion,
+            retries=20,
+            sleep=2,
+            schedule_group_name=schedule_group_name,
+        )

--- a/tests/aws/services/scheduler/conftest.py
+++ b/tests/aws/services/scheduler/conftest.py
@@ -1,11 +1,69 @@
 import logging
+import time
 
 import pytest
 
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
 
 LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def events_scheduler_create_schedule(aws_client, sqs_as_events_schedule_target):
+    schedule_names = []
+
+    def _events_scheduler_create_schedule(
+        name, flexible_time_window=None, schedule_expression=None, target=None, **kwargs
+    ):
+        if not name:
+            name = f"events-test-schedule-{short_uid()}"
+        if not flexible_time_window:
+            flexible_time_window = {
+                "Mode": "OFF",
+            }
+        if not schedule_expression:
+            schedule_expression = "rate(1 minute)"
+        if not target:
+            _, queue_arn, role_arn = sqs_as_events_schedule_target()
+            target = {"Arn": queue_arn, "Input": '{"key": "value"}', "RoleArn": role_arn}
+
+        response = aws_client.scheduler.create_schedule(
+            Name=name,
+            FlexibleTimeWindow=flexible_time_window,
+            ScheduleExpression=schedule_expression,
+            Target=target,
+            **kwargs,
+        )
+        schedule_names.append(name)
+
+        return response
+
+    yield _events_scheduler_create_schedule
+
+    def _wait_for_schedule_deletion(schedule_name):
+        try:
+            aws_client.scheduler.get_schedule_group(Name=schedule_name)
+        except Exception:
+            LOG.info("Schedule %s deleted", schedule_name)
+            return
+
+        raise Exception(f"Schedule {schedule_name} not deleted")
+
+    for schedule_name in schedule_names:
+        try:
+            aws_client.scheduler.delete_schedule(Name=schedule_name)
+        except Exception:
+            LOG.info("Failed to delete schedule %s", schedule_name)
+
+        # wait for resource to be deleted
+        retry(
+            _wait_for_schedule_deletion,
+            retries=20,
+            sleep=2,
+            schedule_name=schedule_name,
+        )
 
 
 @pytest.fixture
@@ -16,10 +74,9 @@ def events_scheduler_create_schedule_group(aws_client):
         if not name:
             name = f"events-test-schedule-groupe-{short_uid()}"
         response = aws_client.scheduler.create_schedule_group(Name=name, **kwargs)
-        schedule_group_arn = response["ScheduleGroupArn"]
         schedule_group_names.append(name)
 
-        return schedule_group_arn
+        return response
 
     yield _events_scheduler_create_schedule_group
 
@@ -45,3 +102,60 @@ def events_scheduler_create_schedule_group(aws_client):
             sleep=2,
             schedule_group_name=schedule_group_name,
         )
+
+
+@pytest.fixture
+def sqs_as_events_schedule_target(aws_client, sqs_get_queue_arn, create_iam_role_with_policy):
+    queue_urls = []
+
+    def _sqs_as_events_schedule_target(queue_name: str | None = None) -> tuple[str, str, str]:
+        if not queue_name:
+            queue_name = f"tests-queue-{short_uid()}"
+        sqs_client = aws_client.sqs
+        queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
+        queue_urls.append(queue_url)
+        queue_arn = sqs_get_queue_arn(queue_url)
+
+        role_name = f"events-scheduler-role-{short_uid()}"
+        policy_name = f"events-scheduler-policy-{short_uid()}"
+        role_definition = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "scheduler.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        policy_definition = {
+            "Version": "2012-10-17",
+            "Id": f"sqs-eventbridge-{short_uid()}",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sqs:SendMessage",
+                    "Resource": queue_arn,
+                }
+            ],
+        }
+        role_arn = create_iam_role_with_policy(
+            RoleName=role_name,
+            PolicyName=policy_name,
+            RoleDefinition=role_definition,
+            PolicyDefinition=policy_definition,
+        )
+
+        if is_aws_cloud():
+            # wait for the role to be available
+            time.sleep(10)
+
+        return queue_url, queue_arn, role_arn
+
+    yield _sqs_as_events_schedule_target
+
+    for queue_url in queue_urls:
+        try:
+            aws_client.sqs.delete_queue(QueueUrl=queue_url)
+        except Exception as e:
+            LOG.debug("error cleaning up queue %s: %s", queue_url, e)

--- a/tests/aws/services/scheduler/test_scheduler.py
+++ b/tests/aws/services/scheduler/test_scheduler.py
@@ -58,3 +58,88 @@ def test_untag_resource(aws_client, events_scheduler_create_schedule_group, snap
     assert response["Tags"] == []
 
     snapshot.match("list-untagged-schedule", response)
+
+
+class TestScheduleGroupe:
+    @markers.aws.validated
+    @pytest.mark.parametrize("with_tags", [True, False])
+    @pytest.mark.parametrize("with_client_token", [True, False])
+    def test_create_schedule_group(
+        self, with_tags, with_client_token, events_scheduler_create_schedule_group, snapshot
+    ):
+        name = f"test-schedule-group-{short_uid()}"
+        kwargs = {}
+        if with_client_token:
+            kwargs["ClientToken"] = f"test-client_token-{short_uid()}"
+        if with_tags:
+            kwargs["Tags"] = [
+                {
+                    "Key": "TagKey",
+                    "Value": "TagValue",
+                }
+            ]
+        response = events_scheduler_create_schedule_group(
+            name,
+            **kwargs,
+        )
+
+        snapshot.add_transformer(snapshot.transform.regex(name, "<name>"))
+        snapshot.match("create-schedule-group", response)
+
+    @markers.aws.validated
+    @pytest.mark.parametrize("with_tags", [True, False])
+    def test_get_schedule_group(
+        self, with_tags, aws_client, events_scheduler_create_schedule_group, snapshot
+    ):
+        name = f"test-schedule-group-{short_uid()}"
+        kwargs = {"Tags": [{"Key": "TagKey", "Value": "TagValue"}]} if with_tags else {}
+        schedule_group_arn = events_scheduler_create_schedule_group(name, **kwargs)
+
+        response = aws_client.scheduler.get_schedule_group(Name=name)
+
+        assert response["Arn"] == schedule_group_arn
+        assert response["Name"] == name
+
+        snapshot.add_transformer(snapshot.transform.regex(name, "<name>"))
+        snapshot.match("get-schedule-group", response)
+
+    @markers.aws.validated
+    def test_get_schedule_group_not_found(self, aws_client, snapshot):
+        with pytest.raises(Exception) as exc:
+            aws_client.scheduler.get_schedule_group(Name="not-existing-name")
+
+        assert exc.typename == "ResourceNotFoundException"
+
+        snapshot.match("get-schedule-group-not-found", exc.value.response)
+
+    @markers.aws.validated
+    @pytest.mark.parametrize("with_tags", [True, False])
+    def test_list_schedule_groups(
+        self, with_tags, aws_client, events_scheduler_create_schedule_group, snapshot
+    ):
+        kwargs = {"Tags": [{"Key": "TagKey", "Value": "TagValue"}]} if with_tags else {}
+        name_one = f"test-schedule-groupe-one-{short_uid()}"
+        events_scheduler_create_schedule_group(name_one, **kwargs)
+
+        name_two = f"test-schedule-groupe-two-{short_uid()}"
+        events_scheduler_create_schedule_group(name_two, **kwargs)
+
+        response = aws_client.scheduler.list_schedule_groups()
+
+        assert len(response["ScheduleGroups"]) == 3  # default schedule group + 2 created
+
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.regex(name_one, "<name-groupe-one>"),
+                snapshot.transform.regex(name_two, "<name-groupe-two>"),
+            ]
+        )
+        snapshot.match("list-schedule-groups", response)
+
+    @markers.aws.validated
+    def test_list_schedule_groups_not_found(self, aws_client, snapshot):
+        response = aws_client.scheduler.list_schedule_groups()
+
+        assert len(response["ScheduleGroups"]) == 1  # default schedule group
+
+        snapshot.match("list-schedule-groups-not-found", response)

--- a/tests/aws/services/scheduler/test_scheduler.py
+++ b/tests/aws/services/scheduler/test_scheduler.py
@@ -18,7 +18,7 @@ def test_list_schedules(aws_client):
 @markers.aws.validated
 def test_tag_resource(aws_client, events_scheduler_create_schedule_group, snapshot):
     name = short_uid()
-    schedule_group_arn = events_scheduler_create_schedule_group(name)
+    schedule_group_arn = events_scheduler_create_schedule_group(name)["ScheduleGroupArn"]
 
     response = aws_client.scheduler.tag_resource(
         ResourceArn=schedule_group_arn,
@@ -47,7 +47,7 @@ def test_untag_resource(aws_client, events_scheduler_create_schedule_group, snap
             "Value": "TagValue",
         }
     ]
-    schedule_group_arn = events_scheduler_create_schedule_group(name, Tags=tags)
+    schedule_group_arn = events_scheduler_create_schedule_group(name, Tags=tags)["ScheduleGroupArn"]
 
     response = aws_client.scheduler.untag_resource(
         ResourceArn=schedule_group_arn, TagKeys=["TagKey"]
@@ -58,6 +58,292 @@ def test_untag_resource(aws_client, events_scheduler_create_schedule_group, snap
     assert response["Tags"] == []
 
     snapshot.match("list-untagged-schedule", response)
+
+
+class TestSchedule:
+    @markers.aws.validated
+    @pytest.mark.parametrize("with_client_token", [True, False])
+    @pytest.mark.parametrize("with_description", [True, False])
+    @pytest.mark.parametrize("action_after_completion", ["NONE", "DELETE"])
+    @pytest.mark.parametrize("state", ["ENABLED", "DISABLED"])
+    @pytest.mark.parametrize("flexible_time_window_mode", ["OFF", "FLEXIBLE"])
+    def test_create_schedule(
+        self,
+        with_client_token,
+        with_description,
+        action_after_completion,
+        state,
+        flexible_time_window_mode,
+        sqs_as_events_schedule_target,
+        events_scheduler_create_schedule,
+        snapshot,
+    ):
+        name = f"test-schedule-{short_uid()}"
+        kwargs = {"ActionAfterCompletion": action_after_completion, "State": state}
+        if with_client_token:
+            kwargs["ClientToken"] = f"test-client_token-{short_uid()}"
+        if with_description:
+            kwargs["Description"] = "Test description"
+
+        flexible_time_window = {
+            "Mode": flexible_time_window_mode,
+        }
+        if flexible_time_window_mode == "FLEXIBLE":
+            flexible_time_window["MaximumWindowInMinutes"] = 60
+
+        schedule_expression = "rate(1 minute)"
+        queue_url, queue_arn, role_arn = sqs_as_events_schedule_target()
+        target = {"Arn": queue_arn, "Input": '{"key": "value"}', "RoleArn": role_arn}
+
+        response = events_scheduler_create_schedule(
+            name, flexible_time_window, schedule_expression, target, **kwargs
+        )
+
+        snapshot.add_transformer(snapshot.transform.regex(name, "<name>"))
+        snapshot.match("create-schedule", response)
+
+    @markers.aws.validated
+    @pytest.mark.parametrize("with_client_token", [True, False])
+    @pytest.mark.parametrize("with_description", [True, False])
+    @pytest.mark.parametrize("action_after_completion", ["NONE", "DELETE"])
+    @pytest.mark.parametrize("state", ["ENABLED", "DISABLED"])
+    @pytest.mark.parametrize("flexible_time_window_mode", ["OFF", "FLEXIBLE"])
+    def test_get_schedule(
+        self,
+        with_client_token,
+        with_description,
+        action_after_completion,
+        state,
+        flexible_time_window_mode,
+        sqs_as_events_schedule_target,
+        events_scheduler_create_schedule,
+        aws_client,
+        snapshot,
+    ):
+        name = f"test-schedule-{short_uid()}"
+        kwargs = {"ActionAfterCompletion": action_after_completion, "State": state}
+        if with_client_token:
+            kwargs["ClientToken"] = f"test-client_token-{short_uid()}"
+        if with_description:
+            kwargs["Description"] = "Test description"
+
+        flexible_time_window = {
+            "Mode": flexible_time_window_mode,
+        }
+        if flexible_time_window_mode == "FLEXIBLE":
+            flexible_time_window["MaximumWindowInMinutes"] = 60
+
+        schedule_expression = "rate(1 minute)"
+        queue_url, queue_arn, role_arn = sqs_as_events_schedule_target()
+        target = {"Arn": queue_arn, "Input": '{"key": "value"}', "RoleArn": role_arn}
+
+        schedule_arn = events_scheduler_create_schedule(
+            name, flexible_time_window, schedule_expression, target, **kwargs
+        )["ScheduleArn"]
+
+        response = aws_client.scheduler.get_schedule(Name=name)
+
+        assert response["Arn"] == schedule_arn
+        assert response["Name"] == name
+
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.regex(name, "<name>"),
+                snapshot.transform.regex(role_arn, "<role-arn>"),
+                snapshot.transform.regex(queue_arn, "<queue-arn>"),
+            ]
+        )
+        snapshot.match("get-schedule", response)
+
+    @markers.aws.validated
+    def test_get_schedule_not_found(self, aws_client, snapshot):
+        with pytest.raises(Exception) as exc:
+            aws_client.scheduler.get_schedule(Name="not-existing-schedule-name")
+
+        assert exc.typename == "ResourceNotFoundException"
+
+        snapshot.match("get-schedule-not-found", exc.value.response)
+
+    @markers.aws.validated
+    def test_list_schedules(
+        self, aws_client, sqs_as_events_schedule_target, events_scheduler_create_schedule, snapshot
+    ):
+        name_one = f"test-schedule-one-{short_uid()}"
+        name_two = f"test-schedule-two-{short_uid()}"
+
+        flexible_time_window = {
+            "Mode": "OFF",
+        }
+        schedule_expression = "rate(1 minute)"
+        queue_url, queue_arn, role_arn = sqs_as_events_schedule_target()
+        target = {"Arn": queue_arn, "Input": '{"key": "value"}', "RoleArn": role_arn}
+
+        schedule_arn_one = events_scheduler_create_schedule(
+            name_one, flexible_time_window, schedule_expression, target
+        )["ScheduleArn"]
+        schedule_arn_two = events_scheduler_create_schedule(
+            name_two, flexible_time_window, schedule_expression, target
+        )["ScheduleArn"]
+
+        response = aws_client.scheduler.list_schedules()
+
+        assert len(response["Schedules"]) == 2
+
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.regex(schedule_arn_one, "<schedule-one-arn>"),
+                snapshot.transform.regex(schedule_arn_two, "<schedule-two-arn>"),
+                snapshot.transform.regex(queue_arn, "<target-sqs-queue-arn>"),
+            ]
+        )
+        snapshot.match("list-schedules", response)
+
+    @markers.aws.validated
+    def test_list_schedules_non(self, aws_client, snapshot):
+        response = aws_client.scheduler.list_schedules()
+
+        assert len(response["Schedules"]) == 0
+
+        snapshot.match("list-schedules-non", response)
+
+    @markers.aws.validated
+    @pytest.mark.parametrize("initially_with_client_token", [True, False])
+    @pytest.mark.parametrize("initially_with_description", [True, False])
+    @pytest.mark.parametrize(
+        "combinations_action_after_completion", [["NONE", "DELETE"], ["NONE", "DELETE"]]
+    )
+    @pytest.mark.parametrize(
+        "combinations_state", [["ENABLED", "DISABLED"], ["ENABLED", "DISABLED"]]
+    )
+    @pytest.mark.parametrize("initial_flexible_time_window_mode", ["OFF", "FLEXIBLE"])
+    def test_update_schedule(
+        self,
+        initially_with_client_token,
+        initially_with_description,
+        combinations_action_after_completion,
+        combinations_state,
+        initial_flexible_time_window_mode,
+        sqs_as_events_schedule_target,
+        events_scheduler_create_schedule,
+        aws_client,
+        snapshot,
+    ):
+        name = f"test-schedule-{short_uid()}"
+        kwargs_initial = {
+            "ActionAfterCompletion": combinations_action_after_completion[0],
+            "State": combinations_state[0],
+        }
+        kwargs_update = {
+            "ActionAfterCompletion": combinations_action_after_completion[1],
+            "State": combinations_state[1],
+        }
+
+        client_token = f"test-client_token-{short_uid()}"
+        if initially_with_client_token:
+            kwargs_initial["ClientToken"] = client_token
+        else:
+            kwargs_update["ClientToken"] = client_token
+
+        description = "Test description"
+        if initially_with_description:
+            kwargs_initial["Description"] = description
+        else:
+            kwargs_update["Description"] = description
+
+        flexible_time_window = {
+            "MaximumWindowInMinutes": 60,
+            "Mode": "FLEXIBLE",
+        }
+        not_flexible_time_window = {
+            "Mode": "OFF",
+        }
+        if initial_flexible_time_window_mode == "FLEXIBLE":
+            initial_flexible_time_window = flexible_time_window
+            update_flexible_time_window = not_flexible_time_window
+        else:
+            initial_flexible_time_window = not_flexible_time_window
+            update_flexible_time_window = flexible_time_window
+
+        initial_schedule_expression = "rate(1 minute)"
+        update_schedule_expression = "rate(2 minute)"
+
+        _, initial_queue_arn, initial_role_arn = sqs_as_events_schedule_target()
+        initial_target = {
+            "Arn": initial_queue_arn,
+            "Input": '{"key": "value"}',
+            "RoleArn": initial_role_arn,
+        }
+
+        _, update_queue_arn, update_role_arn = sqs_as_events_schedule_target()
+        update_target = {
+            "Arn": update_queue_arn,
+            "Input": '{"otherkey": "othervalue"}',
+            "RoleArn": update_role_arn,
+        }
+
+        response = events_scheduler_create_schedule(
+            name,
+            initial_flexible_time_window,
+            initial_schedule_expression,
+            initial_target,
+            **kwargs_initial,
+        )
+
+        # get initial schedule description
+        response = aws_client.scheduler.get_schedule(Name=name)
+
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.regex(name, "<name>"),
+                snapshot.transform.regex(client_token, "<client-token>"),
+                snapshot.transform.regex(initial_queue_arn, "<initial-target-queue-arn>"),
+                snapshot.transform.regex(initial_role_arn, "<initial-target-role-arn>"),
+            ]
+        )
+        snapshot.match("initial-schedule", response)
+
+        response = aws_client.scheduler.update_schedule(
+            Name=name,
+            FlexibleTimeWindow=update_flexible_time_window,
+            ScheduleExpression=update_schedule_expression,
+            Target=update_target,
+            **kwargs_update,
+        )
+
+        snapshot.match("update-schedule", response)
+
+        # get updated schedule description
+        response = aws_client.scheduler.get_schedule(Name=name)
+
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.regex(update_queue_arn, "<update-target-queue-arn>"),
+                snapshot.transform.regex(update_role_arn, "<update-target-role-arn>"),
+            ]
+        )
+        snapshot.match("updated-schedule", response)
+
+    @markers.aws.validated
+    def test_delete_schedule(self, aws_client, events_scheduler_create_schedule, snapshot):
+        name = f"test-schedule-{short_uid()}"
+        events_scheduler_create_schedule(name)
+
+        response = aws_client.scheduler.delete_schedule(Name=name)
+
+        response = aws_client.scheduler.list_schedules()
+
+        assert len(response["Schedules"]) == 0
+
+        snapshot.match("delete-schedule", response)
+
+    @markers.aws.validated
+    def test_delete_schedule_not_found(self, aws_client, snapshot):
+        with pytest.raises(Exception) as exc:
+            aws_client.scheduler.delete_schedule(Name="not-existing-schedule-name")
+
+        assert exc.typename == "ResourceNotFoundException"
+
+        snapshot.match("delete-schedule-not-found", exc.value.response)
 
 
 class TestScheduleGroupe:
@@ -93,7 +379,9 @@ class TestScheduleGroupe:
     ):
         name = f"test-schedule-group-{short_uid()}"
         kwargs = {"Tags": [{"Key": "TagKey", "Value": "TagValue"}]} if with_tags else {}
-        schedule_group_arn = events_scheduler_create_schedule_group(name, **kwargs)
+        schedule_group_arn = events_scheduler_create_schedule_group(name, **kwargs)[
+            "ScheduleGroupArn"
+        ]
 
         response = aws_client.scheduler.get_schedule_group(Name=name)
 

--- a/tests/aws/services/scheduler/test_scheduler.py
+++ b/tests/aws/services/scheduler/test_scheduler.py
@@ -191,6 +191,8 @@ class TestSchedule:
 
         snapshot.add_transformers_list(
             [
+                snapshot.transform.regex(name_one, "<schedule-one-name>"),
+                snapshot.transform.regex(name_two, "<schedule-two-name>"),
                 snapshot.transform.regex(schedule_arn_one, "<schedule-one-arn>"),
                 snapshot.transform.regex(schedule_arn_two, "<schedule-two-arn>"),
                 snapshot.transform.regex(queue_arn, "<target-sqs-queue-arn>"),

--- a/tests/aws/services/scheduler/test_scheduler.snapshot.json
+++ b/tests/aws/services/scheduler/test_scheduler.snapshot.json
@@ -181,5 +181,3908 @@
         }
       }
     }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[ENABLED-NONE-True-True]": {
+    "recorded-date": "07-01-2025, 13:36:52",
+    "recorded-content": {}
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-NONE-True-True]": {
+    "recorded-date": "07-01-2025, 14:23:23",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-NONE-True-False]": {
+    "recorded-date": "07-01-2025, 14:23:35",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-NONE-False-True]": {
+    "recorded-date": "07-01-2025, 14:23:47",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-NONE-False-False]": {
+    "recorded-date": "07-01-2025, 14:23:59",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-DELETE-True-True]": {
+    "recorded-date": "07-01-2025, 14:24:11",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-DELETE-True-False]": {
+    "recorded-date": "07-01-2025, 14:24:23",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-DELETE-False-True]": {
+    "recorded-date": "07-01-2025, 14:24:36",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-DELETE-False-False]": {
+    "recorded-date": "07-01-2025, 14:24:48",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-NONE-True-True]": {
+    "recorded-date": "07-01-2025, 14:25:00",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-NONE-True-False]": {
+    "recorded-date": "07-01-2025, 14:25:12",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-NONE-False-True]": {
+    "recorded-date": "07-01-2025, 14:25:24",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-NONE-False-False]": {
+    "recorded-date": "07-01-2025, 14:25:36",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-DELETE-True-True]": {
+    "recorded-date": "07-01-2025, 14:25:48",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-DELETE-True-False]": {
+    "recorded-date": "07-01-2025, 14:26:00",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-DELETE-False-True]": {
+    "recorded-date": "07-01-2025, 14:26:12",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-DELETE-False-False]": {
+    "recorded-date": "07-01-2025, 14:26:24",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-NONE-True-True]": {
+    "recorded-date": "07-01-2025, 14:26:36",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-NONE-True-False]": {
+    "recorded-date": "07-01-2025, 14:26:48",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-NONE-False-True]": {
+    "recorded-date": "07-01-2025, 14:27:00",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-NONE-False-False]": {
+    "recorded-date": "07-01-2025, 14:27:12",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-DELETE-True-True]": {
+    "recorded-date": "07-01-2025, 14:27:25",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-DELETE-True-False]": {
+    "recorded-date": "07-01-2025, 14:27:37",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-DELETE-False-True]": {
+    "recorded-date": "07-01-2025, 14:27:49",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-DELETE-False-False]": {
+    "recorded-date": "07-01-2025, 14:28:01",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-NONE-True-True]": {
+    "recorded-date": "07-01-2025, 14:28:13",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-NONE-True-False]": {
+    "recorded-date": "07-01-2025, 14:28:25",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-NONE-False-True]": {
+    "recorded-date": "07-01-2025, 14:28:37",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-NONE-False-False]": {
+    "recorded-date": "07-01-2025, 14:28:49",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-DELETE-True-True]": {
+    "recorded-date": "07-01-2025, 14:29:01",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-DELETE-True-False]": {
+    "recorded-date": "07-01-2025, 14:29:13",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-DELETE-False-True]": {
+    "recorded-date": "07-01-2025, 14:29:25",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-DELETE-False-False]": {
+    "recorded-date": "07-01-2025, 14:29:37",
+    "recorded-content": {
+      "create-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-NONE-True-True]": {
+    "recorded-date": "08-01-2025, 09:55:03",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-NONE-True-False]": {
+    "recorded-date": "08-01-2025, 09:55:15",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-NONE-False-True]": {
+    "recorded-date": "08-01-2025, 09:55:27",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-NONE-False-False]": {
+    "recorded-date": "08-01-2025, 09:55:39",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-DELETE-True-True]": {
+    "recorded-date": "08-01-2025, 09:55:51",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-DELETE-True-False]": {
+    "recorded-date": "08-01-2025, 09:56:03",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-DELETE-False-True]": {
+    "recorded-date": "08-01-2025, 09:56:15",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-DELETE-False-False]": {
+    "recorded-date": "08-01-2025, 09:56:27",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-NONE-True-True]": {
+    "recorded-date": "08-01-2025, 09:56:39",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-NONE-True-False]": {
+    "recorded-date": "08-01-2025, 09:56:51",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-NONE-False-True]": {
+    "recorded-date": "08-01-2025, 09:57:02",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-NONE-False-False]": {
+    "recorded-date": "08-01-2025, 09:57:14",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-DELETE-True-True]": {
+    "recorded-date": "08-01-2025, 09:57:26",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-DELETE-True-False]": {
+    "recorded-date": "08-01-2025, 09:57:38",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-DELETE-False-True]": {
+    "recorded-date": "08-01-2025, 09:57:50",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-DELETE-False-False]": {
+    "recorded-date": "08-01-2025, 09:58:02",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-NONE-True-True]": {
+    "recorded-date": "08-01-2025, 09:58:14",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-NONE-True-False]": {
+    "recorded-date": "08-01-2025, 09:58:26",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-NONE-False-True]": {
+    "recorded-date": "08-01-2025, 09:58:38",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-NONE-False-False]": {
+    "recorded-date": "08-01-2025, 09:58:50",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-DELETE-True-True]": {
+    "recorded-date": "08-01-2025, 09:59:03",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-DELETE-True-False]": {
+    "recorded-date": "08-01-2025, 09:59:15",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-DELETE-False-True]": {
+    "recorded-date": "08-01-2025, 09:59:27",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-DELETE-False-False]": {
+    "recorded-date": "08-01-2025, 09:59:39",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-NONE-True-True]": {
+    "recorded-date": "08-01-2025, 09:59:51",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-NONE-True-False]": {
+    "recorded-date": "08-01-2025, 10:00:03",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-NONE-False-True]": {
+    "recorded-date": "08-01-2025, 10:00:15",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-NONE-False-False]": {
+    "recorded-date": "08-01-2025, 10:00:27",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-DELETE-True-True]": {
+    "recorded-date": "08-01-2025, 10:00:39",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-DELETE-True-False]": {
+    "recorded-date": "08-01-2025, 10:00:51",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-DELETE-False-True]": {
+    "recorded-date": "08-01-2025, 10:01:03",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-DELETE-False-False]": {
+    "recorded-date": "08-01-2025, 10:01:15",
+    "recorded-content": {
+      "get-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_list_schedules": {
+    "recorded-date": "08-01-2025, 10:14:29",
+    "recorded-content": {
+      "list-schedules": {
+        "Schedules": [
+          {
+            "Arn": "<schedule-one-arn>",
+            "CreationDate": "<datetime>",
+            "GroupName": "default",
+            "LastModificationDate": "<datetime>",
+            "Name": "test-schedule-one-ecbade8b",
+            "State": "ENABLED",
+            "Target": {
+              "Arn": "<target-sqs-queue-arn>"
+            }
+          },
+          {
+            "Arn": "<schedule-two-arn>",
+            "CreationDate": "<datetime>",
+            "GroupName": "default",
+            "LastModificationDate": "<datetime>",
+            "Name": "test-schedule-two-0bee01c7",
+            "State": "ENABLED",
+            "Target": {
+              "Arn": "<target-sqs-queue-arn>"
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_list_schedules_non": {
+    "recorded-date": "08-01-2025, 10:18:02",
+    "recorded-content": {
+      "list-schedules-non": {
+        "Schedules": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule_not_found": {
+    "recorded-date": "08-01-2025, 10:18:19",
+    "recorded-content": {
+      "get-schedule-not-found": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Schedule not-existing-schedule-name does not exist."
+        },
+        "Message": "Schedule not-existing-schedule-name does not exist.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion0-True-True]": {
+    "recorded-date": "08-01-2025, 11:09:52",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion0-True-False]": {
+    "recorded-date": "08-01-2025, 11:10:15",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion0-False-True]": {
+    "recorded-date": "08-01-2025, 11:10:38",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion0-False-False]": {
+    "recorded-date": "08-01-2025, 11:11:02",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion1-True-True]": {
+    "recorded-date": "08-01-2025, 11:11:25",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion1-True-False]": {
+    "recorded-date": "08-01-2025, 11:25:10",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion1-False-True]": {
+    "recorded-date": "08-01-2025, 11:25:47",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion1-False-False]": {
+    "recorded-date": "08-01-2025, 11:12:36",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion0-True-True]": {
+    "recorded-date": "08-01-2025, 11:12:59",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion0-True-False]": {
+    "recorded-date": "08-01-2025, 11:13:22",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion0-False-True]": {
+    "recorded-date": "08-01-2025, 11:13:46",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion0-False-False]": {
+    "recorded-date": "08-01-2025, 11:14:10",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion1-True-True]": {
+    "recorded-date": "08-01-2025, 11:14:33",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion1-True-False]": {
+    "recorded-date": "08-01-2025, 11:14:57",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion1-False-True]": {
+    "recorded-date": "08-01-2025, 11:15:20",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion1-False-False]": {
+    "recorded-date": "08-01-2025, 11:15:44",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion0-True-True]": {
+    "recorded-date": "08-01-2025, 11:16:07",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion0-True-False]": {
+    "recorded-date": "08-01-2025, 11:16:31",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion0-False-True]": {
+    "recorded-date": "08-01-2025, 11:16:54",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion0-False-False]": {
+    "recorded-date": "08-01-2025, 11:17:18",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion1-True-True]": {
+    "recorded-date": "08-01-2025, 11:17:42",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion1-True-False]": {
+    "recorded-date": "08-01-2025, 11:18:05",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion1-False-True]": {
+    "recorded-date": "08-01-2025, 11:18:29",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion1-False-False]": {
+    "recorded-date": "08-01-2025, 11:18:53",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion0-True-True]": {
+    "recorded-date": "08-01-2025, 11:19:16",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion0-True-False]": {
+    "recorded-date": "08-01-2025, 11:19:40",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion0-False-True]": {
+    "recorded-date": "08-01-2025, 11:20:03",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion0-False-False]": {
+    "recorded-date": "08-01-2025, 11:20:27",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion1-True-True]": {
+    "recorded-date": "08-01-2025, 11:20:50",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion1-True-False]": {
+    "recorded-date": "08-01-2025, 11:21:14",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion1-False-True]": {
+    "recorded-date": "08-01-2025, 11:21:37",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion1-False-False]": {
+    "recorded-date": "08-01-2025, 11:22:01",
+    "recorded-content": {
+      "initial-schedule": {
+        "ActionAfterCompletion": "NONE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 60,
+          "Mode": "FLEXIBLE"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": "<initial-target-queue-arn>",
+          "Input": {
+            "key": "value"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<initial-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-schedule": {
+        "ScheduleArn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-schedule": {
+        "ActionAfterCompletion": "DELETE",
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<name>",
+        "CreationDate": "<datetime>",
+        "Description": "Test description",
+        "FlexibleTimeWindow": {
+          "Mode": "OFF"
+        },
+        "GroupName": "default",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "ScheduleExpression": "rate(2 minute)",
+        "ScheduleExpressionTimezone": "UTC",
+        "State": "DISABLED",
+        "Target": {
+          "Arn": "<update-target-queue-arn>",
+          "Input": {
+            "otherkey": "othervalue"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+          },
+          "RoleArn": "<update-target-role-arn>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_delete_schedule": {
+    "recorded-date": "08-01-2025, 11:27:57",
+    "recorded-content": {
+      "delete-schedule": {
+        "Schedules": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_delete_schedule_not_found": {
+    "recorded-date": "08-01-2025, 11:28:59",
+    "recorded-content": {
+      "delete-schedule-not-found": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Schedule not-existing-schedule-name does not exist."
+        },
+        "Message": "Schedule not-existing-schedule-name does not exist.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/scheduler/test_scheduler.snapshot.json
+++ b/tests/aws/services/scheduler/test_scheduler.snapshot.json
@@ -1691,27 +1691,27 @@
     }
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_list_schedules": {
-    "recorded-date": "08-01-2025, 10:14:29",
+    "recorded-date": "08-01-2025, 14:39:00",
     "recorded-content": {
       "list-schedules": {
         "Schedules": [
           {
-            "Arn": "<schedule-one-arn>",
+            "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<schedule-one-name>",
             "CreationDate": "<datetime>",
             "GroupName": "default",
             "LastModificationDate": "<datetime>",
-            "Name": "test-schedule-one-ecbade8b",
+            "Name": "<schedule-one-name>",
             "State": "ENABLED",
             "Target": {
               "Arn": "<target-sqs-queue-arn>"
             }
           },
           {
-            "Arn": "<schedule-two-arn>",
+            "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule/default/<schedule-two-name>",
             "CreationDate": "<datetime>",
             "GroupName": "default",
             "LastModificationDate": "<datetime>",
-            "Name": "test-schedule-two-0bee01c7",
+            "Name": "<schedule-two-name>",
             "State": "ENABLED",
             "Target": {
               "Arn": "<target-sqs-queue-arn>"

--- a/tests/aws/services/scheduler/test_scheduler.snapshot.json
+++ b/tests/aws/services/scheduler/test_scheduler.snapshot.json
@@ -27,5 +27,159 @@
         }
       }
     }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[True-True]": {
+    "recorded-date": "07-01-2025, 13:06:15",
+    "recorded-content": {
+      "create-schedule-group": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>"
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[True-False]": {
+    "recorded-date": "07-01-2025, 13:06:29",
+    "recorded-content": {
+      "create-schedule-group": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>"
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[False-True]": {
+    "recorded-date": "07-01-2025, 13:06:42",
+    "recorded-content": {
+      "create-schedule-group": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>"
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[False-False]": {
+    "recorded-date": "07-01-2025, 13:06:55",
+    "recorded-content": {
+      "create-schedule-group": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>"
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_get_schedule_group[True]": {
+    "recorded-date": "07-01-2025, 13:07:09",
+    "recorded-content": {
+      "get-schedule-group": {
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>",
+        "CreationDate": "<datetime>",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "State": "ACTIVE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_get_schedule_group[False]": {
+    "recorded-date": "07-01-2025, 13:07:22",
+    "recorded-content": {
+      "get-schedule-group": {
+        "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>",
+        "CreationDate": "<datetime>",
+        "LastModificationDate": "<datetime>",
+        "Name": "<name>",
+        "State": "ACTIVE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_get_schedule_group_not_found": {
+    "recorded-date": "07-01-2025, 13:07:35",
+    "recorded-content": {
+      "get-schedule-group-not-found": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Schedule group not-existing-name does not exist."
+        },
+        "Message": "Schedule group not-existing-name does not exist.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_list_schedule_groups[True]": {
+    "recorded-date": "07-01-2025, 13:07:36",
+    "recorded-content": {
+      "list-schedule-groups": {
+        "ScheduleGroups": [
+          {
+            "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/default",
+            "Name": "default",
+            "State": "ACTIVE"
+          },
+          {
+            "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name-groupe-one>",
+            "CreationDate": "<datetime>",
+            "LastModificationDate": "<datetime>",
+            "Name": "<name-groupe-one>",
+            "State": "ACTIVE"
+          },
+          {
+            "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name-groupe-two>",
+            "CreationDate": "<datetime>",
+            "LastModificationDate": "<datetime>",
+            "Name": "<name-groupe-two>",
+            "State": "ACTIVE"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_list_schedule_groups[False]": {
+    "recorded-date": "07-01-2025, 13:08:02",
+    "recorded-content": {
+      "list-schedule-groups": {
+        "ScheduleGroups": [
+          {
+            "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/default",
+            "Name": "default",
+            "State": "ACTIVE"
+          },
+          {
+            "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name-groupe-one>",
+            "CreationDate": "<datetime>",
+            "LastModificationDate": "<datetime>",
+            "Name": "<name-groupe-one>",
+            "State": "ACTIVE"
+          },
+          {
+            "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name-groupe-two>",
+            "CreationDate": "<datetime>",
+            "LastModificationDate": "<datetime>",
+            "Name": "<name-groupe-two>",
+            "State": "ACTIVE"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_list_schedule_groups_not_found": {
+    "recorded-date": "07-01-2025, 13:08:28",
+    "recorded-content": {
+      "list-schedule-groups-not-found": {
+        "ScheduleGroups": [
+          {
+            "Arn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/default",
+            "Name": "default",
+            "State": "ACTIVE"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/scheduler/test_scheduler.snapshot.json
+++ b/tests/aws/services/scheduler/test_scheduler.snapshot.json
@@ -29,27 +29,51 @@
     }
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[True-True]": {
-    "recorded-date": "07-01-2025, 13:06:15",
+    "recorded-date": "08-01-2025, 14:57:39",
     "recorded-content": {
-      "create-schedule-group": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>"
+      "create-schedule-group": {
+        "ScheduleGroupArn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
     }
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[True-False]": {
-    "recorded-date": "07-01-2025, 13:06:29",
+    "recorded-date": "08-01-2025, 14:57:52",
     "recorded-content": {
-      "create-schedule-group": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>"
+      "create-schedule-group": {
+        "ScheduleGroupArn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
     }
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[False-True]": {
-    "recorded-date": "07-01-2025, 13:06:42",
+    "recorded-date": "08-01-2025, 14:58:06",
     "recorded-content": {
-      "create-schedule-group": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>"
+      "create-schedule-group": {
+        "ScheduleGroupArn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
     }
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[False-False]": {
-    "recorded-date": "07-01-2025, 13:06:55",
+    "recorded-date": "08-01-2025, 14:58:19",
     "recorded-content": {
-      "create-schedule-group": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>"
+      "create-schedule-group": {
+        "ScheduleGroupArn": "arn:<partition>:scheduler:<region>:111111111111:schedule-group/<name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
     }
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_get_schedule_group[True]": {

--- a/tests/aws/services/scheduler/test_scheduler.validation.json
+++ b/tests/aws/services/scheduler/test_scheduler.validation.json
@@ -1,4 +1,307 @@
 {
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-DELETE-False-False]": {
+    "last_validated_date": "2025-01-07T14:29:37+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-DELETE-False-True]": {
+    "last_validated_date": "2025-01-07T14:29:25+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-DELETE-True-False]": {
+    "last_validated_date": "2025-01-07T14:29:13+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-DELETE-True-True]": {
+    "last_validated_date": "2025-01-07T14:29:01+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-NONE-False-False]": {
+    "last_validated_date": "2025-01-07T14:28:49+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-NONE-False-True]": {
+    "last_validated_date": "2025-01-07T14:28:37+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-NONE-True-False]": {
+    "last_validated_date": "2025-01-07T14:28:25+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-DISABLED-NONE-True-True]": {
+    "last_validated_date": "2025-01-07T14:28:13+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-DELETE-False-False]": {
+    "last_validated_date": "2025-01-07T14:28:01+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-DELETE-False-True]": {
+    "last_validated_date": "2025-01-07T14:27:49+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-DELETE-True-False]": {
+    "last_validated_date": "2025-01-07T14:27:37+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-DELETE-True-True]": {
+    "last_validated_date": "2025-01-07T14:27:25+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-NONE-False-False]": {
+    "last_validated_date": "2025-01-07T14:27:12+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-NONE-False-True]": {
+    "last_validated_date": "2025-01-07T14:27:00+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-NONE-True-False]": {
+    "last_validated_date": "2025-01-07T14:26:48+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[FLEXIBLE-ENABLED-NONE-True-True]": {
+    "last_validated_date": "2025-01-07T14:26:36+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-DELETE-False-False]": {
+    "last_validated_date": "2025-01-07T14:26:24+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-DELETE-False-True]": {
+    "last_validated_date": "2025-01-07T14:26:12+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-DELETE-True-False]": {
+    "last_validated_date": "2025-01-07T14:26:00+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-DELETE-True-True]": {
+    "last_validated_date": "2025-01-07T14:25:48+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-NONE-False-False]": {
+    "last_validated_date": "2025-01-07T14:25:36+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-NONE-False-True]": {
+    "last_validated_date": "2025-01-07T14:25:24+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-NONE-True-False]": {
+    "last_validated_date": "2025-01-07T14:25:12+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-DISABLED-NONE-True-True]": {
+    "last_validated_date": "2025-01-07T14:25:00+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-DELETE-False-False]": {
+    "last_validated_date": "2025-01-07T14:24:48+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-DELETE-False-True]": {
+    "last_validated_date": "2025-01-07T14:24:36+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-DELETE-True-False]": {
+    "last_validated_date": "2025-01-07T14:24:23+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-DELETE-True-True]": {
+    "last_validated_date": "2025-01-07T14:24:11+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-NONE-False-False]": {
+    "last_validated_date": "2025-01-07T14:23:59+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-NONE-False-True]": {
+    "last_validated_date": "2025-01-07T14:23:47+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-NONE-True-False]": {
+    "last_validated_date": "2025-01-07T14:23:35+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_create_schedule[OFF-ENABLED-NONE-True-True]": {
+    "last_validated_date": "2025-01-07T14:23:23+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_delete_schedule": {
+    "last_validated_date": "2025-01-08T11:27:57+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_delete_schedule_not_found": {
+    "last_validated_date": "2025-01-08T11:28:59+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-DELETE-False-False]": {
+    "last_validated_date": "2025-01-08T10:01:15+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-DELETE-False-True]": {
+    "last_validated_date": "2025-01-08T10:01:03+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-DELETE-True-False]": {
+    "last_validated_date": "2025-01-08T10:00:51+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-DELETE-True-True]": {
+    "last_validated_date": "2025-01-08T10:00:39+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-NONE-False-False]": {
+    "last_validated_date": "2025-01-08T10:00:27+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-NONE-False-True]": {
+    "last_validated_date": "2025-01-08T10:00:15+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-NONE-True-False]": {
+    "last_validated_date": "2025-01-08T10:00:03+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-DISABLED-NONE-True-True]": {
+    "last_validated_date": "2025-01-08T09:59:51+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-DELETE-False-False]": {
+    "last_validated_date": "2025-01-08T09:59:39+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-DELETE-False-True]": {
+    "last_validated_date": "2025-01-08T09:59:27+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-DELETE-True-False]": {
+    "last_validated_date": "2025-01-08T09:59:15+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-DELETE-True-True]": {
+    "last_validated_date": "2025-01-08T09:59:03+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-NONE-False-False]": {
+    "last_validated_date": "2025-01-08T09:58:50+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-NONE-False-True]": {
+    "last_validated_date": "2025-01-08T09:58:38+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-NONE-True-False]": {
+    "last_validated_date": "2025-01-08T09:58:26+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[FLEXIBLE-ENABLED-NONE-True-True]": {
+    "last_validated_date": "2025-01-08T09:58:14+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-DELETE-False-False]": {
+    "last_validated_date": "2025-01-08T09:58:02+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-DELETE-False-True]": {
+    "last_validated_date": "2025-01-08T09:57:50+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-DELETE-True-False]": {
+    "last_validated_date": "2025-01-08T09:57:38+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-DELETE-True-True]": {
+    "last_validated_date": "2025-01-08T09:57:26+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-NONE-False-False]": {
+    "last_validated_date": "2025-01-08T09:57:14+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-NONE-False-True]": {
+    "last_validated_date": "2025-01-08T09:57:02+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-NONE-True-False]": {
+    "last_validated_date": "2025-01-08T09:56:51+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-DISABLED-NONE-True-True]": {
+    "last_validated_date": "2025-01-08T09:56:39+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-DELETE-False-False]": {
+    "last_validated_date": "2025-01-08T09:56:27+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-DELETE-False-True]": {
+    "last_validated_date": "2025-01-08T09:56:15+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-DELETE-True-False]": {
+    "last_validated_date": "2025-01-08T09:56:03+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-DELETE-True-True]": {
+    "last_validated_date": "2025-01-08T09:55:51+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-NONE-False-False]": {
+    "last_validated_date": "2025-01-08T09:55:39+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-NONE-False-True]": {
+    "last_validated_date": "2025-01-08T09:55:27+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-NONE-True-False]": {
+    "last_validated_date": "2025-01-08T09:55:15+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule[OFF-ENABLED-NONE-True-True]": {
+    "last_validated_date": "2025-01-08T09:55:03+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_get_schedule_not_found": {
+    "last_validated_date": "2025-01-08T10:18:19+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_list_schedules": {
+    "last_validated_date": "2025-01-08T10:14:29+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_list_schedules_non": {
+    "last_validated_date": "2025-01-08T10:18:02+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion0-False-False]": {
+    "last_validated_date": "2025-01-08T11:17:18+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion0-False-True]": {
+    "last_validated_date": "2025-01-08T11:16:54+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion0-True-False]": {
+    "last_validated_date": "2025-01-08T11:16:31+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion0-True-True]": {
+    "last_validated_date": "2025-01-08T11:16:07+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion1-False-False]": {
+    "last_validated_date": "2025-01-08T11:18:53+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion1-False-True]": {
+    "last_validated_date": "2025-01-08T11:18:29+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion1-True-False]": {
+    "last_validated_date": "2025-01-08T11:18:05+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state0-combinations_action_after_completion1-True-True]": {
+    "last_validated_date": "2025-01-08T11:17:42+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion0-False-False]": {
+    "last_validated_date": "2025-01-08T11:20:27+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion0-False-True]": {
+    "last_validated_date": "2025-01-08T11:20:03+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion0-True-False]": {
+    "last_validated_date": "2025-01-08T11:19:40+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion0-True-True]": {
+    "last_validated_date": "2025-01-08T11:19:16+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion1-False-False]": {
+    "last_validated_date": "2025-01-08T11:22:01+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion1-False-True]": {
+    "last_validated_date": "2025-01-08T11:21:37+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion1-True-False]": {
+    "last_validated_date": "2025-01-08T11:21:14+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[FLEXIBLE-combinations_state1-combinations_action_after_completion1-True-True]": {
+    "last_validated_date": "2025-01-08T11:20:50+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion0-False-False]": {
+    "last_validated_date": "2025-01-08T11:11:02+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion0-False-True]": {
+    "last_validated_date": "2025-01-08T11:10:38+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion0-True-False]": {
+    "last_validated_date": "2025-01-08T11:10:15+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion0-True-True]": {
+    "last_validated_date": "2025-01-08T11:09:52+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion1-False-False]": {
+    "last_validated_date": "2025-01-08T11:12:36+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion1-False-True]": {
+    "last_validated_date": "2025-01-08T11:25:47+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion1-True-False]": {
+    "last_validated_date": "2025-01-08T11:25:10+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state0-combinations_action_after_completion1-True-True]": {
+    "last_validated_date": "2025-01-08T11:11:25+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion0-False-False]": {
+    "last_validated_date": "2025-01-08T11:14:10+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion0-False-True]": {
+    "last_validated_date": "2025-01-08T11:13:46+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion0-True-False]": {
+    "last_validated_date": "2025-01-08T11:13:22+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion0-True-True]": {
+    "last_validated_date": "2025-01-08T11:12:59+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion1-False-False]": {
+    "last_validated_date": "2025-01-08T11:15:44+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion1-False-True]": {
+    "last_validated_date": "2025-01-08T11:15:20+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion1-True-False]": {
+    "last_validated_date": "2025-01-08T11:14:57+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_update_schedule[OFF-combinations_state1-combinations_action_after_completion1-True-True]": {
+    "last_validated_date": "2025-01-08T11:14:33+00:00"
+  },
   "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[False-False]": {
     "last_validated_date": "2025-01-07T13:06:55+00:00"
   },

--- a/tests/aws/services/scheduler/test_scheduler.validation.json
+++ b/tests/aws/services/scheduler/test_scheduler.validation.json
@@ -1,4 +1,34 @@
 {
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[False-False]": {
+    "last_validated_date": "2025-01-07T13:06:55+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[False-True]": {
+    "last_validated_date": "2025-01-07T13:06:42+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[True-False]": {
+    "last_validated_date": "2025-01-07T13:06:29+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[True-True]": {
+    "last_validated_date": "2025-01-07T13:06:15+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_get_schedule_group[False]": {
+    "last_validated_date": "2025-01-07T13:07:22+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_get_schedule_group[True]": {
+    "last_validated_date": "2025-01-07T13:07:09+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_get_schedule_group_not_found": {
+    "last_validated_date": "2025-01-07T13:07:35+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_list_schedule_groups[False]": {
+    "last_validated_date": "2025-01-07T13:08:02+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_list_schedule_groups[True]": {
+    "last_validated_date": "2025-01-07T13:07:36+00:00"
+  },
+  "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_list_schedule_groups_not_found": {
+    "last_validated_date": "2025-01-07T13:08:28+00:00"
+  },
   "tests/aws/services/scheduler/test_scheduler.py::test_list_schedules": {
     "last_validated_date": "2024-06-11T22:50:50+00:00"
   },

--- a/tests/aws/services/scheduler/test_scheduler.validation.json
+++ b/tests/aws/services/scheduler/test_scheduler.validation.json
@@ -201,7 +201,7 @@
     "last_validated_date": "2025-01-08T10:18:19+00:00"
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_list_schedules": {
-    "last_validated_date": "2025-01-08T10:14:29+00:00"
+    "last_validated_date": "2025-01-08T14:39:00+00:00"
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestSchedule::test_list_schedules_non": {
     "last_validated_date": "2025-01-08T10:18:02+00:00"

--- a/tests/aws/services/scheduler/test_scheduler.validation.json
+++ b/tests/aws/services/scheduler/test_scheduler.validation.json
@@ -303,16 +303,16 @@
     "last_validated_date": "2025-01-08T11:14:33+00:00"
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[False-False]": {
-    "last_validated_date": "2025-01-07T13:06:55+00:00"
+    "last_validated_date": "2025-01-08T14:58:19+00:00"
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[False-True]": {
-    "last_validated_date": "2025-01-07T13:06:42+00:00"
+    "last_validated_date": "2025-01-08T14:58:06+00:00"
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[True-False]": {
-    "last_validated_date": "2025-01-07T13:06:29+00:00"
+    "last_validated_date": "2025-01-08T14:57:52+00:00"
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_create_schedule_group[True-True]": {
-    "last_validated_date": "2025-01-07T13:06:15+00:00"
+    "last_validated_date": "2025-01-08T14:57:39+00:00"
   },
   "tests/aws/services/scheduler/test_scheduler.py::TestScheduleGroupe::test_get_schedule_group[False]": {
     "last_validated_date": "2025-01-07T13:07:22+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
A user reported a regression for `get_schedule` error code if the schedule was not found. To better understand this and also other discovered regressions and response errors from MOTO (used for implementing event bridge scheduler. And as a preparation for implementing a native localstack event bridge scheduler this PR adds AWS snapshot tests for the CRUD functionality of event bridge scheduler (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/scheduler.html) 

The regressions are fixed in moto is this PR: 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Add AWS snapshot tests for CRUD for schedules and schedule groups
