### PR TITLE
Add docker stats functionality to docker clients

### DIFF
--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -58,7 +58,7 @@ class DockerContainerStats(TypedDict):
     MemUsage: tuple[int, int]
     NetIO: tuple[int, int]
     PIDs: int
-    SDKStats: dict | None
+    SDKStats: Optional[dict]
 
 
 class ContainerException(Exception):

--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -11,7 +11,18 @@ import tempfile
 from abc import ABCMeta, abstractmethod
 from enum import Enum, unique
 from pathlib import Path
-from typing import Dict, List, Literal, NamedTuple, Optional, Protocol, Tuple, Union, get_args
+from typing import (
+    Dict,
+    List,
+    Literal,
+    NamedTuple,
+    Optional,
+    Protocol,
+    Tuple,
+    TypedDict,
+    Union,
+    get_args,
+)
 
 import dotenv
 
@@ -33,6 +44,21 @@ class DockerContainerStatus(Enum):
     NON_EXISTENT = 0
     UP = 1
     PAUSED = 2
+
+
+class DockerContainerStats(TypedDict):
+    """Container usage statistics"""
+
+    Container: str
+    ID: str
+    Name: str
+    BlockIO: tuple[int, int]
+    CPUPerc: float
+    MemPerc: float
+    MemUsage: tuple[int, int]
+    NetIO: tuple[int, int]
+    PIDs: int
+    SDKStats: dict | None
 
 
 class ContainerException(Exception):
@@ -525,7 +551,7 @@ class ContainerClient(metaclass=ABCMeta):
         """Returns the status of the container with the given name"""
         pass
 
-    def get_container_stats(self, container_name: str) -> dict:
+    def get_container_stats(self, container_name: str) -> DockerContainerStats:
         """Returns the usage statistics of the container with the given name"""
         pass
 

--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -525,6 +525,10 @@ class ContainerClient(metaclass=ABCMeta):
         """Returns the status of the container with the given name"""
         pass
 
+    def get_container_stats(self, container_name: str) -> dict:
+        """Returns the usage statistics of the container with the given name"""
+        pass
+
     def get_networks(self, container_name: str) -> List[str]:
         LOG.debug("Getting networks for container: %s", container_name)
         container_attrs = self.inspect_container(container_name_or_id=container_name)

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -112,6 +112,13 @@ class CmdDockerClient(ContainerClient):
         else:
             return DockerContainerStatus.DOWN
 
+    def get_container_stats(self, container_name: str) -> dict:
+        cmd = self._docker_cmd()
+        cmd += ["stats", "--no-stream", "--format", "{{json .}}", container_name]
+        cmd_result = run(cmd)
+
+        return json.loads(cmd_result)
+
     def stop_container(self, container_name: str, timeout: int = 10) -> None:
         cmd = self._docker_cmd()
         cmd += ["stop", "--time", str(timeout), container_name]

--- a/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
@@ -154,6 +154,15 @@ class SdkDockerClient(ContainerClient):
         except APIError as e:
             raise ContainerException() from e
 
+    def get_container_stats(self, container_name: str) -> dict:
+        try:
+            container = self.client().containers.get(container_name)
+            return container.stats(stream=False)
+        except NotFound:
+            raise NoSuchContainer(container_name)
+        except APIError as e:
+            raise ContainerException() from e
+
     def stop_container(self, container_name: str, timeout: int = 10) -> None:
         LOG.debug("Stopping container: %s", container_name)
         try:

