### PR TITLE
Skip flaky Kinesis Lambda test

### DIFF
--- a/tests/aws/test_integration.py
+++ b/tests/aws/test_integration.py
@@ -545,6 +545,7 @@ class TestIntegration:
         retry(check_invocation, retries=16, sleep=5)
 
 
+@pytest.mark.skip("flaky (not waiting for stream to be ready)")
 @markers.aws.unknown
 def test_kinesis_lambda_forward_chain(
     kinesis_create_stream, s3_create_bucket, create_lambda_function, cleanups, aws_client


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This non-aws validated test seems flaky: https://github.com/localstack/localstack/actions/runs/13634627127/job/38110211627#step:22:7603

```
FAILED ../../localstack/tests/aws/test_integration.py::test_kinesis_lambda_forward_chain - botocore.errorfactory.ResourceInUseException: An error occurred (ResourceInUseException) when calling the PutRecord operation: Stream arn:aws:kinesis:us-east-1:000000000000:stream/test-stream-82a63827 is not currently ACTIVE or UPDATING.
```

Locally, I'm getting another assertion error:

```
>           raise Exception("Expected object not found: %s in list %s" % (expected_object, all_objects))
E           Exception: Expected object not found: {'test_data': 'forward_chain_data_ad49f8c0 with \'quotes\\"'} in list []
```

A workaround could be waiter for the stream to be active:


```
    wait_for_stream_ready(stream1_name)
    wait_for_stream_ready(stream2_name)
```

However, we should question whether the test is still needed, especially given it's not aws-validated

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Skip flaky test