### PR TITLE
[ESM] Add backoff between Stream Poller retries

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -205,9 +205,6 @@ class StreamPoller(Poller):
             and not self._is_shutdown.is_set()
         ):
             try:
-                if self.has_record_expired(polled_events[-1]):
-                    abort_condition = "RecordAgeExpired"
-
                 if attempts > 0:
                     # TODO: Should we always backoff (with jitter) before processing since we may not want multiple pollers
                     # all starting up and polling simultaneously


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR leverages the backoff util to ensure, when retrying, we wait between retries so as to not spam the processing loop.

Companion PR to https://github.com/localstack/localstack/pull/12264

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Checks `has_record_expired` every iteration to allow for an expired record to break processing.
- Use `backoff`utility, in conjunction with a `threading.Event`, to exponentially back-off between processing retries.


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
