### PR TITLE
[SQS] Add custom header for overriding WaitTimeSeconds

### DIFF
--- a/localstack-core/localstack/services/sqs/constants.py
+++ b/localstack-core/localstack/services/sqs/constants.py
@@ -47,3 +47,4 @@ LEGACY_STRATEGY_URL_REGEX = (
 
 # HTTP headers used to override internal SQS ReceiveMessage
 HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT = "x-localstack-sqs-override-message-count"
+HEADER_LOCALSTACK_SQS_OVERRIDE_WAIT_TIME_SECONDS = "x-localstack-sqs-override-wait-time-seconds"

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -523,6 +523,8 @@ class SqsQueue:
         num_messages: int = 1,
         wait_time_seconds: int = None,
         visibility_timeout: int = None,
+        *,
+        poll_empty_queue: bool = False,
     ) -> ReceiveMessageResult:
         """
         Receive ``num_messages`` from the queue, and wait at max ``wait_time_seconds``. If a visibility
@@ -531,6 +533,7 @@ class SqsQueue:
         :param num_messages: the number of messages you want to get from the underlying queue
         :param wait_time_seconds: the number of seconds you want to wait
         :param visibility_timeout: an optional new visibility timeout
+        :param poll_empty_queue: whether to keep polling an empty queue until the duration ``wait_time_seconds`` has elapsed
         :return: a ReceiveMessageResult object that contains the result of the operation
         """
         raise NotImplementedError
@@ -798,6 +801,8 @@ class StandardQueue(SqsQueue):
         num_messages: int = 1,
         wait_time_seconds: int = None,
         visibility_timeout: int = None,
+        *,
+        poll_empty_queue: bool = False,
     ) -> ReceiveMessageResult:
         result = ReceiveMessageResult()
 
@@ -819,7 +824,8 @@ class StandardQueue(SqsQueue):
             # setting block to false guarantees that, if we've already waited before, we don't wait the
             # full time again in the next iteration if max_number_of_messages is set but there are no more
             # messages in the queue. see https://github.com/localstack/localstack/issues/5824
-            block = False
+            if not poll_empty_queue:
+                block = False
 
             timeout -= time.time() - start
             if timeout < 0:
@@ -1110,6 +1116,8 @@ class FifoQueue(SqsQueue):
         num_messages: int = 1,
         wait_time_seconds: int = None,
         visibility_timeout: int = None,
