### PR TITLE
fix: DNS records w/ ASCII octal wildcards

### DIFF
--- a/localstack-core/localstack/dns/server.py
+++ b/localstack-core/localstack/dns/server.py
@@ -66,6 +66,7 @@ SERIAL = int((datetime.utcnow() - EPOCH).total_seconds())
 DEFAULT_FALLBACK_DNS_SERVER = "8.8.8.8"
 FALLBACK_DNS_LOCK = threading.RLock()
 VERIFICATION_DOMAIN = config.DNS_VERIFICATION_DOMAIN
+OCTAL_WILDCARD: str = "\u005c\u0030\u0035\u0032\u002e"
 
 RCODE_REFUSED = 5
 
@@ -98,6 +99,10 @@ psutil_cache = TTLCache(maxsize=100, ttl=10)
 # TODO: update route53 provider to use this util
 def normalise_dns_name(name: DNSLabel | str) -> str:
     name = str(name)
+
+    if name[:5] == OCTAL_WILDCARD:
+        name = f"*.{name[5:]}"
+
     if not name.endswith("."):
         return f"{name}."
 


### PR DESCRIPTION
## Motivation

While the AWS CLI and the *rust* SDK client(s) don't appear to, *something* in the Terraform AWS provider causes the `Name` field of route53 `ChangeResourceRecordSets` calls to be sent with an escaped ASCII octal sequence instead of the `*` character when creating wildcard domains via a Terraform [`aws_route53_record`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) resource. While Localstack appears to match AWS in terms of observable behavior from the perspective of API callers, that is *not* the case with respect to records added to Localstack's DNS server. Specifically, a `ResourceRecordSet` that's created with a `Name` like `\052.my.dope.app` causes records to be added to Localstack's DNS server for `\052.my.dope.app`, **_not_** for `*.my.dope.app`. In turn, this causes DNS callers to fail to resolve properly.

Frustratingly, the specific sequence in question (`\052`) **_is_** the correct octal sequence for `*` in Python<sup><a href="#octal">ref</a></sup>, which makes it an absolute pain to deal with in more traditionally flexible ways (e.g. regex). As such, (and in order to limit the scope of a change that mutates user-specified values), this fix: 

1) defines the problematic sequence as pedantically as possible (as unicode literals)<sup><a href="#pedantic">ref</a></sup>
2) explicitly and *only* checks for and replaces the problematic value in the actual wildcard position (i.e. the first character(s) of the name)<sup><a href="#problematic">ref</a></sup>
3) does *not* use [`str.replace()`](https://docs.python.org/3/library/stdtypes.html#str.replace) so as to guarantee the minimal-possible mutation, opting instead to "surgically" replace the problematic sequence explicitly by slicing it out (literally 😅: `f"*.{record_name[5:]}"`)<sup><a href="#surgical">ref</a></sup>

## Changes

- check for and correct record names beginning with an escaped octal wildcard

## Visual Aids

#### Python Octal ASCII Escape
<img id="octal" src="https://github.com/user-attachments/assets/61c59094-5332-4619-8bc2-0cf85eae3ed6" />

#### Pedantic Problematic Sequence Definition
<img id="#pedantic" src="https://github.com/user-attachments/assets/02a7ae41-7671-4e9d-9a2c-fb4b226fcc9e" />

#### Problematic Sequence Example
<img id="#problematic" src="https://github.com/user-attachments/assets/427a38e3-edc8-4ef7-976f-2b41e0752b7b" />

#### Surgical String Slicing
<img id="#surgical" src="https://github.com/user-attachments/assets/38ba2728-cc9b-4ebe-8f3c-add2db49bbe8" />


## Testing

- Spin up a fresh Localstack instance:
```bash
docker run -it -e DEBUG=1 -p 4566:4566 -p "127.0.0.1:53:53" -p "127.0.0.1:53:53/udp" --rm --name='localstack' docker.io/localstack/localstack:4
```

- Apply MRE Terraform module:
```bash
cd path/to/example/terraform \  # wherever you saved ⬇ that as `main.tf`
&& terraform init \
&& terraform apply -auto-approve
```

```hcl
terraform {
  required_version = ">=1.9.0"

  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~>5.64"
    }
  }

  backend "local" {}
}

provider "aws" {
  region = "us-east-2"
  access_key                  = "localstack"
  secret_key                  = "localstack"
  skip_credentials_validation = true
  skip_metadata_api_check     = true
  endpoints {
    iam = "http://localhost.localstack.cloud:4566"
    route53 = "http://localhost.localstack.cloud:4566"
    route53domains = "http://localhost.localstack.cloud:4566"
    route53resolver = "http://localhost.localstack.cloud:4566"
    sts = "http://localhost.localstack.cloud:4566"
 }
}

resource "aws_route53_zone" "dope-app" {
  name = "my.dope.app"
}

resource "aws_route53_record" "dope-app-wildcard" {
  zone_id = aws_route53_zone.dope-app.zone_id
  name    = "*.my.dope.app."
  type    = "A"
  ttl     = 300
  records = ["1.1.1.1"]
}
```

- You should see output similar to [this](https://app.warp.dev/block/HxBD53NsxR1UmhLDkrgwMI)

- Check the resulting DNS record(s)
```bash
dig @localhost service.my.dope.app any
```

- Notice how no records are returned 🥲

- Re-run all of the above, but with the fix "patched" into the container:
```bash
docker run -it -e DEBUG=1 -p 4566:4566 -p "127.0.0.1:53:53" -p "127.0.0.1:53:53/udp" -v ./localstack-core/localstack/dns/server.py:/opt/code/localstack/localstack-core/localstack/dns/server.py --rm --name='localstack' docker.io/localstack/localstack:4
```

- Notice how the records are no longer mangled when added to the DNS server
- Check the DNS resolution again:
```bash
dig @localhost service.my.dope.app any
```
- 🎉✨🎉✨

