### PR TITLE
add service catalog cache loading from static var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,9 @@ RUN --mount=type=cache,target=/root/.cache \
 RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LOCALSTACK_CORE=${LOCALSTACK_BUILD_VERSION} \
     make entrypoints
 
+# Generate service catalog cache in static libs dir
+RUN . .venv/bin/activate && python3 -m localstack.aws.spec
+
 # Install packages which should be shipped by default
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/var/lib/localstack/cache \

--- a/localstack-core/localstack/aws/protocol/service_router.py
+++ b/localstack-core/localstack/aws/protocol/service_router.py
@@ -1,24 +1,18 @@
 import logging
-import os
 from typing import NamedTuple, Optional, Set
 
-import botocore
 from botocore.model import ServiceModel
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.http import parse_dict_header
 
-from localstack import config
 from localstack.aws.spec import (
     ServiceCatalog,
     ServiceModelIdentifier,
-    build_service_index_cache,
-    load_service_index_cache,
+    get_service_catalog,
 )
-from localstack.constants import VERSION
 from localstack.http import Request
 from localstack.services.s3.utils import uses_host_addressing
 from localstack.services.sqs.utils import is_sqs_queue_url
-from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import to_bytes
 from localstack.utils.urls import hostname_from_url
 
@@ -262,33 +256,6 @@ def legacy_rules(request: Request) -> Optional[ServiceModelIdentifier]:
     if uses_host_addressing(request.headers):
         # Note: This needs to be the last rule (and therefore is not in the host rules), since it is incredibly greedy
         return ServiceModelIdentifier("s3")
