### PR TITLE
refactoring of removal of AWS::NoValue in reference list for CFn

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -755,7 +755,7 @@ def _resolve_refs_recursively(
 
         # remove _aws_no_value_ from resulting references
         clean_list = []
-        for i in range(len(value)):
+        for item in value:
             temp_value = resolve_refs_recursively(
                 account_id,
                 region_name,
@@ -764,7 +764,7 @@ def _resolve_refs_recursively(
                 mappings,
                 conditions,
                 parameters,
-                value[i],
+                item,
             )
             if not (isinstance(temp_value, str) and temp_value == PLACEHOLDER_AWS_NO_VALUE):
                 clean_list.append(temp_value)

--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -398,19 +398,18 @@ def _resolve_refs_recursively(
                     join_values,
                 )
 
-            join_values = [
-                resolve_refs_recursively(
-                    account_id,
-                    region_name,
-                    stack_name,
-                    resources,
-                    mappings,
-                    conditions,
-                    parameters,
-                    v,
-                )
-                for v in join_values
-            ]
+            # resolve reference in the items list
+            assert isinstance(join_values, list)
+            join_values = resolve_refs_recursively(
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                join_values,
+            )
 
             none_values = [v for v in join_values if v is None]
             if none_values:
@@ -420,9 +419,7 @@ def _resolve_refs_recursively(
                 raise Exception(
                     f"Cannot resolve CF Fn::Join {value} due to null values: {join_values}"
                 )
-            return value[keys_list[0]][0].join(
-                [str(v) for v in join_values if v != "__aws_no_value__"]
-            )
+            return value[keys_list[0]][0].join([str(v) for v in join_values])
 
         if stripped_fn_lower == "sub":
             item_to_sub = value[keys_list[0]]
@@ -756,8 +753,10 @@ def _resolve_refs_recursively(
                     {inner_list[0]: inner_list[1]},
                 )
 
+        # remove _aws_no_value_ from resulting references
+        clean_list = []
         for i in range(len(value)):
-            value[i] = resolve_refs_recursively(
+            temp_value = resolve_refs_recursively(
                 account_id,
                 region_name,
                 stack_name,
@@ -767,6 +766,9 @@ def _resolve_refs_recursively(
                 parameters,
                 value[i],
             )
+            if not (isinstance(temp_value, str) and temp_value == PLACEHOLDER_AWS_NO_VALUE):
+                clean_list.append(temp_value)
+        value = clean_list
 
     return value
 


### PR DESCRIPTION
## Motivation
As discovered by a customer. CFn should remove the AWS::NoValue from list of references when pasing such list as as an Attribute Value for a resource definition.

Example. In the following code, CFn should remove the AWS::NoValue from the list of RouteTableIds before attempting to create the resource.

```yaml
S3VpcEndpoint:
    Type: AWS::EC2::VPCEndpoint
    Properties:
      RouteTableIds:
        - Fn::If:
            - cNewVpc
            - Ref: PrivateSubnet1RouteTable
            - Ref: AWS::NoValue
        - Fn::If:
            - cNewVpc
            - Ref: PrivateSubnet2RouteTable
            - Ref: AWS::NoValue
``` 

The previous solution (#12163) only managed to fix this for `Fn::Join` list parameter. With the new changes, the fix is applied to any referenced list.

## Changes
- Temployer utils removes the AWS::NoValue from the lists.
- The Fn:Join procces now uses the cleaned result instead of filtering it itself

## No testing
- Since it's a refactoring a green pipeline should be enough.
- Most of the resources that directly accept a list as attribute are available only in PRO
