### PR TITLE
CFn: populate APIGW regional* properties

### DIFF
--- a/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_domainname.py
+++ b/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_domainname.py
@@ -105,6 +105,12 @@ class ApiGatewayDomainNameProvider(ResourceProvider[ApiGatewayDomainNameProperti
         model["DistributionDomainName"] = result.get("distributionDomainName") or result.get(
             "domainName"
         )
+        model["RegionalDomainName"] = (
+            result.get("regionalDomainName") or model["DistributionDomainName"]
+        )
+        model["RegionalHostedZoneId"] = (
+            result.get("regionalHostedZoneId") or model["DistributionHostedZoneId"]
+        )
 
         return ProgressEvent(
             status=OperationStatus.SUCCESS,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A customer provided a template where they used `RegionalDomainName` and `RegionalHostedZoneId`, but these values are not populated correctly in the APIGW CFn resource provider


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Populate these two fields from the response if possible, but fall back to the distribution values if not present

## Testing

A CFn test is implemented in the private repository as creating domain names is a Pro feature

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
