### PR TITLE
KMS: on-demand key rotation

### DIFF
--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -1099,6 +1099,14 @@ class TestKMS:
         assert aws_client.kms.get_key_rotation_status(KeyId=key_id)["KeyRotationEnabled"] is False
 
     @markers.aws.validated
+    def test_rotate_key_on_demand_succeeds_given_symmetric_key(self, kms_key, aws_client):
+        raise NotImplementedError
+
+    @markers.aws.validated
+    def test_rotate_key_on_demand_returns_error_given_non_symmetric_key(self, kms_key, aws_client):
+        raise NotImplementedError
+
+    @markers.aws.validated
     @pytest.mark.parametrize("rotation_period_in_days", [90, 180])
     def test_key_enable_rotation_status(
         self,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Motivated by this enhancement request: https://github.com/localstack/localstack/issues/10723


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Initial implementation of the [on-demand key rotation feature in KMS](https://docs.aws.amazon.com/kms/latest/developerguide/rotating-keys-on-demand.html).

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->

## TODO

What's left to do:

- [ ] Preserve old key material, as specified in AWS's docs
- [ ] Consider multi-region keys, if necessary
