### PR TITLE
add product and edition to session analytics

### DIFF
--- a/localstack-core/localstack/utils/analytics/metadata.py
+++ b/localstack-core/localstack/utils/analytics/metadata.py
@@ -5,7 +5,7 @@ import platform
 from typing import Optional
 
 from localstack import config
-from localstack.constants import VERSION
+from localstack import VERSION, ENV_PRO_ACTIVATED
 from localstack.runtime import hooks
 from localstack.utils.bootstrap import Container
 from localstack.utils.files import rm_rf
@@ -60,6 +60,8 @@ def read_client_metadata() -> ClientMetadata:
         is_ci=os.getenv("CI") is not None,
         is_docker=config.is_in_docker,
         is_testing=config.is_local_test_mode(),
+        product="aws",
+        edition="pro" if config.is_env_true(ENV_PRO_ACTIVATED) else "community"
     )
 
 

--- a/localstack-core/localstack/utils/analytics/metadata.py
+++ b/localstack-core/localstack/utils/analytics/metadata.py
@@ -5,8 +5,8 @@ import platform
 from typing import Optional
 
 from localstack import config
-from localstack.constants import ENV_PRO_ACTIVATED, VERSION
-from localstack.runtime import hooks
+from localstack.constants import VERSION
+from localstack.runtime import get_current_runtime, hooks
 from localstack.utils.bootstrap import Container
 from localstack.utils.files import rm_rf
 from localstack.utils.functions import call_safe
@@ -53,6 +53,8 @@ def get_version_string() -> str:
 
 
 def read_client_metadata() -> ClientMetadata:
+    runtime = get_current_runtime()
+
     return ClientMetadata(
         session_id=get_session_id(),
         machine_id=get_machine_id(),
@@ -62,8 +64,8 @@ def read_client_metadata() -> ClientMetadata:
         is_ci=os.getenv("CI") is not None,
         is_docker=config.is_in_docker,
         is_testing=config.is_local_test_mode(),
-        product="aws",
-        edition="pro" if config.is_env_true(ENV_PRO_ACTIVATED) else "community",
+        product=os.getenv("LOCALSTACK_TELEMETRY_PRODUCT") or runtime.components.name or "unknown",
+        edition=os.getenv("LOCALSTACK_TELEMETRY_EDITION") or get_localstack_edition(),
     )
 
 

--- a/localstack-core/localstack/utils/analytics/metadata.py
+++ b/localstack-core/localstack/utils/analytics/metadata.py
@@ -5,7 +5,7 @@ import platform
 from typing import Optional
 
 from localstack import config
-from localstack import VERSION, ENV_PRO_ACTIVATED
+from localstack.constants import ENV_PRO_ACTIVATED, VERSION
 from localstack.runtime import hooks
 from localstack.utils.bootstrap import Container
 from localstack.utils.files import rm_rf
@@ -29,6 +29,8 @@ class ClientMetadata:
     is_ci: bool
     is_docker: bool
     is_testing: bool
+    product: str
+    edition: str
 
     def __repr__(self):
         d = dataclasses.asdict(self)

--- a/localstack-core/localstack/utils/analytics/metadata.py
+++ b/localstack-core/localstack/utils/analytics/metadata.py
@@ -53,8 +53,6 @@ def get_version_string() -> str:
 
 
 def read_client_metadata() -> ClientMetadata:
-    runtime = get_current_runtime()
-
     return ClientMetadata(
         session_id=get_session_id(),
         machine_id=get_machine_id(),
@@ -64,7 +62,7 @@ def read_client_metadata() -> ClientMetadata:
         is_ci=os.getenv("CI") is not None,
         is_docker=config.is_in_docker,
         is_testing=config.is_local_test_mode(),
-        product=os.getenv("LOCALSTACK_TELEMETRY_PRODUCT") or runtime.components.name or "unknown",
+        product=get_localstack_product(),
         edition=os.getenv("LOCALSTACK_TELEMETRY_EDITION") or get_localstack_edition(),
     )
 
@@ -125,6 +123,18 @@ def get_localstack_edition() -> str:
 
     # Return the base name of the version file, or unknown if no file is found
     return version_file.removesuffix("-version").removeprefix(".") if version_file else "unknown"
