### PR TITLE
Step Functions: Improve Nested Map Run Stability

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/distributed_iteration_component.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/distributed_iteration_component.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import abc
 import json
-import threading
 from typing import Any, Final, Optional
 
 from localstack.aws.api.stepfunctions import (
@@ -36,9 +35,6 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.state
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.itemprocessor.processor_config import (
     ProcessorConfig,
 )
-from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.iteration_worker import (
-    IterationWorker,
-)
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.job import (
     JobClosed,
     JobPool,
@@ -56,6 +52,7 @@ from localstack.services.stepfunctions.asl.eval.event.event_manager import (
 class DistributedIterationComponentEvalInput(InlineIterationComponentEvalInput):
     item_reader: Final[Optional[ItemReader]]
     label: Final[Optional[str]]
+    map_run_record: Final[MapRunRecord]
 
     def __init__(
         self,
@@ -68,6 +65,7 @@ class DistributedIterationComponentEvalInput(InlineIterationComponentEvalInput):
         tolerated_failure_count: int,
         tolerated_failure_percentage: float,
         label: Optional[str],
+        map_run_record: MapRunRecord,
     ):
         super().__init__(
             state_name=state_name,
@@ -80,14 +78,10 @@ class DistributedIterationComponentEvalInput(InlineIterationComponentEvalInput):
         self.tolerated_failure_count = tolerated_failure_count
         self.tolerated_failure_percentage = tolerated_failure_percentage
         self.label = label
+        self.map_run_record = map_run_record
 
 
 class DistributedIterationComponent(InlineIterationComponent, abc.ABC):
-    _eval_input: Optional[DistributedIterationComponentEvalInput]
-    _mutex: Final[threading.Lock]
-    _map_run_record: Optional[MapRunRecord]
-    _workers: list[IterationWorker]
-
     def __init__(
         self,
         query_language: QueryLanguage,
@@ -103,89 +97,59 @@ class DistributedIterationComponent(InlineIterationComponent, abc.ABC):
             comment=comment,
             processor_config=processor_config,
         )
-        self._mutex = threading.Lock()
-        self._map_run_record = None
-        self._workers = list()
 
-    @abc.abstractmethod
-    def _create_worker(self, env: Environment) -> IterationWorker: ...
-
-    def _launch_worker(self, env: Environment) -> IterationWorker:
-        worker = super()._launch_worker(env=env)
-        self._workers.append(worker)
-        return worker
-
-    def _set_active_workers(self, workers_number: int, env: Environment) -> None:
-        with self._mutex:
-            current_workers_number = len(self._workers)
-            workers_diff = workers_number - current_workers_number
-            if workers_diff > 0:
-                for _ in range(workers_diff):
-                    self._launch_worker(env=env)
-            elif workers_diff < 0:
-                deletion_workers = list(self._workers)[workers_diff:]
-                for worker in deletion_workers:
-                    worker.sig_stop()
-                    self._workers.remove(worker)
-
-    def _map_run(self, env: Environment) -> None:
+    def _map_run(
+        self, env: Environment, eval_input: DistributedIterationComponentEvalInput
+    ) -> None:
         input_items: list[json] = env.stack.pop()
 
         input_item_program: Final[Program] = self._get_iteration_program()
-        self._job_pool = JobPool(job_program=input_item_program, job_inputs=input_items)
+        job_pool = JobPool(job_program=input_item_program, job_inputs=input_items)
 
         # TODO: add watch on map_run_record update event and adjust the number of running workers accordingly.
-        max_concurrency = self._map_run_record.max_concurrency
+        max_concurrency = eval_input.map_run_record.max_concurrency
         workers_number = (
             len(input_items)
             if max_concurrency == DEFAULT_MAX_CONCURRENCY_VALUE
             else max_concurrency
         )
-        self._set_active_workers(workers_number=workers_number, env=env)
+        for _ in range(workers_number):
+            self._launch_worker(env=env, eval_input=eval_input, job_pool=job_pool)
 
-        self._job_pool.await_jobs()
+        job_pool.await_jobs()
 
-        worker_exception: Optional[Exception] = self._job_pool.get_worker_exception()
+        worker_exception: Optional[Exception] = job_pool.get_worker_exception()
         if worker_exception is not None:
             raise worker_exception
 
-        closed_jobs: list[JobClosed] = self._job_pool.get_closed_jobs()
+        closed_jobs: list[JobClosed] = job_pool.get_closed_jobs()
         outputs: list[Any] = [closed_job.job_output for closed_job in closed_jobs]
 
         env.stack.append(outputs)
 
     def _eval_body(self, env: Environment) -> None:
-        self._eval_input = env.stack.pop()
-
-        self._map_run_record = MapRunRecord(
-            state_machine_arn=env.states.context_object.context_object_data["StateMachine"]["Id"],
-            execution_arn=env.states.context_object.context_object_data["Execution"]["Id"],
-            max_concurrency=self._eval_input.max_concurrency,
-            tolerated_failure_count=self._eval_input.tolerated_failure_count,
-            tolerated_failure_percentage=self._eval_input.tolerated_failure_percentage,
-            label=self._eval_input.label,
-        )
-        env.map_run_record_pool_manager.add(self._map_run_record)
+        eval_input: DistributedIterationComponentEvalInput = env.stack.pop()
+        map_run_record = eval_input.map_run_record
 
         env.event_manager.add_event(
             context=env.event_history_context,
             event_type=HistoryEventType.MapRunStarted,
             event_details=EventDetails(
                 mapRunStartedEventDetails=MapRunStartedEventDetails(
-                    mapRunArn=self._map_run_record.map_run_arn
+                    mapRunArn=map_run_record.map_run_arn
                 )
             ),
         )
 
         parent_event_manager = env.event_manager
         try:
-            if self._eval_input.item_reader:
-                self._eval_input.item_reader.eval(env=env)
+            if eval_input.item_reader:
+                eval_input.item_reader.eval(env=env)
             else:
-                env.stack.append(self._eval_input.input_items)
+                env.stack.append(eval_input.input_items)
 
             env.event_manager = EventManager()
-            self._map_run(env=env)
+            self._map_run(env=env, eval_input=eval_input)
 
         except FailureEventException as failure_event_ex:
             map_run_fail_event_detail = MapRunFailedEventDetails()
@@ -204,7 +168,7 @@ class DistributedIterationComponent(InlineIterationComponent, abc.ABC):
                 event_type=HistoryEventType.MapRunFailed,
                 event_details=EventDetails(mapRunFailedEventDetails=map_run_fail_event_detail),
             )
-            self._map_run_record.set_stop(status=MapRunStatus.FAILED)
+            map_run_record.set_stop(status=MapRunStatus.FAILED)
             raise failure_event_ex
 
         except Exception as ex:
@@ -214,17 +178,13 @@ class DistributedIterationComponent(InlineIterationComponent, abc.ABC):
                 event_type=HistoryEventType.MapRunFailed,
                 event_details=EventDetails(mapRunFailedEventDetails=MapRunFailedEventDetails()),
             )
-            self._map_run_record.set_stop(status=MapRunStatus.FAILED)
+            map_run_record.set_stop(status=MapRunStatus.FAILED)
             raise ex
         finally:
             env.event_manager = parent_event_manager
-            self._eval_input = None
-            self._workers.clear()
 
-        # TODO: review workflow of program stops and maprunstops
-        # program_state = env.program_state()
-        # if isinstance(program_state, ProgramSucceeded)
+        # TODO: review workflow of program stops and map run stops
         env.event_manager.add_event(
             context=env.event_history_context, event_type=HistoryEventType.MapRunSucceeded
         )
-        self._map_run_record.set_stop(status=MapRunStatus.SUCCEEDED)
+        map_run_record.set_stop(status=MapRunStatus.SUCCEEDED)

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/itemprocessor/distributed_item_processor.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/itemprocessor/distributed_item_processor.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from localstack.services.stepfunctions.asl.component.common.comment import Comment
 from localstack.services.stepfunctions.asl.component.common.flow.start_at import StartAt
 from localstack.services.stepfunctions.asl.component.common.query_language import QueryLanguage
@@ -16,6 +14,9 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.state
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.itemprocessor.processor_config import (
     ProcessorConfig,
 )
+from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.job import (
+    JobPool,
+)
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.parse.typed_props import TypedProps
 
@@ -25,8 +26,6 @@ class DistributedItemProcessorEvalInput(DistributedIterationComponentEvalInput):
 
 
 class DistributedItemProcessor(DistributedIterationComponent):
-    _eval_input: Optional[DistributedItemProcessorEvalInput]
-
     @classmethod
     def from_props(cls, props: TypedProps) -> DistributedItemProcessor:
         item_processor = cls(
@@ -44,13 +43,15 @@ class DistributedItemProcessor(DistributedIterationComponent):
         )
         return item_processor
 
-    def _create_worker(self, env: Environment) -> DistributedItemProcessorWorker:
+    def _create_worker(
+        self, env: Environment, eval_input: DistributedItemProcessorEvalInput, job_pool: JobPool
+    ) -> DistributedItemProcessorWorker:
         return DistributedItemProcessorWorker(
-            work_name=self._eval_input.state_name,
-            job_pool=self._job_pool,
+            work_name=eval_input.state_name,
+            job_pool=job_pool,
             env=env,
-            item_reader=self._eval_input.item_reader,
-            parameters=self._eval_input.parameters,
-            item_selector=self._eval_input.item_selector,
-            map_run_record=self._map_run_record,
+            item_reader=eval_input.item_reader,
+            parameters=eval_input.parameters,
+            item_selector=eval_input.item_selector,
+            map_run_record=eval_input.map_run_record,
         )

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/itemprocessor/inline_item_processor.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/itemprocessor/inline_item_processor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 from localstack.services.stepfunctions.asl.component.common.comment import Comment
 from localstack.services.stepfunctions.asl.component.common.flow.start_at import StartAt
@@ -17,6 +16,9 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.state
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.itemprocessor.processor_config import (
     ProcessorConfig,
 )
+from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.job import (
+    JobPool,
+)
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.parse.typed_props import TypedProps
 
@@ -28,8 +30,6 @@ class InlineItemProcessorEvalInput(InlineIterationComponentEvalInput):
 
 
 class InlineItemProcessor(InlineIterationComponent):
-    _eval_input: Optional[InlineItemProcessorEvalInput]
-
     @classmethod
     def from_props(cls, props: TypedProps) -> InlineItemProcessor:
         if not props.get(States):
@@ -45,11 +45,13 @@ class InlineItemProcessor(InlineIterationComponent):
         )
         return item_processor
 
-    def _create_worker(self, env: Environment) -> InlineItemProcessorWorker:
+    def _create_worker(
+        self, env: Environment, eval_input: InlineItemProcessorEvalInput, job_pool: JobPool
+    ) -> InlineItemProcessorWorker:
         return InlineItemProcessorWorker(
-            work_name=self._eval_input.state_name,
-            job_pool=self._job_pool,
+            work_name=eval_input.state_name,
+            job_pool=job_pool,
             env=env,
-            item_selector=self._eval_input.item_selector,
-            parameters=self._eval_input.parameters,
+            item_selector=eval_input.item_selector,
+            parameters=eval_input.parameters,
         )

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/iteration_component.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/iteration_component.py
@@ -12,6 +12,9 @@ from localstack.services.stepfunctions.asl.component.program.states import State
 
 
 class IterationComponent(EvalComponent, abc.ABC):
+    # Ensure no member variables are used to keep track of the state of
+    # iteration components: the evaluation must be stateless as for all
+    # EvalComponents to ensure they can be reused or used concurrently.
     _query_language: Final[QueryLanguage]
     _start_at: Final[StartAt]
     _states: Final[States]

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/iterator/distributed_iterator.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/iterator/distributed_iterator.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from localstack.services.stepfunctions.asl.component.common.comment import Comment
 from localstack.services.stepfunctions.asl.component.common.flow.start_at import StartAt
 from localstack.services.stepfunctions.asl.component.common.query_language import QueryLanguage
@@ -16,6 +14,9 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.state
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.iterator.distributed_iterator_worker import (
     DistributedIteratorWorker,
 )
+from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.job import (
+    JobPool,
+)
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.parse.typed_props import TypedProps
 
@@ -25,8 +26,6 @@ class DistributedIteratorEvalInput(DistributedIterationComponentEvalInput):
 
 
 class DistributedIterator(DistributedIterationComponent):
-    _eval_input: Optional[DistributedIteratorEvalInput]
-
     @classmethod
     def from_props(cls, props: TypedProps) -> DistributedIterator:
         item_processor = cls(
@@ -44,12 +43,14 @@ class DistributedIterator(DistributedIterationComponent):
         )
         return item_processor
 
-    def _create_worker(self, env: Environment) -> DistributedIteratorWorker:
+    def _create_worker(
+        self, env: Environment, eval_input: DistributedIteratorEvalInput, job_pool: JobPool
+    ) -> DistributedIteratorWorker:
         return DistributedIteratorWorker(
-            work_name=self._eval_input.state_name,
-            job_pool=self._job_pool,
+            work_name=eval_input.state_name,
+            job_pool=job_pool,
             env=env,
-            parameters=self._eval_input.parameters,
-            map_run_record=self._map_run_record,
-            item_selector=self._eval_input.item_selector,
+            parameters=eval_input.parameters,
+            map_run_record=eval_input.map_run_record,
+            item_selector=eval_input.item_selector,
         )

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/iterator/inline_iterator.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/iterator/inline_iterator.py
@@ -13,6 +13,9 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.state
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.iterator.iterator_decl import (
     IteratorDecl,
 )
+from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.job import (
+    JobPool,
+)
 from localstack.services.stepfunctions.asl.eval.environment import Environment
 
 LOG = logging.getLogger(__name__)
@@ -25,13 +28,15 @@ class InlineIteratorEvalInput(InlineIterationComponentEvalInput):
 class InlineIterator(InlineIterationComponent):
     _eval_input: Optional[InlineIteratorEvalInput]
 
-    def _create_worker(self, env: Environment) -> InlineIteratorWorker:
+    def _create_worker(
+        self, env: Environment, eval_input: InlineIteratorEvalInput, job_pool: JobPool
+    ) -> InlineIteratorWorker:
         return InlineIteratorWorker(
-            work_name=self._eval_input.state_name,
-            job_pool=self._job_pool,
+            work_name=eval_input.state_name,
+            job_pool=job_pool,
             env=env,
-            parameters=self._eval_input.parameters,
-            item_selector=self._eval_input.item_selector,
+            parameters=eval_input.parameters,
+            item_selector=eval_input.item_selector,
         )
 
     @classmethod

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/state_map.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/state_map.py
@@ -264,6 +264,8 @@ class StateMap(ExecutionState):
                 label=label,
             )
             env.map_run_record_pool_manager.add(map_run_record)
