### PR TITLE
ElasticSearch: Fix missing JRE in 5.x and 6.x

### DIFF
--- a/localstack-core/localstack/services/opensearch/cluster.py
+++ b/localstack-core/localstack/services/opensearch/cluster.py
@@ -676,13 +676,24 @@ class ElasticsearchCluster(OpensearchCluster):
         settings = {
             "http.port": self.port,
             "http.publish_port": self.port,
-            "transport.port": "0",
             "network.host": self.host,
             "http.compression": "false",
             "path.data": f'"{dirs.data}"',
             "path.repo": f'"{dirs.backup}"',
-            "discovery.type": "single-node",
         }
+
+        # This config option was renamed between 6.7 and 6.8, yet not documented as a breaking change
+        # See https://github.com/elastic/elasticsearch/blob/f220abaf/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java#L1349-L1353
+        if self.version.startswith("Elasticsearch_5.") or (
+            self.version.startswith("Elasticsearch_6.") and self.version != "Elasticsearch_6.8"
+        ):
+            settings["transport.tcp.port"] = "0"
+        else:
+            settings["transport.port"] = "0"
+
+        # `discovery.type` had a different meaning in 5.x
+        if not self.version.startswith("Elasticsearch_5."):
+            settings["discovery.type"] = "single-node"
 
         if os.path.exists(os.path.join(dirs.mods, "x-pack-ml")):
             settings["xpack.ml.enabled"] = "false"

--- a/localstack-core/localstack/services/opensearch/cluster.py
+++ b/localstack-core/localstack/services/opensearch/cluster.py
@@ -16,7 +16,6 @@ from localstack.aws.api.opensearch import (
 )
 from localstack.http.client import SimpleRequestsClient
 from localstack.http.proxy import ProxyHandler
-from localstack.packages import InstallTarget
 from localstack.services.edge import ROUTER
 from localstack.services.opensearch import versions
 from localstack.services.opensearch.packages import elasticsearch_package, opensearch_package
@@ -670,7 +669,7 @@ class ElasticsearchCluster(OpensearchCluster):
         return constants.OS_USER_OPENSEARCH
 
     def _ensure_installed(self):
