### PR TITLE
Step Functions: Add Supported Integrations For Glue

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_glue.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_glue.py
@@ -36,6 +36,23 @@ _SUPPORTED_INTEGRATION_PATTERNS: Final[set[ResourceCondition]] = {
     ResourceCondition.Sync,
 }
 
+_SUPPORTED_API_PARAM_BINDINGS: Final[dict[str, set[str]]] = {
+    "startjobrun": {
+        "JobName",
+        "JobRunQueuingEnabled",
+        "JobRunId",
+        "Arguments",
+        "AllocatedCapacity",
+        "Timeout",
+        "MaxCapacity",
+        "SecurityConfiguration",
+        "NotificationProperty",
+        "WorkerType",
+        "NumberOfWorkers",
+        "ExecutionClass",
+    }
+}
+
 # Set of JobRunState value that indicate the JobRun had terminated in an abnormal state.
 _JOB_RUN_STATE_ABNORMAL_TERMINAL_VALUE: Final[set[str]] = {"FAILED", "TIMEOUT", "ERROR"}
 
@@ -63,6 +80,9 @@ _API_ACTION_HANDLER_BUILDER_TYPE = Callable[
 class StateTaskServiceGlue(StateTaskServiceCallback):
     def __init__(self):
         super().__init__(supported_integration_patterns=_SUPPORTED_INTEGRATION_PATTERNS)
+
+    def _get_supported_parameters(self) -> Optional[set[str]]:
+        return _SUPPORTED_API_PARAM_BINDINGS.get(self.resource.api_action.lower())
 
     def _get_api_action_handler(self) -> _API_ACTION_HANDLER_TYPE:
         api_action = self._get_boto_service_action()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Recent changes in the Step Functions interpreter limited the execution of service integration to the set of the officially supported ones https://github.com/localstack/localstack/pull/12223. This exposed the lack of such checks for the Glue optimized service integration. These changes add such [specification for Glue](https://docs.aws.amazon.com/step-functions/latest/dg/connect-glue.html).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Add the list of supported api parameter bindings for Glue's optimized service integration.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
