### PR TITLE
fix ListObjectVersions pagination when version id marker is deleted

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -1854,6 +1854,13 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                     if version.version_id == version_id_marker:
                         version_key_marker_found = True
                         continue
+
+                    # it is possible that the version_id_marker related object has been deleted, in that case, start
+                    # as soon as the next version id is smaller than the version id marker (meaning this version was
+                    # next after the now-deleted version)
+                    elif version.version_id < version_id_marker:
+                        version_key_marker_found = True
+
                     elif not version_key_marker_found:
                         # as long as we have not passed the version_key_marker, skip the versions
                         continue

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -2,8 +2,10 @@ import base64
 import codecs
 import datetime
 import hashlib
+import itertools
 import logging
 import re
+import time
 import zlib
 from enum import StrEnum
 from secrets import token_bytes
@@ -68,6 +70,7 @@ from localstack.services.s3.constants import (
 from localstack.services.s3.exceptions import InvalidRequest, MalformedXML
 from localstack.utils.aws import arns
 from localstack.utils.aws.arns import parse_arn
+from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import (
     is_base64,
     to_bytes,
@@ -94,8 +97,6 @@ _s3_virtual_host_regex = re.compile(S3_VIRTUAL_HOSTNAME_REGEX)
 
 RFC1123 = "%a, %d %b %Y %H:%M:%S GMT"
 _gmt_zone_info = ZoneInfo("GMT")
-
-_version_id_safe_encode_translation = bytes.maketrans(b"+/", b"._")
 
 
 def s3_response_handler(chain: HandlerChain, context: RequestContext, response: Response):
@@ -1041,10 +1042,14 @@ def generate_safe_version_id() -> str:
     # the safe b64 encoding is inspired by the stdlib base64.urlsafe_b64encode
     # and also using stdlib secrets.token_urlsafe, but with a different alphabet adapted for S3
     # VersionId cannot have `-` in it, as it fails in XML
-    tok = token_bytes(24)
-    return (
-        base64.b64encode(tok)
-        .translate(_version_id_safe_encode_translation)
-        .rstrip(b"=")
-        .decode("ascii")
-    )
+    # we need an ever-increasing number, in order to properly implement pagination around ListObjectVersions
+    # by prepending the version-id with a global increasing number, we can lexicographically sort the versions
+    tok = next(global_version_id_sequence()).to_bytes(length=6) + token_bytes(18)
+    return base64.b64encode(tok, altchars=b"._").rstrip(b"=").decode("ascii")
+
+
+@singleton_factory
+def global_version_id_sequence():
+    start = int(time.time() * 1000)
+    # itertools.count is thread safe over the GIL since its getAndIncrement operation is a single python bytecode op
+    return itertools.count(start)

--- a/tests/aws/services/s3/test_s3_list_operations.py
+++ b/tests/aws/services/s3/test_s3_list_operations.py
@@ -491,6 +491,75 @@ class TestS3ListObjectVersions:
         snapshot.match("list-objects-versions-no-encoding", resp_dict)
 
     @markers.aws.validated
+    def test_list_objects_versions_with_prefix_only_and_pagination(
+        self, s3_bucket, snapshot, aws_client, aws_http_client_factory
+    ):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        aws_client.s3.put_bucket_versioning(
+            Bucket=s3_bucket,
+            VersioningConfiguration={"Status": "Enabled"},
+        )
+
+        for _ in range(10):
+            aws_client.s3.put_object(Bucket=s3_bucket, Key="prefixed_key")
+
+        aws_client.s3.put_object(Bucket=s3_bucket, Key="non_prefixed_key")
+
+        prefixed_full = aws_client.s3.list_object_versions(Bucket=s3_bucket, Prefix="prefix")
+        snapshot.match("list-object-version-prefix-full", prefixed_full)
+
+        full_response = aws_client.s3.list_object_versions(Bucket=s3_bucket)
+        assert len(full_response["Versions"]) == 11
+
+        page_1_response = aws_client.s3.list_object_versions(
+            Bucket=s3_bucket, Prefix="prefix", MaxKeys=5
+        )
+        snapshot.match("list-object-version-prefix-page-1", page_1_response)
+        next_version_id_marker = page_1_response["NextVersionIdMarker"]
+
+        page_2_key_marker_only = aws_client.s3.list_object_versions(
+            Bucket=s3_bucket,
+            Prefix="prefix",
+            MaxKeys=7,
+            KeyMarker=page_1_response["NextKeyMarker"],
+        )
+        snapshot.match("list-object-version-prefix-key-marker-only", page_2_key_marker_only)
+
+        page_2_response = aws_client.s3.list_object_versions(
+            Bucket=s3_bucket,
+            Prefix="prefix",
+            MaxKeys=10,
+            KeyMarker=page_1_response["NextKeyMarker"],
+            VersionIdMarker=page_1_response["NextVersionIdMarker"],
+        )
+        snapshot.match("list-object-version-prefix-page-2", page_2_response)
+
+        delete_version_id_marker = aws_client.s3.delete_objects(
+            Bucket=s3_bucket,
+            Delete={
+                "Objects": [
+                    {"Key": version["Key"], "VersionId": version["VersionId"]}
+                    for version in page_1_response["Versions"]
+                ],
+            },
+        )
+        # result is unordered in AWS, pretty hard to snapshot and tested in other places anyway
+        assert len(delete_version_id_marker["Deleted"]) == 5
+        assert any(
+            version["VersionId"] == next_version_id_marker
+            for version in delete_version_id_marker["Deleted"]
+        )
+
+        page_2_response = aws_client.s3.list_object_versions(
+            Bucket=s3_bucket,
+            Prefix="prefix",
+            MaxKeys=10,
+            KeyMarker=page_1_response["NextKeyMarker"],
+            VersionIdMarker=next_version_id_marker,
+        )
+        snapshot.match("list-object-version-prefix-page-2-after-delete", page_2_response)
+
+    @markers.aws.validated
     def test_s3_list_object_versions_timestamp_precision(
         self, s3_bucket, aws_client, aws_http_client_factory
     ):

--- a/tests/aws/services/s3/test_s3_list_operations.py
+++ b/tests/aws/services/s3/test_s3_list_operations.py
@@ -500,7 +500,7 @@ class TestS3ListObjectVersions:
             VersioningConfiguration={"Status": "Enabled"},
         )
 
-        for _ in range(10):
+        for _ in range(5):
             aws_client.s3.put_object(Bucket=s3_bucket, Key="prefixed_key")
 
         aws_client.s3.put_object(Bucket=s3_bucket, Key="non_prefixed_key")
@@ -509,10 +509,10 @@ class TestS3ListObjectVersions:
         snapshot.match("list-object-version-prefix-full", prefixed_full)
 
         full_response = aws_client.s3.list_object_versions(Bucket=s3_bucket)
-        assert len(full_response["Versions"]) == 11
+        assert len(full_response["Versions"]) == 6
 
         page_1_response = aws_client.s3.list_object_versions(
-            Bucket=s3_bucket, Prefix="prefix", MaxKeys=5
+            Bucket=s3_bucket, Prefix="prefix", MaxKeys=3
         )
         snapshot.match("list-object-version-prefix-page-1", page_1_response)
         next_version_id_marker = page_1_response["NextVersionIdMarker"]
@@ -520,7 +520,7 @@ class TestS3ListObjectVersions:
         page_2_key_marker_only = aws_client.s3.list_object_versions(
             Bucket=s3_bucket,
             Prefix="prefix",
-            MaxKeys=7,
+            MaxKeys=4,
             KeyMarker=page_1_response["NextKeyMarker"],
         )
         snapshot.match("list-object-version-prefix-key-marker-only", page_2_key_marker_only)
@@ -528,7 +528,7 @@ class TestS3ListObjectVersions:
         page_2_response = aws_client.s3.list_object_versions(
             Bucket=s3_bucket,
             Prefix="prefix",
-            MaxKeys=10,
+            MaxKeys=5,
             KeyMarker=page_1_response["NextKeyMarker"],
             VersionIdMarker=page_1_response["NextVersionIdMarker"],
         )
@@ -544,7 +544,7 @@ class TestS3ListObjectVersions:
             },
         )
         # result is unordered in AWS, pretty hard to snapshot and tested in other places anyway