-        elasticsearch_package.install(self.version, target=InstallTarget.VAR_LIBS)
+        elasticsearch_package.install(self.version)
 
     def _base_settings(self, dirs) -> CommandSettings:
         settings = {
@@ -702,9 +701,7 @@ class ElasticsearchCluster(OpensearchCluster):
 
     def _create_env_vars(self, directories: Directories) -> Dict:
         return {
-            **elasticsearch_package.get_installer(self.version).get_java_env_vars(
-                InstallTarget.VAR_LIBS
-            ),
+            **elasticsearch_package.get_installer(self.version).get_java_env_vars(),
             "ES_JAVA_OPTS": os.environ.get("ES_JAVA_OPTS", "-Xms200m -Xmx600m"),
             "ES_TMPDIR": directories.tmp,
         }

--- a/localstack-core/localstack/services/opensearch/cluster.py
+++ b/localstack-core/localstack/services/opensearch/cluster.py
@@ -16,6 +16,7 @@ from localstack.aws.api.opensearch import (
 )
 from localstack.http.client import SimpleRequestsClient
 from localstack.http.proxy import ProxyHandler
+from localstack.packages import InstallTarget
 from localstack.services.edge import ROUTER
 from localstack.services.opensearch import versions
 from localstack.services.opensearch.packages import elasticsearch_package, opensearch_package
@@ -669,7 +670,7 @@ class ElasticsearchCluster(OpensearchCluster):
         return constants.OS_USER_OPENSEARCH
 
     def _ensure_installed(self):
-        elasticsearch_package.install(self.version)
+        elasticsearch_package.install(self.version, target=InstallTarget.VAR_LIBS)
 
     def _base_settings(self, dirs) -> CommandSettings:
         settings = {
@@ -690,7 +691,9 @@ class ElasticsearchCluster(OpensearchCluster):
 
     def _create_env_vars(self, directories: Directories) -> Dict:
         return {
-            "JAVA_HOME": os.path.join(directories.install, "jdk"),
+            **elasticsearch_package.get_installer(self.version).get_java_env_vars(
+                InstallTarget.VAR_LIBS
+            ),
             "ES_JAVA_OPTS": os.environ.get("ES_JAVA_OPTS", "-Xms200m -Xmx600m"),
             "ES_TMPDIR": directories.tmp,
         }

--- a/localstack-core/localstack/services/opensearch/packages.py
+++ b/localstack-core/localstack/services/opensearch/packages.py
@@ -43,7 +43,7 @@ class OpensearchPackage(Package):
 
     def _get_installer(self, version: str) -> PackageInstaller:
         if version in versions._prefixed_elasticsearch_install_versions:
-            if version.startswith("5.") or version.startswith("6."):
+            if version.startswith("Elasticsearch_5.") or version.startswith("Elasticsearch_6."):
                 return ElasticsearchLegacyPackageInstaller(version)
             return ElasticsearchPackageInstaller(version)
         else:

--- a/localstack-core/localstack/services/opensearch/packages.py
+++ b/localstack-core/localstack/services/opensearch/packages.py
@@ -347,9 +347,11 @@ class ElasticsearchPackageInstaller(PackageInstaller):
 
 class ElasticsearchLegacyPackageInstaller(ElasticsearchPackageInstaller):
     """
-    Specialised package installer for ElasticSearch 5.x and 6.x since these releases do not have a bundled JDK.
+    Specialised package installer for ElasticSearch 5.x and 6.x
 
-    This installer ensures that Java is installed as part of the setup.
+    It installs Java during setup because these releases of ES do not have a bundled JDK.
+    This should be removed after these versions are dropped in line with AWS EOL, scheduled for Nov 2026.
+    https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#choosing-version
     """
 
     # ES 5.x and 6.x require Java 8

--- a/localstack-core/localstack/services/opensearch/packages.py
+++ b/localstack-core/localstack/services/opensearch/packages.py
@@ -236,8 +236,8 @@ class ElasticsearchPackageInstaller(PackageInstaller):
     def __init__(self, version: str):
         super().__init__("elasticsearch", version)
 
-    def get_java_env_vars(self, target: InstallTarget) -> dict[str, str]:
-        install_dir = self._get_install_dir(target)
+    def get_java_env_vars(self) -> dict[str, str]:
+        install_dir = self.get_installed_dir()
         return {
             "JAVA_HOME": os.path.join(install_dir, "jdk"),
         }
@@ -272,7 +272,7 @@ class ElasticsearchPackageInstaller(PackageInstaller):
                 **java_system_properties_proxy(),
                 **java_system_properties_ssl(
                     os.path.join(install_dir, "jdk", "bin", "keytool"),
-                    self.get_java_env_vars(target),
+                    self.get_java_env_vars(),
                 ),
             }
             java_opts = system_properties_to_cli_args(sys_props)
@@ -361,7 +361,7 @@ class ElasticsearchLegacyPackageInstaller(ElasticsearchPackageInstaller):
     def _prepare_installation(self, target: InstallTarget) -> None:
         java_package.get_installer(self.JAVA_VERSION).install(target)
 
-    def get_java_env_vars(self, target: InstallTarget) -> dict[str, str]:
+    def get_java_env_vars(self) -> dict[str, str]:
         return {
             "JAVA_HOME": java_package.get_installer(self.JAVA_VERSION).get_java_home(),
         }

--- a/localstack-core/localstack/services/opensearch/packages.py
+++ b/localstack-core/localstack/services/opensearch/packages.py
@@ -18,6 +18,7 @@ from localstack.constants import (
     OPENSEARCH_PLUGIN_LIST,
 )
 from localstack.packages import InstallTarget, Package, PackageInstaller
+from localstack.packages.java import java_package
 from localstack.services.opensearch import versions
 from localstack.utils.archives import download_and_extract_with_retry
 from localstack.utils.files import chmod_r, load_file, mkdir, rm_rf, save_file
@@ -42,6 +43,8 @@ class OpensearchPackage(Package):
 
     def _get_installer(self, version: str) -> PackageInstaller:
         if version in versions._prefixed_elasticsearch_install_versions:
+            if version.startswith("5.") or version.startswith("6."):
+                return ElasticsearchLegacyPackageInstaller(version)
             return ElasticsearchPackageInstaller(version)
         else:
             return OpensearchPackageInstaller(version)
@@ -233,6 +236,10 @@ class ElasticsearchPackageInstaller(PackageInstaller):
     def __init__(self, version: str):
         super().__init__("elasticsearch", version)
 
+    def get_java_env_vars(self, target: InstallTarget) -> dict[str, str]:
+        install_dir = self._get_install_dir(target)
+        return {"JAVA_HOME": os.path.join(install_dir, "jdk")}
+
     def _install(self, target: InstallTarget):
         # locally import to avoid having a dependency on ASF when starting the CLI
         from localstack.aws.api.opensearch import EngineType
@@ -263,7 +270,7 @@ class ElasticsearchPackageInstaller(PackageInstaller):
                 **java_system_properties_proxy(),
                 **java_system_properties_ssl(
                     os.path.join(install_dir, "jdk", "bin", "keytool"),
-                    {"JAVA_HOME": os.path.join(install_dir, "jdk")},
+                    self.get_java_env_vars(target),
                 ),
             }
             java_opts = system_properties_to_cli_args(sys_props)
