### PR TITLE
SNS : fix Message Signature typo and add Lambda URL fixture

### DIFF
--- a/localstack-core/localstack/services/sns/models.py
+++ b/localstack-core/localstack/services/sns/models.py
@@ -1,6 +1,7 @@
 import itertools
 import time
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Dict, List, Literal, Optional, TypedDict, Union
 
 from localstack.aws.api.sns import (
@@ -37,9 +38,15 @@ def get_next_sequence_number():
     return next(global_sns_message_sequence())
 
 
+class SnsMessageType(StrEnum):
+    notification = "Notification"
+    subscription_confirmation = "SubscriptionConfirmation"
+    unsubscribe_confirmation = "UnsubscribeConfirmation"
+
+
 @dataclass
 class SnsMessage:
-    type: str
+    type: SnsMessageType
     message: Union[
         str, Dict
     ]  # can be Dict if after being JSON decoded for validation if structure is `json`
@@ -75,7 +82,7 @@ class SnsMessage:
     @classmethod
     def from_batch_entry(cls, entry: PublishBatchRequestEntry, is_fifo=False) -> "SnsMessage":
         return cls(
-            type="Notification",
+            type=SnsMessageType.notification,
             message=entry["Message"],
             subject=entry.get("Subject"),
             message_structure=entry.get("MessageStructure"),

--- a/localstack-core/localstack/services/sns/models.py
+++ b/localstack-core/localstack/services/sns/models.py
@@ -39,9 +39,9 @@ def get_next_sequence_number():
 
 
 class SnsMessageType(StrEnum):
-    notification = "Notification"
-    subscription_confirmation = "SubscriptionConfirmation"
-    unsubscribe_confirmation = "UnsubscribeConfirmation"
+    Notification = "Notification"
+    SubscriptionConfirmation = "SubscriptionConfirmation"
+    UnsubscribeConfirmation = "UnsubscribeConfirmation"
 
 
 @dataclass
@@ -82,7 +82,7 @@ class SnsMessage:
     @classmethod
     def from_batch_entry(cls, entry: PublishBatchRequestEntry, is_fifo=False) -> "SnsMessage":
         return cls(
-            type=SnsMessageType.notification,
+            type=SnsMessageType.Notification,
             message=entry["Message"],
             subject=entry.get("Subject"),
             message_structure=entry.get("MessageStructure"),

--- a/localstack-core/localstack/services/sns/provider.py
+++ b/localstack-core/localstack/services/sns/provider.py
@@ -439,7 +439,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             #  the owner
             subscription_token = encode_subscription_token_with_region(region=context.region)
             message_ctx = SnsMessage(
-                type=SnsMessageType.unsubscribe_confirmation,
+                type=SnsMessageType.UnsubscribeConfirmation,
                 token=subscription_token,
                 message=f"You have chosen to deactivate subscription {subscription_arn}.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message.",
             )
@@ -612,7 +612,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             store = self.get_store(account_id=context.account_id, region_name=context.region)
 
         message_ctx = SnsMessage(
-            type=SnsMessageType.notification,
+            type=SnsMessageType.Notification,
             message=message,
             message_attributes=message_attributes,
             message_deduplication_id=message_deduplication_id,
@@ -771,7 +771,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         # Send out confirmation message for HTTP(S), fix for https://github.com/localstack/localstack/issues/881
         if protocol in ["http", "https"]:
             message_ctx = SnsMessage(
-                type=SnsMessageType.subscription_confirmation,
+                type=SnsMessageType.SubscriptionConfirmation,
                 token=subscription_token,
                 message=f"You have chosen to subscribe to the topic {topic_arn}.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
             )

--- a/localstack-core/localstack/services/sns/provider.py
+++ b/localstack-core/localstack/services/sns/provider.py
@@ -64,7 +64,13 @@ from localstack.services.sns import constants as sns_constants
 from localstack.services.sns import usage
 from localstack.services.sns.certificate import SNS_SERVER_CERT
 from localstack.services.sns.filter import FilterPolicyValidator
-from localstack.services.sns.models import SnsMessage, SnsStore, SnsSubscription, sns_stores
+from localstack.services.sns.models import (
+    SnsMessage,
+    SnsMessageType,
+    SnsStore,
+    SnsSubscription,
+    sns_stores,
+)
 from localstack.services.sns.publisher import (
     PublishDispatcher,
     SnsBatchPublishContext,
@@ -431,7 +437,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             #  we might need to save the sub token in the store
             subscription_token = encode_subscription_token_with_region(region=context.region)
             message_ctx = SnsMessage(
-                type="UnsubscribeConfirmation",
+                type=SnsMessageType.unsubscribe_confirmation,
                 token=subscription_token,
                 message=f"You have chosen to deactivate subscription {subscription_arn}.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message.",
             )
@@ -604,7 +610,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             store = self.get_store(account_id=context.account_id, region_name=context.region)
 
         message_ctx = SnsMessage(
-            type="Notification",
+            type=SnsMessageType.notification,
             message=message,
             message_attributes=message_attributes,
             message_deduplication_id=message_deduplication_id,
@@ -763,7 +769,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         # Send out confirmation message for HTTP(S), fix for https://github.com/localstack/localstack/issues/881
         if protocol in ["http", "https"]:
             message_ctx = SnsMessage(
-                type="SubscriptionConfirmation",
+                type=SnsMessageType.subscription_confirmation,
                 token=subscription_token,
                 message=f"You have chosen to subscribe to the topic {topic_arn}.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
             )

--- a/localstack-core/localstack/services/sns/provider.py
+++ b/localstack-core/localstack/services/sns/provider.py
@@ -435,6 +435,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         if subscription["Protocol"] in ["http", "https"]:
             # TODO: actually validate this (re)subscribe behaviour somehow (localhost.run?)
             #  we might need to save the sub token in the store
+            # TODO: AWS only sends the UnsubscribeConfirmation if the call is unauthenticated or the requester is not
+            #  the owner
             subscription_token = encode_subscription_token_with_region(region=context.region)
             message_ctx = SnsMessage(
                 type=SnsMessageType.unsubscribe_confirmation,

--- a/tests/aws/services/sns/conftest.py
+++ b/tests/aws/services/sns/conftest.py
@@ -1,0 +1,57 @@
+import pytest
+
+from localstack.utils.strings import short_uid
+
+LAMBDA_FN_SNS_ENDPOINT = """
+import boto3, json, os
+def handler(event, *args):
+    if "AWS_ENDPOINT_URL" in os.environ:
+        sqs_client = boto3.client("sqs", endpoint_url=os.environ["AWS_ENDPOINT_URL"])
+    else:
+        sqs_client = boto3.client("sqs")
+
+    queue_url = os.environ.get("SQS_QUEUE_URL")
+    message = {"event": event}
+    sqs_client.send_message(QueueUrl=queue_url, MessageBody=json.dumps(message), MessageGroupId="1")
+    return {"statusCode": 200}
+"""
+
+
+@pytest.fixture
+def create_sns_http_endpoint_and_queue(
+    aws_client, account_id, create_lambda_function, sqs_create_queue
+):
+    lambda_client = aws_client.lambda_
+
+    def _create_sns_http_endpoint():
+        function_name = f"lambda_fn_sns_endpoint-{short_uid()}"
+
+        # create SQS queue for results
+        queue_name = f"{function_name}.fifo"
+        queue_attrs = {"FifoQueue": "true", "ContentBasedDeduplication": "true"}
+        queue_url = sqs_create_queue(QueueName=queue_name, Attributes=queue_attrs)
+        aws_client.sqs.add_permission(
+            QueueUrl=queue_url,
+            Label=f"lambda-sqs-{short_uid()}",
+            AWSAccountIds=[account_id],
+            Actions=["SendMessage"],
+        )
+
+        create_lambda_function(
+            func_name=function_name,
+            handler_file=LAMBDA_FN_SNS_ENDPOINT,
+            envvars={"SQS_QUEUE_URL": queue_url},
+        )
+        create_url_response = lambda_client.create_function_url_config(
+            FunctionName=function_name, AuthType="NONE", InvokeMode="BUFFERED"
+        )
+        aws_client.lambda_.add_permission(
+            FunctionName=function_name,
+            StatementId="urlPermission",
+            Action="lambda:InvokeFunctionUrl",
+            Principal="*",
+            FunctionUrlAuthType="NONE",
+        )
+        return create_url_response["FunctionUrl"], queue_url
+
+    return _create_sns_http_endpoint

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4987,5 +4987,96 @@
         }
       }
     }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionHttp::test_subscribe_external_http_endpoint_lambda_url_sig_validation": {
+    "recorded-date": "24-01-2025, 18:51:33",
+    "recorded-content": {
+      "subscription-confirmation": {
+        "events": [
+          {
+            "body": {
+              "Message": "You have chosen to subscribe to the topic arn:<partition>:sns:<region>:111111111111:<resource:1>.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
+              "MessageId": "<uuid:1>",
+              "Signature": "<signature>",
+              "SignatureVersion": "1",
+              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
+              "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:<partition>:sns:<region>:111111111111:<resource:1>&Token=<token:1>",
+              "Timestamp": "date",
+              "Token": "<token:1>",
+              "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>",
+              "Type": "SubscriptionConfirmation"
+            },
+            "headers": {
+              "accept-encoding": "gzip,deflate",
+              "content-type": "text/plain; charset=UTF-8",
+              "user-agent": "Amazon Simple Notification Service Agent",
+              "x-amz-sns-message-id": "<uuid:1>",
+              "x-amz-sns-message-type": "SubscriptionConfirmation",
+              "x-amz-sns-topic-arn": "arn:<partition>:sns:<region>:111111111111:<resource:1>"
+            }
+          }
+        ]
+      },
+      "confirm-subscription": {
+        "SubscriptionArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>:<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "publish-event": {
+        "events": [
+          {
+            "body": {
+              "Message": "test_external_http_endpoint",
+              "MessageId": "<uuid:2>",
+              "Signature": "<signature>",
+              "SignatureVersion": "1",
+              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
+              "Timestamp": "date",
+              "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>",
+              "Type": "Notification",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:<partition>:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "headers": {
+              "accept-encoding": "gzip,deflate",
+              "content-type": "text/plain; charset=UTF-8",
+              "user-agent": "Amazon Simple Notification Service Agent",
+              "x-amz-sns-message-id": "<uuid:2>",
+              "x-amz-sns-message-type": "Notification",
+              "x-amz-sns-subscription-arn": "arn:<partition>:sns:<region>:111111111111:<resource:1>:<resource:2>",
+              "x-amz-sns-topic-arn": "arn:<partition>:sns:<region>:111111111111:<resource:1>"
+            }
+          }
+        ]
+      },
+      "unsubscribe-event": {
+        "events": [
+          {
+            "body": {
+              "Message": "You have chosen to deactivate subscription arn:<partition>:sns:<region>:111111111111:<resource:1>:<resource:2>.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message.",
+              "MessageId": "<uuid:3>",
+              "Signature": "<signature>",
+              "SignatureVersion": "1",
+              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
+              "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:<partition>:sns:<region>:111111111111:<resource:1>&Token=<token:2>",
+              "Timestamp": "date",
+              "Token": "<token:2>",
+              "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>",
+              "Type": "UnsubscribeConfirmation"
+            },
+            "headers": {
+              "accept-encoding": "gzip,deflate",
+              "content-type": "text/plain; charset=UTF-8",
+              "user-agent": "Amazon Simple Notification Service Agent",
+              "x-amz-sns-message-id": "<uuid:3>",
+              "x-amz-sns-message-type": "UnsubscribeConfirmation",
+              "x-amz-sns-subscription-arn": "arn:<partition>:sns:<region>:111111111111:<resource:1>:<resource:2>",
+              "x-amz-sns-topic-arn": "arn:<partition>:sns:<region>:111111111111:<resource:1>"
+            }
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -104,6 +104,9 @@
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionHttp::test_subscribe_external_http_endpoint_content_type[True]": {
     "last_validated_date": "2024-10-03T22:35:07+00:00"
   },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionHttp::test_subscribe_external_http_endpoint_lambda_url_sig_validation": {
+    "last_validated_date": "2025-01-24T18:51:32+00:00"
+  },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionLambda::test_publish_lambda_verify_signature[1]": {
     "last_validated_date": "2024-01-04T18:31:41+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #12179, we were not calculating the message signature correctly for `UnsubscribeConfirmation` message for HTTP/HTTPS subscriptions.

I've created an `StrEnum` to avoid this kind of typo in the future.

I had also been talking about creating a Lambda URL fixture to allow forwarding received message to an HTTP endpoint to an SQS queue, so this was a good occasion to do it. 

This can be used as example for other services as well, the fixture could probably live in the global fixture file, once we see we can reuse it, as it can be dependent on what the HTTP endpoint needs to return. 
But I'm thinking of making this fixture to do more SNS related things, like being able to return different status code to enable retries and such, or auto-approve the subscription, so we could probably duplicate it in a more general way.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a new lambda URL function fixture to forward input events to a queue, that allows exposing an accessible HTTP endpoint
- fix the typo and introduce an `StrEnum` to avoid future typos
- create a test to validate the behavior and the proper signature of messages for HTTP endpoints

_fixes #12179_
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
