### PR TITLE
[ESM] Handle polling of batches exceeding SQS message limits

### DIFF
--- a/localstack-core/localstack/constants.py
+++ b/localstack-core/localstack/constants.py
@@ -11,6 +11,8 @@ HEADER_LOCALSTACK_REQUEST_URL = "x-localstack-request-url"
 HEADER_LOCALSTACK_AUTHORIZATION = "x-localstack-authorization"
 HEADER_LOCALSTACK_TARGET = "x-localstack-target"
 HEADER_AMZN_ERROR_TYPE = "X-Amzn-Errortype"
+# HTTP headers used to override internal SQS ReceiveMessage
+HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT = "x-localstack-sqs-override-message-count"
 
 # backend service ports, for services that are behind a proxy (counting down from 4566)
 DEFAULT_PORT_EDGE = 4566

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py
@@ -8,6 +8,7 @@ from botocore.client import BaseClient
 from localstack.aws.api.pipes import PipeSourceSqsQueueParameters
 from localstack.aws.api.sqs import MessageSystemAttributeName
 from localstack.config import internal_service_url
+from localstack.constants import HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT
 from localstack.services.lambda_.event_source_mapping.event_processor import (
     EventProcessor,
     PartialBatchFailureError,
@@ -16,6 +17,7 @@ from localstack.services.lambda_.event_source_mapping.pollers.poller import (
     Poller,
     parse_batch_item_failures,
 )
+from localstack.services.lambda_.event_source_mapping.senders.sender_utils import batched
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.strings import first_char_to_lower
 
@@ -36,6 +38,7 @@ class SqsPoller(Poller):
     ):
         super().__init__(source_arn, source_parameters, source_client, processor)
         self.queue_url = get_queue_url(self.source_arn)
+        self._register_client_hooks()
 
     @property
     def sqs_queue_parameters(self) -> PipeSourceSqsQueueParameters:
@@ -45,6 +48,39 @@ class SqsPoller(Poller):
     def is_fifo_queue(self) -> bool:
         # Alternative heuristic: self.queue_url.endswith(".fifo"), but we need the call to get_queue_attributes for IAM
         return self.get_queue_attributes().get("FifoQueue", "false").lower() == "true"
+
+    def _register_client_hooks(self):
+        event_system = self.source_client.meta.events
+
+        def _handle_receive_message_override(params, context, **kwargs):
+            requested_count = params.get("MaxNumberOfMessages")
+            if not requested_count or requested_count <= DEFAULT_MAX_RECEIVE_COUNT:
+                return
+
+            # Allow overide parameter to be greater than default and less than maxiumum batch size.
+            override = min(requested_count, self.sqs_queue_parameters["BatchSize"])
+            context[HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT] = str(override)
+            params["MaxNumberOfMessages"] = min(requested_count, DEFAULT_MAX_RECEIVE_COUNT)
+
+        def _handle_delete_batch_override(params, context, **kwargs):
+            requested_count = len(params.get("Entries", []))
+            if not requested_count or requested_count <= DEFAULT_MAX_RECEIVE_COUNT:
+                return
+
+            override = min(requested_count, self.sqs_queue_parameters["BatchSize"])
+            context[HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT] = str(override)
+
+        def _handler_inject_header(params, context, **kwargs):
+            if override := context.pop(HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT, None):
+                params["headers"][HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT] = override
+
+        event_system.register(
+            "provide-client-params.sqs.ReceiveMessage", _handle_receive_message_override
+        )
+        event_system.register(
+            "provide-client-params.sqs.DeleteMessageBatch", _handle_delete_batch_override
+        )
+        event_system.register("before-call.sqs.*", _handler_inject_header)
 
     def get_queue_attributes(self) -> dict:
         """The API call to sqs:GetQueueAttributes is required for IAM policy streamsing."""
@@ -66,9 +102,9 @@ class SqsPoller(Poller):
         #  https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-sqs.html#pipes-sqs-scaling
         response = self.source_client.receive_message(
             QueueUrl=self.queue_url,
-            MaxNumberOfMessages=min(
-                self.sqs_queue_parameters["BatchSize"], DEFAULT_MAX_RECEIVE_COUNT
-            ),  # BatchSize cannot exceed 10
+            MaxNumberOfMessages=self.sqs_queue_parameters.get(
+                "BatchSize", DEFAULT_MAX_RECEIVE_COUNT
+            ),
             MessageAttributeNames=["All"],
             MessageSystemAttributeNames=[MessageSystemAttributeName.All],
         )
@@ -171,7 +207,11 @@ class SqsPoller(Poller):
                 for count, message in enumerate(messages)
                 if message["MessageId"] in message_ids_to_delete
             ]
-            self.source_client.delete_message_batch(QueueUrl=self.queue_url, Entries=entries)
+            batch_size = self.sqs_queue_parameters.get("BatchSize", DEFAULT_MAX_RECEIVE_COUNT)
+            for batched_entries in batched(entries, batch_size):
+                self.source_client.delete_message_batch(
+                    QueueUrl=self.queue_url, Entries=batched_entries
+                )
 
 
 def split_by_message_group_id(messages) -> defaultdict[str, list[dict]]:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR allows for SQS requests originating from event source mappings to circumvent message count validations -- allowing for up to `10 000` messages to be returned (or deleted) at a time. 

This is required since polling calls can only be made in batches of 10, making the collection of large batch sizes cumbersome and costly. (i.e 10K messages requires ~1K receive requests + ~1K delete requests).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Add custom `"x-localstack-sqs-override-message-count"` header which the SQS provider uses to override how many messages can be processed in a single call.
- Register event handlers to the AWS client in `SqsPoller`, allowing `ReceiveMessage` and `DeleteMessageBatch` calls to return/delete up to `10 000` records at a time.
- Extend SQS provider to handle custom `"x-localstack-sqs-override-message-count"` headers in boto3 requests.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->


## TODO

What's left to do:

- [ ] (Optional) Rebase against https://github.com/localstack/localstack/pull/12002 if merged in prior to these changes.

