### PR TITLE
Fix SSM parameter handling with paths and queries by ARN

### DIFF
--- a/localstack-core/localstack/services/ssm/provider.py
+++ b/localstack-core/localstack/services/ssm/provider.py
@@ -352,7 +352,12 @@ class SsmProvider(SsmApi, ABC):
     @staticmethod
     def _normalize_name(param_name: ParameterName, validate=False) -> ParameterName:
         if is_arn(param_name):
-            return extract_resource_from_arn(param_name).split("/")[-1]
+            resource_name = extract_resource_from_arn(param_name).replace("parameter/", "")
+            # if the parameter name is only the root path we want to look up without the leading slash.
+            # Otherwise, we add the leading slash
+            if "/" in resource_name:
+                resource_name = f"/{resource_name}"
+            return resource_name
 
         if validate:
             if "//" in param_name or ("/" in param_name and not param_name.startswith("/")):

--- a/tests/aws/services/ssm/test_ssm.py
+++ b/tests/aws/services/ssm/test_ssm.py
@@ -234,3 +234,32 @@ class TestSSM:
 
         # clean up
         clean_up(rule_name=rule_name, target_ids=target_id)
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Tier"])
+    def test_parameters_with_path(self, create_parameter, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("Name"))
+        param_name = f"/test/param-{short_uid()}"
+        put_parameter_response = create_parameter(
+            Name=param_name,
+            Description="test",
+            Value="123",
+            Type="String",
+        )
+        snapshot.match("put-parameter-response", put_parameter_response)
+
+        get_parameter_response = aws_client.ssm.get_parameter(Name=param_name)
+        snapshot.match("get-parameter-response", get_parameter_response)
+
+        get_parameter_by_arn_response = aws_client.ssm.get_parameter(
+            Name=get_parameter_response["Parameter"]["ARN"]
+        )
+        snapshot.match("get-parameter-by-arn-response", get_parameter_by_arn_response)
+
+        get_parameters_response = aws_client.ssm.get_parameters(Names=[param_name])
+        snapshot.match("get-parameters-response", get_parameters_response)
+
+        get_parameters_by_arn_response = aws_client.ssm.get_parameters(
+            Names=[get_parameter_response["Parameter"]["ARN"]]
+        )
+        snapshot.match("get-parameters-by-arn-response", get_parameters_by_arn_response)

--- a/tests/aws/services/ssm/test_ssm.snapshot.json
+++ b/tests/aws/services/ssm/test_ssm.snapshot.json
@@ -12,5 +12,84 @@
         "Version": 1
       }
     }
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_parameters_with_path": {
+    "recorded-date": "08-01-2025, 17:04:53",
+    "recorded-content": {
+      "put-parameter-response": {
+        "Tier": "Standard",
+        "Version": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-parameter-response": {
+        "Parameter": {
+          "ARN": "arn:<partition>:ssm:<region>:111111111111:parameter<name:1>",
+          "DataType": "text",
+          "LastModifiedDate": "<datetime>",
+          "Name": "<name:1>",
+          "Type": "String",
+          "Value": "123",
+          "Version": 1
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-parameter-by-arn-response": {
+        "Parameter": {
+          "ARN": "arn:<partition>:ssm:<region>:111111111111:parameter<name:1>",
+          "DataType": "text",
+          "LastModifiedDate": "<datetime>",
+          "Name": "<name:1>",
+          "Type": "String",
+          "Value": "123",
+          "Version": 1
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-parameters-response": {
+        "InvalidParameters": [],
+        "Parameters": [
+          {
+            "ARN": "arn:<partition>:ssm:<region>:111111111111:parameter<name:1>",
+            "DataType": "text",
+            "LastModifiedDate": "<datetime>",
+            "Name": "<name:1>",
+            "Type": "String",
+            "Value": "123",
+            "Version": 1
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-parameters-by-arn-response": {
+        "InvalidParameters": [],
+        "Parameters": [
+          {
+            "ARN": "arn:<partition>:ssm:<region>:111111111111:parameter<name:1>",
+            "DataType": "text",
+            "LastModifiedDate": "<datetime>",
+            "Name": "<name:1>",
+            "Type": "String",
+            "Value": "123",
+            "Version": 1
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/ssm/test_ssm.validation.json
+++ b/tests/aws/services/ssm/test_ssm.validation.json
@@ -1,5 +1,8 @@
 {
   "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_arn": {
     "last_validated_date": "2024-07-16T17:17:40+00:00"
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_parameters_with_path": {
+    "last_validated_date": "2025-01-08T17:04:53+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
SSM does not properly return parameters stored when querying it by ARN, if the parameter has a path.

We have some logic to "normalize" the parameter name before passing the call to moto, and this logic is flawed when using an ARN to get the parameter, as the normalized name only contains the last segment of the path.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* SSM now properly handles ARNs in its `get_parameter` and `get_parameters` operations, if the parameter contains a path.


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
