### PR TITLE
Core: Add py.typed, Remove docs from source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,10 @@
+exclude .github/**
+exclude .circleci/**
+exclude docs/**
 exclude tests/**
 exclude .test_durations
+exclude .gitignore
+exclude .pre-commit-config.yaml
+exclude .python-version
 include Makefile
 include LICENSE.txt

--- a/localstack-core/localstack/state/core.py
+++ b/localstack-core/localstack/state/core.py
@@ -27,27 +27,27 @@ class StateLifecycleHook:
     - load: the state is injected into the service, or state directories on disk are restored
     """
 
-    def on_before_state_reset(self):
+    def on_before_state_reset(self) -> None:
         """Hook triggered before the provider's state containers are reset/cleared."""
         pass
 
-    def on_after_state_reset(self):
+    def on_after_state_reset(self) -> None:
         """Hook triggered after the provider's state containers have been reset/cleared."""
         pass
 
-    def on_before_state_save(self):
+    def on_before_state_save(self) -> None:
         """Hook triggered before the provider's state containers are saved."""
         pass
 
-    def on_after_state_save(self):
+    def on_after_state_save(self) -> None:
         """Hook triggered after the provider's state containers have been saved."""
         pass
 
-    def on_before_state_load(self):
+    def on_before_state_load(self) -> None:
         """Hook triggered before a previously serialized state is loaded into the provider's state containers."""
         pass
 
-    def on_after_state_load(self):
+    def on_after_state_load(self) -> None:
         """Hook triggered after a previously serialized state has been loaded into the provider's state containers."""
         pass
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
In order to actually use the type-hints, we need to add a `py.typed`-file - see [the mypy-docs](https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages) for more info. We don't have to explicitly configure anything for this file to be part of both the wheel and source dist - we're already including almost all files by default.

Related: while building the source dist I also realized that it currently contains a lot of files/folders that we (IMHO) should not include, like the docs and CI workflows. Excluding these reduces the source dist size from 4.3MB to 3.4MB.