### PR TITLE
Add validation for tags in kms service

### DIFF
--- a/localstack-core/localstack/services/kms/exceptions.py
+++ b/localstack-core/localstack/services/kms/exceptions.py
@@ -9,3 +9,8 @@ class ValidationException(CommonServiceException):
 class AccessDeniedException(CommonServiceException):
     def __init__(self, message: str):
         super().__init__("AccessDeniedException", message, 400, True)
+
+
+class TagException(CommonServiceException):
+    def __init__(self, message=None):
+        super().__init__("TagException", status_code=400, message=message)

--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -572,9 +572,8 @@ class KmsKey:
         # Do not care if we overwrite an existing tag:
         # https://docs.aws.amazon.com/kms/latest/APIReference/API_TagResource.html
         # "To edit a tag, specify an existing tag key and a new tag value."
-        for i in range(len(tags)):
-            tag = tags[i]
-            validate_tag(i + 1, tag)
+        for i, tag in enumerate(tags, start=1):
+            validate_tag(i, tag)
             self.tags[tag.get("TagKey")] = tag.get("TagValue")
 
     def schedule_key_deletion(self, pending_window_in_days: int) -> None:

--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -10,7 +10,7 @@ import struct
 import uuid
 from collections import namedtuple
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
@@ -44,11 +44,12 @@ from localstack.aws.api.kms import (
     OriginType,
     ReplicateKeyRequest,
     SigningAlgorithmSpec,
+    TagList,
     UnsupportedOperationException,
 )
 from localstack.constants import TAG_KEY_CUSTOM_ID
-from localstack.services.kms.exceptions import ValidationException
-from localstack.services.kms.utils import is_valid_key_arn
+from localstack.services.kms.exceptions import TagException, ValidationException
+from localstack.services.kms.utils import is_valid_key_arn, validate_tag
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
 from localstack.utils.aws.arns import get_partition, kms_alias_arn, kms_key_arn
 from localstack.utils.crypto import decrypt, encrypt
@@ -556,15 +557,24 @@ class KmsKey:
                 ReplicaKeys=[],
             )
 
-    def add_tags(self, tags: List) -> None:
+    def add_tags(self, tags: TagList) -> None:
         # Just in case we get None from somewhere.
         if not tags:
             return
 
+        unique_tag_keys = {tag["TagKey"] for tag in tags}
+        if len(unique_tag_keys) < len(tags):
+            raise TagException("Duplicate tag keys")
+
+        if len(tags) > 50:
+            raise TagException("Too many tags")
+
         # Do not care if we overwrite an existing tag:
         # https://docs.aws.amazon.com/kms/latest/APIReference/API_TagResource.html
         # "To edit a tag, specify an existing tag key and a new tag value."
-        for tag in tags:
+        for i in range(len(tags)):
+            tag = tags[i]
+            validate_tag(i + 1, tag)
             self.tags[tag.get("TagKey")] = tag.get("TagValue")
 
     def schedule_key_deletion(self, pending_window_in_days: int) -> None:

--- a/localstack-core/localstack/services/kms/utils.py
+++ b/localstack-core/localstack/services/kms/utils.py
@@ -1,6 +1,7 @@
 import re
 from typing import Tuple
 
+from localstack.aws.api.kms import Tag, TagException
 from localstack.services.kms.exceptions import ValidationException
 from localstack.utils.aws.arns import ARN_PARTITION_REGEX
 
@@ -40,3 +41,20 @@ def validate_alias_name(alias_name: str) -> None:
             'Alias must start with the prefix "alias/". Please see '
             "https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html"
         )
+
+
+def validate_tag(tag_position: int, tag: Tag) -> None:
+    tag_key = tag.get("TagKey")
+    tag_value = tag.get("TagValue")
+
+    if len(tag_key) == 0 or len(tag_key) > 128:
+        raise ValidationException(
+            f"1 validation error detected: Value '{tag_key}' at 'tags.{tag_position}.member.tagKey' failed to satisfy constraint: Member must have length less than or equal to 128"
+        )
+    if len(tag_value) > 256:
+        raise ValidationException(
+            f"1 validation error detected: Value '{tag_value}' at 'tags.{tag_position}.member.tagValue' failed to satisfy constraint: Member must have length less than or equal to 256"
+        )
+
+    if tag_key.lower().startswith("aws:"):
+        raise TagException("Tags beginning with aws: are reserved")

