### PR TITLE
S3: fix trailing slash logic

### DIFF
--- a/localstack-core/localstack/aws/protocol/parser.py
+++ b/localstack-core/localstack/aws/protocol/parser.py
@@ -1091,7 +1091,7 @@ class S3RequestParser(RestXMLRequestParser):
             and shape.serialization.get("location") == "uri"
             and shape.serialization.get("name") == "Key"
             and (
-                (trailing_slashes := request.path.partition(uri_params["Key"])[2])
+                (trailing_slashes := request.path.rpartition(uri_params["Key"])[2])
                 and all(char == "/" for char in trailing_slashes)
             )
         ):

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -532,6 +532,23 @@ class TestS3:
         snapshot.match("del-object-special-char", resp)
 
     @markers.aws.validated
+    def test_put_get_object_single_character_trailing_slash(self, s3_bucket, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("Name"))
+        single_chars = [
+            "a/",
+            "t/",
+            "u/",
+        ]
+        for char in single_chars:
+            resp = aws_client.s3.put_object(Bucket=s3_bucket, Key=char, Body=b"test")
+            snapshot.match(f"put-object-single-char-{char}", resp)
+            resp = aws_client.s3.get_object(Bucket=s3_bucket, Key=char)
+            snapshot.match(f"get-object-single-char-{char}", resp)
+
+        resp = aws_client.s3.list_objects_v2(Bucket=s3_bucket)
+        snapshot.match("list-objects-single-char", resp)
+
+    @markers.aws.validated
     def test_copy_object_special_character(self, s3_bucket, s3_create_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         dest_bucket = s3_create_bucket()

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -14344,5 +14344,135 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_get_object_single_character_trailing_slash": {
+    "recorded-date": "22-01-2025, 19:05:31",
+    "recorded-content": {
+      "put-object-single-char-a/": {
+        "ChecksumCRC32": "2H9+DA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-single-char-a/": {
+        "AcceptRanges": "bytes",
+        "Body": "test",
+        "ChecksumCRC32": "2H9+DA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-single-char-t/": {
+        "ChecksumCRC32": "2H9+DA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-single-char-t/": {
+        "AcceptRanges": "bytes",
+        "Body": "test",
+        "ChecksumCRC32": "2H9+DA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-single-char-u/": {
+        "ChecksumCRC32": "2H9+DA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-single-char-u/": {
+        "AcceptRanges": "bytes",
+        "Body": "test",
+        "ChecksumCRC32": "2H9+DA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-objects-single-char": {
+        "Contents": [
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "a/",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "t/",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "u/",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 3,
+        "MaxKeys": 1000,
+        "Name": "<name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -203,6 +203,9 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_bucket_policy_invalid_account_id[abcd]": {
     "last_validated_date": "2025-01-21T18:28:03+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_get_object_single_character_trailing_slash": {
+    "last_validated_date": "2025-01-22T19:05:31+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_get_object_special_character[a/%F0%9F%98%80/]": {
     "last_validated_date": "2025-01-21T18:26:56+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've got a reported in our Community Slack channel about issue with trailing slashes, especially with short key name (single characters). The trailing slashes would be missing:
```bash
awslocal s3api put-object --bucket sample-bucket2 --key "u/" --content-type "application/x-directory"
awslocal s3api list-objects-v2 --bucket sample-bucket2
...
       {
           "Key": "u",
           "LastModified": "2025-01-22T11:46:17.000Z",
           "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
           "Size": 0,
           "StorageClass": "STANDARD"
       },
...
```

I wrote a test for it and I had a hunch it came from our custom logic to parse URI parameters. We had custom logic for S3 because our router strips trailing slashes by default. We would check if the key name is in the path, and then split on the key and check if the leftover characters in the path are all slashes, to keep them. 

However, to do so, we would partition the path on the parse `Key` parameter. Printing the result showed quite quickly what was the issue: 
```python
uri_params={'Bucket': 'test-bucket-ec3db341', 'Key': 'u'}
request.path.partition(uri_params["Key"])=('/test-b', 'u', 'cket-ec3db341/u/')
```

We would split/partition on the bucket name first while using path style. To avoid this, we need to start from the right side. That way, we properly get all the right side slashes.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add new tests for single characters with trailing slash
- partition the trailing slashes the path by the `Key`, but starting from the right

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
