### PR TITLE
[ESM] Fix constantly triggering SQS back-off

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py
@@ -160,7 +160,6 @@ class SqsPoller(Poller):
 
         messages = response.get("Messages", [])
         if not messages:
-            # TODO: Consider this case triggering longer wait-times (with backoff) between poll_events calls in the outer-loop.
             raise EmptyPollResultsException(service="sqs", source_arn=self.source_arn)
 
         LOG.debug("Polled %d events from %s", len(messages), self.source_arn)

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py
@@ -161,7 +161,7 @@ class SqsPoller(Poller):
         messages = response.get("Messages", [])
         if not messages:
             # TODO: Consider this case triggering longer wait-times (with backoff) between poll_events calls in the outer-loop.
-            return
+            raise EmptyPollResultsException(service="sqs", source_arn=self.source_arn)
 
         LOG.debug("Polled %d events from %s", len(messages), self.source_arn)
         # TODO: implement invocation payload size quota
@@ -193,8 +193,6 @@ class SqsPoller(Poller):
                     e,
                     exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
-        else:
-            raise EmptyPollResultsException(service="sqs", source_arn=self.source_arn)
 
     def handle_messages(self, messages):
         polled_events = transform_into_events(messages)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This fixes an issue that causes our SQS poller to always trigger exponential backoff between poller calls instead of only when a response is empty or exception is raised. Currently, this bug is slowing down performance and should be merged ASAP.

### Why did this happen?

GitHub's automatic rebase (which did not raise a merge conflict) caused our `if-else` conditional to change into a `for-else`. Since the `else` block was where we raised a backoff exception, this has caused our poller to _always_ raise an exception and signals the ESM worker to constantly back-off.

See: 

https://github.com/localstack/localstack/blob/ceb6140362a2dcabd2e687344a399ccbeba6dab9/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py#L196

And:

https://github.com/localstack/localstack/blob/8859590c9974262a222c486ce7aaaeea151cd70f/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/sqs_poller.py#L194

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Moves the backoff exception from always being raised to instead be within the conditional check for no records being found.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
