### PR TITLE
[SQS] Improve shutdown capabilities of SqsProvider

### DIFF
--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -1065,6 +1065,8 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                 queue.region,
                 queue.account_id,
             )
+            # Trigger a shutdown prior to removing the queue resource
+            store.queues[queue.name].shutdown()
             del store.queues[queue.name]
             store.deleted[queue.name] = time.time()
 

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -190,14 +190,14 @@ class CloudwatchDispatcher:
     """
 
     def __init__(self, num_thread: int = 3):
-        self._is_shutdown = threading.Event()
         self.executor = ThreadPoolExecutor(
             num_thread, thread_name_prefix="sqs-metrics-cloudwatch-dispatcher"
         )
+        self.running = True
 
     def shutdown(self):
-        self._is_shutdown.set()
         self.executor.shutdown(wait=False, cancel_futures=True)
+        self.running = False
 
     def dispatch_sqs_metric(
         self,
@@ -217,7 +217,7 @@ class CloudwatchDispatcher:
         :param value The value for that metric, default 1
         :param unit The unit for the value, default "Count"
         """
-        if self._is_shutdown.is_set():
+        if not self.running:
             return
 
         self.executor.submit(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
There are still some hanging threads on SQS shutdown due to:
- Cleanup fixtures deleting SQS queues lifecycle hooks are able to shut them down
- CloudWatch metric dispatcher does not guard against new `submit` jobs when executor is shutdown

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Shutdown internal SQS queue resource upon deletion.
- Prevent dispatching new CW jobs when `ThreadPoolExecutor` object is closed (causing a `RuntimeException`)

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
