### PR TITLE
Match an empty prefix

### DIFF
--- a/localstack-core/localstack/services/events/event_rule_engine.py
+++ b/localstack-core/localstack/services/events/event_rule_engine.py
@@ -95,14 +95,14 @@ class EventRuleEngine:
         elif value is None:
             # the remaining conditions require the value to not be None
             return False
-        elif prefix := condition.get("prefix"):
+        elif (prefix := condition.get("prefix")) is not None:
             if isinstance(prefix, dict):
                 if prefix_equal_ignore_case := prefix.get("equals-ignore-case"):
                     return self._evaluate_prefix(prefix_equal_ignore_case.lower(), value.lower())
             else:
                 return self._evaluate_prefix(prefix, value)
 
-        elif suffix := condition.get("suffix"):
+        elif (suffix := condition.get("suffix")) is not None:
             if isinstance(suffix, dict):
                 if suffix_equal_ignore_case := suffix.get("equals-ignore-case"):
                     return self._evaluate_suffix(suffix_equal_ignore_case.lower(), value.lower())

--- a/tests/aws/services/events/event_pattern_templates/empty_prefix.json5
+++ b/tests/aws/services/events/event_pattern_templates/empty_prefix.json5
@@ -1,0 +1,17 @@
+// Based on https://stackoverflow.com/questions/62406933/aws-eventbridge-pattern-to-capture-all-events
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "state": "pending"
+    }
+  },
+  "EventPattern": {
+    "source": [{"prefix": ""}]
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
https://github.com/localstack/localstack/issues/12148

I was using this pattern to match all events:
https://stackoverflow.com/questions/62406933/aws-eventbridge-pattern-to-capture-all-events

It works in AWS and in localstack before 4.0.3.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

The new rule engine was using truthiness via `condition.get('prefix')` to determine if a condition was a prefix condition.
That assumes a prefix pattern of `''` isn't actually a prefix pattern.
This change instead checks for `None` to determine the condition type and gets empty prefixes to match again.

## Testing
Added a new JSON test case for this