+            # Choose the distributed input type depending on whether the definition
+            # asks for the legacy Iterator component or an ItemProcessor
             if isinstance(self.iteration_component, DistributedIterator):
                 distributed_eval_input_class = DistributedIteratorEvalInput
             elif isinstance(self.iteration_component, DistributedItemProcessor):

--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/state_map.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/state_map.py
@@ -57,6 +57,9 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.state
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.itemprocessor.item_processor_factory import (
     from_item_processor_decl,
 )
+from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.itemprocessor.map_run_record import (
+    MapRunRecord,
+)
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.iteration_component import (
     IterationComponent,
 )
@@ -241,18 +244,6 @@ class StateMap(ExecutionState):
                 parameters=self.parameters,
                 item_selector=self.item_selector,
             )
-        elif isinstance(self.iteration_component, DistributedIterator):
-            eval_input = DistributedIteratorEvalInput(
-                state_name=self.name,
-                max_concurrency=max_concurrency_num,
-                input_items=input_items,
-                parameters=self.parameters,
-                item_selector=self.item_selector,
-                item_reader=self.item_reader,
-                tolerated_failure_count=tolerated_failure_count,
-                tolerated_failure_percentage=tolerated_failure_percentage,
-                label=label,
-            )
         elif isinstance(self.iteration_component, InlineItemProcessor):
             eval_input = InlineItemProcessorEvalInput(
                 state_name=self.name,
@@ -261,21 +252,37 @@ class StateMap(ExecutionState):
                 item_selector=self.item_selector,
                 parameters=self.parameters,
             )
