### PR TITLE
Add tests for KMS resource tagging and untagging

### DIFF
--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -21,8 +21,8 @@ from localstack.utils.crypto import encrypt
 from localstack.utils.strings import short_uid, to_str
 
 
-def create_tags(*key_value_args):
-    return [{"TagKey": key, "TagValue": value} for key, value in key_value_args]
+def create_tags(**kwargs):
+    return [{"TagKey": key, "TagValue": value} for key, value in kwargs.items()]
 
 
 @pytest.fixture(scope="class")
@@ -116,7 +116,7 @@ class TestKMS:
             region_name=region_name, Description="test key 123", KeyUsage="ENCRYPT_DECRYPT"
         )["KeyId"]
 
-        tags = create_tags(("tag1", "value1"), ("tag2", "value2"))
+        tags = create_tags(tag1="value1", tag2="value2")
         kms_client.tag_resource(KeyId=key_id, Tags=tags)
 
         response = kms_client.list_resource_tags(KeyId=key_id)["Tags"]
@@ -134,7 +134,7 @@ class TestKMS:
     ):
         kms_client = kms_client_for_region(region_name)
 
-        tags = create_tags(("tag1", "value1"), ("tag2", "value2"))
+        tags = create_tags(tag1="value1", tag2="value2")
         key_id = kms_create_key(
             region_name=region_name,
             Description="test key 123",
@@ -158,7 +158,7 @@ class TestKMS:
         kms_client = kms_client_for_region(region_name)
 
         tag_key_to_untag = "tag2"
-        tags = create_tags(("tag1", "value1"), (tag_key_to_untag, "value2"), ("tag3", "value3"))
+        tags = create_tags(**{"tag1": "value1", tag_key_to_untag: "value2", "tag3": "value3"})
         key_id = kms_create_key(
             region_name=region_name,
             Description="test key 123",

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -1854,5 +1854,46 @@
         }
       ]
     }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_update_and_add_tags_on_tagged_key": {
+    "recorded-date": "17-01-2025, 12:25:39",
+    "recorded-content": {
+      "list-resource-tags": [
+        {
+          "TagKey": "tag1",
+          "TagValue": "value1"
+        },
+        {
+          "TagKey": "tag2",
+          "TagValue": "value2"
+        },
+        {
+          "TagKey": "tag3",
+          "TagValue": "value3"
+        }
+      ],
+      "list-resource-tags-after-tags-updated": [
+        {
+          "TagKey": "tag1",
+          "TagValue": "value1"
+        },
+        {
+          "TagKey": "tag2",
+          "TagValue": "updated_value2"
+        },
+        {
+          "TagKey": "tag3",
+          "TagValue": "value3"
+        },
+        {
+          "TagKey": "tag4",
+          "TagValue": "value4"
+        },
+        {
+          "TagKey": "tag5",
+          "TagValue": "value5"
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -1793,5 +1793,66 @@
         }
       }
     }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_tag_existing_key_and_untag": {
+    "recorded-date": "10-01-2025, 09:39:48",
+    "recorded-content": {
+      "list-resource-tags": [
+        {
+          "TagKey": "tag1",
+          "TagValue": "value1"
+        },
+        {
+          "TagKey": "tag2",
+          "TagValue": "value2"
+        }
+      ],
+      "list-resource-tags-after-all-untagged": []
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_tag_and_untag": {
+    "recorded-date": "10-01-2025, 09:40:40",
+    "recorded-content": {
+      "list-resource-tags": [
+        {
+          "TagKey": "tag1",
+          "TagValue": "value1"
+        },
+        {
+          "TagKey": "tag2",
+          "TagValue": "value2"
+        }
+      ],
+      "list-resource-tags-after-all-untagged": []
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_untag_key_partially": {
+    "recorded-date": "10-01-2025, 09:41:02",
+    "recorded-content": {
+      "list-resource-tags": [
+        {
+          "TagKey": "tag1",
+          "TagValue": "value1"
+        },
+        {
+          "TagKey": "tag2",
+          "TagValue": "value2"
+        },
+        {
+          "TagKey": "tag3",
+          "TagValue": "value3"
+        }
+      ],
+      "list-resource-tags-after-partially-untagged": [
+        {
+          "TagKey": "tag1",
+          "TagValue": "value1"
+        },
+        {
+          "TagKey": "tag3",
+          "TagValue": "value3"
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -221,6 +221,9 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_update_alias": {
     "last_validated_date": "2024-04-11T15:53:53+00:00"
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_update_and_add_tags_on_tagged_key": {
+    "last_validated_date": "2025-01-17T12:25:39+00:00"
+  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_update_key_description": {
     "last_validated_date": "2024-04-11T15:53:46+00:00"
   },

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -23,6 +23,9 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key": {
     "last_validated_date": "2024-04-11T15:26:14+00:00"
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_tag_and_untag": {
+    "last_validated_date": "2025-01-10T09:40:40+00:00"
+  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_create_list_delete_alias": {
     "last_validated_date": "2024-04-11T15:53:50+00:00"
   },
@@ -206,8 +209,14 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_sign_verify[RSA_4096-RSASSA_PKCS1_V1_5_SHA_512]": {
     "last_validated_date": "2024-04-11T15:53:06+00:00"
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_tag_existing_key_and_untag": {
+    "last_validated_date": "2025-01-10T09:39:48+00:00"
+  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_tag_untag_list_tags": {
     "last_validated_date": "2024-04-11T15:53:57+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_untag_key_partially": {
+    "last_validated_date": "2025-01-10T09:41:02+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_update_alias": {
     "last_validated_date": "2024-04-11T15:53:53+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The AWS-validated snapshot KMS tests for tagging and untagging keys are currently missing. We need to add these tests, collect their responses, and verify them against LocalStack.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- AWS-validated tests for tagging and untagging keys have been added for the KMS service.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
