### PR TITLE
[ESM] Add backoff between poll events calls

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1071,24 +1071,6 @@ LAMBDA_INIT_POST_INVOKE_WAIT_MS = os.environ.get("LAMBDA_INIT_POST_INVOKE_WAIT_M
 # DEV: sbx_user1051 (default when not provided) Alternative system user or empty string to skip dropping privileges.
 LAMBDA_INIT_USER = os.environ.get("LAMBDA_INIT_USER")
 
-# INTERNAL: 1 (default)
-# The duration (in seconds) to wait between each poll call to an event source.
-LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC = float(
-    os.environ.get("LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC") or 1
-)
-
-# INTERNAL: 60 (default)
-# Maximum duration (in seconds) to wait between retries when an event source poll fails.
-LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC = float(
-    os.environ.get("LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC") or 60
-)
-
-# INTERNAL: 10 (default)
-# Maximum duration (in seconds) to wait between polls when an event source returns empty results.
-LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC = float(
-    os.environ.get("LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC") or 10
-)
-
 # Adding Stepfunctions default port
 LOCAL_PORT_STEPFUNCTIONS = int(os.environ.get("LOCAL_PORT_STEPFUNCTIONS") or 8083)
 # Stepfunctions lambda endpoint override

--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1071,6 +1071,24 @@ LAMBDA_INIT_POST_INVOKE_WAIT_MS = os.environ.get("LAMBDA_INIT_POST_INVOKE_WAIT_M
 # DEV: sbx_user1051 (default when not provided) Alternative system user or empty string to skip dropping privileges.
 LAMBDA_INIT_USER = os.environ.get("LAMBDA_INIT_USER")
 
+# INTERNAL: 1 (default)
+# The duration (in seconds) to wait between each poll call to an event source.
+LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC = float(
+    os.environ.get("LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC") or 1
+)
+
+# INTERNAL: 60 (default)
+# Maximum duration (in seconds) to wait between retries when an event source poll fails.
+LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC = float(
+    os.environ.get("LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC") or 60
+)
+
+# INTERNAL: 10 (default)
+# Maximum duration (in seconds) to wait between polls when an event source returns empty results.
+LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC = float(
+    os.environ.get("LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC") or 10
+)
+
 # Adding Stepfunctions default port
 LOCAL_PORT_STEPFUNCTIONS = int(os.environ.get("LOCAL_PORT_STEPFUNCTIONS") or 8083)
 # Stepfunctions lambda endpoint override

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
@@ -5,11 +5,6 @@ from enum import StrEnum
 from localstack.aws.api.lambda_ import (
     EventSourceMappingConfiguration,
 )
-from localstack.config import (
-    LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC,
-    LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC,
-    LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC,
-)
 from localstack.services.lambda_.event_source_mapping.pollers.poller import (
     EmptyPollResultsException,
     Poller,
@@ -19,9 +14,9 @@ from localstack.services.lambda_.provider_utils import get_function_version_from
 from localstack.utils.backoff import ExponentialBackoff
 from localstack.utils.threads import FuncThread
 
-POLL_INTERVAL_SEC: float = LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC
-MAX_BACKOFF_POLL_EMPTY_SEC: float = LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC
-MAX_BACKOFF_POLL_ERROR_SEC: float = LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC
+POLL_INTERVAL_SEC: float = 1
+MAX_BACKOFF_POLL_EMPTY_SEC: float = 10
+MAX_BACKOFF_POLL_ERROR_SEC: float = 60
 
 
 LOG = logging.getLogger(__name__)

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
@@ -158,13 +158,12 @@ class EsmWorker:
                 poll_interval_duration = POLL_INTERVAL_SEC
             except EmptyPollResultsException as miss_ex:
                 # If the event source is empty, backoff
-                poll_miss_boff_duration = empty_boff.next_backoff()
-                LOG.debug(
-                    "The event source %s is empty. Backing off for for %s seconds until next request.",
-                    miss_ex.source_arn,
-                    poll_miss_boff_duration,
-                )
                 poll_interval_duration = empty_boff.next_backoff()
+                LOG.debug(
+                    "The event source %s is empty. Backing off for %s seconds until next request.",
+                    miss_ex.source_arn,
+                    poll_interval_duration,
+                )
             except Exception as e:
                 LOG.error(
                     "Error while polling messages for event source %s: %s",

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/poller.py
@@ -19,8 +19,9 @@ class EmptyPollResultsException(Exception):
     service: str
     source_arn: str
 
-    def __init__(self, *args, service: str = "", source_arn: str = ""):
-        super(EmptyPollResultsException, self).__init__(*args)
+    def __init__(self, service: str = "", source_arn: str = ""):
+        self.service = service
+        self.source_arn = source_arn
 
 
 class PipeStateReasonValues(PipeStateReason):

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/poller.py
@@ -15,6 +15,14 @@ from localstack.utils.aws.arns import parse_arn
 from localstack.utils.event_matcher import matches_event
 
 
+class EmptyPollResultsException(Exception):
+    service: str
+    source_arn: str
+
+    def __init__(self, *args, service: str = "", source_arn: str = ""):
+        super(EmptyPollResultsException, self).__init__(*args)
+
+
 class PipeStateReasonValues(PipeStateReason):
     USER_INITIATED = "USER_INITIATED"
     NO_RECORDS_PROCESSED = "No records processed"

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py
@@ -13,6 +13,7 @@ from localstack.services.lambda_.event_source_mapping.event_processor import (
     PartialBatchFailureError,
 )
 from localstack.services.lambda_.event_source_mapping.pollers.poller import (
+    EmptyPollResultsException,
     Poller,
     parse_batch_item_failures,
 )
@@ -131,6 +132,12 @@ class SqsPoller(Poller):
                     e,
                     exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
+        else:
+            raise EmptyPollResultsException(
+                "No results found in poll call to SQS",
+                service="sqs",
+                source_arn=self.source_arn,
+            )
 
     def handle_messages(self, messages):
         polled_events = transform_into_events(messages)

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py
@@ -133,11 +133,7 @@ class SqsPoller(Poller):
                     exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
         else:
-            raise EmptyPollResultsException(
-                "No results found in poll call to SQS",
-                service="sqs",
-                source_arn=self.source_arn,
-            )
+            raise EmptyPollResultsException(service="sqs", source_arn=self.source_arn)
 
     def handle_messages(self, messages):
         polled_events = transform_into_events(messages)

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -24,6 +24,7 @@ from localstack.services.lambda_.event_source_mapping.pipe_utils import (
     get_internal_client,
 )
 from localstack.services.lambda_.event_source_mapping.pollers.poller import (
+    EmptyPollResultsException,
     Poller,
     get_batch_item_failures,
 )
@@ -157,6 +158,9 @@ class StreamPoller(Poller):
         get_records_response = self.get_records(shard_iterator)
         records = get_records_response["Records"]
         polled_events = self.transform_into_events(records, shard_id)
+        if not polled_events:
+            raise EmptyPollResultsException(service=self.event_source, source_arn=self.source_arn)
+
         # Check MaximumRecordAgeInSeconds
         if maximum_record_age_in_seconds := self.stream_parameters.get("MaximumRecordAgeInSeconds"):
             arrival_timestamp_of_last_event = polled_events[-1]["approximateArrivalTimestamp"]


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As a part of performance improvements to ESM, this PR introduces backoff in poll-frequency when an event source either returns no records or raises an exception on data retrieval.

By delaying polling on empty data sources and errors, we expect to reduce load on the LocalStack gateway and make more resources available for successful processing events.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Small refactor of `poll_events` to better facilitate changing the poll-frequency duration to include backoff.
- New `EmptyPollResultsException` that is raised when a poll request to an event source returns no data. This is used to signal a poll-miss scenario and allows us to decrease poller frequency for empty resources.
- Add an `empty_boff` that returns backoff (up to 10s) when an event source does not return any data (i.e a `EmptyPollResultsException` is raised).
- Add an `error_boff` that returns backoff (up to 60s) when a poll request to an event source raises an exception (other than `EmptyPollResultsException`).
- Note: All backoffs are reset upon a successful poll.

## Benchmarking

Some benchmarks tests were run to assess the extent to which including backoff would improve gateway processing latency of LocalStack. Note, that each experiment was run twice and aggregated appropriately.

We tested exponential backoff with a multiplication factor `x1.5` (default) per iteration.

The below table shows request count, throughput, and latency information about each experiment.
Experiment | # Requests | Average (ms) | Min (ms) | Max (ms) | RPS
-- | -- | -- | -- | -- | --
Baseline | 48096 | 514.275 | 2 | 2247 | 172.56
With Backoff (x1.5) | 111858 | 237.655 | 1 | 1553 | 373.045

The below table shows the percentiles of request-response latency for each experiment.
Experiment | P(50) (ms) | P(90) (ms) | P(95) (ms) | P(99) (ms) | P(100) (ms)
-- | -- | -- | -- | -- | --
Baseline | 480 | 830 | 935 | 1200 | 1800
With Backoff (x1.5) | 225 | 415 | 485 | 665 | 1400

The below table shows factor-level changes comparing backoff experiments to the baseline.
  | P(50) (ms) | RPS
-- | -- | --
With Backoff (x1.5) | -0.531 | +1.162



<details>
<summary><h3>Expand for Baseline Performance Chart(s)</h3></summary>

#### Baseline Performance Chart 1/2
Performance measurements over 5m run for baseline:
![image](https://github.com/user-attachments/assets/cd61b2a6-1477-45a9-91c3-35e86144f4e4)

#### Baseline Performance Chart 2/2
Performance measurements over 5m run for baseline:
![image](https://github.com/user-attachments/assets/c1108416-9385-44a8-895b-56be3c2ede52)
</details>

<details>

<summary><h3>Expand for Performance With Backoff Chart(s)</h3></summary>

#### With Backoff (x1.5) Performance Chart 1/2
Performance measurements over 5m baseline for run with backoff:
![total_requests_per_second_1740565012 795](https://github.com/user-attachments/assets/4f5f19d1-b3d9-42b8-8b9f-454584bcc0fb)


#### With Backoff (x1.5) Performance Chart 2/2
Performance measurements over 5m baseline for run with backoff:
![total_requests_per_second_1740565698 292](https://github.com/user-attachments/assets/6b0849d5-36a5-43ab-a9aa-b3b010638528)

<!-- Optional section: What's left to do before it can be merged? -->
<!--
#### With Backoff (x2.25) Performance Chart 1/2
Performance measurements over 5m baseline for run with backoff:
![image](https://github.com/user-attachments/assets/e1c3eec8-30bc-41fe-8f00-cb84fd4aa96f)

#### With Backoff (x2.25) Performance Chart 2/2
Performance measurements over 5m baseline for run with backoff:
![image](https://github.com/user-attachments/assets/c801a59e-0a78-4cf8-9f0c-2f569956f03d)
</details>

-->


</details>

## Results & Conclusions:

### No. of Requests

Adding backoff on poll-misses saw significant improvements in latency and throughput in our proxy measurement:

- x1.5 backoff: ~2.2x improvement compared to baseline

### RPS

- Baseline Avg: 172.56 RPS
- With Backoff (x1.5) Avg: 373.05 RPS

### P(50)

- Baseline: 480 ms
- With Backoff (x1.5): 225 ms

### P(95)

- Baseline: 935 ms
- With Backoff (x1.5): 485 ms

### Main Findings & Conclusions:

- RPS and P(50) is less variable/noisy over time when backoff is added.
- P(50) + P(95) graphs: The initial performance hit from overlapping requests lessened slightly when compared to baseline -- likely due to backoff on poll-misses reducing the likelihood of request-clustering.
- While adding backoff on poll-misses showed performance gains, without tracking e2e throughput it is unclear how more aggressive backoff will affect the user experience

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