-
-
-@singleton_factory
-def get_service_catalog() -> ServiceCatalog:
-    """Loads the ServiceCatalog (which contains all the service specs), and potentially re-uses a cached index."""
-    if not os.path.isdir(config.dirs.cache):
-        return ServiceCatalog()
-
-    try:
-        ls_ver = VERSION.replace(".", "_")
-        botocore_ver = botocore.__version__.replace(".", "_")
-        cache_file_name = f"service-catalog-{ls_ver}-{botocore_ver}.pickle"
-        cache_file = os.path.join(config.dirs.cache, cache_file_name)
-
-        if not os.path.exists(cache_file):
-            LOG.debug("building service catalog index cache file %s", cache_file)
-            index = build_service_index_cache(cache_file)
-        else:
-            LOG.debug("loading service catalog index cache file %s", cache_file)
-            index = load_service_index_cache(cache_file)
-
-        return ServiceCatalog(index)
-    except Exception:
-        LOG.exception(
-            "error while processing service catalog index cache, falling back to lazy-loaded index"
-        )
-        return ServiceCatalog()
 
 
 def resolve_conflicts(

--- a/localstack-core/localstack/aws/spec.py
+++ b/localstack-core/localstack/aws/spec.py
@@ -271,7 +271,7 @@ def build_service_index_cache(file_path: str) -> ServiceCatalogIndex:
     """
     Creates a new ServiceCatalogIndex and stores it into the given file_path.
 
-    :param file_path: the path to pickle to
+    :param file_path: the path to store the file to
     :return: the created ServiceCatalogIndex
     """
     return save_service_index_cache(LazyServiceCatalogIndex(), file_path)
@@ -279,27 +279,27 @@ def build_service_index_cache(file_path: str) -> ServiceCatalogIndex:
 
 def load_service_index_cache(file: str) -> ServiceCatalogIndex:
     """
-    Loads from the given file the pickled ServiceCatalogIndex.
+    Loads from the given file the stored ServiceCatalogIndex.
 
     :param file: the file to load from
     :return: the loaded ServiceCatalogIndex
     """
-    import pickle
+    import dill
 
     with open(file, "rb") as fd:
-        return pickle.load(fd)
+        return dill.load(fd)
 
 
 def save_service_index_cache(index: LazyServiceCatalogIndex, file_path: str) -> ServiceCatalogIndex:
     """
-    Creates from the given LazyServiceCatalogIndex a ``ServiceCatalogIndex`, pickles its contents into the given file,
+    Creates from the given LazyServiceCatalogIndex a ``ServiceCatalogIndex`, stores its contents into the given file,
     and then returns the newly created index.
 
     :param index: the LazyServiceCatalogIndex to store the index from.
-    :param file_path: the path to pickle to
+    :param file_path: the path to store the binary index cache file to
     :return: the created ServiceCatalogIndex
     """
-    import pickle
+    import dill
 
     cache = ServiceCatalogIndex(
         service_names=index.service_names,
@@ -309,14 +309,15 @@ def save_service_index_cache(index: LazyServiceCatalogIndex, file_path: str) -> 
         target_prefix_index=index.target_prefix_index,
     )
     with open(file_path, "wb") as fd:
-        pickle.dump(cache, fd)
+        # use dill (instead of plain pickle) to avoid issues when serializing the pickle from __main__
+        dill.dump(cache, fd)
     return cache
 
 
 def _get_catalog_filename():
     ls_ver = VERSION.replace(".", "_")
     botocore_ver = botocore.__version__.replace(".", "_")
-    return f"service-catalog-{ls_ver}-{botocore_ver}.pickle"
+    return f"service-catalog-{ls_ver}-{botocore_ver}.dill"
 
 
 @singleton_factory

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -17,7 +17,7 @@ from localstack.aws.connect import (
     connect_to,
     dump_dto,
 )
-from localstack.aws.protocol.service_router import get_service_catalog
+from localstack.aws.spec import get_service_catalog
 from localstack.constants import APPLICATION_JSON, INTERNAL_AWS_ACCESS_KEY_ID
 from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.aws.client_types import ServicePrincipal

--- a/localstack-core/localstack/services/s3/cors.py
+++ b/localstack-core/localstack/services/s3/cors.py
@@ -18,7 +18,7 @@ from localstack.aws.chain import Handler, HandlerChain
 # TODO: refactor those to expose the needed methods
 from localstack.aws.handlers.cors import CorsEnforcer, CorsResponseEnricher
 from localstack.aws.protocol.op_router import RestServiceOperationRouter
-from localstack.aws.protocol.service_router import get_service_catalog
+from localstack.aws.spec import get_service_catalog
 from localstack.config import S3_VIRTUAL_HOSTNAME
 from localstack.http import Request, Response
 from localstack.services.s3.utils import S3_VIRTUAL_HOSTNAME_REGEX

--- a/localstack-core/localstack/services/s3/presigned_url.py
+++ b/localstack-core/localstack/services/s3/presigned_url.py
@@ -33,7 +33,7 @@ from localstack.aws.api.s3 import (
 )
 from localstack.aws.chain import HandlerChain
 from localstack.aws.protocol.op_router import RestServiceOperationRouter
-from localstack.aws.protocol.service_router import get_service_catalog
+from localstack.aws.spec import get_service_catalog
 from localstack.http import Request, Response
 from localstack.http.request import get_raw_path
 from localstack.services.s3.constants import (

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
@@ -4,7 +4,7 @@ from typing import Final
 from botocore.exceptions import ClientError, UnknownServiceError
 
 from localstack.aws.api.stepfunctions import HistoryEventType, TaskFailedEventDetails
-from localstack.aws.protocol.service_router import get_service_catalog
+from localstack.aws.spec import get_service_catalog
 from localstack.services.stepfunctions.asl.component.common.error_name.error_name import ErrorName
 from localstack.services.stepfunctions.asl.component.common.error_name.failure_event import (
     FailureEvent,

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -7,7 +7,8 @@ from botocore.awsrequest import AWSRequest, create_request_object
 from botocore.config import Config
 from botocore.model import OperationModel, ServiceModel, Shape, StructureShape
 
-from localstack.aws.protocol.service_router import determine_aws_service_model, get_service_catalog
+from localstack.aws.protocol.service_router import determine_aws_service_model
+from localstack.aws.spec import get_service_catalog
 from localstack.http import Request
 from localstack.utils.run import to_str
 


### PR DESCRIPTION
## Motivation
With the release of LocalStack 4.1.0, we had issues with the smoke tests of the binary build of our CLI.
It turned out that the initial loading of the service catalog took more than 2 seconds (which is the default connection timeout of `localstack wait`). https://github.com/localstack/localstack-cli/pull/33 introduced a workaround for this, by triggering the service catalog cache creation with a call prior to the `localstack wait` command.
However, this issue has a user impact, as this cache will always be created when localstack is started with a new `botocore` version (even if the localstack volume dir is properly configured).
In fact, this was already discussed with @thrau when he introduced the cache in the first place (https://github.com/localstack/localstack/pull/6672).
This PR solves this issue by generating the service catalog index cache at docker build time and stores it directly in the Docker image (~650kb uncompressed). 

## Changes
- Moves `get_service_catalog` from the `service_router` to the `spec` module.
- Introduces a new lookup directory (highest prio): The static libs directory (usually `/usr/lib/localstack/`).
- Adds a new `main` to the spec which allows to easily generate a `ServiceCatalog` index cache file to the static libs dir.
- Adds an invocation of this command to the Dockerfile

## Testing
- [ ] Update our downstream dependencies to also generate the service catalog as part of their Docker build process.