### PR TITLE
Step Functions: Extended Support for Escape Sequences in String Literals

### DIFF
--- a/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
+++ b/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
@@ -281,3 +281,21 @@ class ScenariosTemplate(TemplateLoader):
     INVALID_JSONPATH_IN_OUTPUTPATH: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/invalid_jsonpath_in_outputpath.json5"
     )
+    ESCAPE_SEQUENCES_STRING_LITERALS: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/escape_sequences_string_literals.json5"
+    )
+    ESCAPE_SEQUENCES_JSONPATH: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/escape_sequences_jsonpath.json5"
+    )
+    ESCAPE_SEQUENCES_JSONATA_COMPARISON_OUTPUT: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/escape_sequences_jsonata_comparison_output.json5"
+    )
+    ESCAPE_SEQUENCES_JSONATA_COMPARISON_ASSIGN: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/escape_sequences_jsonata_comparison_assign.json5"
+    )
+    ESCAPE_SEQUENCES_ILLEGAL_INTRINSIC_FUNCTION: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/escape_sequences_illegal_intrinsic_function.json5"
+    )
+    ESCAPE_SEQUENCES_ILLEGAL_INTRINSIC_FUNCTION_2: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/escape_sequences_illegal_intrinsic_function_2.json5"
+    )

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/escape_sequences_illegal_intrinsic_function.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/escape_sequences_illegal_intrinsic_function.json5
@@ -1,0 +1,12 @@
+{
+  "StartAt": "IntrinsicEscape",
+  "States": {
+    "IntrinsicEscape": {
+      "Type": "Pass",
+      "Parameters": {
+        "parsed.$": "States.StringToJson('{\"text\":\"An \\\"escaped double quote\\\" here\"}')"
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/escape_sequences_illegal_intrinsic_function_2.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/escape_sequences_illegal_intrinsic_function_2.json5
@@ -1,0 +1,12 @@
+{
+  "StartAt": "IntrinsicEscape",
+  "States": {
+    "IntrinsicEscape": {
+      "Type": "Pass",
+      "Parameters": {
+        "parsed.$": "States.Format('He said, \\\"Hello, {}!\\\"', 'Test \\\"Name\\\" Here')"
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/escape_sequences_jsonata_comparison_assign.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/escape_sequences_jsonata_comparison_assign.json5
@@ -1,0 +1,18 @@
+{
+  "QueryLanguage": "JSONata",
+  "StartAt": "Pass",
+  "States": {
+    "Pass": {
+      "Type": "Pass",
+      "Assign": {
+        "var": "\""
+      },
+      "Next": "Check"
+    },
+    "Check": {
+      "Type": "Pass",
+      "Output": "{% $var = '\"' %}",
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/escape_sequences_jsonata_comparison_output.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/escape_sequences_jsonata_comparison_output.json5
@@ -1,0 +1,16 @@
+{
+  "QueryLanguage": "JSONata",
+  "StartAt": "Pass",
+  "States": {
+    "Pass": {
+      "Type": "Pass",
+      "Output": "\"",
+      "Next": "Check"
+    },
+    "Check": {
+      "Type": "Pass",
+      "Output": "{% $states.input = '\"' %}",
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/escape_sequences_jsonpath.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/escape_sequences_jsonpath.json5
@@ -1,0 +1,12 @@
+{
+  "StartAt": "JsonPathEscapeTest",
+  "States": {
+    "JsonPathEscapeTest": {
+      "Type": "Pass",
+      "Parameters": {
+        "value.$": "$['Test\\\"\"Name\"']"
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/escape_sequences_string_literals.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/escape_sequences_string_literals.json5
@@ -1,0 +1,36 @@
+{
+  "StartAt": "TestEscapesParameters",
+  "States": {
+    "TestEscapesParameters": {
+      "Type": "Pass",
+      "Parameters": {
+        "literal_single_quote": "'",
+        "literal_double_quote": "\"",
+        "mixed_quotes": "Text with both \"double\" and 'single' quotes.",
+        "escaped_double_in_string": "An escaped quote: \\\"hello\\\"",
+        "escaped_backslash": "Backslash \\\\ in string",
+        "unicode_double_quote": "\u0022unicode-quote\u0022",
+        "whitespace_escapes": "Line1\nLine2\tTabbed",
+        "emoji": "\uD83C\uDD97",
+      },
+      "Next": "TestEscapesResult"
+    },
+    "TestEscapesResult": {
+      "Type": "Pass",
+      "Result": {
+        "literal_single_quote": "'",
+        "literal_double_quote": "\"",
+        "mixed_quotes": "Text with both \"double\" and 'single' quotes.",
+        "escaped_double_in_string": "An escaped quote: \\\"hello\\\"",
+        "escaped_backslash": "Backslash \\\\ in string",
+        "unicode_double_quote": "\u0022unicode-quote\u0022",
+        "whitespace_escapes": "Line1\nLine2\tTabbed",
+        "emoji": "\uD83C\uDD97",
+        // This tests the lexer in binding a string starting with States.
+        //  to a string literal whenever escape sequences are detected.
+        "not_an_intrinsic_function.$": "States.StringToJson('{\"text\":\"An \\\"escaped double quote\\\" here\"}')"
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
@@ -27427,5 +27427,425 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_escape_sequence_parsing[ESCAPE_SEQUENCES_JSONATA_COMPARISON_ASSIGN]": {
+    "recorded-date": "02-02-2025, 15:45:03",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Test\\\"\"Name\"": "Value\"\\"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Test\\\"\"Name\"": "Value\"\\"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Pass"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "assignedVariables": {
+                "var": "\"\\\"\""
+              },
+              "assignedVariablesDetails": {
+                "truncated": false
+              },
+              "name": "Pass",
+              "output": {
+                "Test\\\"\"Name\"": "Value\"\\"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Test\\\"\"Name\"": "Value\"\\"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Check"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "stateExitedEventDetails": {
+              "name": "Check",
+              "output": "true",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "true",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_escape_sequence_parsing[ESCAPE_SEQUENCES_STRING_LITERALS]": {
+    "recorded-date": "02-02-2025, 15:44:14",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Test\\\"\"Name\"": "Value\"\\"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Test\\\"\"Name\"": "Value\"\\"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "TestEscapesParameters"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "TestEscapesParameters",
+              "output": {
+                "literal_single_quote": "'",
+                "literal_double_quote": "\"",
+                "mixed_quotes": "Text with both \"double\" and 'single' quotes.",
+                "escaped_double_in_string": "An escaped quote: \\\"hello\\\"",
+                "escaped_backslash": "Backslash \\\\ in string",
+                "unicode_double_quote": "\"unicode-quote\"",
+                "whitespace_escapes": "Line1\nLine2\tTabbed",
+                "emoji": "\ud83c\udd97"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "literal_single_quote": "'",
+                "literal_double_quote": "\"",
+                "mixed_quotes": "Text with both \"double\" and 'single' quotes.",
+                "escaped_double_in_string": "An escaped quote: \\\"hello\\\"",
+                "escaped_backslash": "Backslash \\\\ in string",
+                "unicode_double_quote": "\"unicode-quote\"",
+                "whitespace_escapes": "Line1\nLine2\tTabbed",
+                "emoji": "\ud83c\udd97"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "TestEscapesResult"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "stateExitedEventDetails": {
+              "name": "TestEscapesResult",
+              "output": {
+                "literal_single_quote": "'",
+                "literal_double_quote": "\"",
+                "mixed_quotes": "Text with both \"double\" and 'single' quotes.",
+                "escaped_double_in_string": "An escaped quote: \\\"hello\\\"",
+                "escaped_backslash": "Backslash \\\\ in string",
+                "unicode_double_quote": "\"unicode-quote\"",
+                "whitespace_escapes": "Line1\nLine2\tTabbed",
+                "emoji": "\ud83c\udd97",
+                "not_an_intrinsic_function.$": "States.StringToJson('{\"text\":\"An \\\"escaped double quote\\\" here\"}')"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "literal_single_quote": "'",
+                "literal_double_quote": "\"",
+                "mixed_quotes": "Text with both \"double\" and 'single' quotes.",
+                "escaped_double_in_string": "An escaped quote: \\\"hello\\\"",
+                "escaped_backslash": "Backslash \\\\ in string",
+                "unicode_double_quote": "\"unicode-quote\"",
+                "whitespace_escapes": "Line1\nLine2\tTabbed",
+                "emoji": "\ud83c\udd97",
+                "not_an_intrinsic_function.$": "States.StringToJson('{\"text\":\"An \\\"escaped double quote\\\" here\"}')"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_escape_sequence_parsing[ESCAPE_SEQUENCES_JSONPATH]": {
+    "recorded-date": "02-02-2025, 15:44:30",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Test\\\"\"Name\"": "Value\"\\"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Test\\\"\"Name\"": "Value\"\\"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "JsonPathEscapeTest"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "JsonPathEscapeTest",
+              "output": {
+                "value": "Value\"\\"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "value": "Value\"\\"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_escape_sequence_parsing[ESCAPE_SEQUENCES_JSONATA_COMPARISON_OUTPUT]": {
+    "recorded-date": "02-02-2025, 15:44:46",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Test\\\"\"Name\"": "Value\"\\"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Test\\\"\"Name\"": "Value\"\\"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Pass"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Pass",
+              "output": "\"\\\"\"",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": "\"\\\"\"",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Check"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "stateExitedEventDetails": {
+              "name": "Check",
+              "output": "true",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "true",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_illegal_escapes[ESCAPE_SEQUENCES_ILLEGAL_INTRINSIC_FUNCTION]": {
+    "recorded-date": "02-02-2025, 15:46:00",
+    "recorded-content": {
+      "exception": {
+        "exception_typename": "InvalidDefinition",
+        "exception_value": "An error occurred (InvalidDefinition) when calling the CreateStateMachine operation: Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: The value for the field 'parsed.$' must be a valid JSONPath or a valid intrinsic function call at /States/IntrinsicEscape/Parameters'"
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_illegal_escapes[ESCAPE_SEQUENCES_ILLEGAL_INTRINSIC_FUNCTION_2]": {
+    "recorded-date": "02-02-2025, 15:46:15",
+    "recorded-content": {
+      "exception": {
+        "exception_typename": "InvalidDefinition",
+        "exception_value": "An error occurred (InvalidDefinition) when calling the CreateStateMachine operation: Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: The value for the field 'parsed.$' must be a valid JSONPath or a valid intrinsic function call at /States/IntrinsicEscape/Parameters'"
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
@@ -35,11 +35,29 @@
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_choice_unsorted_parameters_positive[CHOICE_STATE_UNSORTED_CHOICE_PARAMETERS_JSONATA]": {
     "last_validated_date": "2024-11-18T11:30:59+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_escape_sequence_parsing[ESCAPE_SEQUENCES_JSONATA_COMPARISON_ASSIGN]": {
+    "last_validated_date": "2025-02-02T15:45:03+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_escape_sequence_parsing[ESCAPE_SEQUENCES_JSONATA_COMPARISON_OUTPUT]": {
+    "last_validated_date": "2025-02-02T15:44:46+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_escape_sequence_parsing[ESCAPE_SEQUENCES_JSONPATH]": {
+    "last_validated_date": "2025-02-02T15:44:30+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_escape_sequence_parsing[ESCAPE_SEQUENCES_STRING_LITERALS]": {
+    "last_validated_date": "2025-02-02T15:44:14+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_fail_cause_jsonata": {
     "last_validated_date": "2024-11-13T16:36:11+00:00"
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_fail_error_jsonata": {
     "last_validated_date": "2024-11-13T16:35:39+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_illegal_escapes[ESCAPE_SEQUENCES_ILLEGAL_INTRINSIC_FUNCTION]": {
+    "last_validated_date": "2025-02-02T15:46:00+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_illegal_escapes[ESCAPE_SEQUENCES_ILLEGAL_INTRINSIC_FUNCTION_2]": {
+    "last_validated_date": "2025-02-02T15:46:15+00:00"
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_invalid_jsonpath[INVALID_JSONPATH_IN_ERRORPATH]": {
     "last_validated_date": "2025-01-02T13:44:29+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The SFN v2 interpreter currently does not consistently handle escape sequences in string literals. This can lead to issues when users declare strings with escape sequences, potentially causing failures in string comparison logic.

Previous changes in [#12072](https://github.com/localstack/localstack/pull/12072) introduced a strategy to correctly interpret string literals containing escape sequences, but this fix was limited to JSONata expression literals. However, escape sequence handling issues persist in other areas, such as baseline string literals, intrinsic functions, and JSONPath strings.

During this investigation, all string literal types were analyzed and tested. However, after extensive research into AWS’s behavior, we found that only strict string literals could be reliably aligned with AWS’s handling of escape sequences. Additionally, issues related to parsing string literals as JSONata expressions in Output and Assign blocks were identified and resolved.

That said, achieving full parity with AWS’s handling of escape sequences in JSONPath and intrinsic functions proved impractical. Specifically, we could not limit LocalStack’s escape sequence support to match AWS’s restrictions without introducing significant limitations. As a result, LocalStack continues to allow escape sequences in more scenarios than AWS.

It's worth noting that with the recent shift towards JSONata expressions, state machines are expected to standardize around just two types of string literals: String Literals and JSONata Expressions. Given this transition, precisely mirroring AWS’s handling of escape sequences in other string types is not an immediate priority.

\* Please refer to the details included in the backlog item associated to these changes for more insights.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- adjust preprocessing logic of base string literals to correctly handle escape sequences; these changes include occurrances of similar logics in preprocessing payload template string values and bindings
- adjust the parsing of JSONata string literals in Assign and Output template
- add several positive and negative snapshot tests regarding the use of escape sequences in various string literal types

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
