### PR TITLE
S3: fix SSE-C parity error message

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -883,7 +883,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                     "The correct parameters must be provided to retrieve the object."
                 )
             elif sse_key_hash != sse_c_key_md5:
-                raise AccessDenied("Access Denied")
+                raise AccessDenied(
+                    "Requests specifying Server Side Encryption with Customer provided keys must provide the correct secret key."
+                )
 
         validate_sse_c(
             algorithm=request.get("SSECustomerAlgorithm"),
@@ -1024,7 +1026,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                     "The correct parameters must be provided to retrieve the object."
                 )
             elif s3_object.sse_key_hash != sse_c_key_md5:
-                raise AccessDenied("Access Denied")
+                raise AccessDenied(
+                    "Requests specifying Server Side Encryption with Customer provided keys must provide the correct secret key."
+                )
 
         validate_sse_c(
             algorithm=request.get("SSECustomerAlgorithm"),

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -12941,12 +12941,12 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_object_retrieval_sse_c": {
-    "recorded-date": "21-01-2025, 18:16:22",
+    "recorded-date": "22-01-2025, 14:21:49",
     "recorded-content": {
       "put-obj-sse-c": {
         "ChecksumCRC32": "qIrZrA==",
         "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"3f1ecdf4a27b54bc3ccafd083183cbc4\"",
+        "ETag": "\"7f021303b8ca8e5af2c5ee7bf1e96a18\"",
         "SSECustomerAlgorithm": "AES256",
         "SSECustomerKeyMD5": "JMwgiexXqwuPqIPjYFmIZQ==",
         "ResponseMetadata": {
@@ -13012,6 +13012,16 @@
         "Error": {
           "Code": "AccessDenied",
           "Message": "Requests specifying Server Side Encryption with Customer provided keys must provide the correct secret key."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "head-obj-sse-c-no-md5": {
+        "Error": {
+          "Code": "403",
+          "Message": "Forbidden"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -798,7 +798,7 @@
     "last_validated_date": "2025-01-21T18:16:43+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_object_retrieval_sse_c": {
-    "last_validated_date": "2025-01-21T18:16:22+00:00"
+    "last_validated_date": "2025-01-22T14:21:48+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3SSECEncryption::test_put_object_lifecycle_with_sse_c": {
     "last_validated_date": "2025-01-21T18:16:15+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #12145, where we had to updates all S3 snapshots. A few parity issues popped up, and this aims to fix them. 

Seems like the error message for SSE-C related exception changes to be more explicit. This PR fixes that.

I've also updated the message for `HeadObject`, but it seems the message is not serialized/parsed by Boto3. It cannot really hurt anyway 🤷 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update the error message for SSE-C related exception
- add a test case for #12136, where I cannot reproduce the user issue, as a `HeadObject` request with no `SSECustomerKeyMD5` will trigger an error in AWS too

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
