### PR TITLE
S3: implement new data integrity for MultipartUpload

### DIFF
--- a/localstack-core/localstack/services/s3/checksums.py
+++ b/localstack-core/localstack/services/s3/checksums.py
@@ -1,0 +1,157 @@
+# code from https://github.com/aliyun/aliyun-oss-python-sdk/blob/master/oss2/crc64_combine.py, MIT licensed
+# this also linked to botocore/httpchecksum.py
+import sys
+
+_CRC64NVME_POLYNOMIAL = 0xAD93D23594C93659
+_CRC32_POLYNOMIAL = 0x104C11DB7
+_CRC32C_POLYNOMIAL = 0x1EDC6F41
+_CRC64_XOR_OUT = 0xFFFFFFFFFFFFFFFF
+_CRC32_XOR_OUT = 0xFFFFFFFF
+_GF2_DIM_64 = 64
+_GF2_DIM_32 = 32
+
+
+def gf2_matrix_square(square, mat):
+    for n in range(len(mat)):
+        square[n] = gf2_matrix_times(mat, mat[n])
+
+
+def gf2_matrix_times(mat, vec):
+    summary = 0
+    mat_index = 0
+
+    while vec:
+        if vec & 1:
+            summary ^= mat[mat_index]
+
+        vec >>= 1
+        mat_index += 1
+
+    return summary
+
+
+def _combine(
+    poly: int,
+    size_bits: int,
+    init_crc: int,
+    rev: bool,
+    xor_out: int,
+    crc1: int,
+    crc2: int,
+    len2: int,
+) -> bytes:
+    if len2 == 0:
+        return _encode_to_bytes(crc1, size_bits)
+
+    even = [0] * size_bits
+    odd = [0] * size_bits
+
+    crc1 ^= init_crc ^ xor_out
+
+    if rev:
+        # put operator for one zero bit in odd
+        odd[0] = poly  # CRC-64 polynomial
+        row = 1
+        for n in range(1, size_bits):
+            odd[n] = row
+            row <<= 1
+    else:
+        row = 2
+        for n in range(0, size_bits - 1):
+            odd[n] = row
+            row <<= 1
+        odd[size_bits - 1] = poly
+
+    gf2_matrix_square(even, odd)
+
+    gf2_matrix_square(odd, even)
+
+    while True:
+        gf2_matrix_square(even, odd)
+        if len2 & 1:
+            crc1 = gf2_matrix_times(even, crc1)
+        len2 >>= 1
+        if len2 == 0:
+            break
+
+        gf2_matrix_square(odd, even)
+        if len2 & 1:
+            crc1 = gf2_matrix_times(odd, crc1)
+        len2 >>= 1
+
+        if len2 == 0:
+            break
+
+    crc1 ^= crc2
+
+    return _encode_to_bytes(crc1, size_bits)
+
+
+def _encode_to_bytes(crc: int, size_bits: int) -> bytes:
+    if size_bits == 64:
+        return crc.to_bytes(8, byteorder="big")
+    elif size_bits == 32:
+        return crc.to_bytes(4, byteorder="big")
+    else:
+        raise ValueError("size_bites must be 32 or 64")
+
+
+def _bitrev(x: int, n: int):
+    # Bit reverse the input value.
+    x = int(x)
+    y = 0
+    for i in range(n):
+        y = (y << 1) | (x & 1)
+        x = x >> 1
+    if ((1 << n) - 1) <= sys.maxsize:
+        return int(y)
+    return y
+
+
+def _verify_params(size_bits: int, init_crc: int, xor_out: int):
+    """
+    The following function validates the parameters of the CRC, namely, poly, and initial/final XOR values.
+    It returns the size of the CRC (in bits), and "sanitized" initial/final XOR values.
+    """
+    mask = (1 << size_bits) - 1
+
+    # Adjust the initial CRC to the correct data type (unsigned value).
+    init_crc = int(init_crc) & mask
+    if mask <= sys.maxsize:
+        init_crc = int(init_crc)
+
+    # Similar for XOR-out value.
+    xor_out = int(xor_out) & mask
+    if mask <= sys.maxsize:
+        xor_out = int(xor_out)
+
+    return size_bits, init_crc, xor_out
+
+
+def create_combine_function(poly: int, size_bits: int, init_crc=~0, rev=True, xor_out=0):
+    size_bits, init_crc, xor_out = _verify_params(size_bits, init_crc, xor_out)
+
+    mask = (1 << size_bits) - 1
+    if rev:
+        poly = _bitrev(poly & mask, size_bits)
+    else:
+        poly = poly & mask
+
+    def combine_func(crc1: bytes | int, crc2: bytes | int, len2: int):
+        if isinstance(crc1, bytes):
+            crc1 = int.from_bytes(crc1, byteorder="big")
+        if isinstance(crc2, bytes):
+            crc2 = int.from_bytes(crc2, byteorder="big")
+        return _combine(poly, size_bits, init_crc ^ xor_out, rev, xor_out, crc1, crc2, len2)
+
+    return combine_func
+
+
+combine_crc64_nvme = create_combine_function(
+    _CRC64NVME_POLYNOMIAL, 64, init_crc=0, xor_out=_CRC64_XOR_OUT
+)
+combine_crc32 = create_combine_function(_CRC32_POLYNOMIAL, 32, init_crc=0, xor_out=_CRC32_XOR_OUT)
+combine_crc32c = create_combine_function(_CRC32C_POLYNOMIAL, 32, init_crc=0, xor_out=_CRC32_XOR_OUT)
+
+
+__all__ = ["combine_crc32", "combine_crc32c", "combine_crc64_nvme"]

--- a/localstack-core/localstack/services/s3/checksums.py
+++ b/localstack-core/localstack/services/s3/checksums.py
@@ -1,5 +1,5 @@
-# code from https://github.com/aliyun/aliyun-oss-python-sdk/blob/master/oss2/crc64_combine.py, MIT licensed
-# this also linked to botocore/httpchecksum.py
+# Code ported/inspired from https://github.com/aliyun/aliyun-oss-python-sdk/blob/master/oss2/crc64_combine.py
+# MIT licensed
 import sys
 
 _CRC64NVME_POLYNOMIAL = 0xAD93D23594C93659

--- a/localstack-core/localstack/services/s3/checksums.py
+++ b/localstack-core/localstack/services/s3/checksums.py
@@ -1,5 +1,6 @@
 # Code ported/inspired from https://github.com/aliyun/aliyun-oss-python-sdk/blob/master/oss2/crc64_combine.py
-# MIT licensed
+# This code implements checksum combinations: the ability to get the full checksum of an object with the checksums of
+# its parts.
 import sys
 
 _CRC64NVME_POLYNOMIAL = 0xAD93D23594C93659
@@ -129,6 +130,17 @@ def _verify_params(size_bits: int, init_crc: int, xor_out: int):
 
 
 def create_combine_function(poly: int, size_bits: int, init_crc=~0, rev=True, xor_out=0):
+    """
+    The function returns the proper function depending on the checksum algorithm wanted.
+    Example, for the CRC64NVME function, you need to pass the proper polynomial, its size (64), and the proper XOR_OUT
+    (taken for the botocore/httpchecksums.py file).
+    :param poly: the CRC polynomial used (each algorithm has its own, for ex. CRC32C is called Castagnioli)
+    :param size_bits: the size of the algorithm, 32 for CRC32 and 64 for CRC64
+    :param init_crc: the init_crc, always 0 in our case
+    :param rev: reversing the polynomial, true in our case as well
+    :param xor_out: value used to initialize the register as we don't specify init_crc
+    :return:
+    """
     size_bits, init_crc, xor_out = _verify_params(size_bits, init_crc, xor_out)
 
     mask = (1 << size_bits) - 1

--- a/localstack-core/localstack/services/s3/models.py
+++ b/localstack-core/localstack/services/s3/models.py
@@ -496,7 +496,6 @@ class S3Multipart:
                 checksum_hash = CombinedCrcHash(self.object.checksum_algorithm)
 
         pos = 0
-        _checksum_value = 0
         parts_map = {}
         for index, part in enumerate(parts):
             part_number = part["PartNumber"]

