### PR TITLE
add resource provider utility to convert LowerCamelCase to Pascal

### DIFF
--- a/localstack-core/localstack/services/cloudformation/provider_utils.py
+++ b/localstack-core/localstack/services/cloudformation/provider_utils.py
@@ -52,6 +52,13 @@ def convert_pascalcase_to_lower_camelcase(item: str) -> str:
         return f"{item[0].lower()}{item[1:]}"
 
 
+def convert_lower_camelcase_to_pascalcase(item: str) -> str:
+    if len(item) <= 1:
+        return item.upper()
+    else:
+        return f"{item[0].upper()}{item[1:]}"
+
+
 def _recurse_properties(obj: dict | list, fn: Callable) -> dict | list:
     obj = fn(obj)
     if isinstance(obj, dict):
@@ -76,6 +83,18 @@ def keys_pascalcase_to_lower_camelcase(model: dict) -> dict:
             return obj
 
     return _recurse_properties(model, _keys_pascalcase_to_lower_camelcase)
+
+
+def keys_lower_camelcase_to_pascalcase(model: dict) -> dict:
+    """Recursively change any dicts keys to PascalCase"""
+
+    def _keys_lower_camelcase_to_pascalcase(obj):
+        if isinstance(obj, dict):
+            return {convert_lower_camelcase_to_pascalcase(k): v for k, v in obj.items()}
+        else:
+            return obj
+
+    return _recurse_properties(model, _keys_lower_camelcase_to_pascalcase)
 
 
 def transform_list_to_dict(param, key_attr_name="Key", value_attr_name="Value"):

--- a/tests/unit/services/cloudformation/test_provider_utils.py
+++ b/tests/unit/services/cloudformation/test_provider_utils.py
@@ -115,3 +115,23 @@ class TestDictUtils:
                 }
             ],
         }
+
+    def test_lower_camelcase_to_pascalcase(self):
+        original_dict = {
+            "eventBusName": "my-event-bus",
+            "targets": [
+                {
+                    "id": "an-id",
+                }
+            ],
+        }
+
+        converted_dict = utils.keys_lower_camelcase_to_pascalcase(original_dict)
+        assert converted_dict == {
+            "EventBusName": "my-event-bus",
+            "Targets": [
+                {
+                    "Id": "an-id",
+                }
+            ],
+        }


### PR DESCRIPTION
## Motivation
This PR adds an utility to convert LowerCamelCase to PascalCase keys in a dictionary. Usefull for read methods in resource providers


## Changes
- new utility for resource providers