### PR TITLE
Bump moto-ext to 5.0.26.post2

### DIFF
--- a/localstack-core/localstack/services/ses/provider.py
+++ b/localstack-core/localstack/services/ses/provider.py
@@ -23,6 +23,7 @@ from localstack.aws.api.ses import (
     ConfigurationSetName,
     CreateConfigurationSetEventDestinationResponse,
     DeleteConfigurationSetEventDestinationResponse,
+    DeleteConfigurationSetResponse,
     DeleteTemplateResponse,
     Destination,
     EventDestination,
@@ -222,6 +223,22 @@ class SesProvider(SesApi, ServiceLifecycleHook):
 
         return result
 
+    @handler("DeleteConfigurationSet")
+    def delete_configuration_set(
+        self, context: RequestContext, configuration_set_name: ConfigurationSetName, **kwargs
+    ) -> DeleteConfigurationSetResponse:
+        # not implemented in moto
+        # TODO: contribute upstream?
+        backend = get_ses_backend(context)
+        try:
+            backend.config_set.pop(configuration_set_name)
+        except KeyError:
+            raise ConfigurationSetDoesNotExistException(
+                f"Configuration set <{configuration_set_name}> does not exist."
+            )
+
+        return DeleteConfigurationSetResponse()
+
     @handler("DeleteConfigurationSetEventDestination")
     def delete_configuration_set_event_destination(
         self,
@@ -235,7 +252,7 @@ class SesProvider(SesApi, ServiceLifecycleHook):
         backend = get_ses_backend(context)
 
         # the configuration set must exist
-        if configuration_set_name not in backend.config_sets:
+        if configuration_set_name not in backend.config_set:
             raise ConfigurationSetDoesNotExistException(
                 f"Configuration set <{configuration_set_name}> does not exist."
             )

--- a/localstack-core/localstack/services/ses/provider.py
+++ b/localstack-core/localstack/services/ses/provider.py
@@ -231,7 +231,7 @@ class SesProvider(SesApi, ServiceLifecycleHook):
         # TODO: contribute upstream?
         backend = get_ses_backend(context)
         try:
-            backend.config_set.pop(configuration_set_name)
+            backend.config_sets.pop(configuration_set_name)
         except KeyError:
             raise ConfigurationSetDoesNotExistException(
                 f"Configuration set <{configuration_set_name}> does not exist."
@@ -252,7 +252,7 @@ class SesProvider(SesApi, ServiceLifecycleHook):
         backend = get_ses_backend(context)
 
         # the configuration set must exist
-        if configuration_set_name not in backend.config_set:
+        if configuration_set_name not in backend.config_sets:
             raise ConfigurationSetDoesNotExistException(
                 f"Configuration set <{configuration_set_name}> does not exist."
             )

--- a/localstack-core/localstack/services/ses/provider.py
+++ b/localstack-core/localstack/services/ses/provider.py
@@ -23,7 +23,6 @@ from localstack.aws.api.ses import (
     ConfigurationSetName,
     CreateConfigurationSetEventDestinationResponse,
     DeleteConfigurationSetEventDestinationResponse,
-    DeleteConfigurationSetResponse,
     DeleteTemplateResponse,
     Destination,
     EventDestination,
@@ -223,22 +222,6 @@ class SesProvider(SesApi, ServiceLifecycleHook):
 
         return result
 
-    @handler("DeleteConfigurationSet")
-    def delete_configuration_set(
-        self, context: RequestContext, configuration_set_name: ConfigurationSetName, **kwargs
-    ) -> DeleteConfigurationSetResponse:
-        # not implemented in moto
-        # TODO: contribute upstream?
-        backend = get_ses_backend(context)
-        try:
-            backend.config_set.pop(configuration_set_name)
-        except KeyError:
-            raise ConfigurationSetDoesNotExistException(
-                f"Configuration set <{configuration_set_name}> does not exist."
-            )
-
-        return DeleteConfigurationSetResponse()
-
     @handler("DeleteConfigurationSetEventDestination")
     def delete_configuration_set_event_destination(
         self,
@@ -252,7 +235,7 @@ class SesProvider(SesApi, ServiceLifecycleHook):
         backend = get_ses_backend(context)
 
         # the configuration set must exist
-        if configuration_set_name not in backend.config_set:
+        if configuration_set_name not in backend.config_sets:
             raise ConfigurationSetDoesNotExistException(
                 f"Configuration set <{configuration_set_name}> does not exist."
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.26.post1",
+    "moto-ext[all]==5.0.26.post2",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -254,7 +254,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.26.post1
+moto-ext==5.0.26.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.26.post1
+moto-ext==5.0.26.post2
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -238,7 +238,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.26.post1
+moto-ext==5.0.26.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -258,7 +258,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.5.0
     # via openapi-core
-moto-ext==5.0.26.post1
+moto-ext==5.0.26.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.0.26.post2

Contains:

- https://github.com/getmoto/moto/pull/8478 @maxhoheiser 

This bump will break SES cloud pods.

## To do

- [x] Ext compatibility (Ext integration tests) AWS / Ext Integration Tests # 2607
- [x] Multi-account/region compatibility ([Randomised credentials test run](https://app.circleci.com/pipelines/github/localstack/localstack/30655/workflows/fc60e78e-00e8-464f-8768-50744e9f389f))