### PR TITLE
[SQS] Cancel pending and future tasks on shutdown

### DIFF
--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -77,7 +77,9 @@ from localstack.http import Request, route
 from localstack.services.edge import ROUTER
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.sqs import constants as sqs_constants
-from localstack.services.sqs.constants import HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT
+from localstack.services.sqs.constants import (
+    HEADER_LOCALSTACK_SQS_OVERRIDE_MESSAGE_COUNT,
+)
 from localstack.services.sqs.exceptions import InvalidParameterValueException
 from localstack.services.sqs.models import (
     FifoQueue,
@@ -192,7 +194,7 @@ class CloudwatchDispatcher:
         )
 
     def shutdown(self):
-        self.executor.shutdown(wait=False)
+        self.executor.shutdown(wait=True, cancel_futures=True)
 
     def dispatch_sqs_metric(
         self,
@@ -468,7 +470,7 @@ class MessageMoveTaskManager:
             for move_task in self.move_tasks.values():
                 move_task.cancel_event.set()
 
-            self.executor.shutdown(wait=False)
+            self.executor.shutdown(wait=True, cancel_futures=True)
 
     def _run(self, move_task: MessageMoveTask):
         try:

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -194,7 +194,7 @@ class CloudwatchDispatcher:
         )
 
     def shutdown(self):
-        self.executor.shutdown(wait=True, cancel_futures=True)
+        self.executor.shutdown(wait=False, cancel_futures=True)
 
     def dispatch_sqs_metric(
         self,
@@ -470,7 +470,7 @@ class MessageMoveTaskManager:
             for move_task in self.move_tasks.values():
                 move_task.cancel_event.set()
 
-            self.executor.shutdown(wait=True, cancel_futures=True)
+            self.executor.shutdown(wait=False, cancel_futures=True)
 
     def _run(self, move_task: MessageMoveTask):
         try:

--- a/localstack-core/localstack/services/sqs/queue.py
+++ b/localstack-core/localstack/services/sqs/queue.py
@@ -12,6 +12,8 @@ class InterruptibleQueue(Queue):
 
     def get(self, block=True, timeout=None):
         with self.not_empty:
+            if self.is_shutdown:
+                raise Empty
             if not block:
                 if not self._qsize():
                     raise Empty


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Under high volumes of SQS receive/send/delete calls, the internal SQS `ThreadPoolExecutors` can execute tasks long after a service has completed their shutdown/stop lifecycle hooks.

That is, when we try stop the SQS service, **currently running** and **future pending** tasks are not cleared from the executor pool -- potentially being executed long after the service signalled to have stopped.

This PR ensures that all **enqueued** tasks are cancelled on shutdown.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Changed the `CloudWatchDispatcher.shutdown` and `MessageMoveTaskManager.close` methods to cancel all pending/future tasks that are currently enqueued for execution.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
