### PR TITLE
Fix failing lambda error reporting test

### DIFF
--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -1777,6 +1777,9 @@ class TestLambdaFeatures:
 
 class TestLambdaErrors:
     @markers.aws.validated
+    # TODO it seems like the used lambda images have a newer version of the RIC than AWS in production
+    # remove this skip once they have caught up
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Payload.stackTrace"])
     def test_lambda_runtime_error(self, aws_client, create_lambda_function, snapshot):
         """Test Lambda that raises an exception during runtime startup."""
         snapshot.add_transformer(snapshot.transform.regex(PATTERN_UUID, "<uuid>"))
@@ -1786,7 +1789,7 @@ class TestLambdaErrors:
             func_name=function_name,
             handler_file=TEST_LAMBDA_PYTHON_RUNTIME_ERROR,
             handler="lambda_runtime_error.handler",
-            runtime=Runtime.python3_12,
+            runtime=Runtime.python3_13,
         )
 
         result = aws_client.lambda_.invoke(

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -3333,7 +3333,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaErrors::test_lambda_runtime_error": {
-    "recorded-date": "16-04-2024, 08:08:32",
+    "recorded-date": "24-02-2025, 16:26:37",
     "recorded-content": {
       "invocation_error": {
         "ExecutedVersion": "$LATEST",
@@ -3343,12 +3343,12 @@
           "errorType": "Exception",
           "requestId": "",
           "stackTrace": [
-            "  File \"/var/lang/lib/python3.12/importlib/__init__.py\", line 90, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n",
+            "  File \"/var/lang/lib/python3.13/importlib/__init__.py\", line 88, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n",
             "  File \"<frozen importlib._bootstrap>\", line 1387, in _gcd_import\n",
             "  File \"<frozen importlib._bootstrap>\", line 1360, in _find_and_load\n",
             "  File \"<frozen importlib._bootstrap>\", line 1331, in _find_and_load_unlocked\n",
             "  File \"<frozen importlib._bootstrap>\", line 935, in _load_unlocked\n",
-            "  File \"<frozen importlib._bootstrap_external>\", line 995, in exec_module\n",
+            "  File \"<frozen importlib._bootstrap_external>\", line 1022, in exec_module\n",
             "  File \"<frozen importlib._bootstrap>\", line 488, in _call_with_frames_removed\n",
             "  File \"/var/task/lambda_runtime_error.py\", line 1, in <module>\n    raise Exception(\"Runtime startup fails\")\n"
           ]

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -96,7 +96,7 @@
     "last_validated_date": "2024-04-08T16:59:34+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaErrors::test_lambda_runtime_error": {
-    "last_validated_date": "2024-04-16T08:08:31+00:00"
+    "last_validated_date": "2025-02-24T16:26:36+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaErrors::test_lambda_runtime_exit": {
     "last_validated_date": "2024-04-08T16:58:35+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With recent updates to `public.ecr.aws/lambda/python:3.12` it seems AWS ships a newer Lambda RIC client with those images than they use in AWS.

This leads to a disparity between the stacktrace returned by aws, and the one in LS.

As the stack trace line numbers are not really important to get _exactly_ right, for me that is a reasonable compromise for now (other option would be pinning the images).

For now I have skipped the stack trace check - we should check in the future to unskip it once AWS incorporates the changes in their environment as well.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Update the test to python 3.13 (sadly this also has the change, but it is good to keep anyway)
* Skip snapshot verify on the stackTrace

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
