### PR TITLE
fix flaky transcribe tests

### DIFF
--- a/localstack-core/localstack/constants.py
+++ b/localstack-core/localstack/constants.py
@@ -33,6 +33,9 @@ ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 # Artifacts endpoint
 ASSETS_ENDPOINT = "https://assets.localstack.cloud"
 
+# Hugging Face endpoint for localstack
+HUGGING_FACE_ENDPOINT = "https://huggingface.co/localstack"
+
 # host to bind to when starting the services
 BIND_HOST = "0.0.0.0"
 

--- a/localstack-core/localstack/services/transcribe/provider.py
+++ b/localstack-core/localstack/services/transcribe/provider.py
@@ -30,6 +30,7 @@ from localstack.aws.api.transcribe import (
     TranscriptionJobSummary,
 )
 from localstack.aws.connect import connect_to
+from localstack.constants import ARTIFACTS_REPO
 from localstack.packages.ffmpeg import ffmpeg_package
 from localstack.services.s3.utils import (
     get_bucket_and_key_from_presign_url,
@@ -43,6 +44,10 @@ from localstack.utils.run import run
 from localstack.utils.threads import start_thread
 
 LOG = logging.getLogger(__name__)
+
+VOSK_MODEL_ARTIFACTS_URL = (
+    f"{ARTIFACTS_REPO}/raw/a1f6e430de71d383bc7477f130da052f8686deec/vosk/models/"
+)
 
 # Map of language codes to language models
 LANGUAGE_MODELS = {
@@ -235,11 +240,26 @@ class TranscribeProvider(TranscribeApi):
 
             LOG.debug("Downloading language model: %s", model_path.name)
 
+            def _try_download(url: str):
+                try:
+                    download(url + str(model_path.name) + ".zip", model_zip_path, verify_ssl=False)
+                except Exception as e:
+                    LOG.error("Download failed from %s: %s", url, e)
+                    return False
+                return True
+
             from vosk import MODEL_PRE_URL  # noqa
 
-            download(
-                MODEL_PRE_URL + str(model_path.name) + ".zip", model_zip_path, verify_ssl=False
-            )
+            download_urls = [VOSK_MODEL_ARTIFACTS_URL, MODEL_PRE_URL]
+
+            for url in download_urls:
+                if _try_download(url):
+                    # Download the models from the localstack artifacts if present else download from the Vosk URL
+                    LOG.info("Successfully downloaded model from %s", url)
+                    break
+                else:
+                    LOG.error("Failed to download model from %s", url)
+                    return
 
             LOG.debug("Extracting language model: %s", model_path.name)
             with ZipFile(model_zip_path, "r") as model_ref:

--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -136,7 +136,6 @@ class TestTranscribe:
             "$..Error..Code",
         ]
     )
-    @pytest.mark.skip(reason="flaky")
     def test_transcribe_happy_path(self, transcribe_create_job, snapshot, aws_client):
         file_path = os.path.join(BASEDIR, "../../files/en-gb.wav")
         job_name = transcribe_create_job(audio_file=file_path)
@@ -181,7 +180,6 @@ class TestTranscribe:
         ],
     )
     @markers.aws.needs_fixing
-    @pytest.mark.skip(reason="flaky")
     def test_transcribe_supported_media_formats(
         self, transcribe_create_job, media_file, speech, aws_client
     ):
@@ -322,7 +320,6 @@ class TestTranscribe:
             (None, None),  # without output bucket and output key
         ],
     )
-    @pytest.mark.skip(reason="flaky")
     def test_transcribe_start_job(
         self,
         output_bucket,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Fix flaky pipeline runs: 
- https://app.circleci.com/pipelines/github/localstack/localstack/31132/workflows/352699b7-785d-4672-a966-a5f073e5a6e6/jobs/277165/tests 
- https://app.circleci.com/pipelines/github/localstack/localstack/31131/workflows/2aaa3688-b9ae-4db9-b661-ba4693df7531/jobs/277148/tests

by making the downloading of vosk models more robust. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This PR: 
- adds provision to download the models from the vosk server and if it fails, it fallbacks to download the models from the [Hugging Face](https://huggingface.co/localstack/vosk-models). 
- removes skipping the flaky tests: `test_transcribe_happy_path`, `test_transcribe_supported_media_formats` and `test_transcribe_start_job`. 

Successful pipeline runs: https://app.circleci.com/pipelines/github/localstack/localstack?branch=test-transcribe

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
