### PR TITLE
APIGW: fix OpenAPI import StatusCode string casting

### DIFF
--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -725,6 +725,7 @@ def import_api_from_openapi_spec(
             # Create the `MethodResponse` for the previously created `Method`
             method_responses = field_schema.get("responses", {})
             for method_status_code, method_response in method_responses.items():
+                method_status_code = str(method_status_code)
                 method_response_model = None
                 model_ref = None
                 # separating the two different versions, Swagger (2.0) and OpenAPI 3.0
@@ -822,7 +823,7 @@ def import_api_from_openapi_spec(
                     )
 
                     integration_response = integration.create_integration_response(
-                        status_code=integration_responses.get("statusCode", 200),
+                        status_code=str(integration_responses.get("statusCode", 200)),
                         selection_pattern=pattern if pattern != "default" else None,
                         response_templates=integration_response_templates,
                         response_parameters=integration_response_parameters,

--- a/tests/aws/files/openapi-method-int.spec.yaml
+++ b/tests/aws/files/openapi-method-int.spec.yaml
@@ -19,7 +19,7 @@ paths:
       x-amazon-apigateway-integration:
         responses:
           default:
-            statusCode: '200'
+            statusCode: 200
             responseParameters:
               method.response.header.Access-Control-Allow-Origin: "'*'"
         requestParameters:

--- a/tests/aws/files/openapi-method-int.spec.yaml
+++ b/tests/aws/files/openapi-method-int.spec.yaml
@@ -6,6 +6,8 @@ paths:
   "/test":
     get:
       responses:
+        # the responses are grouped under the 200 integer status code. In the JSON format, this has to be a string.101:
+        # AWS accepts integer status code in YAML.
         200:
           description: 200 response
           headers:
@@ -19,6 +21,8 @@ paths:
       x-amazon-apigateway-integration:
         responses:
           default:
+            # this represents the IntegrationResponse status code. In the YAML format, AWS accepts an integer, but the
+            # "official" type is string and should be cast as such.
             statusCode: 200
             responseParameters:
               method.response.header.Access-Control-Allow-Origin: "'*'"

--- a/tests/aws/files/openapi-method-int.spec.yaml
+++ b/tests/aws/files/openapi-method-int.spec.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.1
+info:
+  title: test-import-oas-int
+  version: '2.0'
+paths:
+  "/test":
+    get:
+      responses:
+        200:
+          description: 200 response
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Empty"
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: '200'
+            responseParameters:
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+        requestParameters:
+          integration.request.header.X-Amz-Invocation-Type: "'Event'"
+        requestTemplates:
+          application/json: '{"statusCode": 200}'
+        passthroughBehavior: when_no_match
+        type: mock
+
+components:
+  schemas:
+    Empty:
+      title: Empty Schema
+      type: object

--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -910,6 +910,9 @@ class TestApiGatewayImportRestApi:
         apigw_snapshot_imported_resources,
         snapshot,
     ):
+        # the following YAML file contains integer status code for the Method and IntegrationResponse
+        # when importing the API, we need to properly cast them into string to avoid any typing issue when serializing
+        # responses. Most typed languages would fail when parsing.
         snapshot.add_transformer(snapshot.transform.key_value("uri"))
         spec_file = load_file(OAS30_HTTP_STATUS_INT)
         import_resp, root_id = import_apigw(body=spec_file, failOnWarnings=True)

--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -330,7 +330,6 @@ class TestApiGatewayImportRestApi:
 
         response = aws_client.apigateway.get_resources(restApiId=rest_api_id)
         response["items"] = sorted(response["items"], key=itemgetter("path"))
-        print(f"{response=}")
         snapshot.match("resources", response)
 
         # this fixture will iterate over every resource and match its method, methodResponse, integration and
@@ -918,7 +917,6 @@ class TestApiGatewayImportRestApi:
 
         response = aws_client.apigateway.get_resources(restApiId=rest_api_id)
         response["items"] = sorted(response["items"], key=itemgetter("path"))
-        print(f"{response=}")
         snapshot.match("resources", response)
 
         # this fixture will iterate over every resource and match its method, methodResponse, integration and

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -5192,7 +5192,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_integer_http_status_code": {
-    "recorded-date": "14-01-2025, 14:03:07",
+    "recorded-date": "14-01-2025, 14:09:57",
     "recorded-content": {
       "resources": {
         "items": [

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -5190,5 +5190,124 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_integer_http_status_code": {
+    "recorded-date": "14-01-2025, 14:03:07",
+    "recorded-content": {
+      "resources": {
+        "items": [
+          {
+            "id": "<id:1>",
+            "path": "/"
+          },
+          {
+            "id": "<id:2>",
+            "parentId": "<id:1>",
+            "path": "/test",
+            "pathPart": "test",
+            "resourceMethods": {
+              "GET": {}
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-test-get": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "GET",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<id:2>",
+          "integrationResponses": {
+            "200": {
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'*'"
+              },
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "requestParameters": {
+            "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+          },
+          "requestTemplates": {
+            "application/json": {
+              "statusCode": 200
+            }
+          },
+          "timeoutInMillis": 29000,
+          "type": "MOCK"
+        },
+        "methodResponses": {
+          "200": {
+            "responseModels": {
+              "application/json": "Empty"
+            },
+            "responseParameters": {
+              "method.response.header.Access-Control-Allow-Origin": false
+            },
+            "statusCode": "200"
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-response-test-get": {
+        "responseModels": {
+          "application/json": "Empty"
+        },
+        "responseParameters": {
+          "method.response.header.Access-Control-Allow-Origin": false
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-test-get": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<id:2>",
+        "integrationResponses": {
+          "200": {
+            "responseParameters": {
+              "method.response.header.Access-Control-Allow-Origin": "'*'"
+            },
+            "statusCode": "200"
+          }
+        },
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+        },
+        "requestTemplates": {
+          "application/json": {
+            "statusCode": 200
+          }
+        },
+        "timeoutInMillis": 29000,
+        "type": "MOCK",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-response-test-get": {
+        "responseParameters": {
+          "method.response.header.Access-Control-Allow-Origin": "'*'"
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -45,7 +45,7 @@
     "last_validated_date": "2024-04-15T21:38:57+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_integer_http_status_code": {
-    "last_validated_date": "2025-01-14T14:03:07+00:00"
+    "last_validated_date": "2025-01-14T14:09:57+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_stage_variables": {
     "last_validated_date": "2024-08-12T13:42:13+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -44,6 +44,9 @@
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_http_method_integration": {
     "last_validated_date": "2024-04-15T21:38:57+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_integer_http_status_code": {
+    "last_validated_date": "2025-01-14T14:03:07+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_stage_variables": {
     "last_validated_date": "2024-08-12T13:42:13+00:00"
   }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We got a report that importing a specific OpenAPI file in API Gateway v1 would result in a type error in OpenTOFU:
> deserialization failed, failed to decode response body with invalid JSON, expected StatusCode to be of type string, got json.Number instead

This is because we were not casting as string the status code for the Method status code, and the IntegrationResponse.

When importing an API, we do so by creating the resources "in memory" directly and not via API calls, as this was how on the implementation was. This particular piece of code needs to be reworked fully, but this is out of scope of this PR.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a test reproducing a similar exception
- cast imported status codes to string

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
