### PR TITLE
fix SNS FIFO ordering

### DIFF
--- a/localstack-core/localstack/services/sns/executor.py
+++ b/localstack-core/localstack/services/sns/executor.py
@@ -11,13 +11,11 @@ def _worker(work_queue: queue.Queue):
     try:
         while True:
             work_item = work_queue.get(block=True)
-            if work_item is not None:
-                work_item.run()
-
-                del work_item
-                continue
-
-            return
+            if work_item is None:
+                return
+            work_item.run()
+            # delete reference to the work item to avoid it being in memory until the next blocking `queue.get` call returns
+            del work_item
 
     except Exception:
         LOG.exception("Exception in worker")

--- a/localstack-core/localstack/services/sns/executor.py
+++ b/localstack-core/localstack/services/sns/executor.py
@@ -16,6 +16,9 @@ def _worker(work_queue: queue.Queue):
                 work_item.run()
 
                 del work_item
+                continue
+
+            return
 
     except Exception:
         LOG.exception("Exception in worker")

--- a/localstack-core/localstack/services/sns/executor.py
+++ b/localstack-core/localstack/services/sns/executor.py
@@ -1,0 +1,120 @@
+import itertools
+import logging
+import os
+import queue
+import threading
+from typing import Callable
+
+LOG = logging.getLogger(__name__)
+
+
+def _worker(work_queue: queue.Queue):
+    try:
+        while True:
+            work_item = work_queue.get(block=True)
+            if work_item is not None:
+                work_item.run()
+
+                del work_item
+
+    except Exception:
+        LOG.exception("Exception in worker")
+
+
+class _WorkItem:
+    def __init__(self, fn, args, kwargs):
+        self.fn = fn
+        self.args = args
+        self.kwargs = kwargs
+
+    def run(self):
+        try:
+            self.fn(*self.args, **self.kwargs)
+        except Exception:
+            LOG.exception("Unhandled Exception in while running %s", self.fn.__name__)
+
+
+class TopicPartitionedThreadPoolExecutor:
+    """
+    This topic partition the work between workers based on Topics.
+    It guarantees that each Topic only has one worker assigned, and thus that the tasks will be executed sequentially.
+
+    Loosely based on ThreadPoolExecutor for stdlib, but does not return Future as SNS does not need it (fire&forget)
+    Could be extended if needed to fit other needs.
+
+    Currently, we do not re-balance between workers if some of them have more load. This could be investigated.
+    """
+
+    # Used to assign unique thread names when thread_name_prefix is not supplied.
+    _counter = itertools.count().__next__
+
+    def __init__(
+        self, max_workers: int = None, thread_name_prefix: str = "", itemgetter: Callable = None
+    ):
+        if max_workers is None:
+            max_workers = min(32, (os.cpu_count() or 1) + 4)
+        if max_workers <= 0:
+            raise ValueError("max_workers must be greater than 0")
+
+        if itemgetter is not None and not callable(itemgetter):
+            raise TypeError("itemgetter must be a callable")
+
+        self._max_workers = max_workers
+        self._itemgetter = itemgetter
+        self._thread_name_prefix = (
+            thread_name_prefix or f"TopicThreadPoolExecutor-{self._counter()}"
+        )
+
+        # for now, the pool isn't fair and is not redistributed depending on load
+        self._pool = {}
+        self._shutdown = False
+        self._shutdown_lock = threading.Lock()
+        self._threads = set()
+        self._work_queues = []
+        self._cycle = itertools.cycle(range(max_workers))
+
+    def _add_worker(self):
+        num_threads = len(self._threads)
+        if num_threads < self._max_workers:
+            work_queue = queue.SimpleQueue()
+            self._work_queues.append(work_queue)
+            thread_name = f"{self._thread_name_prefix}_{num_threads}"
+            t = threading.Thread(name=thread_name, target=_worker, args=(work_queue,))
+            t.daemon = True
+            t.start()
+            self._threads.add(t)
+
+    def _get_work_queue(self, topic: str) -> queue.SimpleQueue:
+        if not (work_queue := self._pool.get(topic)):
+            index = next(self._cycle)
+            if index <= len(self._work_queues):
+                self._add_worker()
+
+            work_queue = self._work_queues[index]
+            # the pool is not cleaned up at the moment, not sure if we'd need to change the interface
+            self._pool[topic] = work_queue
+        return work_queue
+
+    def submit(self, fn, /, *args, **kwargs) -> None:
+        with self._shutdown_lock:
+            topic = self._itemgetter(*args, **kwargs)
+            work_queue = self._get_work_queue(topic)
+
+            if self._shutdown:
+                raise RuntimeError("cannot schedule new futures after shutdown")
+
+            w = _WorkItem(fn, args, kwargs)
+            work_queue.put(w)
+
+    def shutdown(self, wait=True):
+        with self._shutdown_lock:
+            self._shutdown = True
+
+            # Send a wake-up to prevent threads calling
+            # _work_queue.get(block=True) from permanently blocking.
+            for work_queue in self._work_queues:
+                work_queue.put(None)
+
+        if wait:
+            for t in self._threads:
+                t.join()

