### PR TITLE
APIGW: add validation for AWS ARN in PutIntegration

### DIFF
--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -1963,6 +1963,15 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                     "Lambda function and Firehose stream invocations."
                 )
 
+        moto_rest_api = get_moto_rest_api(context=context, rest_api_id=request.get("restApiId"))
+        resource = moto_rest_api.resources.get(request.get("resourceId"))
+        if not resource:
+            raise NotFoundException("Invalid Resource identifier specified")
+
+        method = resource.resource_methods.get(request.get("httpMethod"))
+        if not method:
+            raise NotFoundException("Invalid Method identifier specified")
+
         # TODO: if the IntegrationType is AWS, `credentials` is mandatory
         moto_request = copy.copy(request)
         moto_request.setdefault("passthroughBehavior", "WHEN_NO_MATCH")

--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -1951,7 +1951,10 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             ):
                 raise BadRequestException("AWS ARN for integration must contain path or action")
 
-            if integration_type == IntegrationType.AWS_PROXY and parsed_arn["account"] != "lambda":
+            if integration_type == IntegrationType.AWS_PROXY and (
+                parsed_arn["account"] != "lambda"
+                or not parsed_arn["resource"].startswith("path/2015-03-31/functions/")
+            ):
                 # the Firehose message is misleading, this is not implemented in AWS
                 raise BadRequestException(
                     "Integrations of type 'AWS_PROXY' currently only supports "

--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -1938,6 +1938,8 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             )
 
         elif integration_type in (IntegrationType.AWS_PROXY, IntegrationType.AWS):
+            if not request.get("integrationHttpMethod"):
+                raise BadRequestException("Enumeration value for HttpMethod must be non-empty")
             if not (integration_uri := request.get("uri") or "").startswith("arn:"):
                 raise BadRequestException("Invalid ARN specified in the request")
 
@@ -1960,15 +1962,6 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                     "Integrations of type 'AWS_PROXY' currently only supports "
                     "Lambda function and Firehose stream invocations."
                 )
