### PR TITLE
S3: implement TransitionDefaultMinimumObjectSize for Lifecycle Configuration

### DIFF
--- a/localstack-core/localstack/services/s3/models.py
+++ b/localstack-core/localstack/services/s3/models.py
@@ -62,6 +62,7 @@ from localstack.aws.api.s3 import (
     SSECustomerKeyMD5,
     SSEKMSKeyId,
     StorageClass,
+    TransitionDefaultMinimumObjectSize,
     WebsiteConfiguration,
     WebsiteRedirectLocation,
 )
@@ -98,6 +99,7 @@ class S3Bucket:
     objects: Union["KeyStore", "VersionedKeyStore"]
     versioning_status: BucketVersioningStatus | None
     lifecycle_rules: Optional[LifecycleRules]
+    transition_default_minimum_object_size: Optional[TransitionDefaultMinimumObjectSize]
     policy: Optional[Policy]
     website_configuration: Optional[WebsiteConfiguration]
     acl: AccessControlPolicy
@@ -145,6 +147,7 @@ class S3Bucket:
         self.logging = {}
         self.cors_rules = None
         self.lifecycle_rules = None
+        self.transition_default_minimum_object_size = None
         self.website_configuration = None
         self.policy = None
         self.accelerate_status = None

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -31,7 +31,7 @@ from localstack_snapshot.snapshots.transformer import RegexTransformer
 import localstack.config
 from localstack import config
 from localstack.aws.api.lambda_ import Runtime
-from localstack.aws.api.s3 import StorageClass
+from localstack.aws.api.s3 import StorageClass, TransitionDefaultMinimumObjectSize
 from localstack.config import S3_VIRTUAL_HOSTNAME
 from localstack.constants import (
     AWS_REGION_US_EAST_1,
@@ -8960,7 +8960,7 @@ class TestS3BucketLifecycle:
         put_lifecycle_varies = aws_client.s3.put_bucket_lifecycle_configuration(
             Bucket=s3_bucket,
             LifecycleConfiguration=lfc,
-            TransitionDefaultMinimumObjectSize="varies_by_storage_class",
+            TransitionDefaultMinimumObjectSize=TransitionDefaultMinimumObjectSize.varies_by_storage_class,
         )
         snapshot.match("varies-by-storage", put_lifecycle_varies)
 
@@ -8979,7 +8979,7 @@ class TestS3BucketLifecycle:
         put_lifecycle_all_storage = aws_client.s3.put_bucket_lifecycle_configuration(
             Bucket=s3_bucket,
             LifecycleConfiguration=lfc,
-            TransitionDefaultMinimumObjectSize="all_storage_classes_128K",
+            TransitionDefaultMinimumObjectSize=TransitionDefaultMinimumObjectSize.all_storage_classes_128K,
         )
         snapshot.match("all-storage", put_lifecycle_all_storage)
 

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -8280,8 +8280,6 @@ class TestS3Routing:
         assert exc.value.response["Error"]["Message"] == "Not Found"
 
 
-# TODO: implement TransitionDefaultMinimumObjectSize
-@markers.snapshot.skip_snapshot_verify(paths=["$..TransitionDefaultMinimumObjectSize"])
 class TestS3BucketLifecycle:
     @markers.aws.validated
     def test_delete_bucket_lifecycle_configuration(self, s3_bucket, snapshot, aws_client):
@@ -8946,6 +8944,55 @@ class TestS3BucketLifecycle:
 
         response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key)
         snapshot.match("head-object", response)
