### PR TITLE
fix ListObjectVersions pagination comparison

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -282,6 +282,7 @@ from localstack.services.s3.utils import (
     get_system_metadata_from_request,
     get_unique_key_id,
     is_bucket_name_valid,
+    is_version_older_than_other,
     parse_copy_source_range_header,
     parse_post_object_tagging_xml,
     parse_range_header,
@@ -1856,9 +1857,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                         continue
 
                     # it is possible that the version_id_marker related object has been deleted, in that case, start
-                    # as soon as the next version id is smaller than the version id marker (meaning this version was
+                    # as soon as the next version id is older than the version id marker (meaning this version was
                     # next after the now-deleted version)
-                    elif version.version_id < version_id_marker:
+                    elif is_version_older_than_other(version.version_id, version_id_marker):
                         version_key_marker_found = True
 
                     elif not version_key_marker_found:

--- a/tests/aws/services/s3/test_s3_list_operations.py
+++ b/tests/aws/services/s3/test_s3_list_operations.py
@@ -562,7 +562,7 @@ class TestS3ListObjectVersions:
         )
         snapshot.match("list-object-version-prefix-page-2-after-delete", page_2_response)
 
-    @markers.aws.only_localstack
+    @markers.aws.validated
     def test_list_objects_versions_with_prefix_only_and_pagination_many_versions(
         self,
         s3_bucket,

--- a/tests/aws/services/s3/test_s3_list_operations.validation.json
+++ b/tests/aws/services/s3/test_s3_list_operations.validation.json
@@ -23,6 +23,9 @@
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjectVersions::test_list_objects_versions_with_prefix_only_and_pagination": {
     "last_validated_date": "2025-02-13T03:52:21+00:00"
   },
+  "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjectVersions::test_list_objects_versions_with_prefix_only_and_pagination_many_versions": {
+    "last_validated_date": "2025-02-13T20:24:26+00:00"
+  },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjectVersions::test_s3_list_object_versions_timestamp_precision": {
     "last_validated_date": "2025-01-21T18:15:06+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #12259, I've introduced flakiness in the tests and bad behavior (also reported). I saw the failed run here: https://github.com/localstack/localstack/actions/runs/13314341024/job/37184566141 and realized my mistake instantly 🤦‍♂️ 

I incorrectly assumed the b64 encoded data could be sorted lexicographically, but this was wrong. The increasing values are cycling from upper case, lower case, digits, back to upper case. However, there is one comparison that fails: `z` to `0`. 

This is because if we look at the proper Unicode code point for the characters, we go from `y`, `z`, `0`, `1` to -> `49`,  `48`, `122`, `121`. So we break the order at this one character. (if they had started with digits, things would have been fine 😝)

I've introduced a small utility function to properly compare version between each other, maybe using hexadecimal characters could have been fine, but who knows what people does with `VersionId` field 😅 keeping the format as close as possible to AWS might be preferable.

Also introduced unit tests for it, and an integration test to validate the paginator behavior. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix the `VersionId` comparison to properly look at the raw data instead of the encoded one
- add unit test for behavior
- add integration test

_fixes #12255_
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
