### PR TITLE
[ESM] Correctly enable exponential backoff inside stream poller

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -202,7 +202,9 @@ class StreamPoller(Poller):
         attempts = 0
         error_payload = {}
 
-        boff = ExponentialBackoff(max_retries=attempts)
+        max_retries = self.stream_parameters.get("MaximumRetryAttempts", -1)
+        # NOTE: max_retries == 0 means exponential backoff is disabled
+        boff = ExponentialBackoff(max_retries=max_retries)
         while (
             not abort_condition
             and not self.max_retries_exceeded(attempts)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
A follow-up PR to https://github.com/localstack/localstack/issues/12281 that correctly initialises the exponential backoff object.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Fixes incorrectly passing the `attempt` counter to the boff object. Instead, the `MaximumRetryAttempts` attribute of the ESM config is used.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
