### PR TITLE
Fix parse container labels in podman

### DIFF
--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -908,12 +908,15 @@ class CmdDockerClient(ContainerClient):
         if any(msg.lower() in process_stdout_lower for msg in error_messages):
             raise NoSuchContainer(container_name_or_id, stdout=error.stdout, stderr=error.stderr)
 
-    def _transform_container_labels(self, labels: str) -> Dict[str, str]:
+    def _transform_container_labels(self, labels: str | Dict[str,str]) -> Dict[str, str]:
         """
         Transforms the container labels returned by the docker command from the key-value pair format to a dict
         :param labels: Input string, comma separated key value pairs. Example: key1=value1,key2=value2
         :return: Dict representation of the passed values, example: {"key1": "value1", "key2": "value2"}
         """
+        if (isinstance(labels, Dict):
+            return labels
+
         labels = labels.split(",")
         labels = [label.partition("=") for label in labels]
         return {label[0]: label[2] for label in labels}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When trying to parse container labels, localstack should first check if they are already an instance of Dict, which is the default in podman. This was already mentioned in https://github.com/localstack/localstack/issues/12084 and I stumbled upon the same problem while to run localstack for the first time. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
When invoking `_transform_container_labels`, I added a check to veryify is the supplied parameter is already a Dict, which is the default in Podman.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