+        *,
+        poll_empty_queue: bool = False,
     ) -> ReceiveMessageResult:
         """
         Receive logic for FIFO queues is different from standard queues. See
@@ -1157,7 +1165,8 @@ class FifoQueue(SqsQueue):
 
             received_groups.add(group)
 
-            block = False
+            if not poll_empty_queue:
+                block = False
 
             # we lock the queue while accessing the groups to not get into races with re-queueing/deleting
             with self.mutex:

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -1241,7 +1241,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             poll_empty_queue = True
         elif wait_time_seconds is None:
             wait_time_seconds = queue.wait_time_seconds
-        elif wait_time_seconds < 1 or wait_time_seconds > 20:
+        elif wait_time_seconds < 0 or wait_time_seconds > 20:
             raise InvalidParameterValueException(
                 f"Value {wait_time_seconds} for parameter WaitTimeSeconds is invalid. "
                 f"Reason: Must be >= 0 and <= 20, if provided."

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -265,6 +265,21 @@ class TestSqsProvider:
         snapshot.match("empty_long_poll_resp", empty_long_poll_resp)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
+    def test_send_receive_wait_time_seconds(self, sqs_queue, snapshot, aws_sqs_client):
+        queue_url = sqs_queue
+        send_result = aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="message")
+        assert send_result["MessageId"]
+
+        MAX_WAIT_TIME_SECONDS = 20
+        with pytest.raises(ClientError) as e:
+            aws_sqs_client.receive_message(
+                QueueUrl=queue_url, WaitTimeSeconds=MAX_WAIT_TIME_SECONDS + 1
+            )
+
+        snapshot.match("recieve_message_error", e.value.response)
+
+    @markers.aws.validated
     def test_receive_message_attributes_timestamp_types(self, sqs_queue, aws_sqs_client):
         aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="message")
 

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -256,7 +256,6 @@ class TestSqsProvider:
         empty_short_poll_resp = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=1
         )
-
         snapshot.match("empty_short_poll_resp", empty_short_poll_resp)
 
         empty_long_poll_resp = aws_sqs_client.receive_message(
@@ -268,16 +267,32 @@ class TestSqsProvider:
     @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
     def test_send_receive_wait_time_seconds(self, sqs_queue, snapshot, aws_sqs_client):
         queue_url = sqs_queue
-        send_result = aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="message")
-        assert send_result["MessageId"]
+        send_result_1 = aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="message")
+        assert send_result_1["MessageId"]
+
+        send_result_2 = aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="message")
+        assert send_result_2["MessageId"]
 
         MAX_WAIT_TIME_SECONDS = 20
         with pytest.raises(ClientError) as e:
             aws_sqs_client.receive_message(
                 QueueUrl=queue_url, WaitTimeSeconds=MAX_WAIT_TIME_SECONDS + 1
             )
+        snapshot.match("recieve_message_error_too_large", e.value.response)
 
-        snapshot.match("recieve_message_error", e.value.response)
+        with pytest.raises(ClientError) as e:
+            aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=-1)
+        snapshot.match("recieve_message_error_too_small", e.value.response)
+
+        empty_short_poll_by_default_resp = aws_sqs_client.receive_message(
+            QueueUrl=queue_url, MaxNumberOfMessages=1
+        )
+        snapshot.match("empty_short_poll_by_default_resp", empty_short_poll_by_default_resp)
+
+        empty_short_poll_explicit_resp = aws_sqs_client.receive_message(
+            QueueUrl=queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=0
+        )
+        snapshot.match("empty_short_poll_explicit_resp", empty_short_poll_explicit_resp)
 
     @markers.aws.validated
     def test_receive_message_attributes_timestamp_types(self, sqs_queue, aws_sqs_client):

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3648,9 +3648,9 @@
     "recorded-content": {}
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_wait_time_seconds[sqs]": {
-    "recorded-date": "23-01-2025, 12:43:53",
+    "recorded-date": "10-02-2025, 13:22:29",
     "recorded-content": {
-      "recieve_message_error": {
+      "recieve_message_error_too_large": {
         "Error": {
           "Code": "InvalidParameterValue",
           "Message": "Value 21 for parameter WaitTimeSeconds is invalid. Reason: Must be >= 0 and <= 20, if provided.",
@@ -3660,15 +3660,54 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
-
+        }
+      },
+      "recieve_message_error_too_small": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value -1 for parameter WaitTimeSeconds is invalid. Reason: Must be >= 0 and <= 20, if provided.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "empty_short_poll_by_default_resp": {
+        "Messages": [
+          {
+            "Body": "message",
+            "MD5OfBody": "78e731027d8fd50ed642340b7c9a63b3",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "empty_short_poll_explicit_resp": {
+        "Messages": [
+          {
+            "Body": "message",
+            "MD5OfBody": "78e731027d8fd50ed642340b7c9a63b3",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_wait_time_seconds[sqs_query]": {
-    "recorded-date": "23-01-2025, 12:43:54",
+    "recorded-date": "10-02-2025, 13:22:32",
     "recorded-content": {
-      "recieve_message_error": {
+      "recieve_message_error_too_large": {
         "Error": {
           "Code": "InvalidParameterValue",
           "Detail": null,
@@ -3679,12 +3718,58 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
         }
+      },
+      "recieve_message_error_too_small": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value -1 for parameter WaitTimeSeconds is invalid. Reason: Must be >= 0 and <= 20, if provided.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "empty_short_poll_by_default_resp": {
+        "Messages": [
+          {
+            "Body": "message",
+            "MD5OfBody": "78e731027d8fd50ed642340b7c9a63b3",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "empty_short_poll_explicit_resp": {
+        "Messages": [
+          {
+            "Body": "message",
+            "MD5OfBody": "78e731027d8fd50ed642340b7c9a63b3",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_empty_queue[sqs]": {
-    "recorded-date": "30-01-2025, 22:32:45",
+    "recorded-date": "10-02-2025, 13:18:17",
     "recorded-content": {
+      "empty_short_poll_resp_no_param": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "empty_short_poll_resp": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3700,8 +3785,14 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_empty_queue[sqs_query]": {
-    "recorded-date": "30-01-2025, 22:32:48",
+    "recorded-date": "10-02-2025, 13:18:20",
     "recorded-content": {
+      "empty_short_poll_resp_no_param": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "empty_short_poll_resp": {
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3647,6 +3647,41 @@
     "recorded-date": "20-08-2024, 14:14:11",
     "recorded-content": {}
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_wait_time_seconds[sqs]": {
+    "recorded-date": "23-01-2025, 12:43:53",
+    "recorded-content": {
+      "recieve_message_error": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value 21 for parameter WaitTimeSeconds is invalid. Reason: Must be >= 0 and <= 20, if provided.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_wait_time_seconds[sqs_query]": {
+    "recorded-date": "23-01-2025, 12:43:54",
+    "recorded-content": {
+      "recieve_message_error": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value 21 for parameter WaitTimeSeconds is invalid. Reason: Must be >= 0 and <= 20, if provided.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_empty_queue[sqs]": {
     "recorded-date": "30-01-2025, 22:32:45",
     "recorded-content": {

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -204,10 +204,10 @@
     "last_validated_date": "2024-04-30T13:34:22+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_empty_queue[sqs]": {
-    "last_validated_date": "2025-01-30T22:32:45+00:00"
+    "last_validated_date": "2025-02-10T13:18:17+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_empty_queue[sqs_query]": {
-    "last_validated_date": "2025-01-30T22:32:48+00:00"
+    "last_validated_date": "2025-02-10T13:18:20+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_attribute_names_filters[sqs]": {
     "last_validated_date": "2024-06-04T11:54:31+00:00"
@@ -330,10 +330,10 @@
     "last_validated_date": "2024-04-30T13:40:05+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_wait_time_seconds[sqs]": {
-    "last_validated_date": "2025-01-23T12:43:53+00:00"
+    "last_validated_date": "2025-02-10T13:22:29+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_wait_time_seconds[sqs_query]": {
-    "last_validated_date": "2025-01-23T12:43:54+00:00"
+    "last_validated_date": "2025-02-10T13:22:32+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_set_empty_redrive_policy[sqs]": {
     "last_validated_date": "2024-08-20T14:14:08+00:00"

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -329,6 +329,12 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_message_multiple_queues": {
     "last_validated_date": "2024-04-30T13:40:05+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_wait_time_seconds[sqs]": {
+    "last_validated_date": "2025-01-23T12:43:53+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_wait_time_seconds[sqs_query]": {
+    "last_validated_date": "2025-01-23T12:43:54+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_set_empty_redrive_policy[sqs]": {
     "last_validated_date": "2024-08-20T14:14:08+00:00"
   },
@@ -400,6 +406,12 @@
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_too_many_entries_in_batch_request[sqs_query]": {
     "last_validated_date": "2024-04-30T13:33:40+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_wait_time_seconds_waits_correctly[sqs]": {
+    "last_validated_date": "2025-01-23T13:57:19+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_wait_time_seconds_waits_correctly[sqs_query]": {
+    "last_validated_date": "2025-01-23T13:57:30+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsQueryApi::test_send_message_via_queue_url_with_json_protocol": {
     "last_validated_date": "2024-04-30T13:35:11+00:00"

--- a/tests/aws/services/sqs/test_sqs_backdoor.py
+++ b/tests/aws/services/sqs/test_sqs_backdoor.py
@@ -471,7 +471,7 @@ class TestSqsOverrideHeaders:
 
         Timer(25, _send_message).start()  # send message asynchronously after 25 seconds
 
-        start_t = time.time()
+        start_t = time.perf_counter()
         response = sqs_client.receive_message(
             QueueUrl=queue_url,
             VisibilityTimeout=30,
@@ -479,7 +479,7 @@ class TestSqsOverrideHeaders:
             WaitTimeSeconds=override_message_wait_time_seconds,
             AttributeNames=["All"],
         )
-        assert time.time() - start_t >= 25
+        assert time.perf_counter() - start_t >= 25
 
         messages = response.get("Messages", [])
         assert len(messages) == 10

--- a/tests/aws/services/sqs/test_sqs_backdoor.py
+++ b/tests/aws/services/sqs/test_sqs_backdoor.py
@@ -1,3 +1,6 @@
+import time
+from threading import Timer
+
 import pytest
 import requests
 import xmltodict
@@ -361,3 +364,128 @@ class TestSqsDeveloperEndpoints:
         assert response.status_code == 400
         doc = response.json()
         assert doc["ErrorResponse"]["Error"]["Code"] == "AWS.SimpleQueueService.NonExistentQueue"
+
+
+class TestSqsOverrideHeaders:
+    @markers.aws.only_localstack
+    def test_receive_message_override_max_number_of_messages(
+        self, sqs_create_queue, aws_client_factory
+    ):
+        # Create standalone boto3 client since registering hooks to the session-wide
+        # aws_client (from the fixture) will have side-effects.
+        aws_client = aws_client_factory().sqs
+
+        override_max_number_of_messages = 20
+
+        from localstack.services.sqs.constants import HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT
+        from localstack.services.sqs.provider import MAX_NUMBER_OF_MESSAGES
+
+        queue_url = sqs_create_queue()
+
+        for i in range(override_max_number_of_messages):
+            aws_client.send_message(QueueUrl=queue_url, MessageBody=f"message-{i}")
+
+        with pytest.raises(ClientError):
+            aws_client.receive_message(
+                QueueUrl=queue_url,
+                VisibilityTimeout=0,
+                MaxNumberOfMessages=override_max_number_of_messages,
+                AttributeNames=["All"],
+            )
+
+        def _handle_receive_message_override(params, context, **kwargs):
+            if not (requested_count := params.get("MaxNumberOfMessages")):
+                return
+            context[HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT] = str(requested_count)
+            params["MaxNumberOfMessages"] = min(MAX_NUMBER_OF_MESSAGES, requested_count)
+
+        def _handler_inject_header(params, context, **kwargs):
+            if override_message_count := context.pop(
+                HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT, None
+            ):
+                params["headers"][HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT] = (
+                    override_message_count
+                )
+
+        aws_client.meta.events.register(
+            "provide-client-params.sqs.ReceiveMessage", _handle_receive_message_override
+        )
+
+        aws_client.meta.events.register("before-call.sqs.ReceiveMessage", _handler_inject_header)
+
+        response = aws_client.receive_message(
+            QueueUrl=queue_url,
+            VisibilityTimeout=30,
+            MaxNumberOfMessages=override_max_number_of_messages,
+            AttributeNames=["All"],
+        )
+
+        messages = response.get("Messages", [])
+        assert len(messages) == 20
+
+    @markers.aws.only_localstack
+    def test_receive_message_override_message_wait_time_seconds(
+        self, sqs_create_queue, aws_client_factory
+    ):
+        aws_client = aws_client_factory().sqs
+
+        override_message_wait_time_seconds = 30
+
+        from localstack.services.sqs.constants import (
+            HEADER_LOCALSTACK_SQS_OVERRIDE_WAIT_TIME_SECONDS,
+        )
+        from localstack.services.sqs.provider import MAX_NUMBER_OF_MESSAGES
+
+        queue_url = sqs_create_queue()
+
+        with pytest.raises(ClientError):
+            aws_client.receive_message(
+                QueueUrl=queue_url,
+                VisibilityTimeout=0,
+                MaxNumberOfMessages=MAX_NUMBER_OF_MESSAGES,
+                WaitTimeSeconds=override_message_wait_time_seconds,
+                AttributeNames=["All"],
+            )
+
+        def _handle_receive_message_override(params, context, **kwargs):
+            if not (requested_wait_time := params.get("WaitTimeSeconds")):
+                return
+            context[HEADER_LOCALSTACK_SQS_OVERRIDE_WAIT_TIME_SECONDS] = str(requested_wait_time)
+            params["WaitTimeSeconds"] = min(20, requested_wait_time)
+
+        def _handler_inject_header(params, context, **kwargs):
+            if override_wait_time := context.pop(
+                HEADER_LOCALSTACK_SQS_OVERRIDE_WAIT_TIME_SECONDS, None
+            ):
+                params["headers"][HEADER_LOCALSTACK_SQS_OVERRIDE_WAIT_TIME_SECONDS] = (
+                    override_wait_time
+                )
+
+        aws_client.meta.events.register(
+            "provide-client-params.sqs.ReceiveMessage", _handle_receive_message_override
+        )
+
+        aws_client.meta.events.register("before-call.sqs.ReceiveMessage", _handler_inject_header)
+
+        def _send_message():
+            aws_client.send_message(QueueUrl=queue_url, MessageBody=f"message-{short_uid()}")
+
+        # Populate with 9 messages (1 below the MaxNumberOfMessages threshold).
+        # This should cause long-polling to exit since MaxNumberOfMessages is met.
+        for _ in range(9):
+            _send_message()
+
+        Timer(25, _send_message).start()  # send message asynchronously after 1 second
+
+        start_t = time.time()
+        response = aws_client.receive_message(
+            QueueUrl=queue_url,
+            VisibilityTimeout=30,
+            MaxNumberOfMessages=MAX_NUMBER_OF_MESSAGES,
+            WaitTimeSeconds=override_message_wait_time_seconds,
+            AttributeNames=["All"],
+        )
+        assert time.time() - start_t >= 25
+
+        messages = response.get("Messages", [])
+        assert len(messages) == 10


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR allows the `WaitTimeSeconds` parameter to be overridden via a custom header. Useful for increasing the amount of time an [SQS long polling request ](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling) can collect for prior to returning.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- New constant `HEADER_LOCALSTACK_SQS_OVERRIDE_WAIT_TIME_SECONDS` with `x-localstack-sqs-override-wait-time-seconds`.
- Add support for replacing value of `WaitTimeSeconds` parameter with value of `x-localstack-sqs-override-wait-time-seconds` header.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
