### PR TITLE
Add Lambda@Edge service principal

### DIFF
--- a/localstack-core/localstack/utils/aws/client_types.py
+++ b/localstack-core/localstack/utils/aws/client_types.py
@@ -272,6 +272,7 @@ class ServicePrincipal(str):
     apigateway = "apigateway"
     cloudformation = "cloudformation"
     dms = "dms"
+    edgelambda = "edgelambda"
     events = "events"
     firehose = "firehose"
     lambda_ = "lambda"


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We are missing a service principal definition for `edgelambda.amazonaws.com` used at Lambda@Edge https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-permissions.html

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Add `edgelambda` to the list of service principals