--- a/localstack-core/localstack/services/kms/utils.py
+++ b/localstack-core/localstack/services/kms/utils.py
@@ -47,7 +47,7 @@ def validate_tag(tag_position: int, tag: Tag) -> None:
     tag_key = tag.get("TagKey")
     tag_value = tag.get("TagValue")
 
-    if len(tag_key) == 0 or len(tag_key) > 128:
+    if len(tag_key) > 128:
         raise ValidationException(
             f"1 validation error detected: Value '{tag_key}' at 'tags.{tag_position}.member.tagKey' failed to satisfy constraint: Member must have length less than or equal to 128"
         )

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -237,7 +237,7 @@ class TestKMS:
     @pytest.mark.parametrize(
         "invalid_tag_key",
         ["aws:key1", "AWS:key1", "a" * 129],
-        ids=["lowercase_prefix", "uppercase_prefix", "too_long_key"]
+        ids=["lowercase_prefix", "uppercase_prefix", "too_long_key"],
     )
     def test_create_key_with_invalid_tag_key(
         self, invalid_tag_key, kms_create_key, snapshot, region_name

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -234,7 +234,11 @@ class TestKMS:
         snapshot.match("invalid-tag-key", e.value.response)
 
     @markers.aws.validated
-    @pytest.mark.parametrize("invalid_tag_key", ["aws:key1", "AWS:key1", "a" * 129])
+    @pytest.mark.parametrize(
+        "invalid_tag_key",
+        ["aws:key1", "AWS:key1", "a" * 129],
+        ids=["lowercase_prefix", "uppercase_prefix", "too_long_key"]
+    )
     def test_create_key_with_invalid_tag_key(
         self, invalid_tag_key, kms_create_key, snapshot, region_name
     ):

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -200,6 +200,83 @@ class TestKMS:
         response = kms_client.list_resource_tags(KeyId=key_id)["Tags"]
         snapshot.match("list-resource-tags-after-tags-updated", response)
 
+    @markers.aws.validated
+    def test_tag_key_with_duplicate_tag_keys_raises_error(
+        self, kms_client_for_region, kms_create_key, snapshot, region_name
+    ):
+        kms_client = kms_client_for_region(region_name)
+        key_id = kms_create_key(
+            region_name=region_name, Description="test key 123", KeyUsage="ENCRYPT_DECRYPT"
+        )["KeyId"]
+
+        tags = [
+            {"TagKey": "tag1", "TagValue": "value1"},
+            {"TagKey": "tag1", "TagValue": "another-value1"},
+        ]
+        with pytest.raises(ClientError) as e:
+            kms_client.tag_resource(KeyId=key_id, Tags=tags)
+        snapshot.match("duplicate-tag-keys", e.value.response)
+
+    @markers.aws.validated
+    def test_create_key_with_too_many_tags_raises_error(
+        self, kms_create_key, snapshot, region_name
+    ):
+        max_tags = 50
+        tags = create_tags(**{f"key{i}": f"value{i}" for i in range(0, max_tags + 1)})
+
+        with pytest.raises(ClientError) as e:
+            kms_create_key(
+                region_name=region_name,
+                Description="test key 123",
+                KeyUsage="ENCRYPT_DECRYPT",
+                Tags=tags,
+            )["KeyId"]
+        snapshot.match("invalid-tag-key", e.value.response)
+
+    @markers.aws.validated
+    @pytest.mark.parametrize("invalid_tag_key", ["aws:key1", "AWS:key1", "a" * 129])
+    def test_create_key_with_invalid_tag_key(
+        self, invalid_tag_key, kms_create_key, snapshot, region_name
+    ):
+        tags = create_tags(**{invalid_tag_key: "value1"})
+
+        with pytest.raises(ClientError) as e:
+            kms_create_key(
+                region_name=region_name,
+                Description="test key 123",
+                KeyUsage="ENCRYPT_DECRYPT",
+                Tags=tags,
+            )["KeyId"]
+        snapshot.match("invalid-tag-key", e.value.response)
+
+    @markers.aws.validated
+    def test_tag_existing_key_with_invalid_tag_key(
+        self, kms_client_for_region, kms_create_key, snapshot, region_name
+    ):
+        kms_client = kms_client_for_region(region_name)
+
+        key_id = kms_create_key(
+            region_name=region_name, Description="test key 123", KeyUsage="ENCRYPT_DECRYPT"
+        )["KeyId"]
+        tags = create_tags(**{"aws:key1": "value1"})
+
+        with pytest.raises(ClientError) as e:
+            kms_client.tag_resource(KeyId=key_id, Tags=tags)
+        snapshot.match("invalid-tag-key", e.value.response)
+
+    @markers.aws.validated
+    def test_key_with_long_tag_value_raises_error(self, kms_create_key, snapshot, region_name):
+        tags = create_tags(**{"tag1": "v" * 257})
+
+        with pytest.raises(ClientError) as e:
+            kms_create_key(
+                region_name=region_name,
+                Description="test key 123",
+                KeyUsage="ENCRYPT_DECRYPT",
+                Tags=tags,
+            )["KeyId"]
+        snapshot.match("too-long-tag-value", e.value.response)
+
     @markers.aws.only_localstack
     def test_create_key_custom_id(self, kms_create_key, aws_client):
         custom_id = str(uuid.uuid4())

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -1895,5 +1895,115 @@
         }
       ]
     }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_tag_key_with_duplicate_tag_keys_raises_error": {
