### PR TITLE
Step Functions: Support for Aliasing

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/backend/alias.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/alias.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import copy
 import datetime
 import random
 import threading
@@ -15,8 +18,8 @@ from localstack.aws.api.stepfunctions import (
 
 class Alias:
     _mutex: Final[threading.Lock]
-    _update_date: Optional[datetime.datetime]
-    _name: Final[CharacterRestrictedName]
+    update_date: Optional[datetime.datetime]
+    name: Final[CharacterRestrictedName]
     _description: Optional[AliasDescription]
     _routing_configuration_list: RoutingConfigurationList
     _state_machine_version_arns: list[Arn]
@@ -32,8 +35,8 @@ class Alias:
         routing_configuration_list: RoutingConfigurationList,
     ):
         self._mutex = threading.Lock()
-        self._update_date = None
-        self._name = name
+        self.update_date = None
+        self.name = name
         self._description = None
         self.state_machine_alias_arn = f"{state_machine_arn}:{name}"
         self.update(description=description, routing_configuration_list=routing_configuration_list)
@@ -44,12 +47,29 @@ class Alias:
 
     def __eq__(self, other):
         if isinstance(other, Alias):
-            return self.state_machine_alias_arn == other.state_machine_alias_arn
+            return self.is_idempotent(other=other)
         return False
+
+    def is_idempotent(self, other: Alias) -> bool:
+        return all(
+            [
+                self.state_machine_alias_arn == other.state_machine_alias_arn,
+                self.name == other.name,
+                self._description == other._description,
+                self._routing_configuration_list == other._routing_configuration_list,
+            ]
+        )
 
     @staticmethod
     def _get_mutex_date() -> datetime.datetime:
         return datetime.datetime.now(tz=datetime.timezone.utc)
+
+    def get_routing_configuration_list(self) -> RoutingConfigurationList:
+        return copy.deepcopy(self._routing_configuration_list)
+
+    def is_router_for(self, state_machine_version_arn: Arn) -> bool:
+        with self._mutex:
+            return state_machine_version_arn in self._state_machine_version_arns
 
     def update(
         self,
@@ -57,7 +77,7 @@ class Alias:
         routing_configuration_list: RoutingConfigurationList,
     ) -> None:
         with self._mutex:
-            self._update_date = self._get_mutex_date()
+            self.update_date = self._get_mutex_date()
 
             if description is not None:
                 self._description = description
@@ -86,12 +106,13 @@ class Alias:
         with self._mutex:
             description = DescribeStateMachineAliasOutput(
                 creationDate=self.create_date,
-                name=self._name,
+                name=self.name,
                 description=self._description,
                 routingConfiguration=self._routing_configuration_list,
+                stateMachineAliasArn=self.state_machine_alias_arn,
             )
-            if self._update_date is not None:
-                description["updateDate"] = self._update_date
+            if self.update_date is not None:
+                description["updateDate"] = self.update_date
             return description
 
     def to_item(self) -> StateMachineAliasListItem:

--- a/localstack-core/localstack/services/stepfunctions/backend/alias.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/alias.py
@@ -1,0 +1,100 @@
+import datetime
+import random
+import threading
+from typing import Final, Optional
+
+from localstack.aws.api.stepfunctions import (
+    AliasDescription,
+    Arn,
+    CharacterRestrictedName,
+    DescribeStateMachineAliasOutput,
+    RoutingConfigurationList,
+    StateMachineAliasListItem,
+)
+
+
+class Alias:
+    _mutex: Final[threading.Lock]
+    _update_date: Optional[datetime.datetime]
+    _name: Final[CharacterRestrictedName]
+    _description: Optional[AliasDescription]
+    _routing_configuration_list: RoutingConfigurationList
+    _state_machine_version_arns: list[Arn]
+    _execution_probability_distribution: list[int]
+    state_machine_alias_arn: Final[Arn]
+    create_date: datetime.datetime
+
+    def __init__(
+        self,
+        state_machine_arn: Arn,
+        name: CharacterRestrictedName,
+        description: Optional[AliasDescription],
+        routing_configuration_list: RoutingConfigurationList,
+    ):
+        self._mutex = threading.Lock()
+        self._update_date = None
+        self._name = name
+        self._description = None
+        self.state_machine_alias_arn = f"{state_machine_arn}:{name}"
+        self.update(description=description, routing_configuration_list=routing_configuration_list)
+        self.create_date = self._get_mutex_date()
+
+    def __hash__(self):
+        return hash(self.state_machine_alias_arn)
+
+    def __eq__(self, other):
+        if isinstance(other, Alias):
+            return self.state_machine_alias_arn == other.state_machine_alias_arn
+        return False
+
+    @staticmethod
+    def _get_mutex_date() -> datetime.datetime:
+        return datetime.datetime.now(tz=datetime.timezone.utc)
+
+    def update(
+        self,
+        description: Optional[AliasDescription],
+        routing_configuration_list: RoutingConfigurationList,
+    ) -> None:
+        with self._mutex:
+            self._update_date = self._get_mutex_date()
+
+            if description is not None:
+                self._description = description
+
+            if routing_configuration_list:
+                self._routing_configuration_list = routing_configuration_list
+                self._state_machine_version_arns = list()
+                self._execution_probability_distribution = list()
+                for routing_configuration in routing_configuration_list:
+                    self._state_machine_version_arns.append(
+                        routing_configuration["stateMachineVersionArn"]
+                    )
+                    self._execution_probability_distribution.append(routing_configuration["weight"])
+
+    def sample(self):
+        with self._mutex:
+            samples = random.choices(
+                self._state_machine_version_arns,
+                weights=self._execution_probability_distribution,
+                k=1,
+            )
+            state_machine_version_arn = samples[0]
+            return state_machine_version_arn
+
+    def to_description(self) -> DescribeStateMachineAliasOutput:
+        with self._mutex:
+            description = DescribeStateMachineAliasOutput(
+                creationDate=self.create_date,
+                name=self._name,
+                description=self._description,
+                routingConfiguration=self._routing_configuration_list,
+            )
+            if self._update_date is not None:
+                description["updateDate"] = self._update_date
+            return description
+
+    def to_item(self) -> StateMachineAliasListItem:
+        return StateMachineAliasListItem(
+            stateMachineAliasArn=self.state_machine_alias_arn, creationDate=self.create_date
+        )

--- a/localstack-core/localstack/services/stepfunctions/backend/execution.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/execution.py
@@ -103,7 +103,10 @@ class Execution:
     region_name: str
 
     state_machine: Final[StateMachineInstance]
+    state_machine_arn: Final[Arn]
+    state_machine_version_arn: Final[Optional[Arn]]
     state_machine_alias_arn: Final[Optional[Arn]]
+
     start_date: Final[Timestamp]
     input_data: Final[Optional[json]]
     input_details: Final[Optional[CloudWatchEventsExecutionDataDetails]]
@@ -146,6 +149,12 @@ class Execution:
         self.account_id = account_id
         self.region_name = region_name
         self.state_machine = state_machine
+        if isinstance(state_machine, StateMachineVersion):
+            self.state_machine_arn = state_machine.source_arn
+            self.state_machine_version_arn = state_machine.arn
+        else:
+            self.state_machine_arn = state_machine.arn
+            self.state_machine_version_arn = None
         self.state_machine_alias_arn = state_machine_alias_arn
         self.start_date = start_date
         self._cloud_watch_logging_session = cloud_watch_logging_session
