### PR TITLE
migrate healthcheck enhancements to S3 image

### DIFF
--- a/Dockerfile.s3
+++ b/Dockerfile.s3
@@ -105,7 +105,7 @@ RUN echo /usr/lib/localstack/python-packages/lib/python3.11/site-packages > loca
 # expose edge service and debugpy
 EXPOSE 4566 5678
 
-HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=10s CMD .venv/bin/localstack status services --format=json
+HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=10s CMD /opt/code/localstack/.venv/bin/localstack status services --format=json
 
 # default volume directory
 VOLUME /var/lib/localstack


### PR DESCRIPTION
## Motivation
https://github.com/localstack/localstack/pull/12344 changed the health check in the `Dockerfile` of the main image to be independent of the working directory (since some tools might be changing the workdir).
Unfortunately during the review, I forgot about the S3 image, which is covered in this PR.

## Changes
- Changes the `HEALTHCHECK` directive in the `Dockerfile.s3` to be independent of the working directory.