-        assert len(delete_version_id_marker["Deleted"]) == 5
+        assert len(delete_version_id_marker["Deleted"]) == 3
         assert any(
             version["VersionId"] == next_version_id_marker
             for version in delete_version_id_marker["Deleted"]
@@ -553,7 +553,7 @@ class TestS3ListObjectVersions:
         page_2_response = aws_client.s3.list_object_versions(
             Bucket=s3_bucket,
             Prefix="prefix",
-            MaxKeys=10,
+            MaxKeys=5,
             KeyMarker=page_1_response["NextKeyMarker"],
             VersionIdMarker=next_version_id_marker,
         )

--- a/tests/aws/services/s3/test_s3_list_operations.snapshot.json
+++ b/tests/aws/services/s3/test_s3_list_operations.snapshot.json
@@ -2801,5 +2801,510 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjectVersions::test_list_objects_versions_with_prefix_only_and_pagination": {
+    "recorded-date": "13-02-2025, 02:27:21",
+    "recorded-content": {
+      "list-object-version-prefix-full": {
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "prefix",
+        "VersionIdMarker": "",
+        "Versions": [
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": true,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:1>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:2>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:3>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:4>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:5>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:6>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:7>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:8>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:9>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:10>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-object-version-prefix-page-1": {
+        "EncodingType": "url",
+        "IsTruncated": true,
+        "KeyMarker": "",
+        "MaxKeys": 5,
+        "Name": "<bucket-name:1>",
+        "NextKeyMarker": "prefixed_key",
+        "NextVersionIdMarker": "<version-id:5>",
+        "Prefix": "prefix",
+        "VersionIdMarker": "",
+        "Versions": [
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": true,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:1>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:2>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:3>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:4>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:5>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-object-version-prefix-key-marker-only": {
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "prefixed_key",
+        "MaxKeys": 7,
+        "Name": "<bucket-name:1>",
+        "Prefix": "prefix",
+        "VersionIdMarker": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-object-version-prefix-page-2": {
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "prefixed_key",
+        "MaxKeys": 10,
+        "Name": "<bucket-name:1>",
+        "Prefix": "prefix",
+        "VersionIdMarker": "<version-id:5>",
+        "Versions": [
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:6>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:7>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:8>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:9>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:10>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-object-version-prefix-page-2-after-delete": {
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "prefixed_key",
+        "MaxKeys": 10,
+        "Name": "<bucket-name:1>",
+        "Prefix": "prefix",
+        "VersionIdMarker": "<version-id:5>",
+        "Versions": [
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": true,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:6>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:7>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:8>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:9>"
+          },
+          {
+            "ChecksumAlgorithm": [
+              "CRC32"
+            ],
+            "ChecksumType": "FULL_OBJECT",
+            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+            "IsLatest": false,
+            "Key": "prefixed_key",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 0,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:10>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_list_operations.snapshot.json
+++ b/tests/aws/services/s3/test_s3_list_operations.snapshot.json
@@ -2803,7 +2803,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjectVersions::test_list_objects_versions_with_prefix_only_and_pagination": {
-    "recorded-date": "13-02-2025, 02:27:21",
+    "recorded-date": "13-02-2025, 03:52:21",
     "recorded-content": {
       "list-object-version-prefix-full": {
         "EncodingType": "url",
@@ -2898,91 +2898,6 @@
             "Size": 0,
             "StorageClass": "STANDARD",
             "VersionId": "<version-id:5>"
-          },
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:6>"
-          },
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:7>"
-          },
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:8>"
-          },
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:9>"
-          },
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:10>"
           }
         ],
         "ResponseMetadata": {
@@ -2994,10 +2909,10 @@
         "EncodingType": "url",
         "IsTruncated": true,
         "KeyMarker": "",
-        "MaxKeys": 5,
+        "MaxKeys": 3,
         "Name": "<bucket-name:1>",
         "NextKeyMarker": "prefixed_key",
-        "NextVersionIdMarker": "<version-id:5>",
+        "NextVersionIdMarker": "<version-id:3>",
         "Prefix": "prefix",
         "VersionIdMarker": "",
         "Versions": [
@@ -3051,7 +2966,35 @@
             "Size": 0,
             "StorageClass": "STANDARD",
             "VersionId": "<version-id:3>"
-          },
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-object-version-prefix-key-marker-only": {
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "prefixed_key",
+        "MaxKeys": 4,
+        "Name": "<bucket-name:1>",
+        "Prefix": "prefix",
+        "VersionIdMarker": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-object-version-prefix-page-2": {
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "prefixed_key",
+        "MaxKeys": 5,
+        "Name": "<bucket-name:1>",
+        "Prefix": "prefix",
+        "VersionIdMarker": "<version-id:3>",
+        "Versions": [
           {
             "ChecksumAlgorithm": [
               "CRC32"
@@ -3092,127 +3035,14 @@
           "HTTPStatusCode": 200
         }
       },
-      "list-object-version-prefix-key-marker-only": {
-        "EncodingType": "url",
-        "IsTruncated": false,
-        "KeyMarker": "prefixed_key",
-        "MaxKeys": 7,
-        "Name": "<bucket-name:1>",
-        "Prefix": "prefix",
-        "VersionIdMarker": "",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-object-version-prefix-page-2": {
-        "EncodingType": "url",
-        "IsTruncated": false,
-        "KeyMarker": "prefixed_key",
-        "MaxKeys": 10,
-        "Name": "<bucket-name:1>",
-        "Prefix": "prefix",
-        "VersionIdMarker": "<version-id:5>",
-        "Versions": [
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:6>"
-          },
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:7>"
-          },
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:8>"
-          },
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:9>"
-          },
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:10>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
       "list-object-version-prefix-page-2-after-delete": {
         "EncodingType": "url",
         "IsTruncated": false,
         "KeyMarker": "prefixed_key",
-        "MaxKeys": 10,
+        "MaxKeys": 5,
         "Name": "<bucket-name:1>",
         "Prefix": "prefix",
-        "VersionIdMarker": "<version-id:5>",
+        "VersionIdMarker": "<version-id:3>",
         "Versions": [
           {
             "ChecksumAlgorithm": [
@@ -3229,7 +3059,7 @@
             },
             "Size": 0,
             "StorageClass": "STANDARD",
-            "VersionId": "<version-id:6>"
+            "VersionId": "<version-id:4>"
           },
           {
             "ChecksumAlgorithm": [
@@ -3246,58 +3076,7 @@
             },
             "Size": 0,
             "StorageClass": "STANDARD",
-            "VersionId": "<version-id:7>"
-          },
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:8>"
-          },
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:9>"
-          },
-          {
-            "ChecksumAlgorithm": [
-              "CRC32"
-            ],
-            "ChecksumType": "FULL_OBJECT",
-            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-            "IsLatest": false,
-            "Key": "prefixed_key",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 0,
-            "StorageClass": "STANDARD",
-            "VersionId": "<version-id:10>"
+            "VersionId": "<version-id:5>"
           }
         ],
         "ResponseMetadata": {

--- a/tests/aws/services/s3/test_s3_list_operations.validation.json
+++ b/tests/aws/services/s3/test_s3_list_operations.validation.json
@@ -21,7 +21,7 @@
     "last_validated_date": "2025-01-21T18:15:03+00:00"
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjectVersions::test_list_objects_versions_with_prefix_only_and_pagination": {
-    "last_validated_date": "2025-02-13T02:27:21+00:00"
+    "last_validated_date": "2025-02-13T03:52:21+00:00"
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjectVersions::test_s3_list_object_versions_timestamp_precision": {
     "last_validated_date": "2025-01-21T18:15:06+00:00"

--- a/tests/aws/services/s3/test_s3_list_operations.validation.json
+++ b/tests/aws/services/s3/test_s3_list_operations.validation.json
@@ -20,6 +20,9 @@
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjectVersions::test_list_objects_versions_with_prefix": {
     "last_validated_date": "2025-01-21T18:15:03+00:00"
   },
+  "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjectVersions::test_list_objects_versions_with_prefix_only_and_pagination": {
+    "last_validated_date": "2025-02-13T02:27:21+00:00"
+  },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjectVersions::test_s3_list_object_versions_timestamp_precision": {
     "last_validated_date": "2025-01-21T18:15:06+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported with #12255, we've had an issue with `ListObjectVersions` and deletion.
The failing scenario is reproduced in the added test, but it can be summarized like that:

The list operation, when paginated and arriving at the max amount it can return, will return a `VersionIdMarker`, representing the last marker it returned (newer operations of S3 return the next one, which is a bit smarter). 

If you happen to delete this version, AWS will return the next value in line after this now deleted marker. Not sure exactly how they do it, if they encode the data in the version id, or keep track of deleted versions. I've tried to reverse engineer the VersionId base64 encoding, but didn't really get anything and didn't try very hard.

We didn't have anything to compare against as those values were randomly generated, and we didn't have a way to compare them against each other. I've introduced some ever increasing number to be the prefix of the b64 encoded value, so that we can lexicographically sort and compare them. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- introduce ever-increasing number byte prefix in the version id of S3 objects to allow comparison
- add the proper comparison in the pagination of `ListObjectVersions`
- add new test for the scenario of the version id marker being deleted, and pagination in general

## Side notes

- I'm packing the sequence number as 6 bytes, so a max of 281 474 976 710 656. Minus the start time in millisecond right now, it would give approx. 279735559077354 increases (meaning new versions) before we overflow. I think we're good 😄 (irrational fear of overflow).

- pagination is a mess in S3, not one operation implements it the same way, there's always a subtle difference 😅


_fixes #12255_
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