--- a/localstack-core/localstack/services/s3/models.py
+++ b/localstack-core/localstack/services/s3/models.py
@@ -424,6 +424,7 @@ class S3Multipart:
     object: S3Object
     upload_id: MultipartUploadId
     checksum_value: Optional[str]
+    checksum_type: Optional[ChecksumType]
     initiated: datetime
     precondition: bool
 
@@ -434,6 +435,7 @@ class S3Multipart:
         expires: Optional[datetime] = None,
         expiration: Optional[datetime] = None,  # come from lifecycle
         checksum_algorithm: Optional[ChecksumAlgorithm] = None,
+        checksum_type: Optional[ChecksumType] = ChecksumType.COMPOSITE,
         encryption: Optional[ServerSideEncryption] = None,  # inherit bucket
         kms_key_id: Optional[SSEKMSKeyId] = None,  # inherit bucket
         bucket_key_enabled: bool = False,  # inherit bucket
@@ -456,6 +458,7 @@ class S3Multipart:
         self.initiator = initiator
         self.tagging = tagging
         self.checksum_value = None
+        self.checksum_type = checksum_type
         self.precondition = precondition
         self.object = S3Object(
             key=key,
@@ -465,7 +468,7 @@ class S3Multipart:
             expires=expires,
             expiration=expiration,
             checksum_algorithm=checksum_algorithm,
-            checksum_type=ChecksumType.COMPOSITE,
+            checksum_type=checksum_type,
             encryption=encryption,
             kms_key_id=kms_key_id,
             bucket_key_enabled=bucket_key_enabled,

--- a/localstack-core/localstack/services/s3/models.py
+++ b/localstack-core/localstack/services/s3/models.py
@@ -436,7 +436,7 @@ class S3Multipart:
         expires: Optional[datetime] = None,
         expiration: Optional[datetime] = None,  # come from lifecycle
         checksum_algorithm: Optional[ChecksumAlgorithm] = None,
-        checksum_type: Optional[ChecksumType] = ChecksumType.COMPOSITE,
+        checksum_type: Optional[ChecksumType] = None,
         encryption: Optional[ServerSideEncryption] = None,  # inherit bucket
         kms_key_id: Optional[SSEKMSKeyId] = None,  # inherit bucket
         bucket_key_enabled: bool = False,  # inherit bucket

--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -2107,6 +2107,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 checksum_type = ChecksumType.FULL_OBJECT
             else:
                 checksum_type = ChecksumType.COMPOSITE
+        elif checksum_type and not checksum_algorithm:
+            raise InvalidRequest(
+                "The x-amz-checksum-type header can only be used with the x-amz-checksum-algorithm header."
+            )
 
         if (
             checksum_type == ChecksumType.COMPOSITE
@@ -2511,21 +2515,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 UploadId=upload_id,
             )
 
-        checksum_map = {}
-        if s3_multipart.object.checksum_algorithm:
-            checksum_map = {
-                "crc32": checksum_crc32,
-                "crc32c": checksum_crc32_c,
-                "crc64nvme": checksum_crc64_nvme,
-                "sha1": checksum_sha1,
-                "sha256": checksum_sha256,
-            }
-
-            if checksum_type and checksum_type != s3_multipart.checksum_type:
-                raise InvalidRequest(
-                    f"The upload was created using the {s3_multipart.checksum_type} checksum mode. "
-                    f"The complete request must use the same checksum mode."
-                )
+        if checksum_type and checksum_type != s3_multipart.checksum_type:
+            raise InvalidRequest(
+                f"The upload was created using the {s3_multipart.checksum_type or 'null'} checksum mode. "
+                f"The complete request must use the same checksum mode."
+            )
 
         # generate the versionId before completing, in case the bucket versioning status has changed between
         # creation and completion? AWS validate this
@@ -2534,6 +2528,13 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         s3_multipart.complete_multipart(parts)
         if s3_multipart.checksum_type == ChecksumType.FULL_OBJECT:
             checksum_algorithm = s3_multipart.object.checksum_algorithm.lower()
+            checksum_map = {
+                "crc32": checksum_crc32,
+                "crc32c": checksum_crc32_c,
+                "crc64nvme": checksum_crc64_nvme,
+                "sha1": checksum_sha1,
+                "sha256": checksum_sha256,
+            }
             checksum_value = checksum_map.get(checksum_algorithm)
             if s3_multipart.checksum_value != checksum_value or not checksum_type:
                 # reset the multipart, the best would have been to pass the checksum value to `complete_multipart`, but
@@ -2804,6 +2805,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                     Owner=multipart.initiator,  # TODO: check the difference
                     Initiator=multipart.initiator,
                 )
+                if multipart.object.checksum_algorithm:
+                    multipart_upload["ChecksumAlgorithm"] = multipart.object.checksum_algorithm
+                    multipart_upload["ChecksumType"] = multipart.checksum_type
+
                 uploads.append(multipart_upload)
 
             count += 1

--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -2675,7 +2675,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 PartNumber=part_number,
                 Size=part.size,
             )
-            if part.checksum_algorithm:
+            if s3_multipart.object.checksum_algorithm:
                 part_item[f"Checksum{part.checksum_algorithm.upper()}"] = part.checksum_value
 
             parts.append(part_item)

--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -2101,8 +2101,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 "Checksum algorithm provided is unsupported. Please try again with any of the valid types: [CRC32, CRC32C, SHA1, SHA256]"
             )
 
-        # TODO: validate the checksum map between COMPOSITE and FULL_OBJECT
-        # get value
         if not (checksum_type := request.get("ChecksumType")) and checksum_algorithm:
             if checksum_algorithm == ChecksumAlgorithm.CRC64NVME:
                 checksum_type = ChecksumType.FULL_OBJECT

--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -2100,6 +2100,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 "Checksum algorithm provided is unsupported. Please try again with any of the valid types: [CRC32, CRC32C, SHA1, SHA256]"
             )
 
