### PR TITLE
Make SQS reject messages with empty body (#12317)

### DIFF
--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -143,14 +143,12 @@ def assert_queue_name(queue_name: str, fifo: bool = False):
             "Can only include alphanumeric characters, hyphens, or underscores. 1 to 80 in length"
         )
 
-def check_message_min_size(
-    message_body: str, message_attributes: MessageBodyAttributeMap
-):
+
+def check_message_min_size(message_body: str):
     print(f"check_message_size: message_body |{message_body}|")
-    if (
-        _message_body_size(message_body) == 0
-    ):
-        raise InvalidParameterValueException('The request must contain the parameter MessageBody.')
+    if _message_body_size(message_body) == 0:
+        raise InvalidParameterValueException("The request must contain the parameter MessageBody.")
+
 
 def check_message_max_size(
     message_body: str, message_attributes: MessageBodyAttributeMap, max_message_size: int
@@ -1206,7 +1204,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         message_deduplication_id: String = None,
         message_group_id: String = None,
     ) -> SqsMessage:
-        check_message_min_size(message_body, message_attributes)
+        check_message_min_size(message_body)
         check_message_max_size(message_body, message_attributes, queue.maximum_message_size)
         check_message_content(message_body)
         check_attributes(message_attributes)

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -236,6 +236,11 @@ class TestSqsProvider:
         assert message["MD5OfBody"] == send_result["MD5OfMessageBody"]
 
     @markers.aws.validated
+    def test_send_empty_message(self, sqs_queue, aws_sqs_client):
+        with pytest.raises(ClientError):
+            aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="")
+
+    @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
     def test_send_receive_max_number_of_messages(self, sqs_queue, snapshot, aws_sqs_client):
         queue_url = sqs_queue


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
To fix #12317 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Before this change localstack accepts SQS messages with empty body. 
After this changes, localstack rejects SQS messages with empty body with an error message "The request must contain the parameter MessageBody"


<!-- Optional section: How to test these changes? -->
## Testing
Added a test case to an existing suite for SQS

Manual testing

```bash
make start

(.venv) (.venv) juanrh@barelinux:~/git/localstack$ QUEUE_URL=$(awslocal sqs create-queue --queue-name Test | jq -r .QueueUrl)
(.venv) (.venv) juanrh@barelinux:~/git/localstack$ $AWS  sqs send-message --queue-url $QUEUE_URL --message-body 'asdas'
{
    "MD5OfMessageBody": "0aa1ea9a5a04b78d4581dd6d17742627",
    "MessageId": "0087c1cd-019b-41d0-beb6-eeb043e76590"
}
(.venv) (.venv) juanrh@barelinux:~/git/localstack$ $AWS  sqs send-message --queue-url $QUEUE_URL --message-body ''

An error occurred (InvalidParameterValue) when calling the SendMessage operation: The request must contain the parameter MessageBody.
(.venv) (.venv) juanrh@barelinux:~/git/localstack$ 
```

I also did run `make format` and `make lint`

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
