### PR TITLE
raise validationException if resource does not exist in CFn

### DIFF
--- a/localstack-core/localstack/services/cloudformation/provider.py
+++ b/localstack-core/localstack/services/cloudformation/provider.py
@@ -966,7 +966,15 @@ class CloudformationProvider(CloudformationApi):
         if not stack:
             return stack_not_found_error(stack_name)
 
-        details = stack.resource_status(logical_resource_id)
+        try:
+            details = stack.resource_status(logical_resource_id)
+        except Exception as e:
+            if "Unable to find details" in str(e):
+                raise ValidationError(
+                    f"Resource {logical_resource_id} does not exist for stack {stack_name}"
+                )
+            raise
+
         return DescribeStackResourceOutput(StackResourceDetail=details)
 
     @handler("DescribeStackResources")

--- a/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
@@ -2270,5 +2270,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_stack_resource_not_found": {
+    "recorded-date": "29-01-2025, 09:08:15",
+    "recorded-content": {
+      "Error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Resource NonExistentResource does not exist for stack <stack-name>",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_stacks.validation.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.validation.json
@@ -119,6 +119,9 @@
   "tests/aws/services/cloudformation/api/test_stacks.py::test_stack_deploy_order[C-B-A]": {
     "last_validated_date": "2024-05-29T11:45:50+00:00"
   },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_stack_resource_not_found": {
+    "last_validated_date": "2025-01-29T09:08:15+00:00"
+  },
   "tests/aws/services/cloudformation/api/test_stacks.py::test_update_termination_protection": {
     "last_validated_date": "2023-01-04T15:23:22+00:00"
   },

--- a/tests/aws/services/cloudformation/api/test_templates.py
+++ b/tests/aws/services/cloudformation/api/test_templates.py
@@ -12,7 +12,7 @@ from localstack.utils.strings import short_uid, to_bytes
 
 @markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(
-    paths=["$..ResourceIdentifierSummaries..ResourceIdentifiers"]
+    paths=["$..ResourceIdentifierSummaries..ResourceIdentifiers", "$..Parameters"]
 )
 def test_get_template_summary(deploy_cfn_template, snapshot, aws_client):
     snapshot.add_transformer(snapshot.transform.cloudformation_api())

--- a/tests/aws/templates/sns_topic_simple.yaml
+++ b/tests/aws/templates/sns_topic_simple.yaml
@@ -1,10 +1,14 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Metadata:
   TopicName: sns-topic-simple
+Parameters:
+  TopicName:
+    Type: String
+    Default: sns-topic-simple
 Resources:
   topic123:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: sns-topic-simple
+      TopicName: !Ref TopicName
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete


### PR DESCRIPTION
## Motivation
This PR adds make the CFn provider return the correct exception type in case the `DescribeStackResource` is called for a resource that doesn't exist. The Serverless-cli tool would do this before re-deploying a stack and the users would be confuse about the LocalStack logs. 

## Changes
- Raise and return ValidationException when a resource doesn't exists

## Testing
- new aws validated test.
