### PR TITLE
Bump moto-ext to 5.0.28.post6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.28.post2",
+    "moto-ext[all]==5.0.28.post3",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.28.post1",
+    "moto-ext[all]==5.0.28.post2",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.28.post4",
+    "moto-ext[all]==5.0.28.post5",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.28.post5",
+    "moto-ext[all]==5.0.28.post6",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.28.post3",
+    "moto-ext[all]==5.0.28.post4",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -6,7 +6,7 @@
 #
 build==1.2.2.post1
     # via localstack-core (pyproject.toml)
-cachetools==5.5.1
+cachetools==5.5.2
     # via localstack-core (pyproject.toml)
 certifi==2025.1.31
     # via requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -251,7 +251,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post3
+moto-ext==5.0.28.post4
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -251,7 +251,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post4
+moto-ext==5.0.28.post5
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -251,7 +251,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post1
+moto-ext==5.0.28.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -251,7 +251,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post5
+moto-ext==5.0.28.post6
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -251,7 +251,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post2
+moto-ext==5.0.28.post3
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post5
+moto-ext==5.0.28.post6
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post4
+moto-ext==5.0.28.post5
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post1
+moto-ext==5.0.28.post2
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post2
+moto-ext==5.0.28.post3
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post3
+moto-ext==5.0.28.post4
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -235,7 +235,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post3
+moto-ext==5.0.28.post4
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -235,7 +235,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post5
+moto-ext==5.0.28.post6
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -235,7 +235,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post2
+moto-ext==5.0.28.post3
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -235,7 +235,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post4
+moto-ext==5.0.28.post5
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -235,7 +235,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post1
+moto-ext==5.0.28.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -255,7 +255,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post2
+moto-ext==5.0.28.post3
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -255,7 +255,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post3
+moto-ext==5.0.28.post4
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -255,7 +255,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post4
+moto-ext==5.0.28.post5
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -255,7 +255,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post5
+moto-ext==5.0.28.post6
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -255,7 +255,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.0.28.post1
+moto-ext==5.0.28.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.0.28.post6

>[!IMPORTANT]
> This release of moto-ext excludes commits related to the ongoing RDS refactoring because it breaks the RDS provider in Ext.

Contains:

- https://github.com/getmoto/moto/pull/8556
  Closes https://github.com/localstack/localstack/issues/11522
- https://github.com/getmoto/moto/pull/8563
- https://github.com/getmoto/moto/pull/8570
  Closes https://github.com/localstack/localstack/issues/11765
- https://github.com/getmoto/moto/pull/8575
- https://github.com/getmoto/moto/pull/8610

## To do

- [x] Ext compatibility (Ext integration tests) AWS / Ext Integration Tests # 3109 :green_circle: 
- [x] Multi-account/region compatibility ([Randomised credentials test run](https://app.circleci.com/pipelines/github/localstack/localstack/31238/workflows/d5d3fb6f-7e50-4ae8-92cb-2febc2422e33)) :green_circle: 