### PR TITLE
Lamba: fix unhandled error when SubnetIds is invalid

### DIFF
--- a/localstack-core/localstack/services/lambda_/api_utils.py
+++ b/localstack-core/localstack/services/lambda_/api_utils.py
@@ -95,6 +95,8 @@ VERSION_REGEX = re.compile(r"^[0-9]+$")
 ALIAS_REGEX = re.compile(r"(?!^[0-9]+$)(^[a-zA-Z0-9-_]+$)")
 # Permission statement id
 STATEMENT_ID_REGEX = re.compile(r"^[a-zA-Z0-9-_]+$")
+# Pattern for a valid SubnetId
+SUBNET_ID_REGEX = re.compile(r"^subnet-[0-9a-z]*$")
 
 
 URL_CHAR_SET = string.ascii_lowercase + string.digits

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -22258,5 +22258,59 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_invalid_vpc_config_subnet": {
+    "recorded-date": "20-02-2025, 17:53:33",
+    "recorded-content": {
+      "create-response-non-existent-subnet-id": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Error occurred while DescribeSubnets. EC2 Error Code: InvalidSubnetID.NotFound. EC2 Error Message: The subnet ID '<subnet_id_1>' does not exist"
+        },
+        "Type": "User",
+        "message": "Error occurred while DescribeSubnets. EC2 Error Code: InvalidSubnetID.NotFound. EC2 Error Message: The subnet ID '<subnet_id_1>' does not exist",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-response-invalid-format-subnet-id": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '[<subnet_id_2>]' at 'vpcConfig.subnetIds' failed to satisfy constraint: Member must satisfy constraint: [Member must have length less than or equal to 1024, Member must have length greater than or equal to 0, Member must satisfy regular expression pattern: ^subnet-[0-9a-z]*$]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_invalid_vpc_config_security_group": {
+    "recorded-date": "20-02-2025, 17:57:29",
+    "recorded-content": {
+      "create-response-non-existent-security-group": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Error occurred while DescribeSecurityGroups. EC2 Error Code: InvalidGroup.NotFound. EC2 Error Message: The security group '<security_group_id_1>' does not exist"
+        },
+        "Type": "User",
+        "message": "Error occurred while DescribeSecurityGroups. EC2 Error Code: InvalidGroup.NotFound. EC2 Error Message: The security group '<security_group_id_1>' does not exist",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-response-invalid-format-security-group": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '[<security_group_id_2>]' at 'vpcConfig.securityGroupIds' failed to satisfy constraint: Member must satisfy constraint: [Member must have length less than or equal to 1024, Member must have length greater than or equal to 0, Member must satisfy regular expression pattern: ^sg-[0-9a-zA-Z]*$]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -356,6 +356,15 @@
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_invalid_invoke": {
     "last_validated_date": "2024-09-12T11:34:43+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_invalid_vpc_config": {
+    "last_validated_date": "2025-02-20T17:44:18+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_invalid_vpc_config_security_group": {
+    "last_validated_date": "2025-02-20T17:57:29+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_invalid_vpc_config_subnet": {
+    "last_validated_date": "2025-02-20T17:53:33+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_s3": {
     "last_validated_date": "2024-09-12T11:29:56+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While working with Lambda and during a support case, I realized we didn't handle the case when the SubnetIds would be invalid. 

While this PR does not implement complet behavior (we only validate the first subnet id in the list), it at least makes sure that we don't return `InternalException`. 

This was the error:
```python
  File "<>/localstack/localstack-core/localstack/services/lambda_/provider.py", line 1007, in create_function
    vpc_config=self._build_vpc_config(
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "<>/localstack/localstack-core/localstack/services/lambda_/provider.py", line 491, in _build_vpc_config
    vpc_id=self._resolve_vpc_id(account_id, region_name, subnet_ids[0]),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<>/localstack/localstack-core/localstack/services/lambda_/provider.py", line 473, in _resolve_vpc_id
    ).ec2.describe_subnets(SubnetIds=[subnet_id])["Subnets"][0]["VpcId"]
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<>/.venv/lib/python3.11/site-packages/botocore/client.py", line 569, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<>/.venv/lib/python3.11/site-packages/botocore/client.py", line 1023, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidSubnetID.NotFound) when calling the DescribeSubnets operation (reached max retries: 0): The subnet ID 'bad-format-1f2656ac' does not exist
, headers={'Content-Type': 'application/json', 'X-Amzn-Errortype': 'InternalError', 'Content-Length': '3057', 'x-amzn-requestid': 'aa043e2f-52d3-4289-8646-ad4ee10ba812', 'x-amz-request-id': 'aa043e2f-52d3-4289-8646-ad4ee10ba812'})
```

And we would return an `InternalError` to the client. 

This PR also implements a skipped test to validate the `SecurityGroups`. I did not implement the logic to actually validate as it is not currently checked, and am not sure if it could lead to issues with users. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add 2 tests for validating `SubnetIds` and `SecurityGroups`
- implement regex validation for the `SubnetIds[0]` of the list
- add a try...except block around the `connect_to` call in order to surface the proper exception to the client

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