--- a/localstack-core/localstack/services/sns/publisher.py
+++ b/localstack-core/localstack/services/sns/publisher.py
@@ -1311,6 +1311,7 @@ class PublishDispatcher:
         self, notifier, ctx: SnsPublishContext | SnsBatchPublishContext, subscriber: SnsSubscription
     ):
         if subscriber.get("TopicArn", "").endswith(".fifo"):
+            # TODO: we still need to implement Message deduplication on the topic level with `should_publish` for FIFO
             self.topic_partitioned_executor.submit(
                 notifier.publish, context=ctx, subscriber=subscriber
             )

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -3047,8 +3047,9 @@ class TestSNSSubscriptionSQSFifo:
             all_messages.append(contents)
 
         # we're expecting the order to be the same across all queues
-        for index, received_content in enumerate(all_messages[1:]):
-            assert received_content == all_messages[index]
+        reference_order = all_messages[0]
+        for received_content in all_messages[1:]:
+            assert received_content == reference_order
 
 
 class TestSNSSubscriptionSES:

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -5078,5 +5078,9 @@
         ]
       }
     }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_message_to_fifo_sqs_ordering": {
+    "recorded-date": "19-02-2025, 01:29:15",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -185,6 +185,9 @@
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_message_to_fifo_sqs[True]": {
     "last_validated_date": "2023-11-09T20:12:03+00:00"
   },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_message_to_fifo_sqs_ordering": {
+    "last_validated_date": "2025-02-19T01:29:14+00:00"
+  },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_publish_batch_messages_from_fifo_topic_to_fifo_queue[False]": {
     "last_validated_date": "2023-11-09T20:10:33+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've got a report with #12276 that SNS FIFO ordering wasn't guaranteed between subscriptions of the same topic (usually first messages are unordered, then they get ordered). 

This PR introduces a "partitioned" thread pool executor: each "topic" (it can be anything, it is not scoped only to SNS), will have its own worker. This allows the guarantee that the work executed on that topic is sequential. 
But you can have multiple workers, and each will have some topics assigned to them. 

The user also added a very good reproducer in Rust: https://github.com/dkales/fifo-example, verifying that ordering is the same across all queues, and it now works all the time. 

<details><summary>Some more context</summary>
<p>

This was something we were aware of with @thrau and had discussed already a long time ago, but the request hadn't come yet. 

A quick fix we thought of was to create a `ThreadPoolExecutor` with only one worker, so that we would make sure things would be executed sequentially, or create our own workers. 

What's happening today is that the `ThreadPoolExecutor` does not have all thread spawned up in the beginning. It takes a while for them to start, and they will start in random order, so publishing 10 messages will awake 10 threads, and thread no. 4 will maybe finish faster than thread no.2
After a while, things get ordered because all threads are "warm", and they are picking up work from the single work queue of the executor in the same "rhythm". 

</p>
</details> 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- introduced a `TopicPartitionedThreadPoolExecutor` loosely based on the standard library one
- use it for FIFO topics in SNS so that we guarantee ordering
- add a test for it

_fixes #12276_


## Testing

Removing the new thread pool logic and trying the new test:
```python
tests/aws/services/sns/test_sns.py:2999 (TestSNSSubscriptionSQSFifo.test_message_to_fifo_sqs_ordering)
['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] != ['0', '2', '1', '3', '4', '5', '6', '7', '8', '9']

Expected :['0', '2', '1', '3', '4', '5', '6', '7', '8', '9']
Actual   :['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
```

I've also tried the new test with 15 topics to validate that it works with more than 10 topics (with the 10 workers)


