### PR TITLE
[Events] Skip flaky test against SQS target

### DIFF
--- a/tests/aws/services/events/test_events_schedule.py
+++ b/tests/aws/services/events/test_events_schedule.py
@@ -82,6 +82,7 @@ class TestScheduleRate:
         }
 
     @markers.aws.validated
+    @pytest.mark.skip(reason="flakey when comparing 'messages-second' against snapshot")
     def tests_schedule_rate_target_sqs(
         self,
         sqs_as_events_target,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Skips flaky test where LocalStack is returning an extra SQS record -- failing the snapshot matching. See [CircleCI job](https://app.circleci.com/pipelines/github/localstack/localstack/31152/workflows/82a46fe8-83c1-400e-bbca-aabe1fa804ca/jobs/277357).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Skips `TestScheduleRate::tests_schedule_rate_target_sqs`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