+        # TODO: validate the checksum map between COMPOSITE and FULL_OBJECT
+        # get value
+        checksum_type = request.get("ChecksumType")
+
         # TODO: we're not encrypting the object with the provided key for now
         sse_c_key_md5 = request.get("SSECustomerKeyMD5")
         validate_sse_c(
@@ -2126,6 +2130,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             user_metadata=request.get("Metadata"),
             system_metadata=system_metadata,
             checksum_algorithm=checksum_algorithm,
+            checksum_type=checksum_type,
             encryption=encryption_parameters.encryption,
             kms_key_id=encryption_parameters.kms_key_id,
             bucket_key_enabled=encryption_parameters.bucket_key_enabled,
@@ -2150,6 +2155,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         if checksum_algorithm:
             response["ChecksumAlgorithm"] = checksum_algorithm
+            response["ChecksumType"] = checksum_type
 
         add_encryption_to_response(response, s3_object=s3_multipart.object)
         if sse_c_key_md5:
@@ -2533,6 +2539,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # TODO: check this?
         if s3_object.checksum_algorithm:
             response[f"Checksum{s3_object.checksum_algorithm.upper()}"] = s3_object.checksum_value
+            response["ChecksumType"] = s3_object.checksum_type
 
         if s3_object.expiration:
             response["Expiration"] = s3_object.expiration  # TODO: properly parse the datetime
@@ -2653,6 +2660,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             response["PartNumberMarker"] = part_number_marker
         if s3_multipart.object.checksum_algorithm:
             response["ChecksumAlgorithm"] = s3_multipart.object.checksum_algorithm
+            response["ChecksumType"] = s3_multipart.checksum_type
 
         return response
 

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -7,7 +7,7 @@ import re
 import zlib
 from enum import StrEnum
 from secrets import token_bytes
-from typing import IO, Any, Dict, Literal, NamedTuple, Optional, Protocol, Tuple, Union
+from typing import Any, Dict, Literal, NamedTuple, Optional, Protocol, Tuple, Union
 from urllib import parse as urlparser
 from zoneinfo import ZoneInfo
 
@@ -54,12 +54,12 @@ from localstack.aws.api.s3 import Type as GranteeType
 from localstack.aws.chain import HandlerChain
 from localstack.aws.connect import connect_to
 from localstack.http import Response
+from localstack.services.s3 import checksums
 from localstack.services.s3.constants import (
     ALL_USERS_ACL_GRANTEE,
     AUTHENTICATED_USERS_ACL_GRANTEE,
     CHECKSUM_ALGORITHMS,
     LOG_DELIVERY_ACL_GRANTEE,
-    S3_CHUNK_SIZE,
     S3_VIRTUAL_HOST_FORWARDED_HEADER,
     SIGNATURE_V2_PARAMS,
     SIGNATURE_V4_PARAMS,
@@ -69,10 +69,6 @@ from localstack.services.s3.exceptions import InvalidRequest, MalformedXML
 from localstack.utils.aws import arns
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.strings import (
-    checksum_crc32,
-    checksum_crc32c,
-    hash_sha1,
-    hash_sha256,
     is_base64,
     to_bytes,
     to_str,
@@ -256,6 +252,32 @@ class S3CRC32Checksum:
         return self.checksum.to_bytes(4, "big")
 
 
+class CombinedCrcHash:
+    def __init__(self, checksum_type: ChecksumAlgorithm):
+        match checksum_type:
+            case ChecksumAlgorithm.CRC32:
+                func = checksums.combine_crc32
+            case ChecksumAlgorithm.CRC32C:
+                func = checksums.combine_crc32c
+            case ChecksumAlgorithm.CRC64NVME:
+                func = checksums.combine_crc64_nvme
+            case _:
+                raise ValueError("You cannot combine SHA based checksums")
+
+        self.combine_function = func
+        self.checksum = b""
+
+    def combine(self, value: bytes, object_len: int):
+        if not self.checksum:
+            self.checksum = value
+            return
+
+        self.checksum = self.combine_function(self.checksum, value, object_len)
+
+    def digest(self):
+        return self.checksum
+
+
 class ObjectRange(NamedTuple):
     """
     NamedTuple representing a parsed Range header with the requested S3 object size
@@ -390,40 +412,6 @@ def get_full_default_bucket_location(bucket_name: BucketName) -> str:
         return f"{config.get_protocol()}://{bucket_name}.s3.{host_definition.host_and_port()}/"
 
 
-def get_object_checksum_for_algorithm(checksum_algorithm: str, data: bytes) -> str:
-    match checksum_algorithm:
-        case ChecksumAlgorithm.CRC32:
-            return checksum_crc32(data)
-
-        case ChecksumAlgorithm.CRC32C:
-            return checksum_crc32c(data)
-
-        case ChecksumAlgorithm.SHA1:
-            return hash_sha1(data)
-
-        case ChecksumAlgorithm.SHA256:
-            return hash_sha256(data)
-
-        case _:
-            # TODO: check proper error? for now validated client side, need to check server response
-            raise InvalidRequest("The value specified in the x-amz-trailer header is not supported")
-
-
-def verify_checksum(checksum_algorithm: str, data: bytes, request: Dict):
-    # TODO: you don't have to specify the checksum algorithm
-    # you can use only the checksum-{algorithm-type} header
-    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
-    key = f"Checksum{checksum_algorithm.upper()}"
-    # TODO: is there a message if the header is missing?
-    checksum = request.get(key)
-    calculated_checksum = get_object_checksum_for_algorithm(checksum_algorithm, data)
-
-    if calculated_checksum != checksum:
-        raise InvalidRequest(
-            f"Value for x-amz-checksum-{checksum_algorithm.lower()} header is invalid."
-        )
-
-
 def etag_to_base_64_content_md5(etag: ETag) -> str:
     """
     Convert an ETag, representing a MD5 hexdigest (might be quoted), to its base64 encoded representation
@@ -452,40 +440,6 @@ def base_64_content_md5_to_etag(content_md5: ContentMD5) -> str | None:
         return None
 
     return hex_digest
-
-
-def decode_aws_chunked_object(
-    stream: IO[bytes],
-    buffer: IO[bytes],
-    content_length: int,
-) -> IO[bytes]:
-    """
-    Decode the incoming stream encoded in `aws-chunked` format into the provided buffer
-    :param stream: the original stream to read, encoded in the `aws-chunked` format
-    :param buffer: the buffer where we set the decoded data
-    :param content_length: the total maximum length of the original stream, we stop decoding after that
-    :return: the provided buffer
-    """
-    buffer.seek(0)
-    buffer.truncate()
-    written = 0
-    while written < content_length:
-        line = stream.readline()
-        chunk_length = int(line.split(b";")[0], 16)
-
-        while chunk_length > 0:
-            amount = min(chunk_length, S3_CHUNK_SIZE)
-            data = stream.read(amount)
-            buffer.write(data)
-
-            real_amount = len(data)
-            chunk_length -= real_amount
-            written += real_amount
-
-        # remove trailing \r\n
-        stream.read(2)
-
-    return buffer
 
 
 def is_presigned_url_request(context: RequestContext) -> bool:

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -12305,6 +12305,17 @@ class TestS3MultipartUploadChecksum:
             )
         snapshot.match("complete-part-bad-checksum", e.value.response)
 
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.complete_multipart_upload(
+                Bucket=s3_bucket,
+                Key=key_name,
+                MultipartUpload=mpu_data,
+                UploadId=upload_id,
+                ChecksumCRC32=checksum_crc32("bad string"),
+                ChecksumType="FULL_OBJECT",
+            )
+        snapshot.match("complete-part-bad-checksum-algo", e.value.response)
+
         complete_mpu = aws_client.s3.complete_multipart_upload(
             Bucket=s3_bucket,
             Key=key_name,

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -12104,10 +12104,13 @@ class TestS3MultipartUploadChecksum:
         snapshot.match("upload-part-different-checksum-exc", e.value.response)
 
     @markers.aws.validated
-    # @markers.snapshot.skip_snapshot_verify(
-    #     # it seems the PartNumber might not be deterministic, possibly parallelized on S3 side?
-    #     paths=["$.complete-multipart-wrong-parts-checksum.Error.PartNumber"]
-    # )
+    @markers.snapshot.skip_snapshot_verify(
+        # it seems the PartNumber might not be deterministic, possibly parallelized on S3 side?
+        paths=[
+            "$.complete-multipart-wrong-parts-checksum.Error.PartNumber",
+            "$.complete-multipart-wrong-parts-checksum.Error.ETag",
+        ]
+    )
     @pytest.mark.parametrize("algorithm", ["CRC32", "CRC32C", "CRC64NVME"])
     def test_complete_multipart_parts_checksum_full_object(
         self, s3_bucket, snapshot, aws_client, algorithm

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -778,14 +778,6 @@ class TestS3:
         snapshot.match("get-object-attrs-v1", response)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$..NextKeyMarker",
-            "$..NextUploadIdMarker",
-            # FIXME: S3 data integrity
-            "$..Parts..ChecksumCRC32",
-        ],
-    )
     def test_multipart_and_list_parts(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(
             [
@@ -11382,8 +11374,6 @@ class TestS3SSECEncryption:
         snapshot.match("copy-obj-target-double-encryption", e.value.response)
 
     @markers.aws.validated
-    # TODO: fix S3 data integrity
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ChecksumCRC32"])
     def test_multipart_upload_sse_c(self, aws_client, s3_bucket, snapshot):
         snapshot.add_transformer(
             [

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -4107,7 +4107,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_and_list_parts": {
-    "recorded-date": "21-01-2025, 18:27:36",
+    "recorded-date": "25-01-2025, 04:30:53",
     "recorded-content": {
       "create-multipart": {
         "Bucket": "bucket",

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -5195,7 +5195,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_composite": {
-    "recorded-date": "24-01-2025, 22:48:06",
+    "recorded-date": "25-01-2025, 17:26:01",
     "recorded-content": {
       "create-mpu-wrong-checksum-algo": {
         "Error": {
@@ -5207,11 +5207,54 @@
           "HTTPStatusCode": 400
         }
       },
-      "create-mpu-no-checksum": {
+      "create-mpu-no-checksum-algo-with-type": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The x-amz-checksum-type header can only be used with the x-amz-checksum-algorithm header."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-mpu-composite-checksum": {
         "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32",
+        "ChecksumType": "COMPOSITE",
         "Key": "test-multipart-checksum-exc",
         "ServerSideEncryption": "AES256",
         "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts": {
+        "Bucket": "bucket",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxUploads": 1000,
+        "NextKeyMarker": "test-multipart-checksum-exc",
+        "NextUploadIdMarker": "<upload-id:1>",
+        "UploadIdMarker": "",
+        "Uploads": [
+          {
+            "ChecksumAlgorithm": "CRC32",
+            "ChecksumType": "COMPOSITE",
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "i-d"
+            },
+            "Key": "test-multipart-checksum-exc",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "i-d"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:1>"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -5228,11 +5271,18 @@
       },
       "complete-part-with-checksum": {
         "Error": {
-          "Code": "InvalidPart",
-          "ETag": "900150983cd24fb0d6963f7d28e17f72",
-          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
-          "PartNumber": "1",
-          "UploadId": "<upload-id:1>"
+          "Code": "BadDigest",
+          "Message": "The sha256 you specified for part 1 did not match what we received."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-part-with-bad-checksum-type": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The upload was created using the COMPOSITE checksum mode. The complete request must use the same checksum mode."
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -15923,8 +15973,18 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_full_object": {
-    "recorded-date": "25-01-2025, 04:22:18",
+    "recorded-date": "25-01-2025, 17:24:19",
     "recorded-content": {
+      "create-mpu-no-checksum-algo-with-type": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The x-amz-checksum-type header can only be used with the x-amz-checksum-algorithm header."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
       "create-mpu-checksum-crc32c": {
         "Bucket": "bucket",
         "ChecksumAlgorithm": "CRC32C",
@@ -15932,6 +15992,37 @@
         "Key": "test-multipart-checksum-exc",
         "ServerSideEncryption": "AES256",
         "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts": {
+        "Bucket": "bucket",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxUploads": 1000,
+        "NextKeyMarker": "test-multipart-checksum-exc",
+        "NextUploadIdMarker": "<upload-id:1>",
+        "UploadIdMarker": "",
+        "Uploads": [
+          {
+            "ChecksumAlgorithm": "CRC32C",
+            "ChecksumType": "FULL_OBJECT",
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "i-d"
+            },
+            "Key": "test-multipart-checksum-exc",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "i-d"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:1>"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -16039,6 +16130,181 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_default": {
+    "recorded-date": "25-01-2025, 17:10:56",
+    "recorded-content": {
+      "create-mpu-no-checksum": {
+        "Bucket": "bucket",
+        "Key": "test-multipart-checksum",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts": {
+        "Bucket": "bucket",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxUploads": 1000,
+        "NextKeyMarker": "test-multipart-checksum",
+        "NextUploadIdMarker": "<upload-id:1>",
+        "UploadIdMarker": "",
+        "Uploads": [
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "i-d"
+            },
+            "Key": "test-multipart-checksum",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "i-d"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-different-checksum-than-default": {
+        "ChecksumCRC32C": "45fn2Q==",
+        "ETag": "\"47bce5c74f589f4867dbd57e9ca9f808\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-multipart-checksum",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 1,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "\"47bce5c74f589f4867dbd57e9ca9f808\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 3
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-parts-checksum": {
+        "Error": {
+          "Code": "InvalidPart",
+          "ETag": "47bce5c74f589f4867dbd57e9ca9f808",
+          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+          "PartNumber": "1",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-wrong-parts-checksum": {
+        "Error": {
+          "Code": "InvalidPart",
+          "ETag": "47bce5c74f589f4867dbd57e9ca9f808",
+          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+          "PartNumber": "1",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-full-object-type": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The upload was created using the null checksum mode. The complete request must use the same checksum mode."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-composite-type": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The upload was created using the null checksum mode. The complete request must use the same checksum mode."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-checksum": {
+        "Bucket": "bucket",
+        "ETag": "\"e2c3da976e66ec9e7dc128fbc782fc91-1\"",
+        "Key": "test-multipart-checksum",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ContentLength": 3,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e2c3da976e66ec9e7dc128fbc782fc91-1\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 3,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e2c3da976e66ec9e7dc128fbc782fc91-1\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs": {
+        "ETag": "e2c3da976e66ec9e7dc128fbc782fc91-1",
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -5194,175 +5194,6 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum": {
-    "recorded-date": "21-01-2025, 18:42:29",
-    "recorded-content": {
-      "create-mpu-checksum": {
-        "Bucket": "bucket",
-        "ChecksumAlgorithm": "SHA256",
-        "ChecksumType": "COMPOSITE",
-        "Key": "test-multipart-checksum",
-        "ServerSideEncryption": "AES256",
-        "UploadId": "<upload-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "upload-part-0": {
-        "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
-        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "upload-part-1": {
-        "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
-        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "upload-part-2": {
-        "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
-        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-parts": {
-        "Bucket": "bucket",
-        "ChecksumAlgorithm": "SHA256",
-        "ChecksumType": "COMPOSITE",
-        "Initiator": {
-          "DisplayName": "display-name",
-          "ID": "i-d"
-        },
-        "IsTruncated": false,
-        "Key": "test-multipart-checksum",
-        "MaxParts": 1000,
-        "NextPartNumberMarker": 3,
-        "Owner": {
-          "DisplayName": "display-name",
-          "ID": "i-d"
-        },
-        "PartNumberMarker": 0,
-        "Parts": [
-          {
-            "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
-            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
-            "LastModified": "datetime",
-            "PartNumber": 1,
-            "Size": 5242881
-          },
-          {
-            "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
-            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
-            "LastModified": "datetime",
-            "PartNumber": 2,
-            "Size": 5242881
-          },
-          {
-            "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
-            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
-            "LastModified": "datetime",
-            "PartNumber": 3,
-            "Size": 5242881
-          }
-        ],
-        "StorageClass": "STANDARD",
-        "UploadId": "<upload-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "complete-multipart-wrong-parts-checksum": {
-        "Error": {
-          "Code": "InvalidPart",
-          "ETag": "c4c753e69bb853187f5854c46cf801c6",
-          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
-          "PartNumber": "3",
-          "UploadId": "<upload-id:1>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "complete-multipart-wrong-checksum": {
-        "Error": {
-          "Code": "InvalidRequest",
-          "Message": "The upload was created using a sha256 checksum. The complete request must include the checksum for each part. It was missing for part 1 in the request."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "complete-multipart-checksum": {
-        "Bucket": "bucket",
-        "ChecksumSHA256": "dVAleH1OmqkLvByTMLIWSjNCz3x2Ul1KJEZw3eQ2Fqg=-3",
-        "ChecksumType": "COMPOSITE",
-        "ETag": "\"c7cb0938a47e31f70cf07028d22e6913-3\"",
-        "Key": "test-multipart-checksum",
-        "Location": "<location:1>",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-object-with-checksum": {
-        "AcceptRanges": "bytes",
-        "Body": "",
-        "ChecksumSHA256": "dVAleH1OmqkLvByTMLIWSjNCz3x2Ul1KJEZw3eQ2Fqg=-3",
-        "ChecksumType": "COMPOSITE",
-        "ContentLength": 15728643,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"c7cb0938a47e31f70cf07028d22e6913-3\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "head-object-with-checksum": {
-        "AcceptRanges": "bytes",
-        "ChecksumSHA256": "dVAleH1OmqkLvByTMLIWSjNCz3x2Ul1KJEZw3eQ2Fqg=-3",
-        "ContentLength": 15728643,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"c7cb0938a47e31f70cf07028d22e6913-3\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-object-attrs": {
-        "Checksum": {
-          "ChecksumSHA256": "dVAleH1OmqkLvByTMLIWSjNCz3x2Ul1KJEZw3eQ2Fqg=",
-          "ChecksumType": "COMPOSITE"
-        },
-        "ETag": "c7cb0938a47e31f70cf07028d22e6913-3",
-        "LastModified": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions": {
     "recorded-date": "21-01-2025, 18:56:16",
     "recorded-content": {
@@ -14682,6 +14513,931 @@
       },
       "get-obj-attrs-no-checksum": {
         "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[CRC32]": {
+    "recorded-date": "24-01-2025, 22:24:33",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-0": {
+        "ChecksumCRC32": "NRU+Sw==",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-1": {
+        "ChecksumCRC32": "NRU+Sw==",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-2": {
+        "ChecksumCRC32": "TBHN8A==",
+        "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32",
+        "ChecksumType": "COMPOSITE",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-multipart-checksum",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 3,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ChecksumCRC32": "NRU+Sw==",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 5242881
+          },
+          {
+            "ChecksumCRC32": "NRU+Sw==",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 2,
+            "Size": 5242881
+          },
+          {
+            "ChecksumCRC32": "TBHN8A==",
+            "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+            "LastModified": "datetime",
+            "PartNumber": 3,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-wrong-parts-checksum": {
+        "Error": {
+          "Code": "InvalidPart",
+          "ETag": "c4c753e69bb853187f5854c46cf801c6",
+          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+          "PartNumber": "1",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-no-checksum": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The upload was created using a crc32 checksum. The complete request must include the checksum for each part. It was missing for part 1 in the request."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-checksum": {
+        "Bucket": "bucket",
+        "ChecksumCRC32": "5FRUiw==-3",
+        "ChecksumType": "COMPOSITE",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "Key": "test-multipart-checksum",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ChecksumCRC32": "5FRUiw==-3",
+        "ChecksumType": "COMPOSITE",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "ChecksumCRC32": "5FRUiw==-3",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs": {
+        "Checksum": {
+          "ChecksumCRC32": "5FRUiw==",
+          "ChecksumType": "COMPOSITE"
+        },
+        "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[CRC32C]": {
+    "recorded-date": "24-01-2025, 22:24:43",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32C",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-0": {
+        "ChecksumCRC32C": "2/Ckiw==",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-1": {
+        "ChecksumCRC32C": "2/Ckiw==",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-2": {
+        "ChecksumCRC32C": "5yZkMA==",
+        "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32C",
+        "ChecksumType": "COMPOSITE",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-multipart-checksum",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 3,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ChecksumCRC32C": "2/Ckiw==",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 5242881
+          },
+          {
+            "ChecksumCRC32C": "2/Ckiw==",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 2,
+            "Size": 5242881
+          },
+          {
+            "ChecksumCRC32C": "5yZkMA==",
+            "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+            "LastModified": "datetime",
+            "PartNumber": 3,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-wrong-parts-checksum": {
+        "Error": {
+          "Code": "InvalidPart",
+          "ETag": "c4c753e69bb853187f5854c46cf801c6",
+          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+          "PartNumber": "2",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-no-checksum": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The upload was created using a crc32c checksum. The complete request must include the checksum for each part. It was missing for part 1 in the request."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-checksum": {
+        "Bucket": "bucket",
+        "ChecksumCRC32C": "XF5+4A==-3",
+        "ChecksumType": "COMPOSITE",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "Key": "test-multipart-checksum",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ChecksumCRC32C": "XF5+4A==-3",
+        "ChecksumType": "COMPOSITE",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "ChecksumCRC32C": "XF5+4A==-3",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs": {
+        "Checksum": {
+          "ChecksumCRC32C": "XF5+4A==",
+          "ChecksumType": "COMPOSITE"
+        },
+        "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[SHA1]": {
+    "recorded-date": "24-01-2025, 22:24:51",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "SHA1",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-0": {
+        "ChecksumSHA1": "bH71WIZUKQtUwR2wKSSkFjCRBPM=",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-1": {
+        "ChecksumSHA1": "bH71WIZUKQtUwR2wKSSkFjCRBPM=",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-2": {
+        "ChecksumSHA1": "NJX/adNGcdHhWzOmPBN5/e3Toyo=",
+        "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "SHA1",
+        "ChecksumType": "COMPOSITE",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-multipart-checksum",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 3,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ChecksumSHA1": "bH71WIZUKQtUwR2wKSSkFjCRBPM=",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 5242881
+          },
+          {
+            "ChecksumSHA1": "bH71WIZUKQtUwR2wKSSkFjCRBPM=",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 2,
+            "Size": 5242881
+          },
+          {
+            "ChecksumSHA1": "NJX/adNGcdHhWzOmPBN5/e3Toyo=",
+            "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+            "LastModified": "datetime",
+            "PartNumber": 3,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-wrong-parts-checksum": {
+        "Error": {
+          "Code": "InvalidPart",
+          "ETag": "c4c753e69bb853187f5854c46cf801c6",
+          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+          "PartNumber": "2",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-no-checksum": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The upload was created using a sha1 checksum. The complete request must include the checksum for each part. It was missing for part 1 in the request."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-checksum": {
+        "Bucket": "bucket",
+        "ChecksumSHA1": "AyE60nyQoBgJcwsyPHWu7aJuxBs=-3",
+        "ChecksumType": "COMPOSITE",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "Key": "test-multipart-checksum",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ChecksumSHA1": "AyE60nyQoBgJcwsyPHWu7aJuxBs=-3",
+        "ChecksumType": "COMPOSITE",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "ChecksumSHA1": "AyE60nyQoBgJcwsyPHWu7aJuxBs=-3",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs": {
+        "Checksum": {
+          "ChecksumSHA1": "AyE60nyQoBgJcwsyPHWu7aJuxBs=",
+          "ChecksumType": "COMPOSITE"
+        },
+        "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[SHA256]": {
+    "recorded-date": "24-01-2025, 22:25:00",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "SHA256",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-0": {
+        "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-1": {
+        "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-2": {
+        "ChecksumSHA256": "vyy1imj2hNlaO3jvj2Ycmk5bCegsyPnMiMzpBSjK6yc=",
+        "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "SHA256",
+        "ChecksumType": "COMPOSITE",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-multipart-checksum",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 3,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 5242881
+          },
+          {
+            "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 2,
+            "Size": 5242881
+          },
+          {
+            "ChecksumSHA256": "vyy1imj2hNlaO3jvj2Ycmk5bCegsyPnMiMzpBSjK6yc=",
+            "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+            "LastModified": "datetime",
+            "PartNumber": 3,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-wrong-parts-checksum": {
+        "Error": {
+          "Code": "InvalidPart",
+          "ETag": "c4c753e69bb853187f5854c46cf801c6",
+          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+          "PartNumber": "2",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-no-checksum": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The upload was created using a sha256 checksum. The complete request must include the checksum for each part. It was missing for part 1 in the request."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-checksum": {
+        "Bucket": "bucket",
+        "ChecksumSHA256": "9o++y6AejqboiJ7MZCx0fahK2Vu5YC/qnNhhYsCLciI=-3",
+        "ChecksumType": "COMPOSITE",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "Key": "test-multipart-checksum",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ChecksumSHA256": "9o++y6AejqboiJ7MZCx0fahK2Vu5YC/qnNhhYsCLciI=-3",
+        "ChecksumType": "COMPOSITE",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "ChecksumSHA256": "9o++y6AejqboiJ7MZCx0fahK2Vu5YC/qnNhhYsCLciI=-3",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs": {
+        "Checksum": {
+          "ChecksumSHA256": "9o++y6AejqboiJ7MZCx0fahK2Vu5YC/qnNhhYsCLciI=",
+          "ChecksumType": "COMPOSITE"
+        },
+        "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC32]": {
+    "recorded-date": "24-01-2025, 22:30:12",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum-compat",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC32C]": {
+    "recorded-date": "24-01-2025, 22:30:13",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32C",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum-compat",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-SHA1]": {
+    "recorded-date": "24-01-2025, 22:30:14",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "SHA1",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum-compat",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-SHA256]": {
+    "recorded-date": "24-01-2025, 22:30:16",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "SHA256",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum-compat",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC64NVME]": {
+    "recorded-date": "24-01-2025, 22:30:17",
+    "recorded-content": {
+      "create-mpu-checksum-exc": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The COMPOSITE checksum type cannot be used with the crc64nvme checksum algorithm."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-CRC32]": {
+    "recorded-date": "24-01-2025, 22:30:18",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32",
+        "ChecksumType": "FULL_OBJECT",
+        "Key": "test-multipart-checksum-compat",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-CRC32C]": {
+    "recorded-date": "24-01-2025, 22:30:20",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32C",
+        "ChecksumType": "FULL_OBJECT",
+        "Key": "test-multipart-checksum-compat",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-SHA1]": {
+    "recorded-date": "24-01-2025, 22:30:21",
+    "recorded-content": {
+      "create-mpu-checksum-exc": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The FULL_OBJECT checksum type cannot be used with the sha1 checksum algorithm."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-SHA256]": {
+    "recorded-date": "24-01-2025, 22:30:22",
+    "recorded-content": {
+      "create-mpu-checksum-exc": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The FULL_OBJECT checksum type cannot be used with the sha256 checksum algorithm."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-CRC64NVME]": {
+    "recorded-date": "24-01-2025, 22:30:24",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC64NVME",
+        "ChecksumType": "FULL_OBJECT",
+        "Key": "test-multipart-checksum-compat",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[CRC32]": {
+    "recorded-date": "24-01-2025, 22:31:58",
+    "recorded-content": {
+      "create-mpu-default-checksum-type": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum-default",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[CRC32C]": {
+    "recorded-date": "24-01-2025, 22:32:00",
+    "recorded-content": {
+      "create-mpu-default-checksum-type": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32C",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum-default",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[SHA1]": {
+    "recorded-date": "24-01-2025, 22:32:01",
+    "recorded-content": {
+      "create-mpu-default-checksum-type": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "SHA1",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum-default",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[SHA256]": {
+    "recorded-date": "24-01-2025, 22:32:03",
+    "recorded-content": {
+      "create-mpu-default-checksum-type": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "SHA256",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum-default",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[CRC64NVME]": {
+    "recorded-date": "24-01-2025, 22:32:04",
+    "recorded-content": {
+      "create-mpu-default-checksum-type": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC64NVME",
+        "ChecksumType": "FULL_OBJECT",
+        "Key": "test-multipart-checksum-default",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -16343,5 +16343,130 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[CRC32]": {
+    "recorded-date": "26-01-2025, 22:40:08",
+    "recorded-content": {
+      "put-wrong-checksum-no-b64": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Value for x-amz-checksum-crc32 header is invalid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-wrong-checksum-value": {
+        "Error": {
+          "Code": "BadDigest",
+          "Message": "The CRC32 you specified did not match the calculated checksum."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[CRC32C]": {
+    "recorded-date": "26-01-2025, 22:40:19",
+    "recorded-content": {
+      "put-wrong-checksum-no-b64": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Value for x-amz-checksum-crc32c header is invalid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-wrong-checksum-value": {
+        "Error": {
+          "Code": "BadDigest",
+          "Message": "The CRC32C you specified did not match the calculated checksum."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[SHA1]": {
+    "recorded-date": "26-01-2025, 22:40:26",
+    "recorded-content": {
+      "put-wrong-checksum-no-b64": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Value for x-amz-checksum-sha1 header is invalid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-wrong-checksum-value": {
+        "Error": {
+          "Code": "BadDigest",
+          "Message": "The SHA1 you specified did not match the calculated checksum."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[SHA256]": {
+    "recorded-date": "26-01-2025, 22:40:36",
+    "recorded-content": {
+      "put-wrong-checksum-no-b64": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Value for x-amz-checksum-sha256 header is invalid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-wrong-checksum-value": {
+        "Error": {
+          "Code": "BadDigest",
+          "Message": "The SHA256 you specified did not match the calculated checksum."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[CRC64NVME]": {
+    "recorded-date": "26-01-2025, 22:40:45",
+    "recorded-content": {
+      "put-wrong-checksum-no-b64": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Value for x-amz-checksum-crc64nvme header is invalid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-wrong-checksum-value": {
+        "Error": {
+          "Code": "BadDigest",
+          "Message": "The CRC64NVME you specified did not match the calculated checksum."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -16308,5 +16308,40 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_size_validation": {
+    "recorded-date": "25-01-2025, 17:40:59",
+    "recorded-content": {
+      "upload-part": {
+        "ChecksumCRC32": "rZjlRQ==",
+        "ETag": "\"74b87337454200d4d33f80c4663dc5e5\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-wrong-size": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The provided 'x-amz-mp-object-size' header value 5 does not match what was computed: 4"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-good-size": {
+        "Bucket": "bucket",
+        "ETag": "\"c890740ac2875a29117863d66dacc4f0-1\"",
+        "Key": "test-multipart-size",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -5194,8 +5194,8 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions": {
-    "recorded-date": "21-01-2025, 18:56:16",
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_composite": {
+    "recorded-date": "24-01-2025, 22:48:06",
     "recorded-content": {
       "create-mpu-wrong-checksum-algo": {
         "Error": {
@@ -5251,7 +5251,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "upload-part-no-checksum-exc": {
+      "upload-part-different-checksum-exc": {
         "Error": {
           "Code": "InvalidRequest",
           "Message": "Checksum Type mismatch occurred, expected checksum Type: sha256, actual checksum Type: crc32"
@@ -15441,6 +15441,594 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC32]": {
+    "recorded-date": "24-01-2025, 22:58:24",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32",
+        "ChecksumType": "FULL_OBJECT",
+        "Key": "test-multipart-checksum",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-0": {
+        "ChecksumCRC32": "NRU+Sw==",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-1": {
+        "ChecksumCRC32": "NRU+Sw==",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-2": {
+        "ChecksumCRC32": "TBHN8A==",
+        "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32",
+        "ChecksumType": "FULL_OBJECT",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-multipart-checksum",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 3,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ChecksumCRC32": "NRU+Sw==",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 5242881
+          },
+          {
+            "ChecksumCRC32": "NRU+Sw==",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 2,
+            "Size": 5242881
+          },
+          {
+            "ChecksumCRC32": "TBHN8A==",
+            "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+            "LastModified": "datetime",
+            "PartNumber": 3,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-wrong-parts-checksum": {
+        "Error": {
+          "Code": "InvalidPart",
+          "ETag": "e09c80c42fda55f9d992e59ca6b3307d",
+          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+          "PartNumber": "3",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-checksum": {
+        "Bucket": "bucket",
+        "ChecksumCRC32": "qSEQSA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "Key": "test-multipart-checksum",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ChecksumCRC32": "qSEQSA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "ChecksumCRC32": "qSEQSA==",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs": {
+        "Checksum": {
+          "ChecksumCRC32": "qSEQSA==",
+          "ChecksumType": "FULL_OBJECT"
+        },
+        "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC32C]": {
+    "recorded-date": "24-01-2025, 22:58:33",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32C",
+        "ChecksumType": "FULL_OBJECT",
+        "Key": "test-multipart-checksum",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-0": {
+        "ChecksumCRC32C": "2/Ckiw==",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-1": {
+        "ChecksumCRC32C": "2/Ckiw==",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-2": {
+        "ChecksumCRC32C": "5yZkMA==",
+        "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32C",
+        "ChecksumType": "FULL_OBJECT",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-multipart-checksum",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 3,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ChecksumCRC32C": "2/Ckiw==",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 5242881
+          },
+          {
+            "ChecksumCRC32C": "2/Ckiw==",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 2,
+            "Size": 5242881
+          },
+          {
+            "ChecksumCRC32C": "5yZkMA==",
+            "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+            "LastModified": "datetime",
+            "PartNumber": 3,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-wrong-parts-checksum": {
+        "Error": {
+          "Code": "InvalidPart",
+          "ETag": "c4c753e69bb853187f5854c46cf801c6",
+          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+          "PartNumber": "1",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-checksum": {
+        "Bucket": "bucket",
+        "ChecksumCRC32C": "eTdAQA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "Key": "test-multipart-checksum",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ChecksumCRC32C": "eTdAQA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "ChecksumCRC32C": "eTdAQA==",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs": {
+        "Checksum": {
+          "ChecksumCRC32C": "eTdAQA==",
+          "ChecksumType": "FULL_OBJECT"
+        },
+        "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC64NVME]": {
+    "recorded-date": "24-01-2025, 22:58:44",
+    "recorded-content": {
+      "create-mpu-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC64NVME",
+        "ChecksumType": "FULL_OBJECT",
+        "Key": "test-multipart-checksum",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-0": {
+        "ChecksumCRC64NVME": "Kg7TOs6algM=",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-1": {
+        "ChecksumCRC64NVME": "Kg7TOs6algM=",
+        "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-2": {
+        "ChecksumCRC64NVME": "DBqAA21lxVU=",
+        "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC64NVME",
+        "ChecksumType": "FULL_OBJECT",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-multipart-checksum",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 3,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ChecksumCRC64NVME": "Kg7TOs6algM=",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 5242881
+          },
+          {
+            "ChecksumCRC64NVME": "Kg7TOs6algM=",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 2,
+            "Size": 5242881
+          },
+          {
+            "ChecksumCRC64NVME": "DBqAA21lxVU=",
+            "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+            "LastModified": "datetime",
+            "PartNumber": 3,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-wrong-parts-checksum": {
+        "Error": {
+          "Code": "InvalidPart",
+          "ETag": "c4c753e69bb853187f5854c46cf801c6",
+          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+          "PartNumber": "2",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-checksum": {
+        "Bucket": "bucket",
+        "ChecksumCRC64NVME": "ZMNX55lZurA=",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "Key": "test-multipart-checksum",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ChecksumCRC64NVME": "ZMNX55lZurA=",
+        "ChecksumType": "FULL_OBJECT",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "ChecksumCRC64NVME": "ZMNX55lZurA=",
+        "ContentLength": 10485772,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"4d45984fc3feb2ac9b22683c49674b56-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs": {
+        "Checksum": {
+          "ChecksumCRC64NVME": "ZMNX55lZurA=",
+          "ChecksumType": "FULL_OBJECT"
+        },
+        "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_full_object": {
+    "recorded-date": "24-01-2025, 23:34:58",
+    "recorded-content": {
+      "create-mpu-checksum-crc32c": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32C",
+        "ChecksumType": "FULL_OBJECT",
+        "Key": "test-multipart-checksum-exc",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-no-checksum-ok": {
+        "ChecksumCRC32C": "Nks/tw==",
+        "ETag": "\"900150983cd24fb0d6963f7d28e17f72\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-part-bad-checksum-type": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The upload was created using the FULL_OBJECT checksum mode. The complete request must use the same checksum mode."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-part-good-checksum-no-type": {
+        "Error": {
+          "Code": "BadDigest",
+          "Message": "The crc32c you specified did not match the calculated checksum."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-part-only-checksum-algo": {
+        "Error": {
+          "Code": "BadDigest",
+          "Message": "The crc32c you specified did not match the calculated checksum."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-part-only-checksum-algo-diff": {
+        "Error": {
+          "Code": "BadDigest",
+          "Message": "The crc32c you specified did not match the calculated checksum."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-part-bad-checksum": {
+        "Error": {
+          "Code": "BadDigest",
+          "Message": "The crc32c you specified did not match the calculated checksum."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-success": {
+        "Bucket": "bucket",
+        "ChecksumCRC32C": "Nks/tw==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"af5da9f45af7a300e3aded972f8ff687-1\"",
+        "Key": "test-multipart-checksum-exc",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-mpu-with-checksum": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32C",
+        "ChecksumType": "FULL_OBJECT",
+        "Key": "test-multipart-checksum-exc",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-different-checksum-exc": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Checksum Type mismatch occurred, expected checksum Type: crc32c, actual checksum Type: crc32"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -15923,7 +15923,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_full_object": {
-    "recorded-date": "24-01-2025, 23:34:58",
+    "recorded-date": "25-01-2025, 04:22:18",
     "recorded-content": {
       "create-mpu-checksum-crc32c": {
         "Bucket": "bucket",
@@ -15987,6 +15987,16 @@
         }
       },
       "complete-part-bad-checksum": {
+        "Error": {
+          "Code": "BadDigest",
+          "Message": "The crc32c you specified did not match the calculated checksum."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-part-bad-checksum-algo": {
         "Error": {
           "Code": "BadDigest",
           "Message": "The crc32c you specified did not match the calculated checksum."

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -635,6 +635,21 @@
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_size_validation": {
     "last_validated_date": "2025-01-25T17:40:59+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[CRC32C]": {
+    "last_validated_date": "2025-01-26T22:40:19+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[CRC32]": {
+    "last_validated_date": "2025-01-26T22:40:08+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[CRC64NVME]": {
+    "last_validated_date": "2025-01-26T22:40:45+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[SHA1]": {
+    "last_validated_date": "2025-01-26T22:40:26+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[SHA256]": {
+    "last_validated_date": "2025-01-26T22:40:36+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockLegalHold::test_delete_locked_object": {
     "last_validated_date": "2025-01-21T18:17:15+00:00"
   },

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -569,6 +569,9 @@
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[SHA256]": {
     "last_validated_date": "2025-01-24T22:25:00+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_default": {
+    "last_validated_date": "2025-01-25T17:10:56+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC32C]": {
     "last_validated_date": "2025-01-24T22:58:33+00:00"
   },
@@ -624,10 +627,10 @@
     "last_validated_date": "2025-01-24T22:32:03+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_composite": {
-    "last_validated_date": "2025-01-24T22:48:05+00:00"
+    "last_validated_date": "2025-01-25T17:26:01+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_full_object": {
-    "last_validated_date": "2025-01-25T04:22:18+00:00"
+    "last_validated_date": "2025-01-25T17:24:19+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockLegalHold::test_delete_locked_object": {
     "last_validated_date": "2025-01-21T18:17:15+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -141,7 +141,7 @@
     "last_validated_date": "2025-01-21T18:26:37+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_and_list_parts": {
-    "last_validated_date": "2025-01-21T18:27:36+00:00"
+    "last_validated_date": "2025-01-25T04:30:53+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_complete_multipart_too_small": {
     "last_validated_date": "2025-01-21T18:27:40+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -632,6 +632,9 @@
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_full_object": {
     "last_validated_date": "2025-01-25T17:24:19+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_size_validation": {
+    "last_validated_date": "2025-01-25T17:40:59+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockLegalHold::test_delete_locked_object": {
     "last_validated_date": "2025-01-21T18:17:15+00:00"
   },

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -158,9 +158,6 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_overwrite_key": {
     "last_validated_date": "2025-01-21T18:32:53+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_parts_checksum_exceptions": {
-    "last_validated_date": "2025-01-21T18:56:16+00:00"
-  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_object_with_slashes_in_key[False]": {
     "last_validated_date": "2025-01-21T18:26:36+00:00"
   },
@@ -572,6 +569,15 @@
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[SHA256]": {
     "last_validated_date": "2025-01-24T22:25:00+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC32C]": {
+    "last_validated_date": "2025-01-24T22:58:33+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC32]": {
+    "last_validated_date": "2025-01-24T22:58:24+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC64NVME]": {
+    "last_validated_date": "2025-01-24T22:58:44+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC32C]": {
     "last_validated_date": "2025-01-24T22:30:13+00:00"
   },
@@ -616,6 +622,12 @@
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[SHA256]": {
     "last_validated_date": "2025-01-24T22:32:03+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_composite": {
+    "last_validated_date": "2025-01-24T22:48:05+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_full_object": {
+    "last_validated_date": "2025-01-24T23:34:58+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockLegalHold::test_delete_locked_object": {
     "last_validated_date": "2025-01-21T18:17:15+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -14,9 +14,6 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_bucket_operation_between_regions": {
     "last_validated_date": "2025-01-21T18:30:52+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_complete_multipart_parts_checksum": {
-    "last_validated_date": "2025-01-21T18:42:29+00:00"
-  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_complete_multipart_parts_order": {
     "last_validated_date": "2025-01-21T18:41:16+00:00"
   },
@@ -562,6 +559,63 @@
   },
   "tests/aws/services/s3/test_s3.py::TestS3DeepArchive::test_s3_get_deep_archive_object_restore": {
     "last_validated_date": "2023-08-14T20:35:53+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[CRC32C]": {
+    "last_validated_date": "2025-01-24T22:24:43+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[CRC32]": {
+    "last_validated_date": "2025-01-24T22:24:33+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[SHA1]": {
+    "last_validated_date": "2025-01-24T22:24:51+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[SHA256]": {
+    "last_validated_date": "2025-01-24T22:25:00+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC32C]": {
+    "last_validated_date": "2025-01-24T22:30:13+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC32]": {
+    "last_validated_date": "2025-01-24T22:30:12+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC64NVME]": {
+    "last_validated_date": "2025-01-24T22:30:17+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-SHA1]": {
+    "last_validated_date": "2025-01-24T22:30:14+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-SHA256]": {
+    "last_validated_date": "2025-01-24T22:30:16+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-CRC32C]": {
+    "last_validated_date": "2025-01-24T22:30:20+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-CRC32]": {
+    "last_validated_date": "2025-01-24T22:30:18+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-CRC64NVME]": {
+    "last_validated_date": "2025-01-24T22:30:24+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-SHA1]": {
+    "last_validated_date": "2025-01-24T22:30:21+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-SHA256]": {
+    "last_validated_date": "2025-01-24T22:30:22+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[CRC32C]": {
+    "last_validated_date": "2025-01-24T22:32:00+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[CRC32]": {
+    "last_validated_date": "2025-01-24T22:31:58+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[CRC64NVME]": {
+    "last_validated_date": "2025-01-24T22:32:04+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[SHA1]": {
+    "last_validated_date": "2025-01-24T22:32:01+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[SHA256]": {
+    "last_validated_date": "2025-01-24T22:32:03+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockLegalHold::test_delete_locked_object": {
     "last_validated_date": "2025-01-21T18:17:15+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -627,7 +627,7 @@
     "last_validated_date": "2025-01-24T22:48:05+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_full_object": {
-    "last_validated_date": "2025-01-24T23:34:58+00:00"
+    "last_validated_date": "2025-01-25T04:22:18+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockLegalHold::test_delete_locked_object": {
     "last_validated_date": "2025-01-21T18:17:15+00:00"

--- a/tests/aws/services/s3/test_s3_list_operations.py
+++ b/tests/aws/services/s3/test_s3_list_operations.py
@@ -744,8 +744,6 @@ class TestS3ListMultipartUploads:
 
 class TestS3ListParts:
     @markers.aws.validated
-    # TODO: fix S3 data integrity
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ChecksumCRC32"])
     def test_list_parts_pagination(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(
             [
@@ -801,8 +799,6 @@ class TestS3ListParts:
         snapshot.match("list-parts-wrong-part", response)
 
     @markers.aws.validated
-    # TODO: fix S3 data integrity
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ChecksumCRC32"])
     def test_list_parts_empty_part_number_marker(self, s3_bucket, snapshot, aws_client_factory):
         # we need to disable validation for this test
         s3_client = aws_client_factory(config=Config(parameter_validation=False)).s3

--- a/tests/unit/services/s3/test_s3_checksum.py
+++ b/tests/unit/services/s3/test_s3_checksum.py
@@ -1,0 +1,65 @@
+import base64
+
+import pytest
+
+from localstack.services.s3 import checksums
+from localstack.services.s3.utils import S3CRC32Checksum
+
+
+@pytest.mark.parametrize("checksum_type", ["CRC32", "CRC32C", "CRC64NVME"])
+def test_s3_checksum_combine(checksum_type):
+    match checksum_type:
+        case "CRC32":
+            checksum = S3CRC32Checksum
+            combine_function = checksums.combine_crc32
+        case "CRC32C":
+            from botocore.httpchecksum import CrtCrc32cChecksum
+
+            checksum = CrtCrc32cChecksum
+            combine_function = checksums.combine_crc32c
+        case "CRC64NVME":
+            from botocore.httpchecksum import CrtCrc64NvmeChecksum
+
+            checksum = CrtCrc64NvmeChecksum
+            combine_function = checksums.combine_crc64_nvme
+        case _:
+            raise f"Bad parameter value! {checksum_type}"
+
+    part_1 = b"123"
+    part_2 = b"456"
+    part_3 = b"789"
+
+    checksum_1 = checksum()
+    checksum_2 = checksum()
+    checksum_3 = checksum()
+
+    checksum_1.update(part_1)
+    checksum_2.update(part_2)
+    checksum_3.update(part_3)
+
+    # those are the validation checksums
+    checksum_sum_1 = checksum()
+    checksum_sum_total = checksum()
+
+    checksum_sum_1.update(part_1 + part_2)
+    checksum_sum_total.update(part_1 + part_2 + part_3)
+
+    digest_1 = checksum_1.digest()
+    digest_2 = checksum_2.digest()
+    digest_3 = checksum_3.digest()
+
+    digest_sum_1 = checksum_sum_1.digest()
+    digest_sum_total = checksum_sum_total.digest()
+
+    crc_partial_1 = base64.b64encode(digest_sum_1).decode()
+    crc_total = base64.b64encode(digest_sum_total).decode()
+
+    # we combine the part 1 and part 2
+    combined = combine_function(digest_1, digest_2, len(part_2))
+    assert combined == digest_sum_1
+    assert base64.b64encode(combined).decode() == crc_partial_1
+
+    # we now combine the partial checksum of 1 + 2 with the last part
+    combined_partial_and_last_part = combine_function(combined, digest_3, len(part_3))
+    assert combined_partial_and_last_part == digest_sum_total
+    assert base64.b64encode(combined_partial_and_last_part).decode() == crc_total

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -182,46 +182,6 @@ class TestS3Utils:
         for bucket_name, expected_result in bucket_names:
             assert s3_utils.is_bucket_name_valid(bucket_name) == expected_result
 
-    def test_verify_checksum(self):
-        valid_checksums = [
-            (
-                "SHA256",
-                b"test data..",
-                {"ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik="},
-            ),
-            ("CRC32", b"test data..", {"ChecksumCRC32": "cZWHwQ=="}),
-            ("CRC32C", b"test data..", {"ChecksumCRC32C": "Pf4upw=="}),
-            ("SHA1", b"test data..", {"ChecksumSHA1": "B++3uSfJMSHWToQMQ1g6lIJY5Eo="}),
-            (
-                "SHA1",
-                b"test data..",
-                {"ChecksumSHA1": "B++3uSfJMSHWToQMQ1g6lIJY5Eo=", "ChecksumCRC32C": "test"},
-            ),
-        ]
-
-        for checksum_algorithm, data, request in valid_checksums:
-            # means that it did not raise an exception
-            assert s3_utils.verify_checksum(checksum_algorithm, data, request) is None
-
-        invalid_checksums = [
-            (
-                "sha256&",
-                b"test data..",
-                {"ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik="},
-            ),
-            (
-                "sha256",
-                b"test data..",
-                {"ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik="},
-            ),
-            ("CRC32", b"test data..", {"ChecksumCRC32": "cZWHwQ==="}),
-            ("CRC32", b"test data.", {"ChecksumCRC32C": "Pf4upw=="}),
-            ("SHA1", b"test da\nta..", {"ChecksumSHA1": "B++3uSfJMSHWToQMQ1g6lIJY5Eo="}),
-        ]
-        for checksum_algorithm, data, request in invalid_checksums:
-            with pytest.raises(Exception):
-                s3_utils.verify_checksum(checksum_algorithm, data, request)
-
     @pytest.mark.parametrize(
         "presign_url, expected_output_bucket, expected_output_key",
         [


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR implements the new data integrity checks for Multipart Upload (shortened MPU), namely the ability to set the `FULL_OBJECT` checksum type for a MPU, allowing the user to not keep track of individual checksum parts to calculate the final one, but instead send the full object checksum to S3. This can be done thanks to `CRC*` type checksums, which can linearize, meaning you can get the full object checksum from the individual parts' checksums (via a somewhat complicated function). 

The PR looks big (3k lines), but 70% of it is snapshots, because I had to cover a lot of different cases, operations' responses, and there was a lot of ground to cover that wasn't previously covered. 

There is a lot of additional validation and default values to check (different relationship between checksum algorithm and checksum type), new validation of the MPU total size at completion time, I've also ported the fix with different error message depending if the checksum value is valid or not.

The biggest part and challenge of this PR is to implement to logic to combine CRC checksums together in order to create the `FULL_OBJECT` checksum. More can be read about this in the following Stack Overflow post: https://stackoverflow.com/a/23126768
I had to look everywhere online to try to find someway to do that, and it was pretty hard to find. I found an old repository of Alibaba, with the function available in Python2 to combine CRC64 checksums, I had to adapt it a little to run with Python3 and fit our use case better. 

More resources to read about the new S3 data integrity push:
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
- https://docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html

There's also a bit of cleanup done, removing some unused functions/code.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement the new checksum types `FULL_OBJECT` and `COMPOSITE` for MPU
- implement the helpers to combine CRC checksums together
- clean up some dead code
- implement a lot of new tests covering as wide as I could think

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
