### PR TITLE
fix cfn template join with noValue

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -420,7 +420,9 @@ def _resolve_refs_recursively(
                 raise Exception(
                     f"Cannot resolve CF Fn::Join {value} due to null values: {join_values}"
                 )
-            return value[keys_list[0]][0].join([str(v) for v in join_values])
+            return value[keys_list[0]][0].join(
+                [str(v) for v in join_values if v != "__aws_no_value__"]
+            )
 
         if stripped_fn_lower == "sub":
             item_to_sub = value[keys_list[0]]

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -263,6 +263,16 @@ class TestIntrinsicFunctions:
         assert stack.outputs["Threshold"] == threshold
         assert stack.outputs["Period"] == period
 
+    @markers.aws.validated
+    def test_join_no_value_construct(self, deploy_cfn_template, snapshot, aws_client):
+        stack = deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__), "../../templates/engine/join_no_value.yml"
+            )
+        )
+
+        snapshot.match("join-output", stack.outputs)
+
 
 class TestImports:
     @markers.aws.validated

--- a/tests/aws/services/cloudformation/test_template_engine.snapshot.json
+++ b/tests/aws/services/cloudformation/test_template_engine.snapshot.json
@@ -673,5 +673,15 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_join_no_value_construct": {
+    "recorded-date": "22-01-2025, 14:01:46",
+    "recorded-content": {
+      "join-output": {
+        "JoinConditionalNoValue": "",
+        "JoinOnlyNoValue": "",
+        "JoinWithNoValue": "Sample"
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -35,6 +35,9 @@
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[us-west-2]": {
     "last_validated_date": "2024-05-09T08:33:45+00:00"
   },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_join_no_value_construct": {
+    "last_validated_date": "2025-01-22T14:01:46+00:00"
+  },
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_sub_number_type": {
     "last_validated_date": "2024-08-09T06:55:16+00:00"
   },

--- a/tests/aws/templates/engine/join_no_value.yml
+++ b/tests/aws/templates/engine/join_no_value.yml
@@ -1,0 +1,34 @@
+Conditions:
+  active: !Equals [ true, true ]
+  inactive: !Equals [ true, false ]
+
+Resources:
+  Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: Sample
+      Name: commands 
+
+Outputs:
+  JoinWithNoValue:
+    Value:
+      Fn::Join:
+        - ","
+        - - !GetAtt Parameter.Value
+          - !Ref AWS::NoValue
+
+  JoinOnlyNoValue:
+    Value:
+      Fn::Join:
+        - ","
+        - - !Ref AWS::NoValue
+
+  JoinConditionalNoValue:
+    Value:
+      Fn::Join:
+        - ","
+        - - Fn::If:
+              - active
+              - !Ref AWS::NoValue
+              - !Ref AWS::NoValue


### PR DESCRIPTION
## Motivation
This PR fixes an issue encountered by a customer when using AWS::NoValue within a Fn::Join in CFn template
 
## Changes
Make  the template deployer ignore the AWS::NoValue when calculaing theh Fn:join result

## Test
- new aws validated test.