### PR TITLE
APIGW: binary support for non-proxy integration

### DIFF
--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -605,6 +605,9 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
             # for path "/responseTemplates/application~1json"
             if "/responseTemplates" in path:
+                integration_response.response_templates = (
+                    integration_response.response_templates or {}
+                )
                 value = patch_operation.get("value")
                 if not isinstance(value, str):
                     raise BadRequestException(
@@ -612,7 +615,13 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                     )
                 param = path.removeprefix("/responseTemplates/")
                 param = param.replace("~1", "/")
-                integration_response.response_templates.pop(param)
+                if op == "remove":
+                    integration_response.response_templates.pop(param)
+                elif op == "add":
+                    integration_response.response_templates[param] = value
+
+            elif "/contentHandling" in path and op == "replace":
+                integration_response.content_handling = patch_operation.get("value")
 
     def update_resource(
         self,

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration.py
@@ -9,8 +9,6 @@ from ..integrations import REST_API_INTEGRATIONS
 LOG = logging.getLogger(__name__)
 
 
-# TODO: this will need to use ApiGatewayIntegration class, using Plugin for discoverability and a PluginManager,
-#  in order to automatically have access to defined Integrations that we can extend
 class IntegrationHandler(RestApiGatewayHandler):
     def __call__(
         self,
@@ -24,7 +22,7 @@ class IntegrationHandler(RestApiGatewayHandler):
         integration = REST_API_INTEGRATIONS.get(integration_type)
 
         if not integration:
-            # TODO: raise proper exception?
+            # this should not happen, as we validated the type in the provider
             raise NotImplementedError(
                 f"This integration type is not yet supported: {integration_type}"
             )

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -186,13 +186,18 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
         if not template:
             return body, {}
 
+        try:
+            body_utf8 = to_str(body)
+        except UnicodeError:
+            raise InternalServerError("Internal server error")
+
         body, request_override = self._vtl_template.render_request(
             template=template,
             variables=MappingTemplateVariables(
                 context=context.context_variables,
                 stageVariables=context.stage_variables or {},
                 input=MappingTemplateInput(
-                    body=to_str(body),
+                    body=body_utf8,
                     params=MappingTemplateParams(
                         path=request.get("path_parameters"),
                         querystring=request.get("query_string_parameters", {}),

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -1,9 +1,10 @@
+import base64
 import logging
 from http import HTTPMethod
 
 from werkzeug.datastructures import Headers
 
-from localstack.aws.api.apigateway import Integration, IntegrationType
+from localstack.aws.api.apigateway import ContentHandlingStrategy, Integration, IntegrationType
 from localstack.constants import APPLICATION_JSON
 from localstack.http import Request, Response
 from localstack.utils.collections import merge_recursive
@@ -13,7 +14,7 @@ from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import IntegrationRequest, InvocationRequest, RestApiInvocationContext
 from ..gateway_response import InternalServerError, UnsupportedMediaTypeError
 from ..header_utils import drop_headers, set_default_headers
-from ..helpers import render_integration_uri
+from ..helpers import mime_type_matches_binary_media_types, render_integration_uri
 from ..parameters_mapping import ParametersMapper, RequestDataMapping
 from ..template_mapping import (
     ApiGatewayVtlTemplate,
@@ -116,8 +117,10 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
                 integration=integration, request=context.invocation_request
             )
 
+            converted_body = self.convert_body(context)
+
             body, request_override = self.render_request_template_mapping(
-                context=context, template=request_template
+                context=context, body=converted_body, template=request_template
             )
             # mutate the ContextVariables with the requestOverride result, as we copy the context when rendering the
             # template to avoid mutation on other fields
@@ -175,10 +178,10 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
     def render_request_template_mapping(
         self,
         context: RestApiInvocationContext,
+        body: str | bytes,
         template: str,
     ) -> tuple[bytes, ContextVarsRequestOverride]:
         request: InvocationRequest = context.invocation_request
-        body = request["body"]
 
         if not template:
             return body, {}
@@ -234,6 +237,39 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
                 LOG.debug("Unknown passthrough behavior: '%s'", passthrough_behavior)
 
         return request_template
+
+    @staticmethod
+    def convert_body(context: RestApiInvocationContext) -> bytes | str:
+        """
+        https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings.html
+        https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-workflow.html
+        :param context:
+        :return: the body, either as is, or converted depending on the table in the second link
+        """
+        request: InvocationRequest = context.invocation_request
+        body = request["body"]
+
+        is_binary_request = mime_type_matches_binary_media_types(
+            mime_type=request["headers"].get("Content-Type"),
+            binary_media_types=context.deployment.rest_api.rest_api.get("binaryMediaTypes", []),
+        )
+        content_handling = context.integration.get("contentHandling")
+        if is_binary_request:
+            if content_handling and content_handling == ContentHandlingStrategy.CONVERT_TO_TEXT:
+                body = base64.b64encode(body)
+            # if the content handling is not defined, or CONVERT_TO_BINARY, we do not touch the body and leave it as
+            # proper binary
+        else:
+            if not content_handling or content_handling == ContentHandlingStrategy.CONVERT_TO_TEXT:
+                body = body.decode(encoding="UTF-8", errors="replace")
+            else:
+                # it means we have CONVERT_TO_BINARY, so we need to try to decode the base64 string
+                try:
+                    body = base64.b64decode(body)
+                except ValueError:
+                    raise InternalServerError("Internal server error")
+
+        return body
 
     @staticmethod
     def _merge_http_proxy_query_string(

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -184,7 +184,7 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
         request: InvocationRequest = context.invocation_request
 
         if not template:
-            return body, {}
+            return to_bytes(body), {}
 
         try:
             body_utf8 = to_str(body)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
@@ -263,7 +263,7 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
         self, context: RestApiInvocationContext, template: str, body: bytes | str
     ) -> tuple[bytes, ContextVarsResponseOverride]:
         if not template:
-            return body, ContextVarsResponseOverride(status=0, header={})
+            return to_bytes(body), ContextVarsResponseOverride(status=0, header={})
 
         # if there are no template, we can pass binary data through
         if not isinstance(body, str):

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
@@ -1,10 +1,16 @@
+import base64
 import json
 import logging
 import re
 
 from werkzeug.datastructures import Headers
 
-from localstack.aws.api.apigateway import Integration, IntegrationResponse, IntegrationType
+from localstack.aws.api.apigateway import (
+    ContentHandlingStrategy,
+    Integration,
+    IntegrationResponse,
+    IntegrationType,
+)
 from localstack.constants import APPLICATION_JSON
 from localstack.http import Response
 from localstack.utils.strings import to_bytes, to_str
@@ -17,6 +23,7 @@ from ..context import (
     RestApiInvocationContext,
 )
 from ..gateway_response import ApiConfigurationError, InternalServerError
+from ..helpers import mime_type_matches_binary_media_types
 from ..parameters_mapping import ParametersMapper, ResponseDataMapping
 from ..template_mapping import (
     ApiGatewayVtlTemplate,
@@ -83,8 +90,15 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
         response_template = self.get_response_template(
             integration_response=integration_response, request=context.invocation_request
         )
+        # binary support
+        converted_body = self.convert_body(
+            context,
+            body=body,
+            content_handling=integration_response.get("contentHandling"),
+        )
+
         body, response_override = self.render_response_template_mapping(
-            context=context, template=response_template, body=body
+            context=context, template=response_template, body=converted_body
         )
 
         # We basically need to remove all headers and replace them with the mapping, then
@@ -197,6 +211,53 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
         template = next(iter(response_templates.values()))
         LOG.warning("No templates were matched, Using template: %s", template)
         return template
+
+    @staticmethod
+    def convert_body(
+        context: RestApiInvocationContext,
+        body: bytes,
+        content_handling: ContentHandlingStrategy | None,
+    ) -> bytes | str:
+        """
+        https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings.html
+        https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-workflow.html
+        :param context: RestApiInvocationContext
+        :param body: the endpoint response body
+        :param content_handling: the contentHandling of the IntegrationResponse
+        :return: the body, either as is, or converted depending on the table in the second link
+        """
+
+        request: InvocationRequest = context.invocation_request
+        response: EndpointResponse = context.endpoint_response
+        binary_media_types = context.deployment.rest_api.rest_api.get("binaryMediaTypes", [])
+
+        is_binary_payload = mime_type_matches_binary_media_types(
+            mime_type=response["headers"].get("Content-Type"),
+            binary_media_types=binary_media_types,
+        )
+        is_binary_accept = mime_type_matches_binary_media_types(
+            mime_type=request["headers"].get("Accept"),
+            binary_media_types=binary_media_types,
+        )
+
+        if is_binary_payload:
+            if (
+                content_handling and content_handling == ContentHandlingStrategy.CONVERT_TO_TEXT
+            ) or (not content_handling and not is_binary_accept):
+                body = base64.b64encode(body)
+        else:
+            # this means the Payload is of type `Text` in AWS terms for the table
+            if (
+                content_handling and content_handling == ContentHandlingStrategy.CONVERT_TO_TEXT
+            ) or (not content_handling and not is_binary_accept):
+                body = body.decode(encoding="UTF-8", errors="replace")
+            else:
+                try:
+                    body = base64.b64decode(body)
+                except ValueError:
+                    raise InternalServerError("Internal server error")
+
+        return body
 
     def render_response_template_mapping(
         self, context: RestApiInvocationContext, template: str, body: bytes | str

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
@@ -71,7 +71,7 @@ class RestAPIResourceRouter:
 
         :param context:
         :return: A tuple with the matched resource and the (already parsed) path params
-        :raises: TODO: Gateway exception in case the given request does not match any operation
+        :raises: MissingAuthTokenError, weird naming but that is the default NotFound for REST API
         """
 
         request = context.request

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -32,7 +32,6 @@ from ..context import (
 from ..gateway_response import IntegrationFailureError, InternalServerError
 from ..header_utils import build_multi_value_headers
 from ..helpers import (
-    accept_header_matches_binary_media_types,
     get_lambda_function_arn_from_invocation_uri,
     get_source_arn,
     mime_type_matches_binary_media_types,

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -32,6 +32,7 @@ from ..context import (
 from ..gateway_response import IntegrationFailureError, InternalServerError
 from ..header_utils import build_multi_value_headers
 from ..helpers import (
+    accept_header_matches_binary_media_types,
     get_lambda_function_arn_from_invocation_uri,
     get_source_arn,
     mime_type_matches_binary_media_types,
@@ -396,8 +397,8 @@ class RestApiAwsProxyIntegration(RestApiIntegration):
         # TODO: maybe centralize this flag inside the context, when we are also using it for other integration types
         #  AWS_PROXY behaves a bit differently, but this could checked only once earlier
         binary_response_accepted = mime_type_matches_binary_media_types(
-            context.invocation_request["headers"].get("Accept"),
-            context.deployment.rest_api.rest_api.get("binaryMediaTypes", []),
+            mime_type=context.invocation_request["headers"].get("Accept"),
+            binary_media_types=context.deployment.rest_api.rest_api.get("binaryMediaTypes", []),
         )
         body = self._parse_body(
             body=lambda_response.get("body"),

--- a/tests/aws/services/apigateway/test_apigateway_s3.py
+++ b/tests/aws/services/apigateway/test_apigateway_s3.py
@@ -706,7 +706,6 @@ class TestApiGatewayS3BinarySupport:
         obj = retry(_invoke, url=invoke_url_text, accept="text/plain", retries=10)
         snapshot.match("text-no-media", {"content": obj.content, "etag": obj.headers.get("ETag")})
 
-        # it tries to decode the object as UTF8 and fails, hence 500
         invoke_url_raw = api_invoke_url(api_id, stage_name, path="/" + object_key_raw)
         obj = retry(_invoke, url=invoke_url_raw, accept="image/png")
         snapshot.match("raw-no-media", {"content": obj.content, "etag": obj.headers.get("ETag")})

--- a/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
@@ -478,5 +478,72 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary_with_request_template": {
+    "recorded-date": "01-02-2025, 00:48:04",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "contentHandling": "CONVERT_TO_BINARY",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "contentHandling": "CONVERT_TO_BINARY",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "integrationResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path"
+        },
+        "requestTemplates": {
+          "application/json": {
+            "data": "$input.body"
+          }
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
+        "ContentType": "image/png",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
@@ -56,488 +56,6 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary": {
-    "recorded-date": "01-02-2025, 03:28:08",
-    "recorded-content": {
-      "put-integration": {
-        "cacheKeyParameters": [],
-        "cacheNamespace": "<cache-namespace:1>",
-        "contentHandling": "CONVERT_TO_BINARY",
-        "credentials": "<credentials:1>",
-        "httpMethod": "ANY",
-        "passthroughBehavior": "WHEN_NO_MATCH",
-        "requestParameters": {
-          "integration.request.header.Content-Type": "method.request.header.Content-Type",
-          "integration.request.path.object_path": "method.request.path.object_path",
-          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
-        },
-        "timeoutInMillis": 29000,
-        "type": "AWS",
-        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "put-obj-raw": {
-        "ChecksumCRC32": "MjWu6g==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-no-binary-media-binary-encoded": {
-        "AcceptRanges": "bytes",
-        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "ContentLength": 67,
-        "ContentType": "image/png",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-binary-media-binary-raw": {
-        "AcceptRanges": "bytes",
-        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "ContentLength": 67,
-        "ContentType": "image/png",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-binary-media-binary-encoded": {
-        "AcceptRanges": "bytes",
-        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "ContentLength": 92,
-        "ContentType": "image/png",
-        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-binary-media-text": {
-        "AcceptRanges": "bytes",
-        "Body": "b'this is a UTF8 text typed object'",
-        "ContentLength": 32,
-        "ContentType": "image/png",
-        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-text-type-binary-encoded": {
-        "AcceptRanges": "bytes",
-        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "ContentLength": 67,
-        "ContentType": "text/plain",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary_with_request_template": {
-    "recorded-date": "01-02-2025, 00:48:04",
-    "recorded-content": {
-      "put-integration": {
-        "cacheKeyParameters": [],
-        "cacheNamespace": "<cache-namespace:1>",
-        "contentHandling": "CONVERT_TO_BINARY",
-        "credentials": "<credentials:1>",
-        "httpMethod": "ANY",
-        "passthroughBehavior": "WHEN_NO_MATCH",
-        "requestParameters": {
-          "integration.request.header.Content-Type": "method.request.header.Content-Type",
-          "integration.request.path.object_path": "method.request.path.object_path"
-        },
-        "timeoutInMillis": 29000,
-        "type": "AWS",
-        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get-integration": {
-        "cacheKeyParameters": [],
-        "cacheNamespace": "<cache-namespace:1>",
-        "contentHandling": "CONVERT_TO_BINARY",
-        "credentials": "<credentials:1>",
-        "httpMethod": "ANY",
-        "integrationResponses": {
-          "200": {
-            "statusCode": "200"
-          }
-        },
-        "passthroughBehavior": "WHEN_NO_MATCH",
-        "requestParameters": {
-          "integration.request.header.Content-Type": "method.request.header.Content-Type",
-          "integration.request.path.object_path": "method.request.path.object_path"
-        },
-        "requestTemplates": {
-          "application/json": {
-            "data": "$input.body"
-          }
-        },
-        "timeoutInMillis": 29000,
-        "type": "AWS",
-        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-encoded": {
-        "AcceptRanges": "bytes",
-        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "ContentLength": 67,
-        "ContentType": "image/png",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_no_content_handling": {
-    "recorded-date": "01-02-2025, 02:20:00",
-    "recorded-content": {
-      "put-integration": {
-        "cacheKeyParameters": [],
-        "cacheNamespace": "<cache-namespace:1>",
-        "credentials": "<credentials:1>",
-        "httpMethod": "ANY",
-        "passthroughBehavior": "WHEN_NO_MATCH",
-        "requestParameters": {
-          "integration.request.header.Content-Type": "method.request.header.Content-Type",
-          "integration.request.path.object_path": "method.request.path.object_path",
-          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
-        },
-        "timeoutInMillis": 29000,
-        "type": "AWS",
-        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "put-obj-binary-raw": {
-        "ChecksumCRC32": "MjWu6g==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-obj-binary-encoded": {
-        "ChecksumCRC32": "P/3olw==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-obj-text": {
-        "ChecksumCRC32": "DzmB0Q==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "text-no-media": {
-        "content": "b'this is a UTF8 text typed object'",
-        "etag": "\"322a648674040849d29154aa1dce24a5\""
-      },
-      "raw-no-media": {
-        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
-        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
-      },
-      "encoded-no-media": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "encoded-payload-text-accept-binary": {
-        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "encoded-payload-binary-accept-binary": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "raw-payload-binary-accept-binary": {
-        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
-      },
-      "text-payload-binary-accept-binary": {
-        "content": "b'this is a UTF8 text typed object'",
-        "etag": "\"322a648674040849d29154aa1dce24a5\""
-      },
-      "encoded-payload-text-accept-text": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "raw-payload-text-accept-text": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "text-payload-text-accept-text": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "encoded-payload-binary-accept-text": {
-        "content": "b'SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTZFJSS003SUw4MUpVVWhLVmNqTUswdk15VXhSQ0ExeDA3VlFLQzRweXN4TEJ3QzRPUkJYTHdBQUFBPT0='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "raw-payload-binary-accept-text": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
-      },
-      "text-payload-binary-accept-text": {
-        "content": "b'dGhpcyBpcyBhIFVURjggdGV4dCB0eXBlZCBvYmplY3Q='",
-        "etag": "\"322a648674040849d29154aa1dce24a5\""
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_text": {
-    "recorded-date": "01-02-2025, 02:31:20",
-    "recorded-content": {
-      "put-integration": {
-        "cacheKeyParameters": [],
-        "cacheNamespace": "<cache-namespace:1>",
-        "credentials": "<credentials:1>",
-        "httpMethod": "ANY",
-        "passthroughBehavior": "WHEN_NO_MATCH",
-        "requestParameters": {
-          "integration.request.header.Content-Type": "method.request.header.Content-Type",
-          "integration.request.path.object_path": "method.request.path.object_path",
-          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
-        },
-        "timeoutInMillis": 29000,
-        "type": "AWS",
-        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "put-obj-binary-raw": {
-        "ChecksumCRC32": "MjWu6g==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-obj-binary-encoded": {
-        "ChecksumCRC32": "P/3olw==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-obj-text": {
-        "ChecksumCRC32": "DzmB0Q==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "text-no-media": {
-        "content": "b'this is a UTF8 text typed object'",
-        "etag": "\"322a648674040849d29154aa1dce24a5\""
-      },
-      "raw-no-media": {
-        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
-        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
-      },
-      "encoded-no-media": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "encoded-payload-text-accept-binary": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "raw-payload-text-accept-binary": {
-        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
-        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
-      },
-      "text-payload-text-accept-binary": {
-        "content": "b'this is a UTF8 text typed object'",
-        "etag": "\"322a648674040849d29154aa1dce24a5\""
-      },
-      "encoded-payload-binary-accept-binary": {
-        "content": "b'SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTZFJSS003SUw4MUpVVWhLVmNqTUswdk15VXhSQ0ExeDA3VlFLQzRweXN4TEJ3QzRPUkJYTHdBQUFBPT0='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "raw-payload-binary-accept-binary": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
-      },
-      "text-payload-binary-accept-binary": {
-        "content": "b'dGhpcyBpcyBhIFVURjggdGV4dCB0eXBlZCBvYmplY3Q='",
-        "etag": "\"322a648674040849d29154aa1dce24a5\""
-      },
-      "encoded-payload-text-accept-text": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "raw-payload-text-accept-text": {
-        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
-        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
-      },
-      "text-payload-text-accept-text": {
-        "content": "b'this is a UTF8 text typed object'",
-        "etag": "\"322a648674040849d29154aa1dce24a5\""
-      },
-      "encoded-payload-binary-accept-text": {
-        "content": "b'SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTZFJSS003SUw4MUpVVWhLVmNqTUswdk15VXhSQ0ExeDA3VlFLQzRweXN4TEJ3QzRPUkJYTHdBQUFBPT0='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "raw-payload-binary-accept-text": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
-      },
-      "text-payload-binary-accept-text": {
-        "content": "b'dGhpcyBpcyBhIFVURjggdGV4dCB0eXBlZCBvYmplY3Q='",
-        "etag": "\"322a648674040849d29154aa1dce24a5\""
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_binary": {
-    "recorded-date": "01-02-2025, 02:45:46",
-    "recorded-content": {
-      "put-integration": {
-        "cacheKeyParameters": [],
-        "cacheNamespace": "<cache-namespace:1>",
-        "credentials": "<credentials:1>",
-        "httpMethod": "ANY",
-        "passthroughBehavior": "WHEN_NO_MATCH",
-        "requestParameters": {
-          "integration.request.header.Content-Type": "method.request.header.Content-Type",
-          "integration.request.path.object_path": "method.request.path.object_path",
-          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
-        },
-        "timeoutInMillis": 29000,
-        "type": "AWS",
-        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "put-obj-binary-raw": {
-        "ChecksumCRC32": "MjWu6g==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-obj-binary-encoded": {
-        "ChecksumCRC32": "P/3olw==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-obj-text": {
-        "ChecksumCRC32": "DzmB0Q==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "encoded-no-media": {
-        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "encoded-payload-text-accept-binary": {
-        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "encoded-payload-binary-accept-binary": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "raw-payload-binary-accept-binary": {
-        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
-      },
-      "text-payload-binary-accept-binary": {
-        "content": "b'this is a UTF8 text typed object'",
-        "etag": "\"322a648674040849d29154aa1dce24a5\""
-      },
-      "encoded-payload-text-accept-text": {
-        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "encoded-payload-binary-accept-text": {
-        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
-      },
-      "raw-payload-binary-accept-text": {
-        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
-      },
-      "text-payload-binary-accept-text": {
-        "content": "b'this is a UTF8 text typed object'",
-        "etag": "\"322a648674040849d29154aa1dce24a5\""
-      }
-    }
-  },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request[None]": {
     "recorded-date": "01-02-2025, 02:56:56",
     "recorded-content": {
@@ -856,6 +374,493 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary": {
+    "recorded-date": "01-02-2025, 03:28:08",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "contentHandling": "CONVERT_TO_BINARY",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-obj-raw": {
+        "ChecksumCRC32": "MjWu6g==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
+        "ContentType": "image/png",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-media-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
+        "ContentType": "image/png",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-media-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "ContentLength": 92,
+        "ContentType": "image/png",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-media-text": {
+        "AcceptRanges": "bytes",
+        "Body": "b'this is a UTF8 text typed object'",
+        "ContentLength": 32,
+        "ContentType": "image/png",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-text-type-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
+        "ContentType": "text/plain",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary_with_request_template": {
+    "recorded-date": "01-02-2025, 04:24:02",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "contentHandling": "CONVERT_TO_BINARY",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "contentHandling": "CONVERT_TO_BINARY",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "integrationResponses": {
+          "200": {
+            "responseParameters": {
+              "method.response.header.ETag": "integration.response.header.ETag"
+            },
+            "statusCode": "200"
+          }
+        },
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
+        },
+        "requestTemplates": {
+          "application/json": {
+            "data": "$input.body"
+          }
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
+        "ContentType": "image/png",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_no_content_handling": {
+    "recorded-date": "01-02-2025, 03:59:15",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-obj-binary-raw": {
+        "ChecksumCRC32": "MjWu6g==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-binary-encoded": {
+        "ChecksumCRC32": "P/3olw==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-text": {
+        "ChecksumCRC32": "DzmB0Q==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "text-no-media": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "raw-no-media": {
+        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "encoded-no-media": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-text-accept-binary": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-binary-accept-binary": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-binary-accept-binary": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-binary-accept-binary": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "encoded-payload-text-accept-text": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-text-accept-text": {
+        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-text-accept-text": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "encoded-payload-binary-accept-text": {
+        "content": "b'SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTZFJSS003SUw4MUpVVWhLVmNqTUswdk15VXhSQ0ExeDA3VlFLQzRweXN4TEJ3QzRPUkJYTHdBQUFBPT0='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-binary-accept-text": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-binary-accept-text": {
+        "content": "b'dGhpcyBpcyBhIFVURjggdGV4dCB0eXBlZCBvYmplY3Q='",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_text": {
+    "recorded-date": "01-02-2025, 04:00:09",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-obj-binary-raw": {
+        "ChecksumCRC32": "MjWu6g==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-binary-encoded": {
+        "ChecksumCRC32": "P/3olw==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-text": {
+        "ChecksumCRC32": "DzmB0Q==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "text-no-media": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "raw-no-media": {
+        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "encoded-no-media": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-text-accept-binary": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-text-accept-binary": {
+        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-text-accept-binary": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "encoded-payload-binary-accept-binary": {
+        "content": "b'SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTZFJSS003SUw4MUpVVWhLVmNqTUswdk15VXhSQ0ExeDA3VlFLQzRweXN4TEJ3QzRPUkJYTHdBQUFBPT0='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-binary-accept-binary": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-binary-accept-binary": {
+        "content": "b'dGhpcyBpcyBhIFVURjggdGV4dCB0eXBlZCBvYmplY3Q='",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "encoded-payload-text-accept-text": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-text-accept-text": {
+        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-text-accept-text": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "encoded-payload-binary-accept-text": {
+        "content": "b'SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTZFJSS003SUw4MUpVVWhLVmNqTUswdk15VXhSQ0ExeDA3VlFLQzRweXN4TEJ3QzRPUkJYTHdBQUFBPT0='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-binary-accept-text": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-binary-accept-text": {
+        "content": "b'dGhpcyBpcyBhIFVURjggdGV4dCB0eXBlZCBvYmplY3Q='",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_binary": {
+    "recorded-date": "01-02-2025, 02:45:46",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-obj-binary-raw": {
+        "ChecksumCRC32": "MjWu6g==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-binary-encoded": {
+        "ChecksumCRC32": "P/3olw==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-text": {
+        "ChecksumCRC32": "DzmB0Q==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "encoded-no-media": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-text-accept-binary": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-binary-accept-binary": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-binary-accept-binary": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-binary-accept-binary": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "encoded-payload-text-accept-text": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-binary-accept-text": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-binary-accept-text": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-binary-accept-text": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
       }
     }
   }

--- a/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
@@ -1,12 +1,30 @@
 {
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_any": {
-    "recorded-date": "13-06-2024, 23:10:19",
+    "recorded-date": "31-01-2025, 19:00:37",
     "recorded-content": {
+      "get-object-empty": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "HostId": "<host-id>",
+          "Key": "test.json",
+          "Message": "The specified key does not exist.",
+          "RequestId": "<request-id:1>"
+        }
+      },
       "get-object-1": {
         "put_id": 1
       },
       "get-object-2": {
         "put_id": 2
+      },
+      "get-object-deleted": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "HostId": "<host-id>",
+          "Key": "test.json",
+          "Message": "The specified key does not exist.",
+          "RequestId": "<request-id:2>"
+        }
       },
       "get-object-s3": {
         "Error": {

--- a/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
@@ -57,25 +57,12 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_no_content_handling": {
-    "recorded-date": "31-01-2025, 22:48:00",
+    "recorded-date": "31-01-2025, 23:06:37",
     "recorded-content": {
-      "put-method": {
-        "apiKeyRequired": false,
-        "authorizationType": "NONE",
-        "httpMethod": "ANY",
-        "requestParameters": {
-          "method.request.header.Content-Type": false,
-          "method.request.path.object_path": true
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
       "put-integration": {
         "cacheKeyParameters": [],
-        "cacheNamespace": "exsgsj",
-        "credentials": "arn:<partition>:iam::111111111111:role/role-eddd8f4f",
+        "cacheNamespace": "<cache-namespace:1>",
+        "credentials": "<credentials:1>",
         "httpMethod": "ANY",
         "passthroughBehavior": "WHEN_NO_MATCH",
         "requestParameters": {
@@ -84,18 +71,28 @@
         },
         "timeoutInMillis": 29000,
         "type": "AWS",
-        "uri": "arn:<partition>:apigateway:<region>:s3:path/test-bucket-093d7100/{object_path}",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
         }
       },
+      "put-obj-raw": {
+        "ChecksumCRC32": "MjWu6g==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "get-obj-no-binary-media-binary-raw": {
         "AcceptRanges": "bytes",
-        "Body": "\u001f\ufffd\b\u0000\fS\ufffdg\u0002\ufffdK\ufffd\ufffd-(J-.NMQHI,I\ufffdQ(\ufffd\ufffd/\ufffdIQHJU\ufffd\ufffd+K\ufffd\ufffdLQ\b\rq\u04f5P(.)\ufffd\ufffdK\u0007\u0000\ufffd9\u0010W/\u0000\u0000\u0000",
+        "Body": "\u001f\ufffd\b\u0000\u0014l\ufffdc\u0002\ufffdK\ufffd\ufffd-(J-.NMQHI,I\ufffdQ(\ufffd\ufffd/\ufffdIQHJU\ufffd\ufffd+K\ufffd\ufffdLQ\b\rq\u04f5P(.)\ufffd\ufffdK\u0007\u0000\ufffd9\u0010W/\u0000\u0000\u0000",
         "ContentLength": 99,
         "ContentType": "image/png",
-        "ETag": "\"ec5fdc19947ad7e9cfc1f08006747412\"",
+        "ETag": "\"7301f0a0e8fc87c6f03320bf795ffde7\"",
         "LastModified": "datetime",
         "Metadata": {},
         "ServerSideEncryption": "AES256",
@@ -106,10 +103,10 @@
       },
       "get-obj-no-binary-media-binary-encoded": {
         "AcceptRanges": "bytes",
-        "Body": "H4sIAAxTnWcC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA==",
+        "Body": "H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA==",
         "ContentLength": 92,
         "ContentType": "image/png",
-        "ETag": "\"d99fd4e509fb30330479fb821438aa53\"",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
         "LastModified": "datetime",
         "Metadata": {},
         "ServerSideEncryption": "AES256",
@@ -134,10 +131,10 @@
       },
       "get-obj-binary-media-binary-raw": {
         "AcceptRanges": "bytes",
-        "Body": "\u001f\ufffd\b\u0000\fS\ufffdg\u0002\ufffdK\ufffd\ufffd-(J-.NMQHI,I\ufffdQ(\ufffd\ufffd/\ufffdIQHJU\ufffd\ufffd+K\ufffd\ufffdLQ\b\rq\u04f5P(.)\ufffd\ufffdK\u0007\u0000\ufffd9\u0010W/\u0000\u0000\u0000",
-        "ContentLength": 99,
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
         "ContentType": "image/png",
-        "ETag": "\"ec5fdc19947ad7e9cfc1f08006747412\"",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
         "LastModified": "datetime",
         "Metadata": {},
         "ServerSideEncryption": "AES256",
@@ -148,10 +145,10 @@
       },
       "get-obj-binary-media-binary-encoded": {
         "AcceptRanges": "bytes",
-        "Body": "H4sIAAxTnWcC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA==",
+        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
         "ContentLength": 92,
         "ContentType": "image/png",
-        "ETag": "\"d99fd4e509fb30330479fb821438aa53\"",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
         "LastModified": "datetime",
         "Metadata": {},
         "ServerSideEncryption": "AES256",
@@ -162,7 +159,7 @@
       },
       "get-obj-binary-media-text": {
         "AcceptRanges": "bytes",
-        "Body": "this is a UTF8 text typed object",
+        "Body": "b'this is a UTF8 text typed object'",
         "ContentLength": 32,
         "ContentType": "text/plain",
         "ETag": "\"322a648674040849d29154aa1dce24a5\"",
@@ -176,10 +173,10 @@
       },
       "get-obj-wrong-binary-media-binary-raw": {
         "AcceptRanges": "bytes",
-        "Body": "\u001f\ufffd\b\u0000\fS\ufffdg\u0002\ufffdK\ufffd\ufffd-(J-.NMQHI,I\ufffdQ(\ufffd\ufffd/\ufffdIQHJU\ufffd\ufffd+K\ufffd\ufffdLQ\b\rq\u04f5P(.)\ufffd\ufffdK\u0007\u0000\ufffd9\u0010W/\u0000\u0000\u0000",
+        "Body": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
         "ContentLength": 99,
         "ContentType": "image/jpg",
-        "ETag": "\"ec5fdc19947ad7e9cfc1f08006747412\"",
+        "ETag": "\"7301f0a0e8fc87c6f03320bf795ffde7\"",
         "LastModified": "datetime",
         "Metadata": {},
         "ServerSideEncryption": "AES256",
@@ -190,10 +187,288 @@
       },
       "get-obj-text-binary-media-binary-raw": {
         "AcceptRanges": "bytes",
-        "Body": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x0cS\\xef\\xbf\\xbdg\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
-        "ContentLength": 99,
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
         "ContentType": "text/plain",
-        "ETag": "\"ec5fdc19947ad7e9cfc1f08006747412\"",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_text": {
+    "recorded-date": "31-01-2025, 23:12:01",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "contentHandling": "CONVERT_TO_TEXT",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-obj-raw": {
+        "ChecksumCRC32": "MjWu6g==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "\u001f\ufffd\b\u0000\u0014l\ufffdc\u0002\ufffdK\ufffd\ufffd-(J-.NMQHI,I\ufffdQ(\ufffd\ufffd/\ufffdIQHJU\ufffd\ufffd+K\ufffd\ufffdLQ\b\rq\u04f5P(.)\ufffd\ufffdK\u0007\u0000\ufffd9\u0010W/\u0000\u0000\u0000",
+        "ContentLength": 99,
+        "ContentType": "image/png",
+        "ETag": "\"7301f0a0e8fc87c6f03320bf795ffde7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA==",
+        "ContentLength": 92,
+        "ContentType": "image/png",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-text": {
+        "AcceptRanges": "bytes",
+        "Body": "this is a UTF8 text typed object",
+        "ContentLength": 32,
+        "ContentType": "text/plain",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-media-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "ContentLength": 92,
+        "ContentType": "image/png",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-media-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "b'SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTZFJSS003SUw4MUpVVWhLVmNqTUswdk15VXhSQ0ExeDA3VlFLQzRweXN4TEJ3QzRPUkJYTHdBQUFBPT0='",
+        "ContentLength": 124,
+        "ContentType": "image/png",
+        "ETag": "\"835317c6c047dd2a13bb05117594a71a\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-media-text": {
+        "AcceptRanges": "bytes",
+        "Body": "b'dGhpcyBpcyBhIFVURjggdGV4dCB0eXBlZCBvYmplY3Q='",
+        "ContentLength": 44,
+        "ContentType": "text/plain",
+        "ETag": "\"1a39ff3d9eff87f24107669698573f35\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-wrong-binary-media-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 99,
+        "ContentType": "image/jpg",
+        "ETag": "\"7301f0a0e8fc87c6f03320bf795ffde7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-text-binary-media-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "ContentLength": 92,
+        "ContentType": "text/plain",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary": {
+    "recorded-date": "01-02-2025, 00:14:21",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "contentHandling": "CONVERT_TO_BINARY",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-obj-raw": {
+        "ChecksumCRC32": "MjWu6g==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
+        "ContentType": "image/png",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-media-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
+        "ContentType": "image/png",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-media-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "ContentLength": 92,
+        "ContentType": "image/png",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-media-text": {
+        "AcceptRanges": "bytes",
+        "Body": "b'this is a UTF8 text typed object'",
+        "ContentLength": 32,
+        "ContentType": "text/plain",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-raw-binary-media-text": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
+        "ContentType": "text/plain",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-raw-binary-media-json": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
+        "ContentType": "application/json",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-encoded-not-binary-media": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
+        "ContentType": "application/xml",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
         "LastModified": "datetime",
         "Metadata": {},
         "ServerSideEncryption": "AES256",

--- a/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
@@ -56,299 +56,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_no_content_handling": {
-    "recorded-date": "31-01-2025, 23:06:37",
-    "recorded-content": {
-      "put-integration": {
-        "cacheKeyParameters": [],
-        "cacheNamespace": "<cache-namespace:1>",
-        "credentials": "<credentials:1>",
-        "httpMethod": "ANY",
-        "passthroughBehavior": "WHEN_NO_MATCH",
-        "requestParameters": {
-          "integration.request.header.Content-Type": "method.request.header.Content-Type",
-          "integration.request.path.object_path": "method.request.path.object_path"
-        },
-        "timeoutInMillis": 29000,
-        "type": "AWS",
-        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "put-obj-raw": {
-        "ChecksumCRC32": "MjWu6g==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-no-binary-media-binary-raw": {
-        "AcceptRanges": "bytes",
-        "Body": "\u001f\ufffd\b\u0000\u0014l\ufffdc\u0002\ufffdK\ufffd\ufffd-(J-.NMQHI,I\ufffdQ(\ufffd\ufffd/\ufffdIQHJU\ufffd\ufffd+K\ufffd\ufffdLQ\b\rq\u04f5P(.)\ufffd\ufffdK\u0007\u0000\ufffd9\u0010W/\u0000\u0000\u0000",
-        "ContentLength": 99,
-        "ContentType": "image/png",
-        "ETag": "\"7301f0a0e8fc87c6f03320bf795ffde7\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-no-binary-media-binary-encoded": {
-        "AcceptRanges": "bytes",
-        "Body": "H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA==",
-        "ContentLength": 92,
-        "ContentType": "image/png",
-        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-no-binary-media-text": {
-        "AcceptRanges": "bytes",
-        "Body": "this is a UTF8 text typed object",
-        "ContentLength": 32,
-        "ContentType": "text/plain",
-        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-binary-media-binary-raw": {
-        "AcceptRanges": "bytes",
-        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "ContentLength": 67,
-        "ContentType": "image/png",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-binary-media-binary-encoded": {
-        "AcceptRanges": "bytes",
-        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "ContentLength": 92,
-        "ContentType": "image/png",
-        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-binary-media-text": {
-        "AcceptRanges": "bytes",
-        "Body": "b'this is a UTF8 text typed object'",
-        "ContentLength": 32,
-        "ContentType": "text/plain",
-        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-wrong-binary-media-binary-raw": {
-        "AcceptRanges": "bytes",
-        "Body": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
-        "ContentLength": 99,
-        "ContentType": "image/jpg",
-        "ETag": "\"7301f0a0e8fc87c6f03320bf795ffde7\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-text-binary-media-binary-raw": {
-        "AcceptRanges": "bytes",
-        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "ContentLength": 67,
-        "ContentType": "text/plain",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_text": {
-    "recorded-date": "31-01-2025, 23:12:01",
-    "recorded-content": {
-      "put-integration": {
-        "cacheKeyParameters": [],
-        "cacheNamespace": "<cache-namespace:1>",
-        "contentHandling": "CONVERT_TO_TEXT",
-        "credentials": "<credentials:1>",
-        "httpMethod": "ANY",
-        "passthroughBehavior": "WHEN_NO_MATCH",
-        "requestParameters": {
-          "integration.request.header.Content-Type": "method.request.header.Content-Type",
-          "integration.request.path.object_path": "method.request.path.object_path"
-        },
-        "timeoutInMillis": 29000,
-        "type": "AWS",
-        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "put-obj-raw": {
-        "ChecksumCRC32": "MjWu6g==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-no-binary-media-binary-raw": {
-        "AcceptRanges": "bytes",
-        "Body": "\u001f\ufffd\b\u0000\u0014l\ufffdc\u0002\ufffdK\ufffd\ufffd-(J-.NMQHI,I\ufffdQ(\ufffd\ufffd/\ufffdIQHJU\ufffd\ufffd+K\ufffd\ufffdLQ\b\rq\u04f5P(.)\ufffd\ufffdK\u0007\u0000\ufffd9\u0010W/\u0000\u0000\u0000",
-        "ContentLength": 99,
-        "ContentType": "image/png",
-        "ETag": "\"7301f0a0e8fc87c6f03320bf795ffde7\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-no-binary-media-binary-encoded": {
-        "AcceptRanges": "bytes",
-        "Body": "H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA==",
-        "ContentLength": 92,
-        "ContentType": "image/png",
-        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-no-binary-media-text": {
-        "AcceptRanges": "bytes",
-        "Body": "this is a UTF8 text typed object",
-        "ContentLength": 32,
-        "ContentType": "text/plain",
-        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-binary-media-binary-raw": {
-        "AcceptRanges": "bytes",
-        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "ContentLength": 92,
-        "ContentType": "image/png",
-        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-binary-media-binary-encoded": {
-        "AcceptRanges": "bytes",
-        "Body": "b'SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTZFJSS003SUw4MUpVVWhLVmNqTUswdk15VXhSQ0ExeDA3VlFLQzRweXN4TEJ3QzRPUkJYTHdBQUFBPT0='",
-        "ContentLength": 124,
-        "ContentType": "image/png",
-        "ETag": "\"835317c6c047dd2a13bb05117594a71a\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-binary-media-text": {
-        "AcceptRanges": "bytes",
-        "Body": "b'dGhpcyBpcyBhIFVURjggdGV4dCB0eXBlZCBvYmplY3Q='",
-        "ContentLength": 44,
-        "ContentType": "text/plain",
-        "ETag": "\"1a39ff3d9eff87f24107669698573f35\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-wrong-binary-media-binary-raw": {
-        "AcceptRanges": "bytes",
-        "Body": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
-        "ContentLength": 99,
-        "ContentType": "image/jpg",
-        "ETag": "\"7301f0a0e8fc87c6f03320bf795ffde7\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-text-binary-media-binary-raw": {
-        "AcceptRanges": "bytes",
-        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
-        "ContentLength": 92,
-        "ContentType": "text/plain",
-        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary": {
-    "recorded-date": "01-02-2025, 00:14:21",
+    "recorded-date": "01-02-2025, 03:28:08",
     "recorded-content": {
       "put-integration": {
         "cacheKeyParameters": [],
@@ -359,7 +68,8 @@
         "passthroughBehavior": "WHEN_NO_MATCH",
         "requestParameters": {
           "integration.request.header.Content-Type": "method.request.header.Content-Type",
-          "integration.request.path.object_path": "method.request.path.object_path"
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
         },
         "timeoutInMillis": 29000,
         "type": "AWS",
@@ -425,7 +135,7 @@
         "AcceptRanges": "bytes",
         "Body": "b'this is a UTF8 text typed object'",
         "ContentLength": 32,
-        "ContentType": "text/plain",
+        "ContentType": "image/png",
         "ETag": "\"322a648674040849d29154aa1dce24a5\"",
         "LastModified": "datetime",
         "Metadata": {},
@@ -435,39 +145,11 @@
           "HTTPStatusCode": 200
         }
       },
-      "get-obj-raw-binary-media-text": {
+      "get-obj-text-type-binary-encoded": {
         "AcceptRanges": "bytes",
         "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
         "ContentLength": 67,
         "ContentType": "text/plain",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-raw-binary-media-json": {
-        "AcceptRanges": "bytes",
-        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "ContentLength": 67,
-        "ContentType": "application/json",
-        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-obj-encoded-not-binary-media": {
-        "AcceptRanges": "bytes",
-        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
-        "ContentLength": 67,
-        "ContentType": "application/xml",
         "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
         "LastModified": "datetime",
         "Metadata": {},
@@ -853,6 +535,327 @@
       "text-payload-binary-accept-text": {
         "content": "b'this is a UTF8 text typed object'",
         "etag": "\"322a648674040849d29154aa1dce24a5\""
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request[None]": {
+    "recorded-date": "01-02-2025, 02:56:56",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-obj-raw": {
+        "ChecksumCRC32": "MjWu6g==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "\u001f\ufffd\b\u0000\u0014l\ufffdc\u0002\ufffdK\ufffd\ufffd-(J-.NMQHI,I\ufffdQ(\ufffd\ufffd/\ufffdIQHJU\ufffd\ufffd+K\ufffd\ufffdLQ\b\rq\u04f5P(.)\ufffd\ufffdK\u0007\u0000\ufffd9\u0010W/\u0000\u0000\u0000",
+        "ContentLength": 99,
+        "ContentType": "image/png",
+        "ETag": "\"7301f0a0e8fc87c6f03320bf795ffde7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA==",
+        "ContentLength": 92,
+        "ContentType": "image/png",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-text": {
+        "AcceptRanges": "bytes",
+        "Body": "this is a UTF8 text typed object",
+        "ContentLength": 32,
+        "ContentType": "image/png",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-type-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 67,
+        "ContentType": "image/png",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-type-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "ContentLength": 92,
+        "ContentType": "image/png",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-type-text": {
+        "AcceptRanges": "bytes",
+        "Body": "b'this is a UTF8 text typed object'",
+        "ContentLength": 32,
+        "ContentType": "image/png",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-text-type-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 99,
+        "ContentType": "text/plain",
+        "ETag": "\"7301f0a0e8fc87c6f03320bf795ffde7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-text-type-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "ContentLength": 92,
+        "ContentType": "text/plain",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-text-type-text": {
+        "AcceptRanges": "bytes",
+        "Body": "b'this is a UTF8 text typed object'",
+        "ContentLength": 32,
+        "ContentType": "text/plain",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request[CONVERT_TO_TEXT]": {
+    "recorded-date": "01-02-2025, 02:57:27",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "contentHandling": "CONVERT_TO_TEXT",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-obj-raw": {
+        "ChecksumCRC32": "MjWu6g==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "\u001f\ufffd\b\u0000\u0014l\ufffdc\u0002\ufffdK\ufffd\ufffd-(J-.NMQHI,I\ufffdQ(\ufffd\ufffd/\ufffdIQHJU\ufffd\ufffd+K\ufffd\ufffdLQ\b\rq\u04f5P(.)\ufffd\ufffdK\u0007\u0000\ufffd9\u0010W/\u0000\u0000\u0000",
+        "ContentLength": 99,
+        "ContentType": "image/png",
+        "ETag": "\"7301f0a0e8fc87c6f03320bf795ffde7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA==",
+        "ContentLength": 92,
+        "ContentType": "image/png",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-text": {
+        "AcceptRanges": "bytes",
+        "Body": "this is a UTF8 text typed object",
+        "ContentLength": 32,
+        "ContentType": "image/png",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-type-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "ContentLength": 92,
+        "ContentType": "image/png",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-type-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "b'SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTZFJSS003SUw4MUpVVWhLVmNqTUswdk15VXhSQ0ExeDA3VlFLQzRweXN4TEJ3QzRPUkJYTHdBQUFBPT0='",
+        "ContentLength": 124,
+        "ContentType": "image/png",
+        "ETag": "\"835317c6c047dd2a13bb05117594a71a\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-type-text": {
+        "AcceptRanges": "bytes",
+        "Body": "b'dGhpcyBpcyBhIFVURjggdGV4dCB0eXBlZCBvYmplY3Q='",
+        "ContentLength": 44,
+        "ContentType": "image/png",
+        "ETag": "\"1a39ff3d9eff87f24107669698573f35\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-text-type-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 99,
+        "ContentType": "text/plain",
+        "ETag": "\"7301f0a0e8fc87c6f03320bf795ffde7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-text-type-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "ContentLength": 92,
+        "ContentType": "text/plain",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-text-type-text": {
+        "AcceptRanges": "bytes",
+        "Body": "b'this is a UTF8 text typed object'",
+        "ContentLength": 32,
+        "ContentType": "text/plain",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   }

--- a/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
@@ -545,5 +545,315 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_no_content_handling": {
+    "recorded-date": "01-02-2025, 02:20:00",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-obj-binary-raw": {
+        "ChecksumCRC32": "MjWu6g==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-binary-encoded": {
+        "ChecksumCRC32": "P/3olw==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-text": {
+        "ChecksumCRC32": "DzmB0Q==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "text-no-media": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "raw-no-media": {
+        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "encoded-no-media": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-text-accept-binary": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-binary-accept-binary": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-binary-accept-binary": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-binary-accept-binary": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "encoded-payload-text-accept-text": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-text-accept-text": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "text-payload-text-accept-text": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-binary-accept-text": {
+        "content": "b'SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTZFJSS003SUw4MUpVVWhLVmNqTUswdk15VXhSQ0ExeDA3VlFLQzRweXN4TEJ3QzRPUkJYTHdBQUFBPT0='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-binary-accept-text": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-binary-accept-text": {
+        "content": "b'dGhpcyBpcyBhIFVURjggdGV4dCB0eXBlZCBvYmplY3Q='",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_text": {
+    "recorded-date": "01-02-2025, 02:31:20",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-obj-binary-raw": {
+        "ChecksumCRC32": "MjWu6g==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-binary-encoded": {
+        "ChecksumCRC32": "P/3olw==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-text": {
+        "ChecksumCRC32": "DzmB0Q==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "text-no-media": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "raw-no-media": {
+        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "encoded-no-media": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-text-accept-binary": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-text-accept-binary": {
+        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-text-accept-binary": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "encoded-payload-binary-accept-binary": {
+        "content": "b'SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTZFJSS003SUw4MUpVVWhLVmNqTUswdk15VXhSQ0ExeDA3VlFLQzRweXN4TEJ3QzRPUkJYTHdBQUFBPT0='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-binary-accept-binary": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-binary-accept-binary": {
+        "content": "b'dGhpcyBpcyBhIFVURjggdGV4dCB0eXBlZCBvYmplY3Q='",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "encoded-payload-text-accept-text": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-text-accept-text": {
+        "content": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x14l\\xef\\xbf\\xbdc\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-text-accept-text": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "encoded-payload-binary-accept-text": {
+        "content": "b'SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTZFJSS003SUw4MUpVVWhLVmNqTUswdk15VXhSQ0ExeDA3VlFLQzRweXN4TEJ3QzRPUkJYTHdBQUFBPT0='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-binary-accept-text": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-binary-accept-text": {
+        "content": "b'dGhpcyBpcyBhIFVURjggdGV4dCB0eXBlZCBvYmplY3Q='",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_binary": {
+    "recorded-date": "01-02-2025, 02:45:46",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-obj-binary-raw": {
+        "ChecksumCRC32": "MjWu6g==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"1e5a1bfed5308938e5549848bab02ac6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-binary-encoded": {
+        "ChecksumCRC32": "P/3olw==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-text": {
+        "ChecksumCRC32": "DzmB0Q==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "encoded-no-media": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-text-accept-binary": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-binary-accept-binary": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-binary-accept-binary": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-binary-accept-binary": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      },
+      "encoded-payload-text-accept-text": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "encoded-payload-binary-accept-text": {
+        "content": "b'H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA=='",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "raw-payload-binary-accept-text": {
+        "content": "b'\\x1f\\x8b\\x08\\x00\\x14l\\xeec\\x02\\xffK\\xce\\xcf-(J-.NMQHI,I\\xd4Q(\\xce\\xc8/\\xcdIQHJU\\xc8\\xcc+K\\xcc\\xc9LQ\\x08\\rq\\xd3\\xb5P(.)\\xca\\xccK\\x07\\x00\\xb89\\x10W/\\x00\\x00\\x00'",
+        "etag": "\"1e5a1bfed5308938e5549848bab02ac6\""
+      },
+      "text-payload-binary-accept-text": {
+        "content": "b'this is a UTF8 text typed object'",
+        "etag": "\"322a648674040849d29154aa1dce24a5\""
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
@@ -863,5 +863,75 @@
         "etag": "\"322a648674040849d29154aa1dce24a5\""
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_binary_with_request_template": {
+    "recorded-date": "01-02-2025, 05:06:24",
+    "recorded-content": {
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "credentials": "<credentials:1>",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path",
+          "integration.request.querystring.response-content-type": "method.request.header.response-content-type"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/<s3-bucket>/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-integration-response": {
+        "contentHandling": "CONVERT_TO_TEXT",
+        "responseParameters": {
+          "method.response.header.ETag": "integration.response.header.ETag"
+        },
+        "responseTemplates": {
+          "application/json": {
+            "data": "$input.body"
+          }
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-encoded": {
+        "ChecksumCRC32": "P/3olw==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"76020056aa8e57ba307f9264167a34e4\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "encoded-text-payload-binary-accept": {
+        "content": "b'{\"data\": \"H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA==\"}'",
+        "etag": "\"76020056aa8e57ba307f9264167a34e4\""
+      },
+      "get-integration-response-update": {
+        "contentHandling": "CONVERT_TO_BINARY",
+        "responseParameters": {
+          "method.response.header.ETag": "integration.response.header.ETag"
+        },
+        "responseTemplates": {
+          "application/json": {
+            "data": "$input.body"
+          }
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.snapshot.json
@@ -55,5 +55,153 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_no_content_handling": {
+    "recorded-date": "31-01-2025, 22:48:00",
+    "recorded-content": {
+      "put-method": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "requestParameters": {
+          "method.request.header.Content-Type": false,
+          "method.request.path.object_path": true
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-integration": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "exsgsj",
+        "credentials": "arn:<partition>:iam::111111111111:role/role-eddd8f4f",
+        "httpMethod": "ANY",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestParameters": {
+          "integration.request.header.Content-Type": "method.request.header.Content-Type",
+          "integration.request.path.object_path": "method.request.path.object_path"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "arn:<partition>:apigateway:<region>:s3:path/test-bucket-093d7100/{object_path}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-obj-no-binary-media-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "\u001f\ufffd\b\u0000\fS\ufffdg\u0002\ufffdK\ufffd\ufffd-(J-.NMQHI,I\ufffdQ(\ufffd\ufffd/\ufffdIQHJU\ufffd\ufffd+K\ufffd\ufffdLQ\b\rq\u04f5P(.)\ufffd\ufffdK\u0007\u0000\ufffd9\u0010W/\u0000\u0000\u0000",
+        "ContentLength": 99,
+        "ContentType": "image/png",
+        "ETag": "\"ec5fdc19947ad7e9cfc1f08006747412\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "H4sIAAxTnWcC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA==",
+        "ContentLength": 92,
+        "ContentType": "image/png",
+        "ETag": "\"d99fd4e509fb30330479fb821438aa53\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-no-binary-media-text": {
+        "AcceptRanges": "bytes",
+        "Body": "this is a UTF8 text typed object",
+        "ContentLength": 32,
+        "ContentType": "text/plain",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-media-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "\u001f\ufffd\b\u0000\fS\ufffdg\u0002\ufffdK\ufffd\ufffd-(J-.NMQHI,I\ufffdQ(\ufffd\ufffd/\ufffdIQHJU\ufffd\ufffd+K\ufffd\ufffdLQ\b\rq\u04f5P(.)\ufffd\ufffdK\u0007\u0000\ufffd9\u0010W/\u0000\u0000\u0000",
+        "ContentLength": 99,
+        "ContentType": "image/png",
+        "ETag": "\"ec5fdc19947ad7e9cfc1f08006747412\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-media-binary-encoded": {
+        "AcceptRanges": "bytes",
+        "Body": "H4sIAAxTnWcC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA==",
+        "ContentLength": 92,
+        "ContentType": "image/png",
+        "ETag": "\"d99fd4e509fb30330479fb821438aa53\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-binary-media-text": {
+        "AcceptRanges": "bytes",
+        "Body": "this is a UTF8 text typed object",
+        "ContentLength": 32,
+        "ContentType": "text/plain",
+        "ETag": "\"322a648674040849d29154aa1dce24a5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-wrong-binary-media-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "\u001f\ufffd\b\u0000\fS\ufffdg\u0002\ufffdK\ufffd\ufffd-(J-.NMQHI,I\ufffdQ(\ufffd\ufffd/\ufffdIQHJU\ufffd\ufffd+K\ufffd\ufffdLQ\b\rq\u04f5P(.)\ufffd\ufffdK\u0007\u0000\ufffd9\u0010W/\u0000\u0000\u0000",
+        "ContentLength": 99,
+        "ContentType": "image/jpg",
+        "ETag": "\"ec5fdc19947ad7e9cfc1f08006747412\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-text-binary-media-binary-raw": {
+        "AcceptRanges": "bytes",
+        "Body": "b'\\x1f\\xef\\xbf\\xbd\\x08\\x00\\x0cS\\xef\\xbf\\xbdg\\x02\\xef\\xbf\\xbdK\\xef\\xbf\\xbd\\xef\\xbf\\xbd-(J-.NMQHI,I\\xef\\xbf\\xbdQ(\\xef\\xbf\\xbd\\xef\\xbf\\xbd/\\xef\\xbf\\xbdIQHJU\\xef\\xbf\\xbd\\xef\\xbf\\xbd+K\\xef\\xbf\\xbd\\xef\\xbf\\xbdLQ\\x08\\rq\\xd3\\xb5P(.)\\xef\\xbf\\xbd\\xef\\xbf\\xbdK\\x07\\x00\\xef\\xbf\\xbd9\\x10W/\\x00\\x00\\x00'",
+        "ContentLength": 99,
+        "ContentType": "text/plain",
+        "ETag": "\"ec5fdc19947ad7e9cfc1f08006747412\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_s3.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_no_content_handling": {
+    "last_validated_date": "2025-01-31T22:48:00+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_any": {
     "last_validated_date": "2025-01-31T19:00:37+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_s3.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.validation.json
@@ -1,6 +1,12 @@
 {
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary": {
+    "last_validated_date": "2025-02-01T00:14:21+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_text": {
+    "last_validated_date": "2025-01-31T23:12:01+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_no_content_handling": {
-    "last_validated_date": "2025-01-31T22:48:00+00:00"
+    "last_validated_date": "2025-01-31T23:06:37+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_any": {
     "last_validated_date": "2025-01-31T19:00:37+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_s3.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.validation.json
@@ -11,6 +11,15 @@
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_no_content_handling": {
     "last_validated_date": "2025-01-31T23:06:37+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_binary": {
+    "last_validated_date": "2025-02-01T02:45:46+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_text": {
+    "last_validated_date": "2025-02-01T02:31:20+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_no_content_handling": {
+    "last_validated_date": "2025-02-01T02:20:00+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_any": {
     "last_validated_date": "2025-01-31T19:00:37+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_s3.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary": {
     "last_validated_date": "2025-02-01T00:14:21+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary_with_request_template": {
+    "last_validated_date": "2025-02-01T00:48:04+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_text": {
     "last_validated_date": "2025-01-31T23:12:01+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_s3.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.validation.json
@@ -9,16 +9,16 @@
     "last_validated_date": "2025-02-01T03:28:08+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary_with_request_template": {
-    "last_validated_date": "2025-02-01T00:48:04+00:00"
+    "last_validated_date": "2025-02-01T04:24:02+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_binary": {
     "last_validated_date": "2025-02-01T02:45:46+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_text": {
-    "last_validated_date": "2025-02-01T02:31:20+00:00"
+    "last_validated_date": "2025-02-01T04:00:09+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_no_content_handling": {
-    "last_validated_date": "2025-02-01T02:20:00+00:00"
+    "last_validated_date": "2025-02-01T03:59:15+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_any": {
     "last_validated_date": "2025-01-31T19:00:37+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_s3.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_any": {
-    "last_validated_date": "2024-06-13T23:10:19+00:00"
+    "last_validated_date": "2025-01-31T19:00:37+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_s3.py::test_apigateway_s3_method_mapping": {
     "last_validated_date": "2024-06-14T16:12:27+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_s3.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.validation.json
@@ -14,6 +14,9 @@
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_binary": {
     "last_validated_date": "2025-02-01T02:45:46+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_binary_with_request_template": {
+    "last_validated_date": "2025-02-01T05:06:24+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_text": {
     "last_validated_date": "2025-02-01T04:00:09+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_s3.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_s3.validation.json
@@ -1,15 +1,15 @@
 {
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request[CONVERT_TO_TEXT]": {
+    "last_validated_date": "2025-02-01T02:57:27+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request[None]": {
+    "last_validated_date": "2025-02-01T02:56:56+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary": {
-    "last_validated_date": "2025-02-01T00:14:21+00:00"
+    "last_validated_date": "2025-02-01T03:28:08+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_binary_with_request_template": {
     "last_validated_date": "2025-02-01T00:48:04+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_convert_to_text": {
-    "last_validated_date": "2025-01-31T23:12:01+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_request_no_content_handling": {
-    "last_validated_date": "2025-01-31T23:06:37+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_s3.py::TestApiGatewayS3BinarySupport::test_apigw_s3_binary_support_response_convert_to_binary": {
     "last_validated_date": "2025-02-01T02:45:46+00:00"

--- a/tests/unit/services/apigateway/test_handler_integration_response.py
+++ b/tests/unit/services/apigateway/test_handler_integration_response.py
@@ -22,6 +22,10 @@ from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 TEST_API_ID = "test-api"
 TEST_API_STAGE = "stage"
 
+BINARY_DATA_1 = b"\x1f\x8b\x08\x00\x14l\xeec\x02\xffK\xce\xcf-(J-.NMQHI,I\xd4Q(\xce\xc8/\xcdIQHJU\xc8\xcc+K\xcc\xc9LQ\x08\rq\xd3\xb5P(.)\xca\xccK\x07\x00\xb89\x10W/\x00\x00\x00"
+BINARY_DATA_2 = b"\x1f\x8b\x08\x00\x14l\xeec\x02\xffK\xce\xcf-(J-.NMQHI,IT0\xd2Q(\xce\xc8/\xcdIQHJU\xc8\xcc+K\xcc\xc9LQ\x08\rq\xd3\xb5P(.)\xca\xccKWH*-QH\xc9LKK-J\xcd+\x01\x00\x99!\xedI?\x00\x00\x00"
+BINARY_DATA_1_SAFE = b"\x1f\xef\xbf\xbd\x08\x00\x14l\xef\xbf\xbdc\x02\xef\xbf\xbdK\xef\xbf\xbd\xef\xbf\xbd-(J-.NMQHI,I\xef\xbf\xbdQ(\xef\xbf\xbd\xef\xbf\xbd/\xef\xbf\xbdIQHJU\xef\xbf\xbd\xef\xbf\xbd+K\xef\xbf\xbd\xef\xbf\xbdLQ\x08\rq\xd3\xb5P(.)\xef\xbf\xbd\xef\xbf\xbdK\x07\x00\xef\xbf\xbd9\x10W/\x00\x00\x00"
+
 
 class TestSelectionPattern:
     def test_selection_pattern_status_code(self):
@@ -243,3 +247,87 @@ class TestHandlerIntegrationResponse:
         ctx.endpoint_response["headers"]["content-type"] = "text/html"
         integration_response_handler(ctx)
         assert ctx.invocation_response["body"] == b"json"
+
+
+class TestIntegrationResponseBinaryHandling:
+    """
+    https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-workflow.html
+    When AWS differentiates between "text" and "binary" types, it means if the MIME type of the Content-Type or Accept
+    header matches one of the binaryMediaTypes configured
+    """
+
+    @pytest.mark.parametrize(
+        "response_content_type,client_accept,binary_medias,content_handling, expected",
+        [
+            (None, None, None, None, "utf8"),
+            (None, None, None, "CONVERT_TO_BINARY", "b64-decoded"),
+            (None, None, None, "CONVERT_TO_TEXT", "utf8"),
+            ("text/plain", "text/plain", ["image/png"], None, "utf8"),
+            ("text/plain", "text/plain", ["image/png"], "CONVERT_TO_BINARY", "b64-decoded"),
+            ("text/plain", "text/plain", ["image/png"], "CONVERT_TO_TEXT", "utf8"),
+            ("text/plain", "image/png", ["image/png"], None, "b64-decoded"),
+            ("text/plain", "image/png", ["image/png"], "CONVERT_TO_BINARY", "b64-decoded"),
+            ("text/plain", "image/png", ["image/png"], "CONVERT_TO_TEXT", "utf8"),
+            ("image/png", "text/plain", ["image/png"], None, "b64-encoded"),
+            ("image/png", "text/plain", ["image/png"], "CONVERT_TO_BINARY", None),
+            ("image/png", "text/plain", ["image/png"], "CONVERT_TO_TEXT", "b64-encoded"),
+            ("image/png", "image/png", ["image/png"], None, None),
+            ("image/png", "image/png", ["image/png"], "CONVERT_TO_BINARY", None),
+            ("image/png", "image/png", ["image/png"], "CONVERT_TO_TEXT", "b64-encoded"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "input_data,possible_values",
+        [
+            (
+                BINARY_DATA_1,
+                {
+                    "b64-encoded": b"H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSdRRKM7IL81JUUhKVcjMK0vMyUxRCA1x07VQKC4pysxLBwC4ORBXLwAAAA==",
+                    "b64-decoded": None,
+                    "utf8": BINARY_DATA_1_SAFE.decode(),
+                },
+            ),
+            (
+                b"H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSVQw0lEozsgvzUlRSEpVyMwrS8zJTFEIDXHTtVAoLinKzEtXSCotUUjJTEtLLUrNKwEAmSHtST8AAAA=",
+                {
+                    "b64-encoded": b"SDRzSUFCUnM3bU1DLzB2T3p5MG9TaTB1VGsxUlNFa3NTVlF3MGxFb3pzZ3Z6VWxSU0VwVnlNd3JTOHpKVEZFSURYSFR0VkFvTGluS3pFdFhTQ290VVVqSlRFdExMVXJOS3dFQW1TSHRTVDhBQUFBPQ==",
+                    "b64-decoded": BINARY_DATA_2,
+                    "utf8": "H4sIABRs7mMC/0vOzy0oSi0uTk1RSEksSVQw0lEozsgvzUlRSEpVyMwrS8zJTFEIDXHTtVAoLinKzEtXSCotUUjJTEtLLUrNKwEAmSHtST8AAAA=",
+                },
+            ),
+            (
+                b"my text string",
+                {
+                    "b64-encoded": b"bXkgdGV4dCBzdHJpbmc=",
+                    "b64-decoded": b"\x9b+^\xc6\xdb-\xae)\xe0",
+                    "utf8": "my text string",
+                },
+            ),
+        ],
+        ids=["binary", "b64-encoded", "text"],
+    )
+    def test_convert_binary(
+        self,
+        response_content_type,
+        client_accept,
+        binary_medias,
+        content_handling,
+        expected,
+        input_data,
+        possible_values,
+        ctx,
+    ):
+        ctx.endpoint_response["headers"]["Content-Type"] = response_content_type
+        ctx.invocation_request["headers"]["Accept"] = client_accept
+        ctx.deployment.rest_api.rest_api["binaryMediaTypes"] = binary_medias
+        convert = IntegrationResponseHandler.convert_body
+
+        outcome = possible_values.get(expected, input_data)
+        if outcome is None:
+            with pytest.raises(Exception):
+                convert(body=input_data, context=ctx, content_handling=content_handling)
+        else:
+            converted_body = convert(
+                body=input_data, context=ctx, content_handling=content_handling
+            )
+            assert converted_body == outcome


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #12199, is reviewable ~but will come out of draft once the base is merged to avoid the rebase review madness~.

This PR implements the full Binary media support for REST APIs. The AWS documentation will do a much better job explaining what this means exactly, but in big line, it allows you to define some behavior in how your payload in being pass through to your integration: it can be pass as is, converted to a safe UTF-8 string, or base64 decoded or encoded. 

There are precise tables on the behavior, but I tend to not trust the documentation so much, so I took it upon myself to write AWS validated tests, which was to be honest, quite a pain again 😅 

The behavior in itself is not too complicated, it is mapping some table to if conditions (which might be simplified, if you see it during the review, please say so, I didn't optimize the conditions). 

Some changes in behavior is how the `responseTemplates` VTL rendering actually needs the value to be a string, and so if it comes out of the "converter", it needs to be of the right type. We might want to add better log statements to help the user understand why it would fail for them. 

I've also sneaked some `TODO` removal, and a small change in `update_integration_response`, this API op really needs to be validated and fixed. 

Resources:
- https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings.html
- https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-workflow.html

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- validate and remove snapshot skips for S3 AWS integration tests, now passing 🥳 
- add a good amount of binary handling tests in the S3 integration tests, as it's very easy to verify binary behavior with S3, and manipulate returned `Content-Type` headers
- add unit tests for the Convert functions 
- implement the logic for converting the request and response bodies
- ~modify the method~ (ported back to base PR) to check if a request if of "binary" type (AWS terms), meaning it matches the `binaryMediaTypes`
- update `UpdateIntegrationResponse` to support our test case
- remove some todos and update some of them

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