-
-        moto_rest_api = get_moto_rest_api(context=context, rest_api_id=request.get("restApiId"))
-        resource = moto_rest_api.resources.get(request.get("resourceId"))
-        if not resource:
-            raise NotFoundException("Invalid Resource identifier specified")
-
-        method = resource.resource_methods.get(request.get("httpMethod"))
-        if not method:
-            raise NotFoundException("Invalid Method identifier specified")
 
         # TODO: if the IntegrationType is AWS, `credentials` is mandatory
         moto_request = copy.copy(request)

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -3509,7 +3509,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_put_integration_response_validation": {
-    "recorded-date": "21-08-2024, 15:09:28",
+    "recorded-date": "03-03-2025, 14:27:24",
     "recorded-content": {
       "put-integration-wrong-method": {
         "Error": {

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -132,7 +132,7 @@
     "last_validated_date": "2024-12-12T10:46:41+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_put_integration_response_validation": {
-    "last_validated_date": "2024-08-21T15:09:28+00:00"
+    "last_validated_date": "2025-03-03T14:27:24+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_put_integration_wrong_type": {
     "last_validated_date": "2024-04-15T20:48:47+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_lambda.py
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.py
@@ -327,7 +327,6 @@ def test_put_integration_aws_proxy_uri(
         authorizationType="NONE",
     )
 
-    # f"arn:aws:apigateway:{region_name}:lambda:path/2015-03-31/functions/{lambda_arn}/invocations",
     default_params = {
         "restApiId": api_id,
         "resourceId": root_resource_id,
@@ -364,6 +363,13 @@ def test_put_integration_aws_proxy_uri(
             uri=f"arn:aws:apigateway:{region_name}:firehose:path/2015-03-31/functions/{lambda_arn}/invocations",
         )
     snapshot.match("put-integration-wrong-firehose", e.value.response)
+
+    with pytest.raises(ClientError) as e:
+        aws_client.apigateway.put_integration(
+            **default_params,
+            uri=f"arn:aws:apigateway:{region_name}:lambda:path/random/value/{lambda_arn}/invocations",
+        )
+    snapshot.match("put-integration-bad-lambda-arn", e.value.response)
 
 
 @markers.aws.validated

--- a/tests/aws/services/apigateway/test_apigateway_lambda.py
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.py
@@ -293,6 +293,80 @@ def test_lambda_aws_proxy_integration(
 
 
 @markers.aws.validated
+def test_put_integration_aws_proxy_uri(
+    aws_client,
+    create_rest_apigw,
+    create_lambda_function,
+    create_role_with_policy,
+    snapshot,
+    region_name,
+):
+    api_id, _, root_resource_id = create_rest_apigw(
+        name=f"test-api-{short_uid()}",
+        description="APIGW test PutIntegration AWS_PROXY URI",
+    )
+    function_name = f"function-{short_uid()}"
+
+    # create lambda
+    create_function_response = create_lambda_function(
+        func_name=function_name,
+        handler_file=TEST_LAMBDA_AWS_PROXY,
+        handler="lambda_aws_proxy.handler",
+        runtime=Runtime.python3_12,
+    )
+    # create invocation role
+    _, role_arn = create_role_with_policy(
+        "Allow", "lambda:InvokeFunction", json.dumps(APIGATEWAY_ASSUME_ROLE_POLICY), "*"
+    )
+    lambda_arn = create_function_response["CreateFunctionResponse"]["FunctionArn"]
+
+    aws_client.apigateway.put_method(
+        restApiId=api_id,
+        resourceId=root_resource_id,
+        httpMethod="ANY",
+        authorizationType="NONE",
+    )
+
+    # f"arn:aws:apigateway:{region_name}:lambda:path/2015-03-31/functions/{lambda_arn}/invocations",
+    default_params = {
+        "restApiId": api_id,
+        "resourceId": root_resource_id,
+        "httpMethod": "ANY",
+        "type": "AWS_PROXY",
+        "integrationHttpMethod": "POST",
+        "credentials": role_arn,
+    }
+
+    with pytest.raises(ClientError) as e:
+        aws_client.apigateway.put_integration(
+            **default_params,
+            uri=lambda_arn,
+        )
+    snapshot.match("put-integration-lambda-uri", e.value.response)
+
+    with pytest.raises(ClientError) as e:
+        aws_client.apigateway.put_integration(
+            **default_params,
+            uri=f"bad-arn:lambda:path/2015-03-31/functions/{lambda_arn}/invocations",
+        )
+    snapshot.match("put-integration-wrong-arn", e.value.response)
+
+    with pytest.raises(ClientError) as e:
+        aws_client.apigateway.put_integration(
+            **default_params,
+            uri=f"arn:aws:apigateway:{region_name}:lambda:test/2015-03-31/functions/{lambda_arn}/invocations",
+        )
+    snapshot.match("put-integration-wrong-type", e.value.response)
+
+    with pytest.raises(ClientError) as e:
+        aws_client.apigateway.put_integration(
+            **default_params,
+            uri=f"arn:aws:apigateway:{region_name}:firehose:path/2015-03-31/functions/{lambda_arn}/invocations",
+        )
+    snapshot.match("put-integration-wrong-firehose", e.value.response)
+
+
+@markers.aws.validated
 def test_lambda_aws_proxy_integration_non_post_method(
     create_rest_apigw, create_lambda_function, create_role_with_policy, snapshot, aws_client
 ):

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1797,7 +1797,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_put_integration_aws_proxy_uri": {
-    "recorded-date": "03-03-2025, 12:39:42",
+    "recorded-date": "03-03-2025, 12:58:39",
     "recorded-content": {
       "put-integration-lambda-uri": {
         "Error": {
@@ -1833,6 +1833,17 @@
         }
       },
       "put-integration-wrong-firehose": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Integrations of type 'AWS_PROXY' currently only supports Lambda function and Firehose stream invocations."
+        },
+        "message": "Integrations of type 'AWS_PROXY' currently only supports Lambda function and Firehose stream invocations.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-integration-bad-lambda-arn": {
         "Error": {
           "Code": "BadRequestException",
           "Message": "Integrations of type 'AWS_PROXY' currently only supports Lambda function and Firehose stream invocations."

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1795,5 +1795,54 @@
         "content": ""
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_lambda.py::test_put_integration_aws_proxy_uri": {
+    "recorded-date": "03-03-2025, 12:39:42",
+    "recorded-content": {
+      "put-integration-lambda-uri": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "AWS ARN for integration must contain path or action"
+        },
+        "message": "AWS ARN for integration must contain path or action",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-integration-wrong-arn": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid ARN specified in the request"
+        },
+        "message": "Invalid ARN specified in the request",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-integration-wrong-type": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "AWS ARN for integration must contain path or action"
+        },
+        "message": "AWS ARN for integration must contain path or action",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-integration-wrong-firehose": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Integrations of type 'AWS_PROXY' currently only supports Lambda function and Firehose stream invocations."
+        },
+        "message": "Integrations of type 'AWS_PROXY' currently only supports Lambda function and Firehose stream invocations.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -31,5 +31,8 @@
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_selection_patterns": {
     "last_validated_date": "2023-09-05T19:54:21+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_lambda.py::test_put_integration_aws_proxy_uri": {
+    "last_validated_date": "2025-03-03T12:39:42+00:00"
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -33,6 +33,6 @@
     "last_validated_date": "2023-09-05T19:54:21+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_put_integration_aws_proxy_uri": {
-    "last_validated_date": "2025-03-03T12:39:42+00:00"
+    "last_validated_date": "2025-03-03T12:58:39+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've got a report from a user with an unhandled error in the invocation logic:
```python
localstack | File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/apigateway/next_gen/execute_api/helpers.py", line 114, in get_lambda_function_arn_from_invocation_uri
localstack | return uri.split("functions/")[1].removesuffix("/invocations")
localstack | ~~~~~~~~~~~~~~~~~~~~~~~^^^
localstack | IndexError: list index out of range
```

This is probably because the Integration URI passed was directly a Lambda ARN, and it needs to be an API Gateway invocation ARN:
Correct format:
`arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:HelloWorld/invocations`
Incorrect format:
`arn:aws:lambda:us-east-1:123456789012:function:HelloWorld`

This PR implements a bit of validation to avoid this. 

Also had to move a bit of validation already done in moto in the provider just to keep proper validation order (with `integrationHttpMethod`)

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a test around the URI format for AWS/AWS_PROXY integration
- add a bit of validation for `PutIntegration`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