@@ -170,7 +179,7 @@ class Execution:
     def to_describe_output(self) -> DescribeExecutionOutput:
         describe_output = DescribeExecutionOutput(
             executionArn=self.exec_arn,
-            stateMachineArn=self.state_machine.arn,
+            stateMachineArn=self.state_machine_arn,
             name=self.name,
             status=self.exec_status,
             startDate=self.start_date,
@@ -186,6 +195,8 @@ class Execution:
             describe_output["error"] = self.error
         if self.cause is not None:
             describe_output["cause"] = self.cause
+        if self.state_machine_version_arn is not None:
+            describe_output["stateMachineVersionArn"] = self.state_machine_version_arn
         if self.state_machine_alias_arn is not None:
             describe_output["stateMachineAliasArn"] = self.state_machine_alias_arn
         return describe_output

--- a/localstack-core/localstack/services/stepfunctions/backend/execution.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/execution.py
@@ -103,6 +103,7 @@ class Execution:
     region_name: str
 
     state_machine: Final[StateMachineInstance]
+    state_machine_alias_arn: Final[Optional[Arn]]
     start_date: Final[Timestamp]
     input_data: Final[Optional[json]]
     input_details: Final[Optional[CloudWatchEventsExecutionDataDetails]]
@@ -136,6 +137,7 @@ class Execution:
         activity_store: dict[Arn, Activity],
         input_data: Optional[json] = None,
         trace_header: Optional[TraceHeader] = None,
+        state_machine_alias_arn: Optional[Arn] = None,
     ):
         self.name = name
         self.sm_type = sm_type
@@ -144,6 +146,7 @@ class Execution:
         self.account_id = account_id
         self.region_name = region_name
         self.state_machine = state_machine
+        self.state_machine_alias_arn = state_machine_alias_arn
         self.start_date = start_date
         self._cloud_watch_logging_session = cloud_watch_logging_session
         self.input_data = input_data
@@ -183,6 +186,8 @@ class Execution:
             describe_output["error"] = self.error
         if self.cause is not None:
             describe_output["cause"] = self.cause
+        if self.state_machine_alias_arn is not None:
+            describe_output["stateMachineAliasArn"] = self.state_machine_alias_arn
         return describe_output
 
     def to_describe_state_machine_for_execution_output(
@@ -231,6 +236,8 @@ class Execution:
         )
         if state_machine_version_arn is not None:
             item["stateMachineVersionArn"] = state_machine_version_arn
+        if self.state_machine_alias_arn is not None:
+            item["stateMachineAliasArn"] = self.state_machine_alias_arn
         return item
 
     def to_history_output(self) -> GetExecutionHistoryOutput:

