### PR TITLE
Bump moto-ext to 5.0.28.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.26.post2",
+    "moto-ext[all]==5.0.28.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -8,7 +8,7 @@ build==1.2.2.post1
     # via localstack-core (pyproject.toml)
 cachetools==5.5.1
     # via localstack-core (pyproject.toml)
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via cryptography

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -254,7 +254,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.26.post2
+moto-ext==5.0.28.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.26.post2
+moto-ext==5.0.28.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -238,7 +238,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.26.post2
+moto-ext==5.0.28.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -258,7 +258,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.26.post2
+moto-ext==5.0.28.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.0.28.post1

Contains:

- https://github.com/getmoto/moto/pull/8531

## To do

- [x] Ext compatibility (Ext integration tests) AWS / Ext Integration Tests
    https://github.com/localstack/localstack-ext/actions/runs/13073190885
- [x] Multi-account/region compatibility (Randomised credentials test run) - CircleCI Pipeline: number 30936, ID ac9507be-9c1a-4c1d-8fae-05c8d1b773eb https://app.circleci.com/pipelines/github/localstack/localstack/30936/workflows/69184467-0936-4d41-b8a8-7234f983d4ba