### PR TITLE
StepFunctions: AWS-SDK Integration Retain Specific Error Names

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
@@ -5,14 +5,9 @@ from botocore.exceptions import ClientError, UnknownServiceError
 
 from localstack.aws.api.stepfunctions import HistoryEventType, TaskFailedEventDetails
 from localstack.aws.protocol.service_router import get_service_catalog
+from localstack.services.stepfunctions.asl.component.common.error_name.error_name import ErrorName
 from localstack.services.stepfunctions.asl.component.common.error_name.failure_event import (
     FailureEvent,
-)
-from localstack.services.stepfunctions.asl.component.common.error_name.states_error_name import (
-    StatesErrorName,
-)
-from localstack.services.stepfunctions.asl.component.common.error_name.states_error_name_type import (
-    StatesErrorNameType,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.credentials import (
     StateCredentials,
@@ -90,7 +85,7 @@ class StateTaskServiceAwsSdk(StateTaskServiceCallback):
     def _get_task_failure_event(self, env: Environment, error: str, cause: str) -> FailureEvent:
         return FailureEvent(
             env=env,
-            error_name=StatesErrorName(typ=StatesErrorNameType.StatesTaskFailed),
+            error_name=ErrorName(error_name=error),
             event_type=HistoryEventType.TaskFailed,
             event_details=EventDetails(
                 taskFailedEventDetails=TaskFailedEventDetails(

--- a/tests/aws/services/stepfunctions/templates/errorhandling/error_handling_templates.py
+++ b/tests/aws/services/stepfunctions/templates/errorhandling/error_handling_templates.py
@@ -7,9 +7,12 @@ _THIS_FOLDER: Final[str] = os.path.dirname(os.path.realpath(__file__))
 
 
 class ErrorHandlingTemplate(TemplateLoader):
-    # State Machines.
     AWS_SDK_TASK_FAILED_S3_LIST_OBJECTS: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/aws_sdk_task_error_s3_list_objects.json5"
+    )
+
+    AWS_SDK_TASK_FAILED_S3_NO_SUCH_KEY: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/aws_sdk_task_error_s3_no_such_key.json5"
     )
 
     AWS_SDK_TASK_FAILED_SECRETSMANAGER_CREATE_SECRET: Final[str] = os.path.join(

--- a/tests/aws/services/stepfunctions/templates/errorhandling/statemachines/aws_sdk_task_error_s3_no_such_key.json5
+++ b/tests/aws/services/stepfunctions/templates/errorhandling/statemachines/aws_sdk_task_error_s3_no_such_key.json5
@@ -1,0 +1,30 @@
+{
+  "QueryLanguage": "JSONata",
+  "StartAt": "StartState",
+  "States": {
+    "StartState": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:getObject",
+      "Arguments": {
+        "Bucket": "{% $states.input.Bucket %}",
+        "Key": "no_such_key.json"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "S3.NoSuchKeyException"
+          ],
+          "Output": "{% $states.errorOutput %}",
+          "Next": "NoSuchKeyState"
+        }
+      ],
+      "Next": "TerminalState"
+    },
+    "TerminalState": {
+      "Type": "Succeed"
+    },
+    "NoSuchKeyState": {
+      "Type": "Fail"
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_aws_sdk.py
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_aws_sdk.py
@@ -49,6 +49,29 @@ class TestAwsSdk:
             exec_input,
         )
 
+    @markers.aws.validated
+    def test_s3_no_such_key(
+        self,
+        aws_client,
+        s3_create_bucket,
+        create_state_machine_iam_role,
+        create_state_machine,
+        sfn_snapshot,
+    ):
+        bucket_name = s3_create_bucket()
+        sfn_snapshot.add_transformer(RegexTransformer(bucket_name, "bucket-name"))
+        template = EHT.load_sfn_template(EHT.AWS_SDK_TASK_FAILED_S3_NO_SUCH_KEY)
+        definition = json.dumps(template)
+        exec_input = json.dumps({"Bucket": bucket_name})
+        create_and_record_execution(
+            aws_client,
+            create_state_machine_iam_role,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
     @pytest.mark.skipif(
         condition=not is_aws_cloud(),
         reason="No parameters validation for dynamodb api calls being returned.",

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_aws_sdk.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_aws_sdk.snapshot.json
@@ -520,5 +520,124 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_aws_sdk.py::TestAwsSdk::test_s3_no_such_key": {
+    "recorded-date": "22-01-2025, 13:27:57",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Bucket": "bucket-name"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Bucket": "bucket-name"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "StartState"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Bucket": "bucket-name",
+                "Key": "no_such_key.json"
+              },
+              "region": "<region>",
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskFailedEventDetails": {
+              "cause": "The specified key does not exist. (Service: S3, Status Code: 404, Request ID: <request_id>, Extended Request ID: <extended_request_id>)",
+              "error": "S3.NoSuchKeyException",
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "StartState",
+              "output": {
+                "Error": "S3.NoSuchKeyException",
+                "Cause": "The specified key does not exist. (Service: S3, Status Code: 404, Request ID: <request_id>, Extended Request ID: <extended_request_id>)"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Error": "S3.NoSuchKeyException",
+                "Cause": "The specified key does not exist. (Service: S3, Status Code: 404, Request ID: <request_id>, Extended Request ID: <extended_request_id>)"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "NoSuchKeyState"
+            },
+            "timestamp": "timestamp",
+            "type": "FailStateEntered"
+          },
+          {
+            "executionFailedEventDetails": {},
+            "id": 8,
+            "previousEventId": 7,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_aws_sdk.validation.json
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_aws_sdk.validation.json
@@ -10,5 +10,8 @@
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_aws_sdk.py::TestAwsSdk::test_no_such_bucket": {
     "last_validated_date": "2023-06-22T11:26:06+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/error_handling/test_aws_sdk.py::TestAwsSdk::test_s3_no_such_key": {
+    "last_validated_date": "2025-01-22T13:27:57+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR addresses an issue in the Step Functions AWS-SDK integration where, upon integration failure, the error name is incorrectly cast to a fixed StatesError. This behavior prevents workflows from catching specific error types and implementing retry logic tailored to particular failures in the AWS-SDK integration: https://github.com/localstack/localstack/issues/12139

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- aws-sdk error decoration logic uses the computed exception name
- added relevant snapshot test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