--- a/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
@@ -26,6 +26,7 @@ from localstack.utils.container_utils.container_client import (
     CancellableStream,
     ContainerClient,
     ContainerException,
+    DockerContainerStats,
     DockerContainerStatus,
     DockerNotAvailable,
     DockerPlatform,
@@ -154,10 +155,70 @@ class SdkDockerClient(ContainerClient):
         except APIError as e:
             raise ContainerException() from e
 
-    def get_container_stats(self, container_name: str) -> dict:
+    def get_container_stats(self, container_name: str) -> DockerContainerStats:
         try:
             container = self.client().containers.get(container_name)
-            return container.stats(stream=False)
+            sdk_stats = container.stats(stream=False)
+
+            # BlockIO: (Read, Write) bytes
+            read_bytes = 0
+            write_bytes = 0
+            for entry in (
+                sdk_stats.get("blkio_stats", {}).get("io_service_bytes_recursive", []) or []
+            ):
+                if entry.get("op") == "read":
+                    read_bytes += entry.get("value", 0)
+                elif entry.get("op") == "write":
+                    write_bytes += entry.get("value", 0)
+
+            # CPU percentage
+            cpu_stats = sdk_stats.get("cpu_stats", {})
+            precpu_stats = sdk_stats.get("precpu_stats", {})
+
+            cpu_delta = cpu_stats.get("cpu_usage", {}).get("total_usage", 0) - precpu_stats.get(
+                "cpu_usage", {}
+            ).get("total_usage", 0)
+
+            system_delta = cpu_stats.get("system_cpu_usage", 0) - precpu_stats.get(
+                "system_cpu_usage", 0
+            )
+
+            online_cpus = cpu_stats.get("online_cpus", 1)
+            cpu_percent = (
+                (cpu_delta / system_delta * 100.0 * online_cpus) if system_delta > 0 else 0.0
+            )
+
+            # Memory (usage, limit) bytes
+            memory_stats = sdk_stats.get("memory_stats", {})
+            mem_usage = memory_stats.get("usage", 0)
+            mem_limit = memory_stats.get("limit", 1)  # Prevent division by zero
+            mem_inactive = memory_stats.get("stats", {}).get("inactive_file", 0)
+            used_memory = max(0, mem_usage - mem_inactive)
+            mem_percent = (used_memory / mem_limit * 100.0) if mem_limit else 0.0
+
+            # Network IO
+            net_rx = 0
+            net_tx = 0
+            for iface in sdk_stats.get("networks", {}).values():
+                net_rx += iface.get("rx_bytes", 0)
+                net_tx += iface.get("tx_bytes", 0)
+
+            # Container ID
+            container_id = sdk_stats.get("id", "")[:12]
+            name = sdk_stats.get("name", "").lstrip("/")
+
+            return DockerContainerStats(
+                Container=container_id,
+                ID=container_id,
+                Name=name,
+                BlockIO=(read_bytes, write_bytes),
+                CPUPerc=round(cpu_percent, 2),
+                MemPerc=round(mem_percent, 2),
+                MemUsage=(used_memory, mem_limit),
+                NetIO=(net_rx, net_tx),
+                PIDs=sdk_stats.get("pids_stats", {}).get("current", 0),
+                SDKStats=sdk_stats,  # keep the raw stats for more detailed information
+            )
         except NotFound:
             raise NoSuchContainer(container_name)
         except APIError as e:

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -20,6 +20,7 @@ from localstack.utils.container_utils.container_client import (
     AccessDenied,
     ContainerClient,
     ContainerException,
+    DockerContainerStats,
     DockerContainerStatus,
     DockerNotAvailable,
     LogConfig,
@@ -2000,6 +2001,14 @@ class TestDockerLabels:
         assert len(containers) == 1
         container = containers[0]
         assert container["labels"] == labels
+
+    def test_get_container_stats(self, docker_client, create_container):
+        container = create_container("alpine", command=["sh", "-c", "while true; do sleep 1; done"])
+        docker_client.start_container(container.container_id)
+        stats: DockerContainerStats = docker_client.get_container_stats(container.container_id)
+        assert stats["Name"] == container.container_name
+        assert container.container_id.startswith(stats["ID"])
+        assert 0.0 <= stats["MemPerc"] <= 100.0
 
 
 def _pull_image_if_not_exists(docker_client: ContainerClient, image_name: str):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When launching sidecar containers we sometimes need ways of monitoring their resource usage (e.g., to detect memory exhaustions in an ollama container).

This is available through the docker stats command. Our container client implementation does not surface that command yet. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

The container client (and its docker sdk and cli client implementations) now has a new `container_stats` method.

This method unifies the output of both cli and sdk output to resemble the CLI output.

## Testing

There's a new test which sanity checks the parsing of the outputs into the TypedDict.

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
