### PR TITLE
Return correct IP address when LS container runs inside K8s cluster

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -290,6 +290,13 @@ def ping(host):
     )
 
 
+def tcp_port4566_open():
+    """
+    Returns True if this runs inside a Kubernetes pod and if the sidecar has port 4566 (TCP) open.
+    """
+    return os.getenv("LOCALSTACK_PORT_4566_TCP_ADDR") is not None
+
+
 def in_docker():
     """
     Returns True if running in a docker container, else False
@@ -382,6 +389,7 @@ def in_docker():
 OVERRIDE_IN_DOCKER = parse_boolean_env("OVERRIDE_IN_DOCKER")
 
 is_in_docker = in_docker()
+is_tcp_port4566_open = tcp_port4566_open()
 is_in_linux = is_linux()
 is_in_macos = is_macos()
 default_ip = "0.0.0.0" if is_in_docker else "127.0.0.1"


### PR DESCRIPTION
## Motivation

The `get_endpoint_for_network` function is used to determine what the IP address of the main container is (whether it's running on Docker or Kubernetes, or in host mode).

We check if the k8s pod adds an env of the `LOCALSTACK_PORT_4566_TCP_ADDR` kind when port 4566 is open. Somehow when attempting to try if the env var associated with port 53 exists or not, it doesn't show up, despite the fact that the deployment has port 53 (tcp/udp) exposed. Anyways, this doesn't seem to be a problem as we make use of the `dns_server.is_server_running` function to determine if the DNS server is running (at the very least). 

## Changes

What's left to do:

- [ ] Change the helm chart / k8s operator codebases to export an env var (i.e. `LOCALSTACK_K8S_POD_IP`) through the use of the `status.podIP` metadata instead. Use `LOCALSTACK_K8S_POD_IP` instead to determine if we're running inside a K8s pod.
