### PR TITLE
DynamoDB: fix GlobalSecondaryIndexes parity in Create and DescribeTable

### DIFF
--- a/localstack-core/localstack/services/dynamodb/provider.py
+++ b/localstack-core/localstack/services/dynamodb/provider.py
@@ -687,6 +687,34 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             )
             table_description["TableClassSummary"] = {"TableClass": table_class}
 
+        if "GlobalSecondaryIndexes" in table_description:
+            gsis = copy.deepcopy(table_description["GlobalSecondaryIndexes"])
+            # update the different values, as DynamoDB-local v2 has a regression around GSI and does not return anything
+            # anymore
+            for gsi in gsis:
+                index_name = gsi.get("IndexName", "")
+                gsi.update(
+                    {
+                        "IndexArn": f"{table_arn}/index/{index_name}",
+                        "IndexSizeBytes": 0,
+                        "IndexStatus": "ACTIVE",
+                        "ItemCount": 0,
+                    }
+                )
+                gsi_provisioned_throughput = gsi.setdefault("ProvisionedThroughput", {})
+                gsi_provisioned_throughput["NumberOfDecreasesToday"] = 0
+
+                if billing_mode == BillingMode.PAY_PER_REQUEST:
+                    gsi_provisioned_throughput["ReadCapacityUnits"] = 0
+                    gsi_provisioned_throughput["WriteCapacityUnits"] = 0
+
+            # table_definitions["GlobalSecondaryIndexes"] = gsis
+            table_description["GlobalSecondaryIndexes"] = gsis
+
+        if "ProvisionedThroughput" in table_description:
+            if "NumberOfDecreasesToday" not in table_description["ProvisionedThroughput"]:
+                table_description["ProvisionedThroughput"]["NumberOfDecreasesToday"] = 0
+
         tags = table_definitions.pop("Tags", [])
         if tags:
             get_store(context.account_id, context.region).TABLE_TAGS[table_arn] = {
@@ -764,6 +792,17 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                 table_description["TableClassSummary"] = {
                     "TableClass": table_definitions["TableClass"]
                 }
+
+        if "GlobalSecondaryIndexes" in table_description:
+            for gsi in table_description["GlobalSecondaryIndexes"]:
+                default_values = {
+                    "NumberOfDecreasesToday": 0,
+                    "ReadCapacityUnits": 0,
+                    "WriteCapacityUnits": 0,
+                }
+                # even if the billing mode is PAY_PER_REQUEST, AWS returns the Read and Write Capacity Units
+                # Terraform depends on this parity for update operations
+                gsi["ProvisionedThroughput"] = default_values | gsi.get("ProvisionedThroughput", {})
 
         return DescribeTableOutput(
             Table=select_from_typed_dict(TableDescription, table_description)

--- a/localstack-core/localstack/services/dynamodb/provider.py
+++ b/localstack-core/localstack/services/dynamodb/provider.py
@@ -708,7 +708,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                     gsi_provisioned_throughput["ReadCapacityUnits"] = 0
                     gsi_provisioned_throughput["WriteCapacityUnits"] = 0
 
-            # table_definitions["GlobalSecondaryIndexes"] = gsis
             table_description["GlobalSecondaryIndexes"] = gsis
 
         if "ProvisionedThroughput" in table_description:

--- a/localstack-core/localstack/services/dynamodb/utils.py
+++ b/localstack-core/localstack/services/dynamodb/utils.py
@@ -33,7 +33,7 @@ LOG = logging.getLogger(__name__)
 SCHEMA_CACHE = TTLCache(maxsize=50, ttl=20)
 
 _ddb_local_arn_pattern = re.compile(
-    r'("TableArn"|"LatestStreamArn"|"StreamArn"|"ShardIterator")\s*:\s*"arn:[a-z-]+:dynamodb:ddblocal:000000000000:([^"]+)"'
+    r'("TableArn"|"LatestStreamArn"|"StreamArn"|"ShardIterator"|"IndexArn")\s*:\s*"arn:[a-z-]+:dynamodb:ddblocal:000000000000:([^"]+)"'
 )
 _ddb_local_region_pattern = re.compile(r'"awsRegion"\s*:\s*"([^"]+)"')
 _ddb_local_exception_arn_pattern = re.compile(r'arn:[a-z-]+:dynamodb:ddblocal:000000000000:([^"]+)')

--- a/localstack-core/localstack/services/dynamodb/v2/provider.py
+++ b/localstack-core/localstack/services/dynamodb/v2/provider.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 import os
@@ -526,6 +527,34 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             )
             table_description["TableClassSummary"] = {"TableClass": table_class}
 
+        if "GlobalSecondaryIndexes" in table_description:
+            gsis = copy.deepcopy(table_description["GlobalSecondaryIndexes"])
+            # update the different values, as DynamoDB-local v2 has a regression around GSI and does not return anything
+            # anymore
+            for gsi in gsis:
+                index_name = gsi.get("IndexName", "")
+                gsi.update(
+                    {
+                        "IndexArn": f"{table_arn}/index/{index_name}",
+                        "IndexSizeBytes": 0,
+                        "IndexStatus": "ACTIVE",
+                        "ItemCount": 0,
+                    }
+                )
+                gsi_provisioned_throughput = gsi.setdefault("ProvisionedThroughput", {})
+                gsi_provisioned_throughput["NumberOfDecreasesToday"] = 0
+
+                if billing_mode == BillingMode.PAY_PER_REQUEST:
+                    gsi_provisioned_throughput["ReadCapacityUnits"] = 0
+                    gsi_provisioned_throughput["WriteCapacityUnits"] = 0
+
+            # table_definitions["GlobalSecondaryIndexes"] = gsis
+            table_description["GlobalSecondaryIndexes"] = gsis
+
+        if "ProvisionedThroughput" in table_description:
+            if "NumberOfDecreasesToday" not in table_description["ProvisionedThroughput"]:
+                table_description["ProvisionedThroughput"]["NumberOfDecreasesToday"] = 0
+
         tags = table_definitions.pop("Tags", [])
         if tags:
             get_store(context.account_id, context.region).TABLE_TAGS[table_arn] = {
@@ -602,6 +631,17 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                 table_description["TableClassSummary"] = {
                     "TableClass": table_definitions["TableClass"]
                 }
+
+        if "GlobalSecondaryIndexes" in table_description:
+            for gsi in table_description["GlobalSecondaryIndexes"]:
+                default_values = {
+                    "NumberOfDecreasesToday": 0,
+                    "ReadCapacityUnits": 0,
+                    "WriteCapacityUnits": 0,
+                }
+                # even if the billing mode is PAY_PER_REQUEST, AWS returns the Read and Write Capacity Units
+                # Terraform depends on this parity for update operations
+                gsi["ProvisionedThroughput"] = default_values | gsi.get("ProvisionedThroughput", {})
 
         return DescribeTableOutput(
             Table=select_from_typed_dict(TableDescription, table_description)

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -2341,6 +2341,14 @@ class TestDynamoDB:
 
     @markers.aws.validated
     @pytest.mark.parametrize("billing_mode", ["PAY_PER_REQUEST", "PROVISIONED"])
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            # LS returns those and not AWS, probably because no changes happened there yet
+            "$..ProvisionedThroughput.LastDecreaseDateTime",
+            "$..ProvisionedThroughput.LastIncreaseDateTime",
+            "$..TableDescription.BillingModeSummary.LastUpdateToPayPerRequestDateTime",
+        ]
+    )
     def test_gsi_with_billing_mode(
         self, aws_client, dynamodb_create_table_with_parameters, snapshot, billing_mode
     ):

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -2338,3 +2338,58 @@ class TestDynamoDB:
 
         retry(lambda: _get_records_amount(1), sleep=1, retries=3)
         snapshot.match("get-records", {"Records": records})
+
+    @markers.aws.validated
+    @pytest.mark.parametrize("billing_mode", ["PAY_PER_REQUEST", "PROVISIONED"])
+    def test_gsi_with_billing_mode(
+        self, aws_client, dynamodb_create_table_with_parameters, snapshot, billing_mode
+    ):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("TableName"),
+                snapshot.transform.key_value(
+                    "TableStatus", reference_replacement=False, value_replacement="<table-status>"
+                ),
+                snapshot.transform.key_value(
+                    "IndexStatus", reference_replacement=False, value_replacement="<index-status>"
+                ),
+            ]
+        )
+
+        table_name = f"test-table-{short_uid()}"
+        create_table_kwargs = {}
+        global_secondary_index = {
+            "IndexName": "TransactionRecordID",
+            "KeySchema": [
+                {"AttributeName": "TRID", "KeyType": "HASH"},
+            ],
+            "Projection": {"ProjectionType": "ALL"},
+        }
+
+        if billing_mode == "PROVISIONED":
+            create_table_kwargs["ProvisionedThroughput"] = {
+                "ReadCapacityUnits": 5,
+                "WriteCapacityUnits": 5,
+            }
+            global_secondary_index["ProvisionedThroughput"] = {
+                "ReadCapacityUnits": 1,
+                "WriteCapacityUnits": 1,
+            }
+
+        create_table = dynamodb_create_table_with_parameters(
+            TableName=table_name,
+            KeySchema=[
+                {"AttributeName": "TID", "KeyType": "HASH"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "TID", "AttributeType": "S"},
+                {"AttributeName": "TRID", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[global_secondary_index],
+            BillingMode=billing_mode,
+            **create_table_kwargs,
+        )
+        snapshot.match("create-table-with-gsi", create_table)
+
+        describe_table = aws_client.dynamodb.describe_table(TableName=table_name)
+        snapshot.match("describe-table", describe_table)

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1471,5 +1471,262 @@
         }
       }
     }
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_gsi_with_billing_mode[PAY_PER_REQUEST]": {
+    "recorded-date": "08-01-2025, 18:17:06",
+    "recorded-content": {
+      "create-table-with-gsi": {
+        "TableDescription": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "TID",
+              "AttributeType": "S"
+            },
+            {
+              "AttributeName": "TRID",
+              "AttributeType": "S"
+            }
+          ],
+          "BillingModeSummary": {
+            "BillingMode": "PAY_PER_REQUEST"
+          },
+          "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
+          "GlobalSecondaryIndexes": [
+            {
+              "IndexArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table-name:1>/index/TransactionRecordID",
+              "IndexName": "TransactionRecordID",
+              "IndexSizeBytes": 0,
+              "IndexStatus": "<index-status>",
+              "ItemCount": 0,
+              "KeySchema": [
+                {
+                  "AttributeName": "TRID",
+                  "KeyType": "HASH"
+                }
+              ],
+              "Projection": {
+                "ProjectionType": "ALL"
+              },
+              "ProvisionedThroughput": {
+                "NumberOfDecreasesToday": 0,
+                "ReadCapacityUnits": 0,
+                "WriteCapacityUnits": 0
+              }
+            }
+          ],
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "TID",
+              "KeyType": "HASH"
+            }
+          ],
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 0,
+            "WriteCapacityUnits": 0
+          },
+          "TableArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table-name:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<table-name:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "<table-status>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-table": {
+        "Table": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "TID",
+              "AttributeType": "S"
+            },
+            {
+              "AttributeName": "TRID",
+              "AttributeType": "S"
+            }
+          ],
+          "BillingModeSummary": {
+            "BillingMode": "PAY_PER_REQUEST",
+            "LastUpdateToPayPerRequestDateTime": "datetime"
+          },
+          "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
+          "GlobalSecondaryIndexes": [
+            {
+              "IndexArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table-name:1>/index/TransactionRecordID",
+              "IndexName": "TransactionRecordID",
+              "IndexSizeBytes": 0,
+              "IndexStatus": "<index-status>",
+              "ItemCount": 0,
+              "KeySchema": [
+                {
+                  "AttributeName": "TRID",
+                  "KeyType": "HASH"
+                }
+              ],
+              "Projection": {
+                "ProjectionType": "ALL"
+              },
+              "ProvisionedThroughput": {
+                "NumberOfDecreasesToday": 0,
+                "ReadCapacityUnits": 0,
+                "WriteCapacityUnits": 0
+              }
+            }
+          ],
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "TID",
+              "KeyType": "HASH"
+            }
+          ],
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 0,
+            "WriteCapacityUnits": 0
+          },
+          "TableArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table-name:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<table-name:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "<table-status>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_gsi_with_billing_mode[PROVISIONED]": {
+    "recorded-date": "08-01-2025, 18:17:21",
+    "recorded-content": {
+      "create-table-with-gsi": {
+        "TableDescription": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "TID",
+              "AttributeType": "S"
+            },
+            {
+              "AttributeName": "TRID",
+              "AttributeType": "S"
+            }
+          ],
+          "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
+          "GlobalSecondaryIndexes": [
+            {
+              "IndexArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table-name:1>/index/TransactionRecordID",
+              "IndexName": "TransactionRecordID",
+              "IndexSizeBytes": 0,
+              "IndexStatus": "<index-status>",
+              "ItemCount": 0,
+              "KeySchema": [
+                {
+                  "AttributeName": "TRID",
+                  "KeyType": "HASH"
+                }
+              ],
+              "Projection": {
+                "ProjectionType": "ALL"
+              },
+              "ProvisionedThroughput": {
+                "NumberOfDecreasesToday": 0,
+                "ReadCapacityUnits": 1,
+                "WriteCapacityUnits": 1
+              }
+            }
+          ],
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "TID",
+              "KeyType": "HASH"
+            }
+          ],
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 5,
+            "WriteCapacityUnits": 5
+          },
+          "TableArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table-name:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<table-name:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "<table-status>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-table": {
+        "Table": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "TID",
+              "AttributeType": "S"
+            },
+            {
+              "AttributeName": "TRID",
+              "AttributeType": "S"
+            }
+          ],
+          "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
+          "GlobalSecondaryIndexes": [
+            {
+              "IndexArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table-name:1>/index/TransactionRecordID",
+              "IndexName": "TransactionRecordID",
+              "IndexSizeBytes": 0,
+              "IndexStatus": "<index-status>",
+              "ItemCount": 0,
+              "KeySchema": [
+                {
+                  "AttributeName": "TRID",
+                  "KeyType": "HASH"
+                }
+              ],
+              "Projection": {
+                "ProjectionType": "ALL"
+              },
+              "ProvisionedThroughput": {
+                "NumberOfDecreasesToday": 0,
+                "ReadCapacityUnits": 1,
+                "WriteCapacityUnits": 1
+              }
+            }
+          ],
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "TID",
+              "KeyType": "HASH"
+            }
+          ],
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 5,
+            "WriteCapacityUnits": 5
+          },
+          "TableArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table-name:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<table-name:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "<table-status>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -62,6 +62,12 @@
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_empty_and_binary_values": {
     "last_validated_date": "2023-08-23T14:32:29+00:00"
   },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_gsi_with_billing_mode[PAY_PER_REQUEST]": {
+    "last_validated_date": "2025-01-08T18:17:06+00:00"
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_gsi_with_billing_mode[PROVISIONED]": {
+    "last_validated_date": "2025-01-08T18:17:21+00:00"
+  },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_return_values_in_put_item": {
     "last_validated_date": "2023-08-23T14:32:21+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #12014, we've had a regression in our handling of GlobalSecondaryIndexes, probably due to the update of DDB-local from v1 to v2. 

This really broke some users setup with Terraform, causing it to try to redeploy and fail. 

I confirmed that with this fix, deploying the Terraform file and trying to applying it again do not fail anymore. 

_fixes #12014_

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add test regarding the behavior of `GlobalSecondaryIndexes` depending on the `BillingMode`
- fix the parity of both `CreateTable` and `DescribeTable` by adding the missing fields to the responses

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
