### PR TITLE
Track Lambda runtime environment timeout

### DIFF
--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -48,6 +48,7 @@ TRACKED_ENV_VAR = [
     "LAMBDA_XRAY_INIT",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
     "LAMBDA_PREBUILD_IMAGES",
     "LAMBDA_RUNTIME_EXECUTOR",
+    "LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT",
     "LEGACY_EDGE_PROXY",  # Not functional; deprecated in 1.0.0, removed in 2.0.0
     "LS_LOG",
     "MOCK_UNIMPLEMENTED",  # Not functional; deprecated in 1.3.0, removed in 3.0.0


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

I'm often seeing customers configuring the `LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT`, potentially working around slow cold starts or runtime startup errors. Getting analytics helps to decide whether/how we should adjust the default value.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* [Track Lambda runtime environment timeout](https://github.com/localstack/localstack/commit/4e0166f0454399f679c761033b530253ad314c4e)