### PR TITLE
fix pre-signed URL with JS SDK, enable test_presigned_url_v4_x_amz_in_qs

### DIFF
--- a/localstack-core/localstack/services/s3/presigned_url.py
+++ b/localstack-core/localstack/services/s3/presigned_url.py
@@ -661,9 +661,8 @@ class S3SigV4SignatureContext:
                     # The JS SDK is adding the `x-amz-checksum-crc32` header to query parameters, even though it cannot
                     # know in advance the actual checksum. Those are ignored by AWS, if they're not put in the
                     # SignedHeaders
-                    if qs_param_low.startswith("x-amz-checksum-"):
-                        continue
-                    query_args_to_headers[qs_param_low] = qs_value
+                    if not qs_param_low.startswith("x-amz-checksum-"):
+                        query_args_to_headers[qs_param_low] = qs_value
 
             new_query_args[qs_parameter] = qs_value
 

--- a/localstack-core/localstack/services/s3/presigned_url.py
+++ b/localstack-core/localstack/services/s3/presigned_url.py
@@ -658,6 +658,11 @@ class S3SigV4SignatureContext:
                     # specially in the old JS SDK v2
                     headers.add(qs_param_low, qs_value)
                 else:
+                    # The JS SDK is adding the `x-amz-checksum-crc32` header to query parameters, even though it cannot
+                    # know in advance the actual checksum. Those are ignored by AWS, if they're not put in the
+                    # SignedHeaders
+                    if qs_param_low.startswith("x-amz-checksum-"):
+                        continue
                     query_args_to_headers[qs_param_low] = qs_value
 
             new_query_args[qs_parameter] = qs_value

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -7560,6 +7560,16 @@ class TestS3PresignedUrl:
         )
         assert response.status_code == 200
 
+        # assert that the checksum-crc-32 value is still validated and important for the signature
+        bad_presigned_url = presigned_url.replace("crc32=AAAAAA%3D%3D", "crc32=BBBBBB%3D%3D")
+        response = requests.put(
+            bad_presigned_url,
+            data=b"123456",
+            verify=False,
+            headers={"Content-MD5": "4QrcOUm6Wau+VuBX8g+IPg=="},
+        )
+        assert response.status_code == 403
+
         # verify that we properly saved the data
         head_object = aws_client.s3.head_object(
             Bucket=function_name, Key=object_key, ChecksumMode="ENABLED"

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11773,7 +11773,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_v4_x_amz_in_qs": {
-    "recorded-date": "21-01-2025, 18:25:21",
+    "recorded-date": "22-01-2025, 18:05:11",
     "recorded-content": {
       "head-object": {
         "AcceptRanges": "bytes",

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11773,7 +11773,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_v4_x_amz_in_qs": {
-    "recorded-date": "22-01-2025, 18:05:11",
+    "recorded-date": "22-01-2025, 18:21:12",
     "recorded-content": {
       "head-object": {
         "AcceptRanges": "bytes",

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -708,7 +708,7 @@
     "last_validated_date": "2025-01-21T18:25:34+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_v4_x_amz_in_qs": {
-    "last_validated_date": "2025-01-21T18:25:21+00:00"
+    "last_validated_date": "2025-01-22T18:05:11+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_with_different_user_credentials": {
     "last_validated_date": "2025-01-21T18:23:55+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -708,7 +708,7 @@
     "last_validated_date": "2025-01-21T18:25:34+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_v4_x_amz_in_qs": {
-    "last_validated_date": "2025-01-22T18:05:11+00:00"
+    "last_validated_date": "2025-01-22T18:21:12+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_with_different_user_credentials": {
     "last_validated_date": "2025-01-21T18:23:55+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We had pipeline failures due to the `test_presigned_url_v4_x_amz_in_qs` test suddenly failing. This happened at the same time we've had a big update in S3 data integrity and checksums in our boto update.

I suspected a change in behavior in the Javascript SDK: what happens now is that the JS SDK is adding a checksum value for pre-signed URL, which in itself is quite a bad idea, as you cannot know in advance what the value of the object can be. 

So it seems AWS is just flat out ignoring the query string parameter. 

Pre-signed URLs are a funny concept: you pass some values that would normally be headers in a regular signed request as query string parameters, so that the URL can be shared. To not have to manually parse query string parameters in our S3 provider, our pre-signed URL handler is picking up the query string parameters and putting them back as headers and mutating the request before it being parsed, so that we can fully enjoy the ASF power. See #8918

But in that case, the query string parameter is important for the signature, if you try modifying it, S3 will raise an invalid signature exception. But you need to ignore it before passing it down to the provider. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- ignore any `x-amz-checksum-<>` header that is not in the signed headers, and do not pass it down the provider
- re-enable the test and add a few checks

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
