### PR TITLE
APIGW: add Binary Media support for response in `AWS_PROXY`

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
@@ -148,3 +148,26 @@ def parse_trace_id(trace_id: str) -> dict[str, str]:
             trace_values[key_value[0].capitalize()] = key_value[1]
 
     return trace_values
+
+
+def accept_header_matches_binary_media_types(accept: str | None, binary_media_types: list[str]):
+    accept_type_and_subtype = accept.split(",")[0].split(";")[0].split("/")
+    if len(accept_type_and_subtype) != 2:
+        return False
+    accept_type, accept_subtype = accept_type_and_subtype
+
+    for bmt in binary_media_types:
+        type_and_subtype = bmt.split(";")[0].split("/")
+        if len(type_and_subtype) != 2:
+            continue
+        _type, subtype = type_and_subtype
+        if _type == "*":
+            continue
+
+        if subtype == "*" and accept_type == _type:
+            return True
+
+        if accept_type == _type and accept_subtype == subtype:
+            return True
+
+    return False

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
@@ -150,11 +150,14 @@ def parse_trace_id(trace_id: str) -> dict[str, str]:
     return trace_values
 
 
-def accept_header_matches_binary_media_types(accept: str | None, binary_media_types: list[str]):
-    accept_type_and_subtype = accept.split(",")[0].split(";")[0].split("/")
-    if len(accept_type_and_subtype) != 2:
+def mime_type_matches_binary_media_types(mime_type: str | None, binary_media_types: list[str]):
+    if not mime_type or not binary_media_types:
         return False
-    accept_type, accept_subtype = accept_type_and_subtype
+
+    mime_type_and_subtype = mime_type.split(",")[0].split(";")[0].split("/")
+    if len(mime_type_and_subtype) != 2:
+        return False
+    mime_type, mime_subtype = mime_type_and_subtype
 
     for bmt in binary_media_types:
         type_and_subtype = bmt.split(";")[0].split("/")