+    "recorded-date": "17-01-2025, 13:35:08",
+    "recorded-content": {
+      "duplicate-tag-keys": {
+        "Error": {
+          "Code": "TagException",
+          "Message": "Duplicate tag keys"
+        },
+        "message": "Duplicate tag keys",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_too_many_tags_raises_error": {
+    "recorded-date": "21-01-2025, 17:15:38",
+    "recorded-content": {
+      "invalid-tag-key": {
+        "Error": {
+          "Code": "TagException",
+          "Message": "Too many tags"
+        },
+        "message": "Too many tags",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[aws:key1]": {
+    "recorded-date": "21-01-2025, 17:49:54",
+    "recorded-content": {
+      "invalid-tag-key": {
+        "Error": {
+          "Code": "TagException",
+          "Message": "Tags beginning with aws: are reserved"
+        },
+        "message": "Tags beginning with aws: are reserved",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[AWS:key1]": {
+    "recorded-date": "21-01-2025, 17:49:54",
+    "recorded-content": {
+      "invalid-tag-key": {
+        "Error": {
+          "Code": "TagException",
+          "Message": "Tags beginning with aws: are reserved"
+        },
+        "message": "Tags beginning with aws: are reserved",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]": {
+    "recorded-date": "21-01-2025, 17:49:54",
+    "recorded-content": {
+      "invalid-tag-key": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'tags.1.member.tagKey' failed to satisfy constraint: Member must have length less than or equal to 128"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_tag_existing_key_with_invalid_tag_key": {
+    "recorded-date": "21-01-2025, 17:17:25",
+    "recorded-content": {
+      "invalid-tag-key": {
+        "Error": {
+          "Code": "TagException",
+          "Message": "Tags beginning with aws: are reserved"
+        },
+        "message": "Tags beginning with aws: are reserved",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_key_with_long_tag_value_raises_error": {
+    "recorded-date": "21-01-2025, 17:18:18",
+    "recorded-content": {
+      "too-long-tag-value": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv' at 'tags.1.member.tagValue' failed to satisfy constraint: Member must have length less than or equal to 256"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -1928,53 +1928,6 @@
       }
     }
   },
-  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[aws:key1]": {
-    "recorded-date": "21-01-2025, 17:49:54",
-    "recorded-content": {
-      "invalid-tag-key": {
-        "Error": {
-          "Code": "TagException",
-          "Message": "Tags beginning with aws: are reserved"
-        },
-        "message": "Tags beginning with aws: are reserved",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[AWS:key1]": {
-    "recorded-date": "21-01-2025, 17:49:54",
-    "recorded-content": {
-      "invalid-tag-key": {
-        "Error": {
-          "Code": "TagException",
-          "Message": "Tags beginning with aws: are reserved"
-        },
-        "message": "Tags beginning with aws: are reserved",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]": {
-    "recorded-date": "21-01-2025, 17:49:54",
-    "recorded-content": {
-      "invalid-tag-key": {
-        "Error": {
-          "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'tags.1.member.tagKey' failed to satisfy constraint: Member must have length less than or equal to 128"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_tag_existing_key_with_invalid_tag_key": {
     "recorded-date": "21-01-2025, 17:17:25",
     "recorded-content": {
@@ -1998,6 +1951,53 @@
         "Error": {
           "Code": "ValidationException",
           "Message": "1 validation error detected: Value 'vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv' at 'tags.1.member.tagValue' failed to satisfy constraint: Member must have length less than or equal to 256"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[lowercase_prefix]": {
+    "recorded-date": "22-01-2025, 13:37:31",
+    "recorded-content": {
+      "invalid-tag-key": {
+        "Error": {
+          "Code": "TagException",
+          "Message": "Tags beginning with aws: are reserved"
+        },
+        "message": "Tags beginning with aws: are reserved",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[uppercase_prefix]": {
+    "recorded-date": "22-01-2025, 13:37:32",
+    "recorded-content": {
+      "invalid-tag-key": {
+        "Error": {
+          "Code": "TagException",
+          "Message": "Tags beginning with aws: are reserved"
+        },
+        "message": "Tags beginning with aws: are reserved",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[too_long_key]": {
+    "recorded-date": "22-01-2025, 13:37:32",
+    "recorded-content": {
+      "invalid-tag-key": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'tags.1.member.tagKey' failed to satisfy constraint: Member must have length less than or equal to 128"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -23,8 +23,20 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key": {
     "last_validated_date": "2024-04-11T15:26:14+00:00"
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[AWS:key1]": {
+    "last_validated_date": "2025-01-21T17:49:54+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]": {
+    "last_validated_date": "2025-01-21T17:49:54+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[aws:key1]": {
+    "last_validated_date": "2025-01-21T17:49:54+00:00"
+  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_tag_and_untag": {
     "last_validated_date": "2025-01-10T09:40:40+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_too_many_tags_raises_error": {
+    "last_validated_date": "2025-01-21T17:15:38+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_create_list_delete_alias": {
     "last_validated_date": "2024-04-11T15:53:50+00:00"
@@ -158,6 +170,9 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_key_rotation_status": {
     "last_validated_date": "2024-04-11T15:53:48+00:00"
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_key_with_long_tag_value_raises_error": {
+    "last_validated_date": "2025-01-21T17:18:18+00:00"
+  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_list_aliases_of_key": {
     "last_validated_date": "2024-04-11T15:53:36+00:00"
   },
@@ -211,6 +226,12 @@
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_tag_existing_key_and_untag": {
     "last_validated_date": "2025-01-10T09:39:48+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_tag_existing_key_with_invalid_tag_key": {
+    "last_validated_date": "2025-01-21T17:17:25+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_tag_key_with_duplicate_tag_keys_raises_error": {
+    "last_validated_date": "2025-01-17T13:35:08+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_tag_untag_list_tags": {
     "last_validated_date": "2024-04-11T15:53:57+00:00"

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -23,14 +23,14 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key": {
     "last_validated_date": "2024-04-11T15:26:14+00:00"
   },
-  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[AWS:key1]": {
-    "last_validated_date": "2025-01-21T17:49:54+00:00"
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[lowercase_prefix]": {
+    "last_validated_date": "2025-01-22T13:37:31+00:00"
   },
-  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]": {
-    "last_validated_date": "2025-01-21T17:49:54+00:00"
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[too_long_key]": {
+    "last_validated_date": "2025-01-22T13:37:32+00:00"
   },
-  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[aws:key1]": {
-    "last_validated_date": "2025-01-21T17:49:54+00:00"
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_invalid_tag_key[uppercase_prefix]": {
+    "last_validated_date": "2025-01-22T13:37:32+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_create_key_with_tag_and_untag": {
     "last_validated_date": "2025-01-10T09:40:40+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Implement validation for tags in the KMS service with the following rules:

- Duplicate tag keys are not permitted
- A maximum of 50 tags can be applied
- Enforce a limit on the length of tag keys and tag values
- Tag keys cannot use the reserved `aws:` prefix

    
<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added new test cases for invalid tag keys and values, excessive tag counts (over 50 tags), overly long tag keys and values, and duplicate tag keys.
- Introduced a new method for tag validation and updated the add_tags method.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