+
+    @markers.aws.validated
+    def test_s3_transition_default_minimum_object_size(self, aws_client, s3_bucket, snapshot):
+        lfc = {
+            "Rules": [
+                {
+                    "Expiration": {"Days": 7},
+                    "ID": "wholebucket",
+                    "Filter": {"Prefix": ""},
+                    "Status": "Enabled",
+                }
+            ]
+        }
+        put_lifecycle_varies = aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=s3_bucket,
+            LifecycleConfiguration=lfc,
+            TransitionDefaultMinimumObjectSize="varies_by_storage_class",
+        )
+        snapshot.match("varies-by-storage", put_lifecycle_varies)
+
+        get_lifecycle_varies = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-varies-by-storage", get_lifecycle_varies)
+
+        put_lifecycle_default = aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=s3_bucket,
+            LifecycleConfiguration=lfc,
+        )
+        snapshot.match("default", put_lifecycle_default)
+
+        get_default = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-default", get_default)
+
+        put_lifecycle_all_storage = aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=s3_bucket,
+            LifecycleConfiguration=lfc,
+            TransitionDefaultMinimumObjectSize="all_storage_classes_128K",
+        )
+        snapshot.match("all-storage", put_lifecycle_all_storage)
+
+        get_all_storage = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-all-storage", get_all_storage)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_bucket_lifecycle_configuration(
+                Bucket=s3_bucket,
+                LifecycleConfiguration=lfc,
+                TransitionDefaultMinimumObjectSize="value",
+            )
+        snapshot.match("bad-value", e.value.response)
 
 
 class TestS3ObjectLockRetention:

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -16470,7 +16470,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3BucketLifecycle::test_s3_transition_default_minimum_object_size": {
-    "recorded-date": "30-01-2025, 21:21:20",
+    "recorded-date": "03-02-2025, 10:15:23",
     "recorded-content": {
       "varies-by-storage": {
         "TransitionDefaultMinimumObjectSize": "varies_by_storage_class",

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -16468,5 +16468,98 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3BucketLifecycle::test_s3_transition_default_minimum_object_size": {
+    "recorded-date": "30-01-2025, 21:21:20",
+    "recorded-content": {
+      "varies-by-storage": {
+        "TransitionDefaultMinimumObjectSize": "varies_by_storage_class",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-varies-by-storage": {
+        "Rules": [
+          {
+            "Expiration": {
+              "Days": 7
+            },
+            "Filter": {
+              "Prefix": ""
+            },
+            "ID": "wholebucket",
+            "Status": "Enabled"
+          }
+        ],
+        "TransitionDefaultMinimumObjectSize": "varies_by_storage_class",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "default": {
+        "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-default": {
+        "Rules": [
+          {
+            "Expiration": {
+              "Days": 7
+            },
+            "Filter": {
+              "Prefix": ""
+            },
+            "ID": "wholebucket",
+            "Status": "Enabled"
+          }
+        ],
+        "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "all-storage": {
+        "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-all-storage": {
+        "Rules": [
+          {
+            "Expiration": {
+              "Days": 7
+            },
+            "Filter": {
+              "Prefix": ""
+            },
+            "ID": "wholebucket",
+            "Status": "Enabled"
+          }
+        ],
+        "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "bad-value": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Invalid TransitionDefaultMinimumObjectSize found: value"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -537,7 +537,7 @@
     "last_validated_date": "2025-01-21T18:18:24+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3BucketLifecycle::test_s3_transition_default_minimum_object_size": {
-    "last_validated_date": "2025-01-30T21:21:20+00:00"
+    "last_validated_date": "2025-02-03T10:15:22+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3BucketLogging::test_put_bucket_logging": {
     "last_validated_date": "2023-08-12T17:54:07+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -536,6 +536,9 @@
   "tests/aws/services/s3/test_s3.py::TestS3BucketLifecycle::test_put_bucket_lifecycle_conf_exc": {
     "last_validated_date": "2025-01-21T18:18:24+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3BucketLifecycle::test_s3_transition_default_minimum_object_size": {
+    "last_validated_date": "2025-01-30T21:21:20+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3BucketLogging::test_put_bucket_logging": {
     "last_validated_date": "2023-08-12T17:54:07+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As a follow up from #12145, there was a new field introduced for operation related to S3 Buckets `LifecycleConfiguration`.

This fix allows us to now validate and return the field as well, even though we do not support Lifecycle transitions, some IaC providers might expect us to return it. 

This is what the field is for:
> In September 2024 Amazon S3 updated the default transition behavior for small objects, as follows:
>
> - Updated default transition behavior — Starting September 2024, the default behavior prevents objects smaller than 128 KB from being transitioned to any storage class.
> - Previous default transition behavior — Before September 2024, the default behavior allowed objects smaller than 128 KB to be transitioned only to the S3 Glacier and S3 Glacier Deep Archive storage classes.

See:
- Documentation on the field for the operation:
https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html#AmazonS3-PutBucketLifecycleConfiguration-request-header-TransitionDefaultMinimumObjectSize
- Announcement:
https://aws.amazon.com/about-aws/whats-new/2024/09/amazon-s3-default-minimum-object-size-lifecycle-transition-rules/


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- write small test case to cover the CRUD functionality
- implement the change in our model and provider
  - add additional safety when upgrading from an older model

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
