### PR TITLE
Add Z flag in volume binds to support SELINUX

### DIFF
--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -389,7 +389,9 @@ class VolumeBind:
         args.append(self.container_dir)
 
         if self.read_only:
-            args.append("ro")
+            args.append("ro,Z")
+       	else:
+            args.append("Z")
 
         return ":".join(args)
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR should fix https://github.com/localstack/localstack/issues/12237. localstack can't even start because the container can't correctly do a bind mount to the host if the host is running SELINUX

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Add the Z option to bind mount. Specifically, adds the option when a `VolumeBind` is transformed into a string.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
