### PR TITLE
S3: fix exception from ObjectLock retention

### DIFF
--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3589,12 +3589,8 @@ class TestS3:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        path=[
-            "$..Deleted..VersionId",  # we cannot guarantee order nor we can sort it
-            "$..Delimiter",
-            "$..EncodingType",
-            "$..VersionIdMarker",
-        ]
+        # we cannot guarantee order nor we can sort it
+        path=["$..Deleted..VersionId"],
     )
     def test_delete_keys_in_versioned_bucket(self, s3_bucket, snapshot, aws_client):
         # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html
@@ -4417,9 +4413,6 @@ class TestS3:
         snapshot.match("head_object_key2", rs)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$..Delimiter", "$..EncodingType", "$..VersionIdMarker"]
-    )
     def test_get_bucket_versioning_order(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         rs = aws_client.s3.list_object_versions(Bucket=s3_bucket, EncodingType="url")
@@ -4461,9 +4454,6 @@ class TestS3:
         snapshot.match("get_object_range", rs)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$..Delimiter", "$..EncodingType", "$..VersionIdMarker"]
-    )
     def test_s3_delete_object_with_version_id(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
 
@@ -4510,9 +4500,6 @@ class TestS3:
         snapshot.match("get_bucket_versioning_suspended", rs)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$..Delimiter", "$..EncodingType", "$..VersionIdMarker"]
-    )
     def test_s3_put_object_versioned(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
 
@@ -4644,9 +4631,6 @@ class TestS3:
         snapshot.match("list-remaining-objects", response)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$..DeleteResult.Deleted..VersionId", "$..Prefix", "$..DeleteResult.@xmlns"]
-    )
     def test_s3_batch_delete_public_objects_using_requests(
         self, s3_bucket, allow_bucket_acl, snapshot, aws_client, anonymous_client
     ):
@@ -4696,11 +4680,6 @@ class TestS3:
         snapshot.match("list-remaining-objects", response)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$..Prefix",
-        ]
-    )
     def test_s3_batch_delete_objects(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         snapshot.add_transformer(snapshot.transform.key_value("Key"))
@@ -6162,7 +6141,6 @@ class TestS3:
         "use_virtual_address",
         [True, False],
     )
-    @markers.snapshot.skip_snapshot_verify(paths=["$..x-amz-server-side-encryption"])
     @markers.aws.validated
     def test_get_object_content_length_with_virtual_host(
         self,
@@ -9345,16 +9323,6 @@ class TestS3BucketLifecycle:
 
 class TestS3ObjectLockRetention:
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            # TODO: fix the exception for update-retention-no-bypass
-            "$.update-retention-no-bypass..ArgumentName",
-            "$.update-retention-no-bypass..ArgumentValue",
-            "$.update-retention-no-bypass..Code",
-            "$.update-retention-no-bypass..HTTPStatusCode",
-            "$.update-retention-no-bypass..Message",
-        ]
-    )
     def test_s3_object_retention_exc(self, aws_client, s3_create_bucket, snapshot):
         snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
         s3_bucket_locked = s3_create_bucket(ObjectLockEnabledForBucket=True)
@@ -9409,9 +9377,19 @@ class TestS3ObjectLockRetention:
                 Bucket=s3_bucket_locked,
                 Key=object_key,
                 VersionId=version_id,
-                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2025, 1, 1)},
+                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2029, 1, 1)},
             )
         snapshot.match("update-retention-no-bypass", e.value.response)
+
+        # update a retention with date in the past
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_retention(
+                Bucket=s3_bucket_locked,
+                Key=object_key,
+                VersionId=version_id,
+                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2020, 1, 1)},
+            )
+        snapshot.match("update-retention-past-date", e.value.response)
 
         s3_bucket_basic = s3_create_bucket(ObjectLockEnabledForBucket=False)  # same as default
         aws_client.s3.put_object(Bucket=s3_bucket_basic, Key=object_key, Body="test")

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -9608,7 +9608,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_exc": {
-    "recorded-date": "21-01-2025, 18:17:43",
+    "recorded-date": "22-01-2025, 17:19:21",
     "recorded-content": {
       "put-object-retention-no-bucket": {
         "Error": {
@@ -9654,8 +9654,18 @@
       },
       "update-retention-no-bypass": {
         "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied because object protected by object lock."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "update-retention-past-date": {
+        "Error": {
           "ArgumentName": "RetainUntilDate",
-          "ArgumentValue": "Tue Dec 31 16:00:00 PST 2024",
+          "ArgumentValue": "Tue Dec 31 16:00:00 PST 2019",
           "Code": "InvalidArgument",
           "Message": "The retain until date must be in the future!"
         },

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -591,7 +591,7 @@
     "last_validated_date": "2025-01-21T18:17:58+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_exc": {
-    "last_validated_date": "2025-01-21T18:17:43+00:00"
+    "last_validated_date": "2025-01-22T17:19:21+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
     "last_validated_date": "2024-09-23T11:02:16+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from regenerating snapshots in #12145, one date that was set in the future actually was now in the past 😅 and triggered a new kind of exception. It had been skipped. This PR now implements this exception.

Also removed a few now useless snapshot markers that have been fixed in the meantime but not removed. 

Note: weird thing but S3 returns the error in the PST timezone, interesting 🤔 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix the exception raised in the date was invalid
- remove a few now useless snapshot markers

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
