### PR TITLE
Fix legacy test that broke pipeline after eventbridge cron update

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_events.py
+++ b/tests/aws/services/cloudformation/resources/test_events.py
@@ -154,10 +154,11 @@ def test_event_rule_to_logs(deploy_cfn_template, aws_client):
     assert message_token in log_events["events"][0]["message"]
 
 
-# {"LogicalResourceId": "TestRule99A50909", "ResourceType": "AWS::Events::Rule", "ResourceStatus": "CREATE_FAILED", "ResourceStatusReason": "Parameter ScheduleExpression is not valid."}
-@markers.aws.needs_fixing
-def test_event_rule_creation_without_target(deploy_cfn_template, aws_client):
+@markers.aws.validated
+def test_event_rule_creation_without_target(deploy_cfn_template, aws_client, snapshot):
     event_rule_name = f"event-rule-{short_uid()}"
+    snapshot.add_transformer(snapshot.transform.regex(event_rule_name, "event-rule-name"))
+
     deploy_cfn_template(
         template_path=os.path.join(
             os.path.dirname(__file__), "../../../templates/events_rule_without_targets.yaml"
@@ -168,7 +169,7 @@ def test_event_rule_creation_without_target(deploy_cfn_template, aws_client):
     response = aws_client.events.describe_rule(
         Name=event_rule_name,
     )
-    assert response
+    snapshot.match("describe_rule", response)
 
 
 @markers.aws.validated

--- a/tests/aws/services/cloudformation/resources/test_events.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_events.snapshot.json
@@ -49,5 +49,22 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_events.py::test_event_rule_creation_without_target": {
+    "recorded-date": "22-01-2025, 14:15:04",
+    "recorded-content": {
+      "describe_rule": {
+        "Arn": "arn:<partition>:events:<region>:111111111111:rule/event-rule-name",
+        "CreatedBy": "111111111111",
+        "EventBusName": "default",
+        "Name": "event-rule-name",
+        "ScheduleExpression": "cron(0 1 * * ? *)",
+        "State": "ENABLED",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_events.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_events.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/cloudformation/resources/test_events.py::test_cfn_event_api_destination_resource": {
     "last_validated_date": "2024-04-16T06:36:56+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_events.py::test_event_rule_creation_without_target": {
+    "last_validated_date": "2025-01-22T14:15:04+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_events.py::test_eventbus_policy_statement": {
     "last_validated_date": "2024-11-14T21:46:23+00:00"
   },

--- a/tests/aws/services/events/test_events_schedule.py
+++ b/tests/aws/services/events/test_events_schedule.py
@@ -13,6 +13,7 @@ from localstack.utils.sync import retry
 from tests.aws.services.events.helper_functions import (
     events_time_string_to_timestamp,
     get_cron_expression,
+    is_old_provider,
     sqs_collect_messages,
 )
 
@@ -310,9 +311,14 @@ class TestScheduleCron:
         snapshot.match("list-rules", response)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        is_old_provider(),
+        reason="V1 provider does not properly validate",
+    )
     @pytest.mark.parametrize(
         "schedule_cron",
         [
+            "cron(0 1 * * * *)",  # you can't specify the Day-of-month and Day-of-week fields in the same cron expression
             "cron(7 20 * * NOT *)",
             "cron(INVALID)",
             "cron(0 dummy ? * MON-FRI *)",

--- a/tests/aws/services/events/test_events_schedule.snapshot.json
+++ b/tests/aws/services/events/test_events_schedule.snapshot.json
@@ -146,7 +146,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0 10 * * ? *)]": {
-    "recorded-date": "21-01-2025, 17:46:05",
+    "recorded-date": "22-01-2025, 13:22:45",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -173,7 +173,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(15 12 * * ? *)]": {
-    "recorded-date": "21-01-2025, 17:46:05",
+    "recorded-date": "22-01-2025, 13:22:46",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -200,7 +200,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0 18 ? * MON-FRI *)]": {
-    "recorded-date": "21-01-2025, 17:46:06",
+    "recorded-date": "22-01-2025, 13:22:47",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -227,7 +227,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0 8 1 * ? *)]": {
-    "recorded-date": "21-01-2025, 17:46:06",
+    "recorded-date": "22-01-2025, 13:22:47",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -254,7 +254,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0/15 * * * ? *)]": {
-    "recorded-date": "21-01-2025, 17:46:07",
+    "recorded-date": "22-01-2025, 13:22:48",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -281,7 +281,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0/10 * ? * MON-FRI *)]": {
-    "recorded-date": "21-01-2025, 17:46:07",
+    "recorded-date": "22-01-2025, 13:22:48",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -308,7 +308,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0/5 8-17 ? * MON-FRI *)]": {
-    "recorded-date": "21-01-2025, 17:46:08",
+    "recorded-date": "22-01-2025, 13:22:49",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -335,7 +335,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0/30 20-23 ? * MON-FRI *)]": {
-    "recorded-date": "21-01-2025, 17:46:08",
+    "recorded-date": "22-01-2025, 13:22:49",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -362,7 +362,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0/30 0-2 ? * MON-FRI *)]": {
-    "recorded-date": "21-01-2025, 17:46:09",
+    "recorded-date": "22-01-2025, 13:22:50",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -419,7 +419,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_invalid_schedule_cron[cron(INVALID)]": {
-    "recorded-date": "21-01-2025, 17:46:10",
+    "recorded-date": "22-01-2025, 13:55:49",
     "recorded-content": {
       "invalid-put-rule": {
         "Error": {
@@ -434,7 +434,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_invalid_schedule_cron[cron(0 dummy ? * MON-FRI *)]": {
-    "recorded-date": "21-01-2025, 17:46:11",
+    "recorded-date": "22-01-2025, 13:55:50",
     "recorded-content": {
       "invalid-put-rule": {
         "Error": {
@@ -449,7 +449,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0 2 ? * SAT *)]": {
-    "recorded-date": "21-01-2025, 17:46:01",
+    "recorded-date": "22-01-2025, 13:22:42",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -476,7 +476,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0 12 * * ? *)]": {
-    "recorded-date": "21-01-2025, 17:46:01",
+    "recorded-date": "22-01-2025, 13:22:42",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -503,7 +503,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(5,35 14 * * ? *)]": {
-    "recorded-date": "21-01-2025, 17:46:02",
+    "recorded-date": "22-01-2025, 13:22:43",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -530,7 +530,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(15 10 ? * 6L 2002-2005)]": {
-    "recorded-date": "21-01-2025, 17:46:02",
+    "recorded-date": "22-01-2025, 13:22:43",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -557,7 +557,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0 2 ? * SAT#3 *)]": {
-    "recorded-date": "21-01-2025, 17:46:03",
+    "recorded-date": "22-01-2025, 13:22:44",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -584,7 +584,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(* * ? * SAT#3 *)]": {
-    "recorded-date": "21-01-2025, 17:46:03",
+    "recorded-date": "22-01-2025, 13:22:44",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -611,7 +611,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0/5 5 ? JAN 1-5 2022)]": {
-    "recorded-date": "21-01-2025, 17:46:04",
+    "recorded-date": "22-01-2025, 13:22:45",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:<partition>:events:<region>:111111111111:rule/<rule-name>",
@@ -638,7 +638,7 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_invalid_schedule_cron[cron(7 20 * * NOT *)]": {
-    "recorded-date": "21-01-2025, 17:46:09",
+    "recorded-date": "22-01-2025, 13:55:49",
     "recorded-content": {
       "invalid-put-rule": {
         "Error": {
@@ -653,7 +653,22 @@
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_invalid_schedule_cron[cron(71 8 1 * ? *)]": {
-    "recorded-date": "21-01-2025, 17:46:11",
+    "recorded-date": "22-01-2025, 13:55:50",
+    "recorded-content": {
+      "invalid-put-rule": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Parameter ScheduleExpression is not valid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_invalid_schedule_cron[cron(0 1 * * * *)]": {
+    "recorded-date": "22-01-2025, 13:55:48",
     "recorded-content": {
       "invalid-put-rule": {
         "Error": {

--- a/tests/aws/services/events/test_events_schedule.validation.json
+++ b/tests/aws/services/events/test_events_schedule.validation.json
@@ -2,68 +2,71 @@
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::test_schedule_cron_target_sqs": {
     "last_validated_date": "2024-05-15T10:58:53+00:00"
   },
+  "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_invalid_schedule_cron[cron(0 1 * * * *)]": {
+    "last_validated_date": "2025-01-22T13:55:48+00:00"
+  },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_invalid_schedule_cron[cron(0 dummy ? * MON-FRI *)]": {
-    "last_validated_date": "2025-01-21T17:46:11+00:00"
+    "last_validated_date": "2025-01-22T13:55:50+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_invalid_schedule_cron[cron(7 20 * * NOT *)]": {
-    "last_validated_date": "2025-01-21T17:46:09+00:00"
+    "last_validated_date": "2025-01-22T13:55:49+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_invalid_schedule_cron[cron(71 8 1 * ? *)]": {
-    "last_validated_date": "2025-01-21T17:46:11+00:00"
+    "last_validated_date": "2025-01-22T13:55:50+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_invalid_schedule_cron[cron(INVALID)]": {
-    "last_validated_date": "2025-01-21T17:46:10+00:00"
+    "last_validated_date": "2025-01-22T13:55:49+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron": {
     "last_validated_date": "2024-05-14T14:50:51+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(* * ? * SAT#3 *)]": {
-    "last_validated_date": "2025-01-21T17:46:03+00:00"
+    "last_validated_date": "2025-01-22T13:22:44+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0 10 * * ? *)]": {
-    "last_validated_date": "2025-01-21T17:46:05+00:00"
+    "last_validated_date": "2025-01-22T13:22:45+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0 12 * * ? *)]": {
-    "last_validated_date": "2025-01-21T17:46:01+00:00"
+    "last_validated_date": "2025-01-22T13:22:42+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0 18 ? * MON-FRI *)]": {
-    "last_validated_date": "2025-01-21T17:46:06+00:00"
+    "last_validated_date": "2025-01-22T13:22:47+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0 2 ? * SAT *)]": {
-    "last_validated_date": "2025-01-21T17:46:01+00:00"
+    "last_validated_date": "2025-01-22T13:22:42+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0 2 ? * SAT#3 *)]": {
-    "last_validated_date": "2025-01-21T17:46:03+00:00"
+    "last_validated_date": "2025-01-22T13:22:44+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0 8 1 * ? *)]": {
-    "last_validated_date": "2025-01-21T17:46:06+00:00"
+    "last_validated_date": "2025-01-22T13:22:47+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0/10 * ? * MON-FRI *)]": {
-    "last_validated_date": "2025-01-21T17:46:07+00:00"
+    "last_validated_date": "2025-01-22T13:22:48+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0/15 * * * ? *)]": {
-    "last_validated_date": "2025-01-21T17:46:07+00:00"
+    "last_validated_date": "2025-01-22T13:22:48+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0/30 0-2 ? * MON-FRI *)]": {
-    "last_validated_date": "2025-01-21T17:46:09+00:00"
+    "last_validated_date": "2025-01-22T13:22:50+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0/30 20-23 ? * MON-FRI *)]": {
-    "last_validated_date": "2025-01-21T17:46:08+00:00"
+    "last_validated_date": "2025-01-22T13:22:49+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0/5 5 ? JAN 1-5 2022)]": {
-    "last_validated_date": "2025-01-21T17:46:04+00:00"
+    "last_validated_date": "2025-01-22T13:22:45+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(0/5 8-17 ? * MON-FRI *)]": {
-    "last_validated_date": "2025-01-21T17:46:08+00:00"
+    "last_validated_date": "2025-01-22T13:22:49+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(15 10 ? * 6L 2002-2005)]": {
-    "last_validated_date": "2025-01-21T17:46:02+00:00"
+    "last_validated_date": "2025-01-22T13:22:43+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(15 12 * * ? *)]": {
-    "last_validated_date": "2025-01-21T17:46:05+00:00"
+    "last_validated_date": "2025-01-22T13:22:46+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(5,35 14 * * ? *)]": {
-    "last_validated_date": "2025-01-21T17:46:02+00:00"
+    "last_validated_date": "2025-01-22T13:22:43+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleRate::test_put_rule_with_invalid_schedule_rate[ rate(10 minutes)]": {
     "last_validated_date": "2024-05-14T11:27:18+00:00"

--- a/tests/aws/templates/events_rule_without_targets.yaml
+++ b/tests/aws/templates/events_rule_without_targets.yaml
@@ -8,4 +8,4 @@ Resources:
     Properties:
       Name: 
         Ref: EventRuleName
-      ScheduleExpression: 'cron(0 1 * * * *)'
+      ScheduleExpression: 'cron(0 1 * * ? *)'


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
After merging this [PR](https://github.com/localstack/localstack/pull/12156) on eventbridge schedule validation, this integration test broke the pipeline: `test_event_rule_creation_without_target`.
That PR actually brought more parity with AWS and broke an existing test that shouldn't have passed.
Now the test is aws_validated 🚀 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Fixed a cron schedule: in `events_rule_without_targets`.yaml. ` 'cron(0 1 * * * *)' `-->  `'cron(0 1 * * ? *)'`
- Test snapshot tested and aws validated.


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
