### PR TITLE
[ESM] Fix validation of StartingPosition streams parameter

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -139,6 +139,10 @@ from localstack.aws.api.lambda_ import (
 )
 from localstack.aws.api.lambda_ import FunctionVersion as FunctionVersionApi
 from localstack.aws.api.lambda_ import ServiceException as LambdaServiceException
+from localstack.aws.api.pipes import (
+    DynamoDBStreamStartPosition,
+    KinesisStreamStartPosition,
+)
 from localstack.aws.connect import connect_to
 from localstack.aws.spec import load_service
 from localstack.services.edge import ROUTER
@@ -1923,11 +1927,28 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             service = extract_service_from_arn(request["EventSourceArn"])
 
         batch_size = api_utils.validate_and_set_batch_size(service, request.get("BatchSize"))
-        if service in ["dynamodb", "kinesis"] and "StartingPosition" not in request:
-            raise InvalidParameterValueException(
-                "1 validation error detected: Value null at 'startingPosition' failed to satisfy constraint: Member must not be null.",
-                Type="User",
-            )
+        if service in ["dynamodb", "kinesis"]:
+            starting_position = request.get("StartingPosition")
+            if not starting_position:
+                raise InvalidParameterValueException(
+                    "1 validation error detected: Value null at 'startingPosition' failed to satisfy constraint: Member must not be null.",
+                    Type="User",
+                )
+
+            if starting_position not in KinesisStreamStartPosition.__members__:
+                raise ValidationException(
+                    f"1 validation error detected: Value '{starting_position}' at 'startingPosition' failed to satisfy constraint: Member must satisfy enum value set: [LATEST, AT_TIMESTAMP, TRIM_HORIZON]"
+                )
+            # AT_TIMESTAMP is not allowed for DynamoDB Streams
+            elif (
+                service == "dynamodb"
+                and starting_position not in DynamoDBStreamStartPosition.__members__
+            ):
+                raise InvalidParameterValueException(
+                    f"Unsupported starting position for arn type: {request['EventSourceArn']}",
+                    Type="User",
+                )
+
         if service in ["sqs", "sqs-fifo"]:
             if batch_size > 10 and request.get("MaximumBatchingWindowInSeconds", 0) == 0:
                 raise InvalidParameterValueException(

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -12368,15 +12368,37 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_validation": {
-    "recorded-date": "10-04-2024, 09:22:02",
+    "recorded-date": "03-03-2025, 17:07:45",
     "recorded-content": {
-      "error": {
+      "no_starting_position": {
         "Error": {
           "Code": "InvalidParameterValueException",
           "Message": "1 validation error detected: Value null at 'startingPosition' failed to satisfy constraint: Member must not be null."
         },
         "Type": "User",
         "message": "1 validation error detected: Value null at 'startingPosition' failed to satisfy constraint: Member must not be null.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid_starting_position": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'invalid' at 'startingPosition' failed to satisfy constraint: Member must satisfy enum value set: [LATEST, AT_TIMESTAMP, TRIM_HORIZON]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "incompatible_starting_position": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Unsupported starting position for arn type: arn:<partition>:dynamodb:<region>:111111111111:table/<table-name>/stream/<stream-name>"
+        },
+        "Type": "User",
+        "message": "Unsupported starting position for arn type: arn:<partition>:dynamodb:<region>:111111111111:table/<table-name>/stream/<stream-name>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -22305,6 +22327,33 @@
         "Error": {
           "Code": "ValidationException",
           "Message": "1 validation error detected: Value '[<security_group_id_2>]' at 'vpcConfig.securityGroupIds' failed to satisfy constraint: Member must satisfy constraint: [Member must have length less than or equal to 1024, Member must have length greater than or equal to 0, Member must satisfy regular expression pattern: ^sg-[0-9a-zA-Z]*$]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_validation_kinesis": {
+    "recorded-date": "03-03-2025, 16:49:40",
+    "recorded-content": {
+      "no_starting_position": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "1 validation error detected: Value null at 'startingPosition' failed to satisfy constraint: Member must not be null."
+        },
+        "Type": "User",
+        "message": "1 validation error detected: Value null at 'startingPosition' failed to satisfy constraint: Member must not be null.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid_starting_position": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'invalid' at 'startingPosition' failed to satisfy constraint: Member must satisfy enum value set: [LATEST, AT_TIMESTAMP, TRIM_HORIZON]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -42,7 +42,10 @@
     "last_validated_date": "2024-09-03T20:58:27+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_validation": {
-    "last_validated_date": "2024-04-10T09:21:59+00:00"
+    "last_validated_date": "2025-03-03T17:07:41+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_validation_kinesis": {
+    "last_validated_date": "2025-03-03T16:49:39+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_event_source_mapping_exceptions": {
     "last_validated_date": "2024-12-05T10:52:30+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Adds validations for an ESM stream's `StartingPosition` parameter.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Extends the `dynamodbstreams` test `test_create_event_source_validation` to include some invalid/incompatible params
- Adds a `test_create_event_source_validation_kinesis` to test for kinesis parameter validations.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