@@ -334,6 +341,30 @@ class ElasticsearchPackageInstaller(PackageInstaller):
             return ELASTICSEARCH_DEFAULT_VERSION
 
         return versions.get_install_version(self.version)
+
+
+class ElasticsearchLegacyPackageInstaller(ElasticsearchPackageInstaller):
+    """
+    Specialised package installer for ElasticSearch 5.x and 6.x since these releases do not have a bundled JDK.
+
+    This installer ensures that Java is installed as part of the setup.
+    """
+
+    # ES 5.x and 6.x require Java 8
+    # See: https://www.elastic.co/guide/en/elasticsearch/reference/6.0/zip-targz.html
+    JAVA_VERSION = "8"
+
+    def _prepare_installation(self, target: InstallTarget) -> None:
+        java_package.get_installer(self.JAVA_VERSION).install(target)
+
+    def get_java_env_vars(self, target: InstallTarget) -> dict[str, str]:
+        java_home = java_package.get_installer(self.JAVA_VERSION).get_java_home()
+        path = f"{java_home}/bin:{os.environ['PATH']}"
+
+        return {
+            "JAVA_HOME": java_home,
+            "PATH": path,
+        }
 
 
 opensearch_package = OpensearchPackage(default_version=OPENSEARCH_DEFAULT_VERSION)

--- a/localstack-core/localstack/services/opensearch/packages.py
+++ b/localstack-core/localstack/services/opensearch/packages.py
@@ -238,7 +238,9 @@ class ElasticsearchPackageInstaller(PackageInstaller):
 
     def get_java_env_vars(self, target: InstallTarget) -> dict[str, str]:
         install_dir = self._get_install_dir(target)
-        return {"JAVA_HOME": os.path.join(install_dir, "jdk")}
+        return {
+            "JAVA_HOME": os.path.join(install_dir, "jdk"),
+        }
 
     def _install(self, target: InstallTarget):
         # locally import to avoid having a dependency on ASF when starting the CLI
@@ -358,12 +360,8 @@ class ElasticsearchLegacyPackageInstaller(ElasticsearchPackageInstaller):
         java_package.get_installer(self.JAVA_VERSION).install(target)
 
     def get_java_env_vars(self, target: InstallTarget) -> dict[str, str]:
-        java_home = java_package.get_installer(self.JAVA_VERSION).get_java_home()
-        path = f"{java_home}/bin:{os.environ['PATH']}"
-
         return {
-            "JAVA_HOME": java_home,
-            "PATH": path,
+            "JAVA_HOME": java_package.get_installer(self.JAVA_VERSION).get_java_home(),
         }
 
 


### PR DESCRIPTION
## Background

In https://github.com/localstack/localstack/pull/11462, we changed the ElasticSearch/OpenSearch installers to use the [bundled JRE](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html#jvm-version). However, based on https://github.com/localstack/localstack/issues/12231, it was identified that ElasticSearch 5.x and 6.x builds [do not](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/zip-targz.html) have a bundled JRE and instead require a separate JRE installation.

## Changes

This PR introduces a specialised package installer for ElasticSearch 5.x and 6.x which manages the Java dependency through standardised approach.

## Tests

Tested manually locally. On the CI, automated tests run only against the latest versions, which was also why this went undetected.

## Related

Closes: https://github.com/localstack/localstack/issues/12231