+
+
+def get_localstack_product() -> str:
+    """
+    Returns the telemetry product name from the env var, runtime, or "unknown".
+    """
+    try:
+        runtime_product = get_current_runtime().components.name
+    except ValueError:
+        runtime_product = None
+
+    return os.getenv("LOCALSTACK_TELEMETRY_PRODUCT") or runtime_product or "unknown"
 
 
 def is_license_activated() -> bool:

--- a/localstack-core/localstack/utils/analytics/metadata.py
+++ b/localstack-core/localstack/utils/analytics/metadata.py
@@ -63,7 +63,7 @@ def read_client_metadata() -> ClientMetadata:
         is_docker=config.is_in_docker,
         is_testing=config.is_local_test_mode(),
         product="aws",
-        edition="pro" if config.is_env_true(ENV_PRO_ACTIVATED) else "community"
+        edition="pro" if config.is_env_true(ENV_PRO_ACTIVATED) else "community",
     )
 
 

--- a/tests/unit/utils/analytics/conftest.py
+++ b/tests/unit/utils/analytics/conftest.py
@@ -1,9 +1,23 @@
 import pytest
 
 from localstack import config
+from localstack.runtime.current import set_current_runtime
 
 
 @pytest.fixture(autouse=True)
 def enable_analytics(monkeypatch):
     """Makes sure that all tests in this package are executed with analytics enabled."""
     monkeypatch.setattr(config, "DISABLE_EVENTS", False)
+
+class MockComponents:
+    name = "dummy-product"
+
+class MockRuntime:
+    components = MockComponents()
+
+@pytest.fixture(autouse=True)
+def mock_runtime():
+    runtime = MockRuntime()
+    set_current_runtime(runtime)
+    yield
+    set_current_runtime(None)

--- a/tests/unit/utils/analytics/conftest.py
+++ b/tests/unit/utils/analytics/conftest.py
@@ -10,7 +10,7 @@ def enable_analytics(monkeypatch):
     monkeypatch.setattr(config, "DISABLE_EVENTS", False)
 
 class MockComponents:
-    name = "dummy-product"
+    name = "mock-product"
 
 class MockRuntime:
     components = MockComponents()

--- a/tests/unit/utils/analytics/conftest.py
+++ b/tests/unit/utils/analytics/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from localstack import config
-from localstack.runtime.current import set_current_runtime
+from localstack.runtime.current import get_current_runtime, set_current_runtime
 
 
 @pytest.fixture(autouse=True)
@@ -20,7 +20,12 @@ class MockRuntime:
 
 @pytest.fixture(autouse=True)
 def mock_runtime():
-    runtime = MockRuntime()
-    set_current_runtime(runtime)
-    yield
-    set_current_runtime(None)
+    try:
+        # don't do anything if a runtime is set
+        get_current_runtime()
+        yield
+    except ValueError:
+        # set a mock runtime if no runtime is set
+        set_current_runtime(MockRuntime())
+        yield
+        set_current_runtime(None)

--- a/tests/unit/utils/analytics/conftest.py
+++ b/tests/unit/utils/analytics/conftest.py
@@ -9,11 +9,14 @@ def enable_analytics(monkeypatch):
     """Makes sure that all tests in this package are executed with analytics enabled."""
     monkeypatch.setattr(config, "DISABLE_EVENTS", False)
 
+
 class MockComponents:
     name = "mock-product"
 
+
 class MockRuntime:
     components = MockComponents()
+
 
 @pytest.fixture(autouse=True)
 def mock_runtime():


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds `product` and `edition` to the session's `ClientMetadata`. Given LocalStack's growing number of products, the distinction will help distinguish where a session is coming from. 

Both `product` and `edition` can be overwritten by environment variables to cover cases where a runtime is not necessarily given or correct (e.g. when packaging an extension).


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- adds `product` and `edition` to the session's `ClientMetadata`
- adds `mock_runtime` fixture. Analytics unit tests rely on client metadata - but `get_current_runtime()` [throws an error](https://github.com/localstack/localstack/blob/873d150c009f4bc6acaee6a4c48a57ab53c66f0e/localstack-core/localstack/runtime/current.py#L20) when not having an initialized runtime.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