-        elif isinstance(self.iteration_component, DistributedItemProcessor):
-            eval_input = DistributedItemProcessorEvalInput(
-                state_name=self.name,
+        else:
+            map_run_record = MapRunRecord(
+                state_machine_arn=env.states.context_object.context_object_data["StateMachine"][
+                    "Id"
+                ],
+                execution_arn=env.states.context_object.context_object_data["Execution"]["Id"],
                 max_concurrency=max_concurrency_num,
-                input_items=input_items,
-                item_reader=self.item_reader,
-                item_selector=self.item_selector,
-                parameters=self.parameters,
                 tolerated_failure_count=tolerated_failure_count,
                 tolerated_failure_percentage=tolerated_failure_percentage,
                 label=label,
             )
-        else:
-            raise RuntimeError(
-                f"Unknown iteration component of type '{type(self.iteration_component)}' '{self.iteration_component}'."
+            env.map_run_record_pool_manager.add(map_run_record)
+            if isinstance(self.iteration_component, DistributedIterator):
+                distributed_eval_input_class = DistributedIteratorEvalInput
+            elif isinstance(self.iteration_component, DistributedItemProcessor):
+                distributed_eval_input_class = DistributedItemProcessorEvalInput
+            else:
+                raise RuntimeError(
+                    f"Unknown iteration component of type '{type(self.iteration_component)}' '{self.iteration_component}'."
+                )
+            eval_input = distributed_eval_input_class(
+                state_name=self.name,
+                max_concurrency=max_concurrency_num,
+                input_items=input_items,
+                parameters=self.parameters,
+                item_selector=self.item_selector,
+                item_reader=self.item_reader,
+                tolerated_failure_count=tolerated_failure_count,
+                tolerated_failure_percentage=tolerated_failure_percentage,
+                label=label,
+                map_run_record=map_run_record,
             )
 
         env.stack.append(eval_input)

--- a/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
+++ b/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
@@ -88,6 +88,9 @@ class ScenariosTemplate(TemplateLoader):
     MAP_STATE_NESTED_CONFIG_DISTRIBUTED: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/map_state_nested_config_distributed.json5"
     )
+    MAP_STATE_NESTED_CONFIG_DISTRIBUTED_NO_MAX_CONCURRENCY: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/map_state_nested_config_distributed_no_max_concurrency.json5"
+    )
     MAP_STATE_NO_PROCESSOR_CONFIG: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/map_state_no_processor_config.json5"
     )

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_nested_config_distributed_no_max_concurrency.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_nested_config_distributed_no_max_concurrency.json5
@@ -1,0 +1,79 @@
+{
+  "StartAt": "InputValue",
+  "States": {
+    "InputValue": {
+      "Type": "Pass",
+      "Result": {
+        "outerJobs": [
+          {
+            "innerJobs": [0, 1, 2, 3, 4]
+          },
+          {
+            "innerJobs": [0, 1, 2, 3, 4]
+          },
+          {
+            "innerJobs": [0, 1, 2, 3, 4]
+          },
+          {
+            "innerJobs": [0, 1, 2, 3, 4]
+          },
+        ]
+      },
+      "Next": "OuterMap"
+    },
+    "OuterMap": {
+      "Type": "Map",
+      "ResultPath": null,
+      "Next": "FinalState",
+      "ItemsPath": "$.outerJobs",
+      "ItemSelector": {
+        "innerJobs.$": "$$.Map.Item.Value.innerJobs"
+      },
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "DISTRIBUTED",
+          "ExecutionType": "STANDARD"
+        },
+        "StartAt": "InnerMap",
+        "States": {
+          "InnerMap": {
+            "Type": "Map",
+            "ResultPath": null,
+            "End": true,
+            "ItemsPath": "$.innerJobs",
+            "ItemSelector": {
+              "job.$": "$$.Map.Item.Value"
+            },
+            "ItemProcessor": {
+              "ProcessorConfig": {
+                "Mode": "DISTRIBUTED",
+                "ExecutionType": "STANDARD"
+              },
+              "StartAt": "ProcessJob",
+              "States": {
+                "ProcessJob": {
+                  "Type": "Task",
+                  "Resource": "arn:aws:states:::lambda:invoke",
+                  "Parameters": {
+                    "FunctionName": "__tbd__",
+                    "Payload": {
+                      "job.$": "$.job"
+                    }
+                  },
+                  "End": true
+                }
+              }
+            },
+            "MaxConcurrency": 9
+          }
+        }
+      },
+      "MaxConcurrency": 50
+    },
+    "FinalState": {
+      "Type": "Pass",
+      "End": true
+    }
+  }
+}
+

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
@@ -27847,5 +27847,385 @@
         "exception_value": "An error occurred (InvalidDefinition) when calling the CreateStateMachine operation: Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: The value for the field 'parsed.$' must be a valid JSONPath or a valid intrinsic function call at /States/IntrinsicEscape/Parameters'"
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_nested_config_distributed_no_max_max_concurrency": {
+    "recorded-date": "05-03-2025, 12:09:21",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "InputValue"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "InputValue",
+              "output": {
+                "outerJobs": [
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  }
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "outerJobs": [
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  }
+                ]
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "OuterMap"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 5,
+            "mapStateStartedEventDetails": {
+              "length": 4
+            },
+            "previousEventId": 4,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "id": 6,
+            "mapRunStartedEventDetails": {
+              "mapRunArn": "arn:<partition>:states:<region>:111111111111:mapRun:<ArnPart_0idx>/<MapRunArnPart0_0idx>:<MapRunArnPart1_0idx>"
+            },
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "MapRunStarted"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "MapRunSucceeded"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "timestamp": "timestamp",
+            "type": "MapStateSucceeded"
+          },
+          {
+            "id": 9,
+            "previousEventId": 6,
+            "stateExitedEventDetails": {
+              "name": "OuterMap",
+              "output": {
+                "outerJobs": [
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  }
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateExited"
+          },
+          {
+            "id": 10,
+            "previousEventId": 9,
+            "stateEnteredEventDetails": {
+              "input": {
+                "outerJobs": [
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  }
+                ]
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "FinalState"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 11,
+            "previousEventId": 10,
+            "stateExitedEventDetails": {
+              "name": "FinalState",
+              "output": {
+                "outerJobs": [
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  }
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "outerJobs": [
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  {
+                    "innerJobs": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  }
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 12,
+            "previousEventId": 11,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
@@ -341,6 +341,9 @@
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_nested_config_distributed": {
     "last_validated_date": "2024-12-13T13:38:16+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_nested_config_distributed_no_max_max_concurrency": {
+    "last_validated_date": "2025-03-05T12:09:21+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_no_processor_config": {
     "last_validated_date": "2023-12-15T21:25:27+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, the Step Functions v2 interpreter encounters issues when evaluating nested MapRun calls distributed across multiple MapRuns https://github.com/localstack/localstack/issues/12335. This arises from two main issues: certain map run components inappropriately use member variables to share state, and the worker number management is shared across multiple map runs, causing no workers to start for jobs beyond the first job in nested scenarios.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This pull request addresses the anti-pattern of stateful objects in the map run logic by making them stateless. Additionally, it corrects the creation of workers so they are appropriately initiated for all nested map runs.

## Testing
Added a relevant snapshot test to verify the correct functioning of distributed nested map runs without maximum concurrency settings.


<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
