### PR TITLE
fix: Explicitly stop ESM workers on LocalStack shutdown

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
@@ -79,6 +79,11 @@ class EsmWorker:
     def uuid(self) -> str:
         return self.esm_config["UUID"]
 
+    def stop_for_shutdown(self):
+        # Signal the worker's poller_loop thread to gracefully shutdown
+        # TODO: Once ESM state is de-coupled from lambda store, re-think this approach.
+        self._shutdown_event.set()
+
     def create(self):
         if self.enabled:
             with self._state_lock:

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -382,6 +382,9 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         get_runtime_executor().validate_environment()
 
     def on_before_stop(self) -> None:
+        for esm_worker in self.esm_workers.values():
+            esm_worker.stop_for_shutdown()
+
         # TODO: should probably unregister routes?
         self.lambda_service.stop()
         # Attempt to signal to the Lambda Debug Mode session object to stop.


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

ESM workers were not being explicitly shut down when LocalStack was being closed. This PR fixes this by explicilty closing all workers on the `on_before_stop` hook prior to the Lambda service.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Loop over all ESM workers and signal them for graceful shutdown in `on_before_stop`
- Add a `stop_for_shutdown` method that signals to close the `poller_loop`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
