### PR TITLE
[ESM] Validate event sources existence

### DIFF
--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping": {
-    "recorded-date": "12-10-2024, 10:55:29",
+    "recorded-date": "22-02-2025, 03:03:03",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -4457,6 +4457,23 @@
         },
         "timestamp": "<timestamp:2022-07-13T13:48:01.000Z>",
         "version": "1.0"
+      }
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_esm_with_not_existing_dynamodb_stream": {
+    "recorded-date": "26-02-2025, 03:08:09",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Stream not found: arn:<partition>:dynamodb:<region>:111111111111:table/test-table-4a53f4e8/stream/2025-02-22T03:03:25.490"
+        },
+        "Type": "User",
+        "message": "Stream not found: arn:<partition>:dynamodb:<region>:111111111111:table/test-table-4a53f4e8/stream/2025-02-22T03:03:25.490",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
       }
     }
   }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.validation.json
@@ -36,7 +36,7 @@
     "last_validated_date": "2024-10-12T11:11:04+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping": {
-    "last_validated_date": "2024-10-12T10:55:26+00:00"
+    "last_validated_date": "2025-02-22T03:03:01+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_on_failure_destination_config": {
     "last_validated_date": "2024-10-12T11:01:14+00:00"
@@ -88,5 +88,8 @@
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_report_batch_item_success_scenarios[null_success]": {
     "last_validated_date": "2024-10-12T11:42:04+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_esm_with_not_existing_dynamodb_stream": {
+    "last_validated_date": "2025-02-26T03:08:08+00:00"
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
@@ -3156,5 +3156,22 @@
         "version": "1.0"
       }
     }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_esm_with_not_existing_kinesis_stream": {
+    "recorded-date": "26-02-2025, 03:05:30",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Stream not found: arn:<partition>:kinesis:<region>:111111111111:stream/test-foobar-81ded7e8"
+        },
+        "Type": "User",
+        "message": "Stream not found: arn:<partition>:kinesis:<region>:111111111111:stream/test-foobar-81ded7e8",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -14,6 +14,9 @@
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_duplicate_event_source_mappings": {
     "last_validated_date": "2024-12-13T14:03:01+00:00"
   },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_esm_with_not_existing_kinesis_stream": {
+    "last_validated_date": "2025-02-26T03:05:29+00:00"
+  },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_empty_provided": {
     "last_validated_date": "2024-12-13T14:45:29+00:00"
   },

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py
@@ -56,6 +56,30 @@ def _snapshot_transformers(snapshot):
 
 
 @markers.aws.validated
+def test_esm_with_not_existing_sqs_queue(
+    aws_client, account_id, region_name, create_lambda_function, lambda_su_role, snapshot
+):
+    function_name = f"simple-lambda-{short_uid()}"
+    create_lambda_function(
+        func_name=function_name,
+        handler_file=LAMBDA_SQS_INTEGRATION_FILE,
+        runtime=Runtime.python3_12,
+        role=lambda_su_role,
+        timeout=5,
+    )
+    not_existing_queue_arn = (
+        f"arn:aws:sqs:{region_name}:{account_id}:not-existing-queue-{short_uid()}"
+    )
+    with pytest.raises(ClientError) as e:
+        aws_client.lambda_.create_event_source_mapping(
+            EventSourceArn=not_existing_queue_arn,
+            FunctionName=function_name,
+            BatchSize=1,
+        )
+    snapshot.match("error", e.value.response)
+
+
+@markers.aws.validated
 def test_failing_lambda_retries_after_visibility_timeout(
     create_lambda_function,
     sqs_create_queue,

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.snapshot.json
@@ -4559,5 +4559,22 @@
         }
       ]
     }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_esm_with_not_existing_sqs_queue": {
+    "recorded-date": "26-02-2025, 03:01:33",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Error occurred while ReceiveMessage. SQS Error Code: AWS.SimpleQueueService.NonExistentQueue. SQS Error Message: The specified queue does not exist."
+        },
+        "Type": "User",
+        "message": "Error occurred while ReceiveMessage. SQS Error Code: AWS.SimpleQueueService.NonExistentQueue. SQS Error Message: The specified queue does not exist.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.validation.json
@@ -104,6 +104,9 @@
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[simple string]": {
     "last_validated_date": "2024-10-12T13:43:40+00:00"
   },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_esm_with_not_existing_sqs_queue": {
+    "last_validated_date": "2025-02-26T03:01:32+00:00"
+  },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py::test_failing_lambda_retries_after_visibility_timeout": {
     "last_validated_date": "2024-11-25T12:12:47+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR allows for the ESM to validate the existence of different event source resources

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Adds check for sqs existence in the event source validation
- Adds check for kinesis streams existence in the event source validation
- Adds check for dynamodb streams existence in the event source validation

<!-- Optional section: How to test these changes? -->

## Testing
- Created the `test_esm_with_not_existing_sqs_queue` test inside the `test_lambda_integration_sqs.py` tests

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