@@ -164,10 +167,10 @@ def accept_header_matches_binary_media_types(accept: str | None, binary_media_ty
         if _type == "*":
             continue
 
-        if subtype == "*" and accept_type == _type:
+        if subtype == "*" and mime_type == _type:
             return True
 
-        if accept_type == _type and accept_subtype == subtype:
+        if mime_type == _type and mime_subtype == subtype:
             return True
 
     return False

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -32,9 +32,9 @@ from ..context import (
 from ..gateway_response import IntegrationFailureError, InternalServerError
 from ..header_utils import build_multi_value_headers
 from ..helpers import (
-    accept_header_matches_binary_media_types,
     get_lambda_function_arn_from_invocation_uri,
     get_source_arn,
+    mime_type_matches_binary_media_types,
     render_uri_with_stage_variables,
     validate_sub_dict_of_typed_dict,
 )
@@ -395,7 +395,7 @@ class RestApiAwsProxyIntegration(RestApiIntegration):
 
         # TODO: maybe centralize this flag inside the context, when we are also using it for other integration types
         #  AWS_PROXY behaves a bit differently, but this could checked only once earlier
-        binary_response_accepted = accept_header_matches_binary_media_types(
+        binary_response_accepted = mime_type_matches_binary_media_types(
             context.invocation_request["headers"].get("Accept"),
             context.deployment.rest_api.rest_api.get("binaryMediaTypes", []),
         )

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -32,6 +32,7 @@ from ..context import (
 from ..gateway_response import IntegrationFailureError, InternalServerError
 from ..header_utils import build_multi_value_headers
 from ..helpers import (
+    accept_header_matches_binary_media_types,
     get_lambda_function_arn_from_invocation_uri,
     get_source_arn,
     render_uri_with_stage_variables,
@@ -392,9 +393,20 @@ class RestApiAwsProxyIntegration(RestApiIntegration):
         response_headers = self._merge_lambda_response_headers(lambda_response)
         headers.update(response_headers)
 
+        # TODO: maybe centralize this flag inside the context, when we are also using it for other integration types
+        #  AWS_PROXY behaves a bit differently, but this could checked only once earlier
+        binary_response_accepted = accept_header_matches_binary_media_types(
+            context.invocation_request["headers"].get("Accept"),
+            context.deployment.rest_api.rest_api.get("binaryMediaTypes", []),
+        )
+        body = self._parse_body(
+            body=lambda_response.get("body"),
+            is_base64_encoded=binary_response_accepted and lambda_response.get("isBase64Encoded"),
+        )
+
         return EndpointResponse(
             headers=headers,
-            body=to_bytes(lambda_response.get("body") or ""),
+            body=body,
             status_code=int(lambda_response.get("statusCode") or 200),
         )
 
@@ -551,6 +563,19 @@ class RestApiAwsProxyIntegration(RestApiIntegration):
             return body.decode("utf-8"), False
         except UnicodeDecodeError:
             return to_str(base64.b64encode(body)), True
+
+    @staticmethod
+    def _parse_body(body: str | None, is_base64_encoded: bool) -> bytes:
+        if not body:
+            return b""
+
+        if is_base64_encoded:
+            try:
+                return base64.b64decode(body)
+            except Exception:
+                raise InternalServerError("Internal server error", status_code=500)
+
+        return to_bytes(body)
 
     @staticmethod
     def _merge_lambda_response_headers(lambda_response: LambdaProxyResponse) -> dict:

--- a/tests/aws/services/apigateway/test_apigateway_lambda.py
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.py
@@ -1455,7 +1455,7 @@ def test_aws_proxy_binary_response(
     assert _assert_invoke(accept="image/png,image/*,*/*;q=0.8", expect_binary=True)
 
     # lambda is returning that the payload is not b64 encoded
-    decoded_response.pop("isBase64Encoded")
+    decoded_response["isBase64Encoded"] = False
     assert _assert_invoke(accept="image/png", expect_binary=False)
 
     patch_operations = [

--- a/tests/aws/services/apigateway/test_apigateway_lambda.py
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.py
@@ -1,17 +1,19 @@
 import base64
 import json
 import os
+import time
 
 import pytest
 import requests
 from botocore.exceptions import ClientError
 
 from localstack.aws.api.lambda_ import Runtime
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.aws import arns
 from localstack.utils.files import load_file
 from localstack.utils.strings import short_uid
-from localstack.utils.sync import retry
+from localstack.utils.sync import poll_condition, retry
 from tests.aws.services.apigateway.apigateway_fixtures import api_invoke_url, create_rest_resource
 from tests.aws.services.apigateway.conftest import (
     APIGATEWAY_ASSUME_ROLE_POLICY,
@@ -1312,3 +1314,206 @@ def test_lambda_aws_proxy_integration_request_data_mapping(
     # retry is necessary against AWS, probably IAM permission delay
     invoke_response = retry(invoke_api, sleep=2, retries=10, url=invocation_url)
     snapshot.match("http-proxy-invocation-data-mapping", invoke_response)
+
+
+@markers.aws.validated
+def test_aws_proxy_binary_response(
+    create_rest_apigw,
+    create_lambda_function,
+    create_role_with_policy,
+    aws_client,
+    region_name,
+):
+    _, role_arn = create_role_with_policy(
+        "Allow", "lambda:InvokeFunction", json.dumps(APIGATEWAY_ASSUME_ROLE_POLICY), "*"
+    )
+    timeout = 30 if is_aws_cloud() else 3
+
+    function_name = f"response-format-apigw-{short_uid()}"
+    create_function_response = create_lambda_function(
+        handler_file=LAMBDA_RESPONSE_FROM_BODY,
+        func_name=function_name,
+        runtime=Runtime.python3_12,
+    )
+    # create invocation role
+    lambda_arn = create_function_response["CreateFunctionResponse"]["FunctionArn"]
+
+    # create rest api
+    api_id, _, root = create_rest_apigw(
+        name=f"test-api-{short_uid()}",
+        description="Integration test API",
+    )
+
+    resource_id = aws_client.apigateway.create_resource(
+        restApiId=api_id, parentId=root, pathPart="{proxy+}"
+    )["id"]
+
+    aws_client.apigateway.put_method(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="ANY",
+        authorizationType="NONE",
+    )
+
+    # Lambda AWS_PROXY integration
+    aws_client.apigateway.put_integration(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="ANY",
+        type="AWS_PROXY",
+        integrationHttpMethod="POST",
+        uri=f"arn:aws:apigateway:{region_name}:lambda:path/2015-03-31/functions/{lambda_arn}/invocations",
+        credentials=role_arn,
+    )
+
+    # this deployment does not have any `binaryMediaTypes` configured, so it should not return any binary data
+    stage_1 = "test"
+    aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_1)
+    endpoint = api_invoke_url(api_id=api_id, path="/test", stage=stage_1)
+    # Base64-encoded PNG image (example: 1x1 pixel transparent PNG)
+    image_base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgkBAyMAlYwAAAAASUVORK5CYII="
+    binary_data = base64.b64decode(image_base64)
+
+    decoded_response = {
+        "statusCode": 200,
+        "body": image_base64,
+        "isBase64Encoded": True,
+        "headers": {
+            "Content-Type": "image/png",
+            "Cache-Control": "no-cache",
+        },
+    }
+
+    def _assert_invoke(accept: str | None, expect_binary: bool) -> bool:
+        headers = {"User-Agent": "python/test"}
+        if accept:
+            headers["Accept"] = accept
+
+        _response = requests.post(
+            url=endpoint,
+            data=json.dumps(decoded_response),
+            headers=headers,
+        )
+        if not _response.status_code == 200:
+            return False
+
+        if expect_binary:
+            return _response.content == binary_data
+        else:
+            return _response.text == image_base64
+
+    # we poll that the API is returning the right data after deployment
+    poll_condition(
+        lambda: _assert_invoke(accept="image/png", expect_binary=False), timeout=timeout, interval=1
+    )
+    if is_aws_cloud():
+        time.sleep(5)
+
+    # we did not configure binaryMedias so the API is not returning binary data even if all conditions are met
+    assert _assert_invoke(accept="image/png", expect_binary=False)
+
+    patch_operations = [
+        {"op": "add", "path": "/binaryMediaTypes/image~1png"},
+        # seems like wildcard with star on the left is not supported
+        {"op": "add", "path": "/binaryMediaTypes/*~1test"},
+    ]
+    aws_client.apigateway.update_rest_api(restApiId=api_id, patchOperations=patch_operations)
+    # this deployment has `binaryMediaTypes` configured, so it should now return binary data if the client sends the
+    # right `Accept` header and the lambda returns the Content-Type
+    if is_aws_cloud():
+        time.sleep(10)
+    stage_2 = "test2"
+    endpoint = api_invoke_url(api_id=api_id, path="/test", stage=stage_2)
+    aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_2)
+
+    # we poll that the API is returning the right data after deployment
+    poll_condition(
+        lambda: _assert_invoke(accept="image/png", expect_binary=True), timeout=timeout, interval=1
+    )
+    if is_aws_cloud():
+        time.sleep(5)
+
+    # all conditions are met
+    assert _assert_invoke(accept="image/png", expect_binary=True)
+
+    # client is sending the wrong accept, so the API returns the base64 data
+    assert _assert_invoke(accept="image/jpg", expect_binary=False)
+
+    # client is sending an accept that matches the wildcard, but does not match the returned Content-Type
+    assert _assert_invoke(accept="random/test", expect_binary=False)
+
+    # wildcard on the left is not supported
+    assert _assert_invoke(accept="*/test", expect_binary=False)
+
+    # Accept has to exactly match what is configured
+    assert _assert_invoke(accept="*/*", expect_binary=False)
+
+    # client is sending a multiple accept, but AWS only checks the first one
+    assert _assert_invoke(accept="image/webp,image/*,*/*;q=0.8", expect_binary=False)
+
+    # client is sending a multiple accept, but AWS only checks the first one
+    assert _assert_invoke(accept="image/png,image/*,*/*;q=0.8", expect_binary=True)
+
+    # lambda is returning that the payload is not b64 encoded
+    decoded_response.pop("isBase64Encoded")
+    assert _assert_invoke(accept="image/png", expect_binary=False)
+
+    patch_operations = [
+        {"op": "add", "path": "/binaryMediaTypes/application~1*"},
+        {"op": "add", "path": "/binaryMediaTypes/image~1jpg"},
+        {"op": "remove", "path": "/binaryMediaTypes/*~1test"},
+    ]
+    aws_client.apigateway.update_rest_api(restApiId=api_id, patchOperations=patch_operations)
+    if is_aws_cloud():
+        time.sleep(10)
+    # this deployment has `binaryMediaTypes` configured, so it should now return binary data if the client sends the
+    # right `Accept` header and the lambda returns the Content-Type
+    stage_3 = "test3"
+    endpoint = api_invoke_url(api_id=api_id, path="/test", stage=stage_3)
+    aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_3)
+    decoded_response["isBase64Encoded"] = True
+
+    # we poll that the API is returning the right data after deployment
+    poll_condition(
+        lambda: _assert_invoke(accept="image/png", expect_binary=True), timeout=timeout, interval=1
+    )
+    if is_aws_cloud():
+        time.sleep(5)
+
+    # partial wildcard are simply not supported it seems
+    # ???
+    decoded_response["headers"]["Content-Type"] = "application/test"
+    assert _assert_invoke(accept="application/whatever", expect_binary=True)
+    assert _assert_invoke(accept="application/test", expect_binary=True)
+    assert _assert_invoke(accept="application/*", expect_binary=True)
+
+    # lambda is returning a content-type that matches one binaryMediaType, but Accept matches another binaryMediaType
+    decoded_response["headers"]["Content-Type"] = "image/png"
+    assert _assert_invoke(accept="image/jpg", expect_binary=True)
+
+    # lambda is returning a content-type that matches the wildcard, but Accept matches another binaryMediaType
+    decoded_response["headers"]["Content-Type"] = "application/whatever"
+    assert _assert_invoke(accept="image/png", expect_binary=True)
+
+    # does content-type matters?
+    decoded_response["headers"].pop("Content-Type")
+    assert _assert_invoke(accept="image/png", expect_binary=True)
+
+    # reverse the logic with Content-Type/Accept
+    decoded_response["headers"]["Content-Type"] = "image/jpg"
+    assert _assert_invoke(accept="image/png", expect_binary=True)
+
+    # bad Accept
+    assert _assert_invoke(accept="application", expect_binary=False)
+
+    # no Accept
+    assert _assert_invoke(accept=None, expect_binary=False)
+
+    # bad base64
+    decoded_response["body"] = "èé+à)("
+    bad_b64_response = requests.post(
+        url=endpoint,
+        data=json.dumps(decoded_response),
+        headers={"User-Agent": "python/test", "Accept": "image/png"},
+    )
+    assert bad_b64_response.status_code == 500

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_aws_proxy_binary_response": {
-    "last_validated_date": "2025-01-28T23:32:07+00:00"
+    "last_validated_date": "2025-01-28T23:48:45+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_aws_proxy_response_payload_format_validation": {
     "last_validated_date": "2024-11-15T17:48:06+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/apigateway/test_apigateway_lambda.py::test_aws_proxy_binary_response": {
+    "last_validated_date": "2025-01-28T23:32:07+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_aws_proxy_response_payload_format_validation": {
     "last_validated_date": "2024-11-15T17:48:06+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_aws_proxy_binary_response": {
-    "last_validated_date": "2025-01-28T23:48:45+00:00"
+    "last_validated_date": "2025-01-29T00:14:36+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_aws_proxy_response_payload_format_validation": {
     "last_validated_date": "2024-11-15T17:48:06+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #12115, we did not support returning binary responses from `AWS_PROXY` integration. In the previous implementation of API Gateway, we were returning binary responses but in the wrong way: if the `isBase64Encoded` was set to `True` in the response, we decode it and send binary data. 

However, it has a deep link to the `binaryMediaTypes` configuration of the REST API. Only if the client sends an `Accept` header that matches the `binaryMediaTypes` then the `AWS_PROXY` will respond with binary data. 

This PR was quite frustrating, as it took me hours to implement the test and all the different cases, and I hit some caching issues, things failing in one run and not another, I had to deploy to different stages to be sure I wasn't hitting some weird issues. 

And the implementation itself took less than 15min 🤦‍♂️ At least we have confidence in the different cases, and that the `Content-Type` header is actually not taken into account. 

The implementation for now only covers `AWS_PROXY`, because the logic for other integrations is more complex, as there also is logic to decode the incoming payload, and the `ContentHandling` parameter, both for input and output. This will be tackled in a follow up. 
I can set the `Accept` header and `binaryMediaTypes` in the request context then, if needed. 

More resources from AWS:
- https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings.html
- https://docs.aws.amazon.com/apigateway/latest/developerguide/lambda-proxy-binary-media.html

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement a pretty thorough test (without snapshot!) to test all the possible use cases I could think of
- implement the logic in the `AWS_PROXY` integration to return or not binary data


_fixes #12115_
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
