### PR TITLE
No sve dynamodb m4

### DIFF
--- a/localstack-core/localstack/services/dynamodb/server.py
+++ b/localstack-core/localstack/services/dynamodb/server.py
@@ -154,7 +154,13 @@ class DynamodbServer(Server):
         # This command returns all supported JVM options
         with contextlib.suppress(subprocess.CalledProcessError):
             stdout = run(
-                cmd=["java", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintFlagsFinal", "-version"],
+                cmd=[
+                    "java",
+                    "-XX:UseSVE=0",
+                    "-XX:+UnlockDiagnosticVMOptions",
+                    "-XX:+PrintFlagsFinal",
+                    "-version",
+                ],
                 env_vars=dynamodblocal_installer.get_java_env_vars(),
                 print_error=True,
             )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Fixes https://github.com/localstack/localstack/issues/12054.

[Previous fix](https://github.com/localstack/localstack/pull/12112) was using a java command to check available VM options, and this command was crashing for exactly the same reason as the DynamoDB process.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Added `-XX:UseSVE=0` to java VM options check and limited the check to arm64 architecture (otherwise check can't be run reliably - with option it will crash on arm64 and without option it will crash on m4 macs)

## Testing

Tested on M4 instance.

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
