### PR TITLE
[SQS] Stop blocking Queue.get() call on LocalStack shutdown

### DIFF
--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -301,7 +301,7 @@ class SqsQueue:
         self.permissions = set()
         self.mutex = threading.RLock()
 
-    def do_shutdown(self):
+    def shutdown(self):
         pass
 
     def default_attributes(self) -> QueueAttributeMap:
@@ -739,7 +739,7 @@ class StandardQueue(SqsQueue):
     def approx_number_of_messages(self):
         return self.visible.qsize()
 
-    def do_shutdown(self):
+    def shutdown(self):
         self.visible.shutdown()
 
     def put(
@@ -966,7 +966,7 @@ class FifoQueue(SqsQueue):
             n += len(message_group.messages)
         return n
 
-    def do_shutdown(self):
+    def shutdown(self):
         self.message_group_queue.shutdown()
 
     def get_message_group(self, message_group_id: str) -> MessageGroup:

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -818,6 +818,10 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
         self._queue_update_worker.stop()
         self._message_move_task_manager.close()
+        for _, _, store in sqs_stores.iter_stores():
+            for queue in store.queues.values():
+                queue.do_shutdown()
+
         self._stop_cloudwatch_metrics_reporting()
 
     @staticmethod

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -820,7 +820,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         self._message_move_task_manager.close()
         for _, _, store in sqs_stores.iter_stores():
             for queue in store.queues.values():
-                queue.do_shutdown()
+                queue.shutdown()
 
         self._stop_cloudwatch_metrics_reporting()
 

--- a/localstack-core/localstack/services/sqs/queue.py
+++ b/localstack-core/localstack/services/sqs/queue.py
@@ -1,14 +1,14 @@
-import threading
 import time
 from queue import Empty, PriorityQueue, Queue
 
 
 class InterruptibleQueue(Queue):
-    shutdown_event: threading.Event
+    # is_shutdown is used to check whether we have triggered a shutdown of the Queue
+    is_shutdown: bool
 
     def __init__(self, maxsize=0):
         super().__init__(maxsize)
-        self.shutdown_event = threading.Event()
+        self.is_shutdown = False
 
     def get(self, block=True, timeout=None):
         with self.not_empty:
@@ -16,26 +16,31 @@ class InterruptibleQueue(Queue):
                 if not self._qsize():
                     raise Empty
             elif timeout is None:
-                while not self._qsize() and not self.shutdown_event.is_set():
+                while not self._qsize() and not self.is_shutdown:  # additional shutdown check
                     self.not_empty.wait()
             elif timeout < 0:
                 raise ValueError("'timeout' must be a non-negative number")
             else:
                 endtime = time.time() + timeout
-                while not self._qsize() and not self.shutdown_event.is_set():
+                while not self._qsize() and not self.is_shutdown:  # additional shutdown check
                     remaining = endtime - time.time()
                     if remaining <= 0.0:
                         raise Empty
                     self.not_empty.wait(remaining)
-            if self.shutdown_event.is_set():
+            if self.is_shutdown:  # additional shutdown check
                 raise Empty
             item = self._get()
             self.not_full.notify()
             return item
 
     def shutdown(self):
-        self.shutdown_event.set()
+        """
+        `shutdown` signals to stop all current and future `Queue.get` calls from executing.
+
+        This is helpful for exiting otherwise blocking calls early.
+        """
         with self.not_empty:
+            self.is_shutdown = True
             self.not_empty.notify_all()
 
 

--- a/localstack-core/localstack/services/sqs/queue.py
+++ b/localstack-core/localstack/services/sqs/queue.py
@@ -1,0 +1,43 @@
+import threading
+import time
+from queue import Empty, PriorityQueue, Queue
+
+
+class InterruptibleQueue(Queue):
+    shutdown_event: threading.Event
+
+    def __init__(self, maxsize=0):
+        super().__init__(maxsize)
+        self.shutdown_event = threading.Event()
+
+    def get(self, block=True, timeout=None):
+        with self.not_empty:
+            if not block:
+                if not self._qsize():
+                    raise Empty
+            elif timeout is None:
+                while not self._qsize() and not self.shutdown_event.is_set():
+                    self.not_empty.wait()
+            elif timeout < 0:
+                raise ValueError("'timeout' must be a non-negative number")
+            else:
+                endtime = time.time() + timeout
+                while not self._qsize() and not self.shutdown_event.is_set():
+                    remaining = endtime - time.time()
+                    if remaining <= 0.0:
+                        raise Empty
+                    self.not_empty.wait(remaining)
+            if self.shutdown_event.is_set():
+                raise Empty
+            item = self._get()
+            self.not_full.notify()
+            return item
+
+    def shutdown(self):
+        self.shutdown_event.set()
+        with self.not_empty:
+            self.not_empty.notify_all()
+
+
+class InterruptiblePriorityQueue(PriorityQueue, InterruptibleQueue):
+    pass

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3646,5 +3646,39 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_set_empty_redrive_policy[sqs_query]": {
     "recorded-date": "20-08-2024, 14:14:11",
     "recorded-content": {}
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_empty_queue[sqs]": {
+    "recorded-date": "30-01-2025, 22:32:45",
+    "recorded-content": {
+      "empty_short_poll_resp": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "empty_long_poll_resp": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_empty_queue[sqs_query]": {
+    "recorded-date": "30-01-2025, 22:32:48",
+    "recorded-content": {
+      "empty_short_poll_resp": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "empty_long_poll_resp": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -203,6 +203,12 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_posting_to_fifo_requires_deduplicationid_group_id[sqs_query]": {
     "last_validated_date": "2024-04-30T13:34:22+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_empty_queue[sqs]": {
+    "last_validated_date": "2025-01-30T22:32:45+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_empty_queue[sqs_query]": {
+    "last_validated_date": "2025-01-30T22:32:48+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_attribute_names_filters[sqs]": {
     "last_validated_date": "2024-06-04T11:54:31+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Blocking calls in the SQS provider's internal queue implementation cause LocalStack shutdown to hang, and in some cases time-out. 

This PR allows for these blocking `Queue.get` calls to exit early if LocalStack is shutting down and the `do_shutdown` method is called.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Add an `InterruptibleQueue` class that overwrites a `Queue` implementations `get` method to leverage a shutdown `Threading.Event`.
- `InterruptibleQueue` also has a `do_shutdown` method that a queue to be shutdown early if it is currently undergoing a blocking call.
- Add queue closing to the SQS provider's `on_before_stop` lifecycle hook (which happens after persistence) to ensure no hanging threads prevent LS from shutting down.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
