### PR TITLE
Makes docker healthcheck more robust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -170,7 +170,7 @@ RUN echo /usr/lib/localstack/python-packages/lib/python3.11/site-packages > loca
 # expose edge service, external service ports, and debugpy
 EXPOSE 4566 4510-4559 5678
 
-HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=10s CMD /usr/lib/localstack/.venv/bin/localstack status services --format=json
+HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=10s CMD /opt/code/localstack/.venv/bin/localstack status services --format=json
 
 # default volume directory
 VOLUME /var/lib/localstack

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,7 +170,7 @@ RUN echo /usr/lib/localstack/python-packages/lib/python3.11/site-packages > loca
 # expose edge service, external service ports, and debugpy
 EXPOSE 4566 4510-4559 5678
 
-HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=10s CMD .venv/bin/localstack status services --format=json
+HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=10s CMD /usr/lib/localstack/.venv/bin/localstack status services --format=json
 
 # default volume directory
 VOLUME /var/lib/localstack


### PR DESCRIPTION
## Motivation

Running the localstack/localstack docker with a different --workdir makes it "unhealthy". Ex: `docker run -it --workdir /opt localstack/localstack:stable`

## Changes

Changes the docker healthcheck to use absolute path when executing the binary
