### PR TITLE
add build time service catalog cache generation to s3 image

### DIFF
--- a/Dockerfile.s3
+++ b/Dockerfile.s3
@@ -93,6 +93,9 @@ RUN --mount=type=cache,target=/root/.cache \
 RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LOCALSTACK_CORE=${LOCALSTACK_BUILD_VERSION} \
     make entrypoints
 
+# Generate service catalog cache in static libs dir
+RUN . .venv/bin/activate && python3 -m localstack.aws.spec
+
 # link the python package installer virtual environments into the localstack venv
 RUN echo /var/lib/localstack/lib/python-packages/lib/python3.11/site-packages > localstack-var-python-packages-venv.pth && \
     mv localstack-var-python-packages-venv.pth .venv/lib/python*/site-packages/


### PR DESCRIPTION
## Motivation
https://github.com/localstack/localstack/pull/12314 introduced a docker-build-time generation of the service catalog cache.
Unfortunately, I forgot about the `Dockerfile` for the S3 image.

## Changes
- Adds a small step to generate the service catalog cache at docker build time for the S3-only `Dockerfile`.