### PR TITLE
adjust --follow arg positioning to be compatible with docker and podman

### DIFF
--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -470,7 +470,7 @@ class CmdDockerClient(ContainerClient):
         self.inspect_container(container_name_or_id)  # guard to check whether container is there
 
         cmd = self._docker_cmd()
-        cmd += ["logs", container_name_or_id, "--follow"]
+        cmd += ["logs", "--follow", container_name_or_id]
 
         process: subprocess.Popen = run(
             cmd, asynchronous=True, outfile=subprocess.PIPE, stderr=subprocess.STDOUT


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As described in this issue:
https://github.com/localstack/localstack/issues/12201

localstack fails to log under podman.  Before this PR, starting logstack when using podman will reach the following error:

```
⠼ Starting LocalStack container2025-01-28T19:11:00.121 DEBUG --- [-log-printer] localstack.utils.run       : Executing command: ['docker', 'logs', '261b4f90dcc37e74bce5b97cf390a7b935fc2d1e0d12ecd41c8df632b7587e76', '--follow']          
────────────────────────────────────────────────────────────────────────────────── LocalStack Runtime Log (press CTRL-C to quit) ───────────────────────────────────────────────────────────────────────────────────
Error: no container with name or ID "--follow" found: no such container  
```
and logging will stop.

technically localstack will start, but no further console logs are produced after the above error.

In short, podman appears to be sensitive to the position of the `-f` or `--follow` argument.  Moving the argument before the container id is compatible with both docker and podman
<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
localstack will now start without generating a logging error under podman, allowing console logs to be followed.

<!-- Optional section: How to test these changes? -->
<!--
## Testing
I tested this change on both docker and podman powered localstack.
-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