--- a/localstack-core/localstack/services/stepfunctions/backend/state_machine.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/state_machine.py
@@ -30,6 +30,7 @@ from localstack.services.stepfunctions.asl.eval.event.logging import (
 from localstack.services.stepfunctions.asl.static_analyser.variable_references_static_analyser import (
     VariableReferencesStaticAnalyser,
 )
+from localstack.services.stepfunctions.backend.alias import Alias
 from localstack.utils.strings import long_uid
 
 
@@ -163,6 +164,7 @@ class StateMachineRevision(StateMachineInstance):
     _next_version_number: int
     versions: Final[dict[RevisionId, Arn]]
     tag_manager: Final[TagManager]
+    aliases: Final[set[Alias]]
 
     def __init__(
         self,
@@ -194,6 +196,7 @@ class StateMachineRevision(StateMachineInstance):
         self.tag_manager = TagManager()
         if tags:
             self.tag_manager.add_all(tags)
+        self.aliases = set()
 
     def create_revision(
         self,

--- a/localstack-core/localstack/services/stepfunctions/backend/store.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/store.py
@@ -3,6 +3,7 @@ from typing import Final
 
 from localstack.aws.api.stepfunctions import Arn
 from localstack.services.stepfunctions.backend.activity import Activity
+from localstack.services.stepfunctions.backend.alias import Alias
 from localstack.services.stepfunctions.backend.execution import Execution
 from localstack.services.stepfunctions.backend.state_machine import StateMachineInstance
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
@@ -11,6 +12,8 @@ from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttr
 class SFNStore(BaseStore):
     # Maps ARNs to state machines.
     state_machines: Final[dict[Arn, StateMachineInstance]] = LocalAttribute(default=dict)
+    # Map Alias ARNs to state machine aliases
+    aliases: Final[dict[Arn, Alias]] = LocalAttribute(default=dict)
     # Maps Execution-ARNs to state machines.
     executions: Final[dict[Arn, Execution]] = LocalAttribute(
         default=OrderedDict

--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -1292,8 +1292,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         store = self.get_store(context=context)
         alias = store.aliases.get(state_machine_alias_arn)
         if alias is None:
-            # TODO: test the exact behaviour in case of update for some non-existent alias arn.
-            self._raise_state_machine_does_not_exist(state_machine_arn=state_machine_alias_arn)
+            raise ResourceNotFound("Request references a resource that does not exist.")
 
         alias.update(description=description, routing_configuration_list=routing_configuration)
         return UpdateStateMachineAliasOutput(updateDate=alias.update_date)

--- a/localstack-core/localstack/testing/pytest/stepfunctions/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/stepfunctions/fixtures.py
@@ -267,6 +267,31 @@ def create_state_machine():
 
 
 @pytest.fixture
+def create_state_machine_alias():
+    state_machine_alias_arn_and_client = list()
+
+    def _create_state_machine_alias(target_aws_client, **kwargs):
+        step_functions_client = target_aws_client.stepfunctions
+        create_state_machine_response = step_functions_client.create_state_machine_alias(**kwargs)
+        state_machine_alias_arn_and_client.append(
+            (create_state_machine_response["stateMachineAliasArn"], step_functions_client)
+        )
+        return create_state_machine_response
+
+    yield _create_state_machine_alias
+
+    for state_machine_alias_arn, sfn_client in state_machine_alias_arn_and_client:
+        try:
+            sfn_client.delete_state_machine_alias(stateMachineAliasArn=state_machine_alias_arn)
+        except Exception as ex:
+            LOG.debug(
+                "Unable to delete the state machine alias '%s' during cleanup due '%s'",
+                state_machine_alias_arn,
+                ex,
+            )
+
+
+@pytest.fixture
 def create_activity(aws_client):
     activities_arns: Final[list[str]] = list()
 

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py
@@ -1,0 +1,861 @@
+import json
+
+import pytest
+from localstack_snapshot.snapshots.transformer import RegexTransformer
+
+from localstack.aws.api.stepfunctions import Arn, RoutingConfigurationListItem
+from localstack.testing.pytest import markers
+from localstack.testing.pytest.stepfunctions.utils import (
+    await_execution_terminated,
+    await_state_machine_alias_is_created,
+    await_state_machine_alias_is_deleted,
+)
+from localstack.utils.strings import short_uid
+from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
+
+
+@markers.snapshot.skip_snapshot_verify(paths=["$..tracingConfiguration"])
+class TestSfnApiAliasing:
+    @markers.aws.validated
+    def test_base_create_alias_single_router_config(
+        self,
+        create_state_machine_iam_role,
+        create_state_machine,
+        create_state_machine_alias,
+        sfn_snapshot,
+        aws_client,
+    ):
+        sfn_role_arn = create_state_machine_iam_role(aws_client)
+        sfn_snapshot.add_transformer(RegexTransformer(sfn_role_arn, "sfn_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition_str = json.dumps(definition)
+
+        state_machine_name = f"state_machine_{short_uid()}"
+        create_state_machine_response = create_state_machine(
+            target_aws_client=aws_client,
+            name=state_machine_name,
+            definition=definition_str,
+            roleArn=sfn_role_arn,
+            publish=True,
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_create_arn(create_state_machine_response, 0)
+        )
+
+        state_machine_version_arn = create_state_machine_response["stateMachineVersionArn"]
+        state_machine_alias_name = f"AliasName-{short_uid()}"
+        sfn_snapshot.add_transformer(
+            RegexTransformer(state_machine_alias_name, "state_machine_alias_name")
+        )
+
+        create_state_machine_alias_response = create_state_machine_alias(
+            target_aws_client=aws_client,
+            description="create state machine alias description",
+            name=state_machine_alias_name,
+            routingConfiguration=[
+                RoutingConfigurationListItem(
+                    stateMachineVersionArn=state_machine_version_arn, weight=100
+                )
+            ],
+        )
+        sfn_snapshot.match(
+            "create_state_machine_alias_response", create_state_machine_alias_response
+        )
+
+    @markers.aws.validated
+    def test_error_create_alias_with_state_machine_arn(
+        self,
+        create_state_machine_iam_role,
+        create_state_machine,
+        create_state_machine_alias,
+        sfn_snapshot,
+        aws_client,
+    ):
+        sfn_role_arn = create_state_machine_iam_role(aws_client)
+        sfn_snapshot.add_transformer(RegexTransformer(sfn_role_arn, "sfn_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition_str = json.dumps(definition)
+
+        state_machine_name = f"state_machine_{short_uid()}"
+        create_state_machine_response = create_state_machine(
+            target_aws_client=aws_client,
+            name=state_machine_name,
+            definition=definition_str,
+            roleArn=sfn_role_arn,
+            publish=True,
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_create_arn(create_state_machine_response, 0)
+        )
+        state_machine_arn = create_state_machine_response["stateMachineArn"]
+
+        with pytest.raises(Exception) as exc:
+            create_state_machine_alias(
+                target_aws_client=aws_client,
+                description="create state machine alias description",
+                name=f"AliasName-{short_uid()}",
+                routingConfiguration=[
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_arn, weight=100
+                    )
+                ],
+            )
+        sfn_snapshot.match(
+            "exception", {"exception_typename": exc.typename, "exception_value": exc.value}
+        )
+
+    @markers.aws.validated
+    def test_error_create_alias_not_idempotent(
+        self,
+        create_state_machine_iam_role,
+        create_state_machine,
+        create_state_machine_alias,
+        sfn_snapshot,
+        aws_client,
+    ):
+        sfn_role_arn = create_state_machine_iam_role(aws_client)
+        sfn_snapshot.add_transformer(RegexTransformer(sfn_role_arn, "sfn_role_arn"))
+
+        state_machine_name = f"state_machine_{short_uid()}"
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        create_state_machine_response = create_state_machine(
+            target_aws_client=aws_client,
+            name=state_machine_name,
+            definition=json.dumps(definition),
+            roleArn=sfn_role_arn,
+            publish=True,
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_create_arn(create_state_machine_response, 0)
+        )
+        state_machine_arn = create_state_machine_response["stateMachineArn"]
+        state_machine_version_arn_v0 = create_state_machine_response["stateMachineVersionArn"]
+
+        definition["Comment"] = "Definition v1"
+        update_state_machine_response = aws_client.stepfunctions.update_state_machine(
+            stateMachineArn=state_machine_arn, definition=json.dumps(definition), publish=True
+        )
+        state_machine_version_arn_v1 = update_state_machine_response["stateMachineVersionArn"]
+
+        state_machine_alias_name = f"AliasName-{short_uid()}"
+        state_machine_alias_description = "create state machine alias description"
+        state_machine_alias_routing_configuration = [
+            RoutingConfigurationListItem(
+                stateMachineVersionArn=state_machine_version_arn_v0, weight=100
+            )
+        ]
+        sfn_snapshot.add_transformer(
+            RegexTransformer(state_machine_alias_name, "state_machine_alias_name")
+        )
+        create_state_machine_alias_response = create_state_machine_alias(
+            target_aws_client=aws_client,
+            description=state_machine_alias_description,
+            name=state_machine_alias_name,
+            routingConfiguration=state_machine_alias_routing_configuration,
+        )
+        sfn_snapshot.match(
+            "create_state_machine_alias_response", create_state_machine_alias_response
+        )
+
+        with pytest.raises(Exception) as exc:
+            create_state_machine_alias(
+                target_aws_client=aws_client,
+                description="This is a different description",
+                name=state_machine_alias_name,
+                routingConfiguration=state_machine_alias_routing_configuration,
+            )
+        sfn_snapshot.match(
+            "not_idempotent_description",
+            {"exception_typename": exc.typename, "exception_value": exc.value},
+        )
+
+        with pytest.raises(Exception) as exc:
+            create_state_machine_alias(
+                target_aws_client=aws_client,
+                description=state_machine_alias_description,
+                name=state_machine_alias_name,
+                routingConfiguration=[
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arn_v0, weight=50
+                    ),
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arn_v1, weight=50
+                    ),
+                ],
+            )
+        sfn_snapshot.match(
+            "not_idempotent_routing_configuration",
+            {"exception_typename": exc.typename, "exception_value": exc.value},
+        )
+
+    @markers.aws.validated
+    def test_idempotent_create_alias(
+        self,
+        create_state_machine_iam_role,
+        create_state_machine,
+        create_state_machine_alias,
+        sfn_snapshot,
+        aws_client,
+    ):
+        sfn_role_arn = create_state_machine_iam_role(aws_client)
+        sfn_snapshot.add_transformer(RegexTransformer(sfn_role_arn, "sfn_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition_str = json.dumps(definition)
+
+        state_machine_name = f"state_machine_{short_uid()}"
+        create_state_machine_response = create_state_machine(
+            target_aws_client=aws_client,
+            name=state_machine_name,
+            definition=definition_str,
+            roleArn=sfn_role_arn,
+            publish=True,
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_create_arn(create_state_machine_response, 0)
+        )
+
+        state_machine_arn = create_state_machine_response["stateMachineArn"]
+        state_machine_version_arn = create_state_machine_response["stateMachineVersionArn"]
+        state_machine_alias_name = f"AliasName-{short_uid()}"
+        sfn_snapshot.add_transformer(
+            RegexTransformer(state_machine_alias_name, "state_machine_alias_name")
+        )
+
+        for attempt_number in range(2):
+            create_state_machine_alias_response = create_state_machine_alias(
+                target_aws_client=aws_client,
+                description="create state machine alias description",
+                name=state_machine_alias_name,
+                routingConfiguration=[
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arn, weight=100
+                    )
+                ],
+            )
+            sfn_snapshot.match(
+                f"create_state_machine_alias_response_attempt_{attempt_number}",
+                create_state_machine_alias_response,
+            )
+
+        create_state_machine_alias_response = create_state_machine_alias(
+            target_aws_client=aws_client,
+            description="create state machine alias description",
+            name=f"{state_machine_alias_name}-second",
+            routingConfiguration=[
+                RoutingConfigurationListItem(
+                    stateMachineVersionArn=state_machine_version_arn, weight=100
+                )
+            ],
+        )
+        sfn_snapshot.match(
+            "create_state_machine_alias_response_different_name",
+            create_state_machine_alias_response,
+        )
+
+        list_state_machine_aliases_response = aws_client.stepfunctions.list_state_machine_aliases(
+            stateMachineArn=state_machine_arn
+        )
+        sfn_snapshot.match(
+            "list_state_machine_aliases_response", list_state_machine_aliases_response
+        )
+
+    @markers.aws.validated
+    def test_error_create_alias_invalid_router_configs(
+        self,
+        create_state_machine_iam_role,
+        create_state_machine,
+        create_state_machine_alias,
+        sfn_snapshot,
+        aws_client,
+    ):
+        sfn_client = aws_client.stepfunctions
+
+        sfn_role_arn = create_state_machine_iam_role(aws_client)
+        sfn_snapshot.add_transformer(RegexTransformer(sfn_role_arn, "sfn_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        state_machine_name = f"state_machine_{short_uid()}"
+        create_state_machine_response = create_state_machine(
+            target_aws_client=aws_client,
+            name=state_machine_name,
+            definition=json.dumps(definition),
+            roleArn=sfn_role_arn,
+            publish=True,
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_create_arn(create_state_machine_response, 0)
+        )
+        state_machine_arn = create_state_machine_response["stateMachineArn"]
+
+        state_machine_version_arns: list[Arn] = list()
+        state_machine_version_arns.append(create_state_machine_response["stateMachineVersionArn"])
+        for version_number in range(2):
+            definition["Comment"] = f"Definition for version {version_number}"
+            update_state_machine_response = sfn_client.update_state_machine(
+                stateMachineArn=state_machine_arn, definition=json.dumps(definition), publish=True
+            )
+            state_machine_version_arn = update_state_machine_response["stateMachineVersionArn"]
+            state_machine_version_arns.append(state_machine_version_arn)
+
+        with pytest.raises(Exception) as exc:
+            create_state_machine_alias(
+                target_aws_client=aws_client,
+                name=f"AliasName-{short_uid()}",
+                routingConfiguration=[],
+            )
+        sfn_snapshot.match(
+            "no_routing", {"exception_typename": exc.typename, "exception_value": exc.value}
+        )
+
+        with pytest.raises(Exception) as exc:
+            create_state_machine_alias(
+                target_aws_client=aws_client,
+                name=f"AliasName-{short_uid()}",
+                routingConfiguration=[
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arns[0], weight=50
+                    ),
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arns[1], weight=30
+                    ),
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arns[2], weight=20
+                    ),
+                ],
+            )
+        sfn_snapshot.match(
+            "too_many_routing", {"exception_typename": exc.typename, "exception_value": exc.value}
+        )
+
+        with pytest.raises(Exception) as exc:
+            create_state_machine_alias(
+                target_aws_client=aws_client,
+                name=f"AliasName-{short_uid()}",
+                routingConfiguration=[
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arns[0], weight=50
+                    ),
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arns[0], weight=50
+                    ),
+                ],
+            )
+        sfn_snapshot.match(
+            "duplicate_routing", {"exception_typename": exc.typename, "exception_value": exc.value}
+        )
+
+        with pytest.raises(Exception) as exc:
+            create_state_machine_alias(
+                target_aws_client=aws_client,
+                name=f"AliasName-{short_uid()}",
+                routingConfiguration=[
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_arn, weight=70
+                    ),
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arns[1], weight=30
+                    ),
+                ],
+            )
+        sfn_snapshot.match(
+            "invalid_arn", {"exception_typename": exc.typename, "exception_value": exc.value}
+        )
+
+        with pytest.raises(Exception) as exc:
+            create_state_machine_alias(
+                target_aws_client=aws_client,
+                name=f"AliasName-{short_uid()}",
+                routingConfiguration=[
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arns[0], weight=101
+                    )
+                ],
+            )
+        sfn_snapshot.match(
+            "weight_too_large", {"exception_typename": exc.typename, "exception_value": exc.value}
+        )
+
+        with pytest.raises(Exception) as exc:
+            create_state_machine_alias(
+                target_aws_client=aws_client,
+                name=f"AliasName-{short_uid()}",
+                routingConfiguration=[
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arns[0], weight=-1
+                    )
+                ],
+            )
+        sfn_snapshot.match(
+            "weight_too_small", {"exception_typename": exc.typename, "exception_value": exc.value}
+        )
+
+        with pytest.raises(Exception) as exc:
+            create_state_machine_alias(
+                target_aws_client=aws_client,
+                name=f"AliasName-{short_uid()}",
+                routingConfiguration=[
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arns[0], weight=70
+                    ),
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arns[1], weight=29
+                    ),
+                ],
+            )
+        sfn_snapshot.match(
+            "sum_weights_less_than_100",
+            {"exception_typename": exc.typename, "exception_value": exc.value},
+        )
+
+        with pytest.raises(Exception) as exc:
+            create_state_machine_alias(
+                target_aws_client=aws_client,
+                name=f"AliasName-{short_uid()}",
+                routingConfiguration=[
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arns[0], weight=70
+                    ),
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arns[1], weight=31
+                    ),
+                ],
+            )
+        sfn_snapshot.match(
+            "sum_weights_more_than_100",
+            {"exception_typename": exc.typename, "exception_value": exc.value},
+        )
+
+    @markers.aws.validated
+    def test_error_create_alias_invalid_name(
+        self,
+        create_state_machine_iam_role,
+        create_state_machine,
+        create_state_machine_alias,
+        sfn_snapshot,
+        aws_client,
+    ):
+        sfn_role_arn = create_state_machine_iam_role(aws_client)
+        sfn_snapshot.add_transformer(RegexTransformer(sfn_role_arn, "sfn_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition_str = json.dumps(definition)
+
+        state_machine_name = f"state_machine_{short_uid()}"
+        create_state_machine_response = create_state_machine(
+            target_aws_client=aws_client,
+            name=state_machine_name,
+            definition=definition_str,
+            roleArn=sfn_role_arn,
+            publish=True,
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_create_arn(create_state_machine_response, 0)
+        )
+        state_machine_version_arn = create_state_machine_response["stateMachineVersionArn"]
+
+        invalid_names = ["123", "", "A" * 81, "INVALID ALIAS", "!INVALID", "ALIAS@"]
+        for invalid_name in invalid_names:
+            with pytest.raises(Exception) as exc:
+                create_state_machine_alias(
+                    target_aws_client=aws_client,
+                    description="create state machine alias description",
+                    name=invalid_name,
+                    routingConfiguration=[
+                        RoutingConfigurationListItem(
+                            stateMachineVersionArn=state_machine_version_arn, weight=100
+                        )
+                    ],
+                )
+            sfn_snapshot.match(
+                f"exception_for_name{invalid_name}",
+                {"exception_typename": exc.typename, "exception_value": exc.value},
+            )
+
+    @markers.aws.validated
+    def test_base_lifecycle_create_delete_list(
+        self,
+        create_state_machine_iam_role,
+        create_state_machine,
+        create_state_machine_alias,
+        sfn_snapshot,
+        aws_client,
+    ):
+        sfn_client = aws_client.stepfunctions
+
+        sfn_role_arn = create_state_machine_iam_role(aws_client)
+        sfn_snapshot.add_transformer(RegexTransformer(sfn_role_arn, "sfn_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition_str = json.dumps(definition)
+
+        state_machine_name = f"state_machine_{short_uid()}"
+        create_state_machine_response = create_state_machine(
+            target_aws_client=aws_client,
+            name=state_machine_name,
+            definition=definition_str,
+            roleArn=sfn_role_arn,
+            publish=True,
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_create_arn(create_state_machine_response, 0)
+        )
+
+        state_machine_arn = create_state_machine_response["stateMachineArn"]
+        state_machine_version_arn = create_state_machine_response["stateMachineVersionArn"]
+
+        list_state_machine_aliases_response = sfn_client.list_state_machine_aliases(
+            stateMachineArn=state_machine_arn
+        )
+        sfn_snapshot.match(
+            "list_state_machine_aliases_response_empty", list_state_machine_aliases_response
+        )
+
+        state_machine_alias_base_name = f"AliasName-{short_uid()}"
+        sfn_snapshot.add_transformer(
+            RegexTransformer(state_machine_alias_base_name, "state_machine_alias_base_name")
+        )
+        state_machine_alias_arns: list[str] = list()
+        for num in range(3):
+            state_machine_alias_name = f"{state_machine_alias_base_name}-{num}"
+            create_state_machine_alias_response = create_state_machine_alias(
+                target_aws_client=aws_client,
+                description="create state machine alias description",
+                name=state_machine_alias_name,
+                routingConfiguration=[
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arn, weight=100
+                    )
+                ],
+            )
+            sfn_snapshot.match(
+                f"create_state_machine_alias_response_num_{num}",
+                create_state_machine_alias_response,
+            )
+            state_machine_alias_arn = create_state_machine_alias_response["stateMachineAliasArn"]
+            state_machine_alias_arns.append(state_machine_alias_arn)
+
+            await_state_machine_alias_is_created(
+                stepfunctions_client=sfn_client,
+                state_machine_arn=state_machine_arn,
+                state_machine_alias_arn=state_machine_alias_arn,
+            )
+
+            list_state_machine_aliases_response = sfn_client.list_state_machine_aliases(
+                stateMachineArn=state_machine_arn
+            )
+            sfn_snapshot.match(
+                f"list_state_machine_aliases_response_after_creation_{num}",
+                list_state_machine_aliases_response,
+            )
+
+        for num, state_machine_alias_arn in enumerate(state_machine_alias_arns):
+            delete_state_machine_alias_response = sfn_client.delete_state_machine_alias(
+                stateMachineAliasArn=state_machine_alias_arn
+            )
+            sfn_snapshot.match(
+                f"delete_state_machine_alias_response_{num}",
+                delete_state_machine_alias_response,
+            )
+
+            await_state_machine_alias_is_deleted(
+                stepfunctions_client=sfn_client,
+                state_machine_arn=state_machine_arn,
+                state_machine_alias_arn=state_machine_alias_arn,
+            )
+
+            list_state_machine_aliases_response = sfn_client.list_state_machine_aliases(
+                stateMachineArn=state_machine_arn
+            )
+            sfn_snapshot.match(
+                f"list_state_machine_aliases_response_after_deletion_{num}",
+                list_state_machine_aliases_response,
+            )
+
+    @markers.aws.validated
+    def test_base_lifecycle_create_invoke_describe_list(
+        self,
+        create_state_machine_iam_role,
+        create_state_machine,
+        create_state_machine_alias,
+        sfn_snapshot,
+        aws_client,
+    ):
+        sfn_client = aws_client.stepfunctions
+
+        sfn_role_arn = create_state_machine_iam_role(aws_client)
+        sfn_snapshot.add_transformer(RegexTransformer(sfn_role_arn, "sfn_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition_str = json.dumps(definition)
+
+        state_machine_name = f"state_machine_{short_uid()}"
+        create_state_machine_response = create_state_machine(
+            target_aws_client=aws_client,
+            name=state_machine_name,
+            definition=definition_str,
+            roleArn=sfn_role_arn,
+            publish=True,
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_create_arn(create_state_machine_response, 0)
+        )
+
+        state_machine_arn = create_state_machine_response["stateMachineArn"]
+        state_machine_version_arn = create_state_machine_response["stateMachineVersionArn"]
+
+        list_state_machine_aliases_response = sfn_client.list_state_machine_aliases(
+            stateMachineArn=state_machine_arn
+        )
+        sfn_snapshot.match(
+            "list_state_machine_aliases_response_empty", list_state_machine_aliases_response
+        )
+
+        state_machine_alias_name = f"AliasName-{short_uid()}"
+        sfn_snapshot.add_transformer(
+            RegexTransformer(state_machine_alias_name, "state_machine_alias_name")
+        )
+
+        create_state_machine_alias_response = create_state_machine_alias(
+            target_aws_client=aws_client,
+            description="create state machine alias description",
+            name=state_machine_alias_name,
+            routingConfiguration=[
+                RoutingConfigurationListItem(
+                    stateMachineVersionArn=state_machine_version_arn, weight=100
+                )
+            ],
+        )
+        sfn_snapshot.match(
+            "create_state_machine_alias_response", create_state_machine_alias_response
+        )
+        state_machine_alias_arn = create_state_machine_alias_response["stateMachineAliasArn"]
+
+        await_state_machine_alias_is_created(
+            stepfunctions_client=sfn_client,
+            state_machine_arn=state_machine_arn,
+            state_machine_alias_arn=state_machine_alias_arn,
+        )
+
+        start_execution_response = sfn_client.start_execution(
+            stateMachineArn=state_machine_alias_arn, input="{}"
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_exec_arn(start_execution_response, 0)
+        )
+        execution_arn = start_execution_response["executionArn"]
+        sfn_snapshot.match("start_execution_response_through_alias", start_execution_response)
+
+        await_execution_terminated(stepfunctions_client=sfn_client, execution_arn=execution_arn)
+
+        describe_execution_response = sfn_client.describe_execution(executionArn=execution_arn)
+        sfn_snapshot.match("describe_execution_response_through_alias", describe_execution_response)
+
+        start_execution_response = sfn_client.start_execution(
+            stateMachineArn=state_machine_version_arn, input="{}"
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_exec_arn(start_execution_response, 1)
+        )
+        execution_arn = start_execution_response["executionArn"]
+        sfn_snapshot.match("start_execution_response_through_version_arn", start_execution_response)
+
+        await_execution_terminated(stepfunctions_client=sfn_client, execution_arn=execution_arn)
+
+        describe_execution_response = sfn_client.describe_execution(executionArn=execution_arn)
+        sfn_snapshot.match(
+            "describe_execution_response_through_version_arn", describe_execution_response
+        )
+
+        list_executions_response = sfn_client.list_executions(stateMachineArn=state_machine_arn)
+        sfn_snapshot.match("list_executions_response", list_executions_response)
+
+    @markers.aws.validated
+    def test_base_lifecycle_create_update_describe(
+        self,
+        create_state_machine_iam_role,
+        create_state_machine,
+        create_state_machine_alias,
+        sfn_snapshot,
+        aws_client,
+    ):
+        sfn_client = aws_client.stepfunctions
+
+        sfn_role_arn = create_state_machine_iam_role(aws_client)
+        sfn_snapshot.add_transformer(RegexTransformer(sfn_role_arn, "sfn_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+
+        state_machine_name = f"state_machine_{short_uid()}"
+        create_state_machine_response = create_state_machine(
+            target_aws_client=aws_client,
+            name=state_machine_name,
+            definition=json.dumps(definition),
+            roleArn=sfn_role_arn,
+            publish=True,
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_create_arn(create_state_machine_response, 0)
+        )
+        state_machine_arn = create_state_machine_response["stateMachineArn"]
+
+        state_machine_version_arns: list[Arn] = list()
+        state_machine_version_arns.append(create_state_machine_response["stateMachineVersionArn"])
+        for version_number in range(2):
+            definition["Comment"] = f"Definition for version {version_number}"
+            update_state_machine_response = sfn_client.update_state_machine(
+                stateMachineArn=state_machine_arn, definition=json.dumps(definition), publish=True
+            )
+            state_machine_version_arn = update_state_machine_response["stateMachineVersionArn"]
+            state_machine_version_arns.append(state_machine_version_arn)
+
+        state_machine_alias_name = f"AliasName-{short_uid()}"
+        sfn_snapshot.add_transformer(
+            RegexTransformer(state_machine_alias_name, "state_machine_alias_name")
+        )
+
+        create_state_machine_alias_response = create_state_machine_alias(
+            target_aws_client=aws_client,
+            description="create state machine alias description",
+            name=state_machine_alias_name,
+            routingConfiguration=[
+                RoutingConfigurationListItem(
+                    stateMachineVersionArn=state_machine_version_arns[0], weight=100
+                )
+            ],
+        )
+        sfn_snapshot.match(
+            "create_state_machine_alias_response", create_state_machine_alias_response
+        )
+        state_machine_alias_arn = create_state_machine_alias_response["stateMachineAliasArn"]
+
+        update_state_machine_alias_response = sfn_client.update_state_machine_alias(
+            stateMachineAliasArn=state_machine_alias_arn,
+            description="new description",
+        )
+        sfn_snapshot.match(
+            "update_state_machine_alias_description_response", update_state_machine_alias_response
+        )
+        describe_state_machine_alias_response = sfn_client.describe_state_machine_alias(
+            stateMachineAliasArn=state_machine_alias_arn
+        )
+        sfn_snapshot.match(
+            "describe_state_machine_alias_update_description_response",
+            describe_state_machine_alias_response,
+        )
+
+        update_state_machine_alias_response = sfn_client.update_state_machine_alias(
+            stateMachineAliasArn=state_machine_alias_arn,
+            routingConfiguration=[
+                RoutingConfigurationListItem(
+                    stateMachineVersionArn=state_machine_version_arns[0], weight=50
+                ),
+                RoutingConfigurationListItem(
+                    stateMachineVersionArn=state_machine_version_arns[1], weight=50
+                ),
+            ],
+        )
+        sfn_snapshot.match(
+            "update_state_machine_alias_routing_configuration_response",
+            update_state_machine_alias_response,
+        )
+        describe_state_machine_alias_response = sfn_client.describe_state_machine_alias(
+            stateMachineAliasArn=state_machine_alias_arn
+        )
+        sfn_snapshot.match(
+            "describe_state_machine_alias_update_routing_configuration_response",
+            describe_state_machine_alias_response,
+        )
+
+    @markers.aws.validated
+    def test_delete_version_with_alias(
+        self,
+        create_state_machine_iam_role,
+        create_state_machine,
+        create_state_machine_alias,
+        sfn_snapshot,
+        aws_client,
+    ):
+        sfn_client = aws_client.stepfunctions
+
+        sfn_role_arn = create_state_machine_iam_role(aws_client)
+        sfn_snapshot.add_transformer(RegexTransformer(sfn_role_arn, "sfn_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+
+        state_machine_name = f"state_machine_{short_uid()}"
+        create_state_machine_response = create_state_machine(
+            target_aws_client=aws_client,
+            name=state_machine_name,
+            definition=json.dumps(definition),
+            roleArn=sfn_role_arn,
+            publish=True,
+        )
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_create_arn(create_state_machine_response, 0)
+        )
+        state_machine_arn = create_state_machine_response["stateMachineArn"]
+        state_machine_version_arn = create_state_machine_response["stateMachineVersionArn"]
+
+        state_machine_alias_name = f"AliasName-{short_uid()}"
+        sfn_snapshot.add_transformer(
+            RegexTransformer(state_machine_alias_name, "state_machine_alias_name")
+        )
+
+        create_state_machine_alias_response = create_state_machine_alias(
+            target_aws_client=aws_client,
+            description="create state machine alias description",
+            name=state_machine_alias_name,
+            routingConfiguration=[
+                RoutingConfigurationListItem(
+                    stateMachineVersionArn=state_machine_version_arn, weight=100
+                )
+            ],
+        )
+        sfn_snapshot.match(
+            "create_state_machine_alias_response", create_state_machine_alias_response
+        )
+        state_machine_alias_arn = create_state_machine_alias_response["stateMachineAliasArn"]
+        await_state_machine_alias_is_created(
+            stepfunctions_client=sfn_client,
+            state_machine_arn=state_machine_arn,
+            state_machine_alias_arn=state_machine_alias_arn,
+        )
+
+        with pytest.raises(Exception) as exc:
+            sfn_client.delete_state_machine_version(
+                stateMachineVersionArn=state_machine_version_arn
+            )
+        sfn_snapshot.match(
+            "exception_delete_version_with_alias_reference",
+            {"exception_typename": exc.typename, "exception_value": exc.value},
+        )
+
+        definition["Comment"] = "Definition v1"
+        update_state_machine_response = aws_client.stepfunctions.update_state_machine(
+            stateMachineArn=state_machine_arn, definition=json.dumps(definition), publish=True
+        )
+        state_machine_version_arn_v1 = update_state_machine_response["stateMachineVersionArn"]
+
+        sfn_client.update_state_machine_alias(
+            stateMachineAliasArn=state_machine_alias_arn,
+            routingConfiguration=[
+                RoutingConfigurationListItem(
+                    stateMachineVersionArn=state_machine_version_arn_v1, weight=100
+                )
+            ],
+        )
+        describe_state_machine_alias_response = sfn_client.describe_state_machine_alias(
+            stateMachineAliasArn=state_machine_alias_arn
+        )
+        sfn_snapshot.match(
+            "describe_state_machine_alias_response", describe_state_machine_alias_response
+        )
+
+        delete_version_response = sfn_client.delete_state_machine_version(
+            stateMachineVersionArn=state_machine_version_arn
+        )
+        sfn_snapshot.match("delete_version_response", delete_version_response)

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_create_alias_single_router_config": {
-    "recorded-date": "25-02-2025, 08:09:58",
+    "recorded-date": "03-03-2025, 13:12:29",
     "recorded-content": {
       "create_state_machine_alias_response": {
         "creationDate": "datetime",
@@ -13,7 +13,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_with_state_machine_arn": {
-    "recorded-date": "25-02-2025, 08:10:13",
+    "recorded-date": "03-03-2025, 13:12:48",
     "recorded-content": {
       "exception": {
         "exception_typename": "ValidationException",
@@ -22,7 +22,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_not_idempotent": {
-    "recorded-date": "25-02-2025, 08:10:27",
+    "recorded-date": "03-03-2025, 13:13:02",
     "recorded-content": {
       "create_state_machine_alias_response": {
         "creationDate": "datetime",
@@ -43,7 +43,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_idempotent_create_alias": {
-    "recorded-date": "25-02-2025, 08:10:42",
+    "recorded-date": "03-03-2025, 13:13:16",
     "recorded-content": {
       "create_state_machine_alias_response_attempt_0": {
         "creationDate": "datetime",
@@ -88,7 +88,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_invalid_router_configs": {
-    "recorded-date": "25-02-2025, 08:10:59",
+    "recorded-date": "03-03-2025, 13:13:32",
     "recorded-content": {
       "no_routing": {
         "exception_typename": "ParamValidationError",
@@ -125,7 +125,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_invalid_name": {
-    "recorded-date": "25-02-2025, 08:11:18",
+    "recorded-date": "03-03-2025, 13:13:52",
     "recorded-content": {
       "exception_for_name123": {
         "exception_typename": "ValidationException",
@@ -154,7 +154,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_delete_list": {
-    "recorded-date": "25-02-2025, 08:11:47",
+    "recorded-date": "03-03-2025, 13:14:23",
     "recorded-content": {
       "list_state_machine_aliases_response_empty": {
         "stateMachineAliases": [],
@@ -291,7 +291,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_invoke_describe_list": {
-    "recorded-date": "25-02-2025, 08:12:16",
+    "recorded-date": "03-03-2025, 13:20:29",
     "recorded-content": {
       "list_state_machine_aliases_response_empty": {
         "stateMachineAliases": [],
@@ -386,7 +386,8 @@
             "startDate": "datetime",
             "stateMachineArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
             "stateMachineVersionArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
-            "status": "RUNNING"
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
           },
           {
             "executionArn": "arn:<partition>:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
@@ -408,7 +409,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_update_describe": {
-    "recorded-date": "25-02-2025, 08:12:31",
+    "recorded-date": "03-03-2025, 13:15:57",
     "recorded-content": {
       "create_state_machine_alias_response": {
         "creationDate": "datetime",
@@ -456,7 +457,11 @@
         "routingConfiguration": [
           {
             "stateMachineVersionArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
-            "weight": 100
+            "weight": 50
+          },
+          {
+            "stateMachineVersionArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:2",
+            "weight": 50
           }
         ],
         "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
@@ -469,7 +474,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_version_with_alias": {
-    "recorded-date": "25-02-2025, 09:00:20",
+    "recorded-date": "03-03-2025, 13:16:42",
     "recorded-content": {
       "create_state_machine_alias_response": {
         "creationDate": "datetime",
@@ -501,6 +506,44 @@
         }
       },
       "delete_version_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_revision_with_alias": {
+    "recorded-date": "03-03-2025, 13:34:23",
+    "recorded-content": {
+      "create_state_machine_alias_response": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_state_machine_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_no_such_alias_arn": {
+    "recorded-date": "03-03-2025, 13:37:24",
+    "recorded-content": {
+      "create_state_machine_alias_response": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_state_machine_alias_response": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.snapshot.json
@@ -550,5 +550,22 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_update_no_such_alias_arn": {
+    "recorded-date": "03-03-2025, 15:00:26",
+    "recorded-content": {
+      "create_state_machine_alias_response": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update_no_such_alias_arn": {
+        "exception_typename": "ResourceNotFound",
+        "exception_value": "An error occurred (ResourceNotFound) when calling the UpdateStateMachineAlias operation: Request references a resource that does not exist."
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.snapshot.json
@@ -1,0 +1,511 @@
+{
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_create_alias_single_router_config": {
+    "recorded-date": "25-02-2025, 08:09:58",
+    "recorded-content": {
+      "create_state_machine_alias_response": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_with_state_machine_arn": {
+    "recorded-date": "25-02-2025, 08:10:13",
+    "recorded-content": {
+      "exception": {
+        "exception_typename": "ValidationException",
+        "exception_value": "An error occurred (ValidationException) when calling the CreateStateMachineAlias operation: Routing configuration must contain state machine version ARNs. Received: [arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>]"
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_not_idempotent": {
+    "recorded-date": "25-02-2025, 08:10:27",
+    "recorded-content": {
+      "create_state_machine_alias_response": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "not_idempotent_description": {
+        "exception_typename": "ConflictException",
+        "exception_value": "An error occurred (ConflictException) when calling the CreateStateMachineAlias operation: Failed to create alias because an alias with the same name and a different routing configuration already exists."
+      },
+      "not_idempotent_routing_configuration": {
+        "exception_typename": "ConflictException",
+        "exception_value": "An error occurred (ConflictException) when calling the CreateStateMachineAlias operation: Failed to create alias because an alias with the same name and a different routing configuration already exists."
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_idempotent_create_alias": {
+    "recorded-date": "25-02-2025, 08:10:42",
+    "recorded-content": {
+      "create_state_machine_alias_response_attempt_0": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_state_machine_alias_response_attempt_1": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_state_machine_alias_response_different_name": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name-second",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_state_machine_aliases_response": {
+        "stateMachineAliases": [
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name-second"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_invalid_router_configs": {
+    "recorded-date": "25-02-2025, 08:10:59",
+    "recorded-content": {
+      "no_routing": {
+        "exception_typename": "ParamValidationError",
+        "exception_value": "Parameter validation failed:\nInvalid length for parameter routingConfiguration, value: 0, valid min length: 1"
+      },
+      "too_many_routing": {
+        "exception_typename": "ValidationException",
+        "exception_value": "An error occurred (ValidationException) when calling the CreateStateMachineAlias operation: 1 validation error detected: Value '[RoutingConfigurationListItem(stateMachineVersionArn=arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1, weight=50), RoutingConfigurationListItem(stateMachineVersionArn=arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:2, weight=30), RoutingConfigurationListItem(stateMachineVersionArn=arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:3, weight=20)]' at 'routingConfiguration' failed to satisfy constraint: Member must have length less than or equal to 2"
+      },
+      "duplicate_routing": {
+        "exception_typename": "ValidationException",
+        "exception_value": "An error occurred (ValidationException) when calling the CreateStateMachineAlias operation: Routing configuration must contain distinct state machine version ARNs. Received: [arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1, arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1]"
+      },
+      "invalid_arn": {
+        "exception_typename": "ValidationException",
+        "exception_value": "An error occurred (ValidationException) when calling the CreateStateMachineAlias operation: Routing configuration must contain state machine version ARNs. Received: [arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>, arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:2]"
+      },
+      "weight_too_large": {
+        "exception_typename": "ValidationException",
+        "exception_value": "An error occurred (ValidationException) when calling the CreateStateMachineAlias operation: 1 validation error detected: Value '101' at 'routingConfiguration.1.member.weight' failed to satisfy constraint: Member must have value less than or equal to 100"
+      },
+      "weight_too_small": {
+        "exception_typename": "ParamValidationError",
+        "exception_value": "Parameter validation failed:\nInvalid value for parameter routingConfiguration[0].weight, value: -1, valid min value: 0"
+      },
+      "sum_weights_less_than_100": {
+        "exception_typename": "ValidationException",
+        "exception_value": "An error occurred (ValidationException) when calling the CreateStateMachineAlias operation: Sum of routing configuration weights must equal 100. Received: [70, 29]"
+      },
+      "sum_weights_more_than_100": {
+        "exception_typename": "ValidationException",
+        "exception_value": "An error occurred (ValidationException) when calling the CreateStateMachineAlias operation: Sum of routing configuration weights must equal 100. Received: [70, 31]"
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_invalid_name": {
+    "recorded-date": "25-02-2025, 08:11:18",
+    "recorded-content": {
+      "exception_for_name123": {
+        "exception_typename": "ValidationException",
+        "exception_value": "An error occurred (ValidationException) when calling the CreateStateMachineAlias operation: 1 validation error detected: Value '123' at 'name' failed to satisfy constraint: Member must satisfy regular expression pattern: ^(?=.*[a-zA-Z_\\-\\.])[a-zA-Z0-9_\\-\\.]+$"
+      },
+      "exception_for_name": {
+        "exception_typename": "ParamValidationError",
+        "exception_value": "Parameter validation failed:\nInvalid length for parameter name, value: 0, valid min length: 1"
+      },
+      "exception_for_nameAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA": {
+        "exception_typename": "ValidationException",
+        "exception_value": "An error occurred (ValidationException) when calling the CreateStateMachineAlias operation: 1 validation error detected: Value 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' at 'name' failed to satisfy constraint: Member must have length less than or equal to 80"
+      },
+      "exception_for_nameINVALID ALIAS": {
+        "exception_typename": "ValidationException",
+        "exception_value": "An error occurred (ValidationException) when calling the CreateStateMachineAlias operation: 1 validation error detected: Value 'INVALID ALIAS' at 'name' failed to satisfy constraint: Member must satisfy regular expression pattern: ^(?=.*[a-zA-Z_\\-\\.])[a-zA-Z0-9_\\-\\.]+$"
+      },
+      "exception_for_name!INVALID": {
+        "exception_typename": "ValidationException",
+        "exception_value": "An error occurred (ValidationException) when calling the CreateStateMachineAlias operation: 1 validation error detected: Value '!INVALID' at 'name' failed to satisfy constraint: Member must satisfy regular expression pattern: ^(?=.*[a-zA-Z_\\-\\.])[a-zA-Z0-9_\\-\\.]+$"
+      },
+      "exception_for_nameALIAS@": {
+        "exception_typename": "ValidationException",
+        "exception_value": "An error occurred (ValidationException) when calling the CreateStateMachineAlias operation: 1 validation error detected: Value 'ALIAS@' at 'name' failed to satisfy constraint: Member must satisfy regular expression pattern: ^(?=.*[a-zA-Z_\\-\\.])[a-zA-Z0-9_\\-\\.]+$"
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_delete_list": {
+    "recorded-date": "25-02-2025, 08:11:47",
+    "recorded-content": {
+      "list_state_machine_aliases_response_empty": {
+        "stateMachineAliases": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_state_machine_alias_response_num_0": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_base_name-0",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_state_machine_aliases_response_after_creation_0": {
+        "stateMachineAliases": [
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_base_name-0"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_state_machine_alias_response_num_1": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_base_name-1",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_state_machine_aliases_response_after_creation_1": {
+        "stateMachineAliases": [
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_base_name-0"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_base_name-1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_state_machine_alias_response_num_2": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_base_name-2",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_state_machine_aliases_response_after_creation_2": {
+        "stateMachineAliases": [
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_base_name-0"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_base_name-1"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_base_name-2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_state_machine_alias_response_0": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_state_machine_aliases_response_after_deletion_0": {
+        "stateMachineAliases": [
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_base_name-1"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_base_name-2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_state_machine_alias_response_1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_state_machine_aliases_response_after_deletion_1": {
+        "stateMachineAliases": [
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_base_name-2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_state_machine_alias_response_2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_state_machine_aliases_response_after_deletion_2": {
+        "stateMachineAliases": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_invoke_describe_list": {
+    "recorded-date": "25-02-2025, 08:12:16",
+    "recorded-content": {
+      "list_state_machine_aliases_response_empty": {
+        "stateMachineAliases": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_state_machine_alias_response": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_execution_response_through_alias": {
+        "executionArn": "arn:<partition>:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_execution_response_through_alias": {
+        "executionArn": "arn:<partition>:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
+        "input": {},
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<ExecArnPart_0idx>",
+        "output": {
+          "Arg1": "argument1"
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "redriveCount": 0,
+        "redriveStatus": "NOT_REDRIVABLE",
+        "redriveStatusReason": "Execution is SUCCEEDED and cannot be redriven",
+        "startDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "stateMachineArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "stateMachineVersionArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_execution_response_through_version_arn": {
+        "executionArn": "arn:<partition>:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_1idx>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_execution_response_through_version_arn": {
+        "executionArn": "arn:<partition>:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_1idx>",
+        "input": {},
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<ExecArnPart_1idx>",
+        "output": {
+          "Arg1": "argument1"
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "redriveCount": 0,
+        "redriveStatus": "NOT_REDRIVABLE",
+        "redriveStatusReason": "Execution is SUCCEEDED and cannot be redriven",
+        "startDate": "datetime",
+        "stateMachineArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "stateMachineVersionArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_executions_response": {
+        "executions": [
+          {
+            "executionArn": "arn:<partition>:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_1idx>",
+            "name": "<ExecArnPart_1idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "RUNNING"
+          },
+          {
+            "executionArn": "arn:<partition>:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
+            "name": "<ExecArnPart_0idx>",
+            "redriveCount": 0,
+            "startDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+            "stateMachineArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "stateMachineVersionArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_update_describe": {
+    "recorded-date": "25-02-2025, 08:12:31",
+    "recorded-content": {
+      "create_state_machine_alias_response": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update_state_machine_alias_description_response": {
+        "updateDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_state_machine_alias_update_description_response": {
+        "creationDate": "datetime",
+        "description": "new description",
+        "name": "state_machine_alias_name",
+        "routingConfiguration": [
+          {
+            "stateMachineVersionArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "weight": 100
+          }
+        ],
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "updateDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update_state_machine_alias_routing_configuration_response": {
+        "updateDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_state_machine_alias_update_routing_configuration_response": {
+        "creationDate": "datetime",
+        "description": "new description",
+        "name": "state_machine_alias_name",
+        "routingConfiguration": [
+          {
+            "stateMachineVersionArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:1",
+            "weight": 100
+          }
+        ],
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "updateDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_version_with_alias": {
+    "recorded-date": "25-02-2025, 09:00:20",
+    "recorded-content": {
+      "create_state_machine_alias_response": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exception_delete_version_with_alias_reference": {
+        "exception_typename": "ConflictException",
+        "exception_value": "An error occurred (ConflictException) when calling the DeleteStateMachineVersion operation: Version to be deleted must not be referenced by an alias. Current list of aliases referencing this version: [state_machine_alias_name]"
+      },
+      "describe_state_machine_alias_response": {
+        "creationDate": "datetime",
+        "description": "create state machine alias description",
+        "name": "state_machine_alias_name",
+        "routingConfiguration": [
+          {
+            "stateMachineVersionArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:2",
+            "weight": 100
+          }
+        ],
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "updateDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_version_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.validation.json
@@ -1,0 +1,32 @@
+{
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_create_alias_single_router_config": {
+    "last_validated_date": "2025-02-25T08:09:58+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_delete_list": {
+    "last_validated_date": "2025-02-25T08:11:47+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_invoke_describe_list": {
+    "last_validated_date": "2025-02-25T08:12:16+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_update_describe": {
+    "last_validated_date": "2025-02-25T08:12:31+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_version_with_alias": {
+    "last_validated_date": "2025-02-25T09:00:20+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_invalid_name": {
+    "last_validated_date": "2025-02-25T08:11:18+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_invalid_router_configs": {
+    "last_validated_date": "2025-02-25T08:10:59+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_not_idempotent": {
+    "last_validated_date": "2025-02-25T08:10:27+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_with_state_machine_arn": {
+    "last_validated_date": "2025-02-25T08:10:13+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_idempotent_create_alias": {
+    "last_validated_date": "2025-02-25T08:10:42+00:00"
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.validation.json
@@ -1,32 +1,38 @@
 {
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_create_alias_single_router_config": {
-    "last_validated_date": "2025-02-25T08:09:58+00:00"
+    "last_validated_date": "2025-03-03T13:12:29+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_delete_list": {
-    "last_validated_date": "2025-02-25T08:11:47+00:00"
+    "last_validated_date": "2025-03-03T13:14:23+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_invoke_describe_list": {
-    "last_validated_date": "2025-02-25T08:12:16+00:00"
+    "last_validated_date": "2025-03-03T13:20:29+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_update_describe": {
-    "last_validated_date": "2025-02-25T08:12:31+00:00"
+    "last_validated_date": "2025-03-03T13:15:57+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_no_such_alias_arn": {
+    "last_validated_date": "2025-03-03T13:37:24+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_revision_with_alias": {
+    "last_validated_date": "2025-03-03T13:34:23+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_version_with_alias": {
-    "last_validated_date": "2025-02-25T09:00:20+00:00"
+    "last_validated_date": "2025-03-03T13:16:42+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_invalid_name": {
-    "last_validated_date": "2025-02-25T08:11:18+00:00"
+    "last_validated_date": "2025-03-03T13:13:52+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_invalid_router_configs": {
-    "last_validated_date": "2025-02-25T08:10:59+00:00"
+    "last_validated_date": "2025-03-03T13:13:32+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_not_idempotent": {
-    "last_validated_date": "2025-02-25T08:10:27+00:00"
+    "last_validated_date": "2025-03-03T13:13:02+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_with_state_machine_arn": {
-    "last_validated_date": "2025-02-25T08:10:13+00:00"
+    "last_validated_date": "2025-03-03T13:12:48+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_idempotent_create_alias": {
-    "last_validated_date": "2025-02-25T08:10:42+00:00"
+    "last_validated_date": "2025-03-03T13:13:16+00:00"
   }
 }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.validation.json
@@ -34,5 +34,8 @@
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_idempotent_create_alias": {
     "last_validated_date": "2025-03-03T13:13:16+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_update_no_such_alias_arn": {
+    "last_validated_date": "2025-03-03T15:00:26+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
These changes introduce initial support for [AWS Step Functions aliasing](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-state-machine-alias.html) features.

Future work on aliasing: CloudFormation support; paging in ListStateMachineAliases 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added a new object representation for State Machine aliases, including logic for sampling and handling alias-specific attributes.
- Store updates: extended the Step Functions provider’s store to manage and track aliases
- API actions: CreateStateMachineAlias, DescribeStateMachineAlias, ListStateMachineAliases (no pagination support yet), UpdateStateMachineAlias, DeleteStateMachineAlias
- Complexity considerations: these changes focus on allowing creation and execution api actions of aliases to be optimized for constant time complexity; this comes at the cost of other operations such as deletion and listing that retain a linear complexity.
- Included basic validations for alias operations and entities


## Testing
- Added new test suite for Step Functions aliasing features and lifecycles with positive and negative snapshot tests for all the api actions added in these changes


<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
