### PR TITLE
S3: fix ContentEncoding with aws-chunked

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -761,6 +761,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             decoded_content_length = int(headers.get("x-amz-decoded-content-length", 0))
             body = AwsChunkedDecoder(body, decoded_content_length, s3_object=s3_object)
 
+            # S3 removes the `aws-chunked` value from ContentEncoding
             if content_encoding := s3_object.system_metadata.pop("ContentEncoding", None):
                 encodings = [enc for enc in content_encoding.split(",") if enc != "aws-chunked"]
                 if encodings:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following this discussion here: https://github.com/localstack/localstack/issues/9782#issuecomment-2595044611

We mishandled how the `aws-chunked` `Content-Enconding` header was saved on the object. If given, S3 should remove the header, [this was confirmed](https://github.com/aws/aws-sdk-java-v2/issues/5769#issuecomment-2594242699) by people at Amazon working on the SDK themselves.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- remove the `aws-chunked` value in the object `ContentEncoding`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
