### PR TITLE
Docker Utils: Utility method to create file in container

### DIFF
--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -779,6 +779,19 @@ class TestDockerClient:
         )
         assert "foo" in out.decode(config.DEFAULT_ENCODING)
 
+    def test_create_file_in_container(
+        self, tmpdir, docker_client: ContainerClient, create_container
+    ):
+        content = b"fancy content"
+        container_path = "/tmp/myfile.txt"
+
+        c = create_container("alpine", command=["cat", container_path])
+
+        docker_client.create_file_in_container(c.container_name, content, container_path)
+
+        output, _ = docker_client.start_container(c.container_id, attach=True)
+        assert output == content
+
     def test_get_network_non_existing_container(self, docker_client: ContainerClient):
         with pytest.raises(ContainerException):
             docker_client.get_networks("this_container_does_not_exist")


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Adds a utility method to create a file in the docker container, by just passing the content of the file. I find myself reusing the same approach quite often, so IMO it would be much nicer to have it available as a utility.

#### Permissions
When running this inside a container, the file will be created by the `root` user. If the target container runs it's process as a custom (non-root) user, it may not have access to files created by `root`. 

The additional `chmod_mode` argument can be used to ensure the file is available to the custom user. (We could presumably also `chown` the file to the same effect, but I only used `chmod` so far to make files available in this scenario.)