### PR TITLE
Implement IAM service specific credentials CRUD

### DIFF
--- a/localstack-core/localstack/services/iam/iam_patches.py
+++ b/localstack-core/localstack/services/iam/iam_patches.py
@@ -7,6 +7,7 @@ from moto.iam.models import (
     IAMBackend,
     InlinePolicy,
     Policy,
+    User,
 )
 from moto.iam.models import Role as MotoRole
 from moto.iam.policy_validation import VALID_STATEMENT_ELEMENTS
@@ -151,3 +152,13 @@ def apply_iam_patches():
         if not config.PARITY_AWS_ACCESS_KEY_ID:
             prefix = "L" + prefix[1:]
         fn(self, user_name, prefix, account_id, status, **kwargs)
+
+    @patch(User.__init__)
+    def user__init__(
+        fn,
+        self,
+        *args,
+        **kwargs,
+    ):
+        fn(self, *args, **kwargs)
+        self.service_specific_credentials = []

--- a/localstack-core/localstack/services/iam/provider.py
+++ b/localstack-core/localstack/services/iam/provider.py
@@ -575,6 +575,17 @@ class IamProvider(IamApi):
             raise NoSuchEntityException(f"No such credential {credential_id} exists")
         return matching_credentials[0]
 
+    def _validate_status(self, status: str):
+        # validate status
+        try:
+            statusType(status)
+        except ValueError:
+            raise ValidationError(
+                [
+                    "Value at 'status' failed to satisfy constraint: Member must satisfy enum value set"
+                ]
+            )
+
     def update_service_specific_credential(
         self,
         context: RequestContext,
@@ -583,13 +594,7 @@ class IamProvider(IamApi):
         user_name: userNameType = None,
         **kwargs,
     ) -> None:
-        # validate status
-        if status not in statusType:
-            raise ValidationError(
-                [
-                    "Value at 'status' failed to satisfy constraint: Member must satisfy enum value set"
-                ]
-            )
+        self._validate_status(status)
 
         credential = self._find_credential_in_user_by_id(
             user_name, service_specific_credential_id, context

--- a/localstack-core/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack-core/localstack/testing/snapshots/transformer_utility.py
@@ -9,7 +9,6 @@ from localstack_snapshot.snapshots.transformer import (
     PATTERN_ISO8601,
     JsonpathTransformer,
     KeyValueBasedTransformer,
-    KeyValueFunctionBasedTransformer,
     RegexTransformer,
     ResponseMetaDataTransformer,
     SortingTransformer,
@@ -67,29 +66,6 @@ class TransformerUtility:
         return KeyValueBasedTransformer(
             lambda k, v: v if k == key and (v is not None and v != "") else None,
             replacement=value_replacement or _replace_camel_string_with_hyphen(key),
-            replace_reference=reference_replacement,
-        )
-
-    @staticmethod
-    def key_value_length(
-        key: str, value_replacement: Optional[str] = None, reference_replacement: bool = True
-    ):
-        """Creates a new KeyValueBasedTransformer. If the key matches, the value will be replaced.
-
-        :param key: the name of the key which should be replaced
-        :param value_replacement: the value which will replace the original value. The end value will also include the length of the replaced object.
-        By default it is the key-name in lowercase, separated with hyphen
-        :param reference_replacement: if False, only the original value for this key will be replaced.
-        If True all references of this value will be replaced (using a regex pattern), for the entire test case.
-        In this case, the replaced value will be nummerated as well.
-        Default: True
-
-        :return: KeyValueBasedTransformer
-        """
-        replacement = value_replacement or _replace_camel_string_with_hyphen(key)
-        return KeyValueFunctionBasedTransformer(
-            lambda k, v: v if k == key and (v is not None and v != "") else None,
-            replacement_function=lambda k, v: f"{replacement}({len(v)})",
             replace_reference=reference_replacement,
         )
 

--- a/localstack-core/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack-core/localstack/testing/snapshots/transformer_utility.py
@@ -9,6 +9,7 @@ from localstack_snapshot.snapshots.transformer import (
     PATTERN_ISO8601,
     JsonpathTransformer,
     KeyValueBasedTransformer,
+    KeyValueFunctionBasedTransformer,
     RegexTransformer,
     ResponseMetaDataTransformer,
     SortingTransformer,
@@ -66,6 +67,29 @@ class TransformerUtility:
         return KeyValueBasedTransformer(
             lambda k, v: v if k == key and (v is not None and v != "") else None,
             replacement=value_replacement or _replace_camel_string_with_hyphen(key),
+            replace_reference=reference_replacement,
+        )
+
+    @staticmethod
+    def key_value_length(
+        key: str, value_replacement: Optional[str] = None, reference_replacement: bool = True
+    ):
+        """Creates a new KeyValueBasedTransformer. If the key matches, the value will be replaced.
+
+        :param key: the name of the key which should be replaced
+        :param value_replacement: the value which will replace the original value. The end value will also include the length of the replaced object.
+        By default it is the key-name in lowercase, separated with hyphen
+        :param reference_replacement: if False, only the original value for this key will be replaced.
+        If True all references of this value will be replaced (using a regex pattern), for the entire test case.
+        In this case, the replaced value will be nummerated as well.
+        Default: True
+
+        :return: KeyValueBasedTransformer
+        """
+        replacement = value_replacement or _replace_camel_string_with_hyphen(key)
+        return KeyValueFunctionBasedTransformer(
+            lambda k, v: v if k == key and (v is not None and v != "") else None,
+            replacement_function=lambda k, v: f"{replacement}({len(v)})",
             replace_reference=reference_replacement,
         )
 

--- a/tests/aws/conftest.py
+++ b/tests/aws/conftest.py
@@ -125,7 +125,6 @@ def snapshot(request, _snapshot_session: SnapshotSession, account_id, region_nam
         "tests/aws/services/cloudformation",
         "tests/aws/services/dynamodb",
         "tests/aws/services/events",
-        "tests/aws/services/iam",
         "tests/aws/services/kinesis",
         "tests/aws/services/kms",
         "tests/aws/services/lambda_",

--- a/tests/aws/services/iam/test_iam.py
+++ b/tests/aws/services/iam/test_iam.py
@@ -869,8 +869,8 @@ class TestIAMServiceSpecificCredentials:
     @pytest.fixture(autouse=True)
     def register_snapshot_transformers(self, snapshot):
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.key_value_length("ServicePassword"))
-        snapshot.add_transformer(snapshot.transform.key_value_length("ServiceSpecificCredentialId"))
+        snapshot.add_transformer(snapshot.transform.key_value("ServicePassword"))
+        snapshot.add_transformer(snapshot.transform.key_value("ServiceSpecificCredentialId"))
 
     @pytest.fixture
     def create_service_specific_credential(self, aws_client):

--- a/tests/aws/services/iam/test_iam.snapshot.json
+++ b/tests/aws/services/iam/test_iam.snapshot.json
@@ -565,7 +565,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_service_specific_credential_lifecycle[codecommit.amazonaws.com]": {
-    "recorded-date": "06-03-2025, 14:28:04",
+    "recorded-date": "06-03-2025, 16:58:34",
     "recorded-content": {
       "create-user-response": {
         "User": {
@@ -584,8 +584,8 @@
         "ServiceSpecificCredential": {
           "CreateDate": "<datetime>",
           "ServiceName": "codecommit.amazonaws.com",
-          "ServicePassword": "<service-password(60):1>",
-          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServicePassword": "<service-password:1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
           "ServiceUserName": "<user-name:1>-at-111111111111",
           "Status": "Active",
           "UserName": "<user-name:1>"
@@ -600,7 +600,7 @@
           {
             "CreateDate": "<datetime>",
             "ServiceName": "codecommit.amazonaws.com",
-            "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+            "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
             "ServiceUserName": "<user-name:1>-at-111111111111",
             "Status": "Active",
             "UserName": "<user-name:1>"
@@ -622,7 +622,7 @@
           {
             "CreateDate": "<datetime>",
             "ServiceName": "codecommit.amazonaws.com",
-            "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+            "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
             "ServiceUserName": "<user-name:1>-at-111111111111",
             "Status": "Inactive",
             "UserName": "<user-name:1>"
@@ -637,8 +637,8 @@
         "ServiceSpecificCredential": {
           "CreateDate": "<datetime>",
           "ServiceName": "codecommit.amazonaws.com",
-          "ServicePassword": "<service-password(60):2>",
-          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServicePassword": "<service-password:2>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
           "ServiceUserName": "<user-name:1>-at-111111111111",
           "Status": "Inactive",
           "UserName": "<user-name:1>"
@@ -657,7 +657,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_service_specific_credential_lifecycle[cassandra.amazonaws.com]": {
-    "recorded-date": "06-03-2025, 14:28:06",
+    "recorded-date": "06-03-2025, 16:58:36",
     "recorded-content": {
       "create-user-response": {
         "User": {
@@ -676,8 +676,8 @@
         "ServiceSpecificCredential": {
           "CreateDate": "<datetime>",
           "ServiceName": "cassandra.amazonaws.com",
-          "ServicePassword": "<service-password(60):1>",
-          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServicePassword": "<service-password:1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
           "ServiceUserName": "<user-name:1>-at-111111111111",
           "Status": "Active",
           "UserName": "<user-name:1>"
@@ -692,7 +692,7 @@
           {
             "CreateDate": "<datetime>",
             "ServiceName": "cassandra.amazonaws.com",
-            "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+            "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
             "ServiceUserName": "<user-name:1>-at-111111111111",
             "Status": "Active",
             "UserName": "<user-name:1>"
@@ -714,7 +714,7 @@
           {
             "CreateDate": "<datetime>",
             "ServiceName": "cassandra.amazonaws.com",
-            "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+            "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
             "ServiceUserName": "<user-name:1>-at-111111111111",
             "Status": "Inactive",
             "UserName": "<user-name:1>"
@@ -729,8 +729,8 @@
         "ServiceSpecificCredential": {
           "CreateDate": "<datetime>",
           "ServiceName": "cassandra.amazonaws.com",
-          "ServicePassword": "<service-password(60):2>",
-          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServicePassword": "<service-password:2>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
           "ServiceUserName": "<user-name:1>-at-111111111111",
           "Status": "Inactive",
           "UserName": "<user-name:1>"
@@ -765,7 +765,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_create_service_specific_credential_invalid_user": {
-    "recorded-date": "06-03-2025, 14:27:10",
+    "recorded-date": "06-03-2025, 16:58:36",
     "recorded-content": {
       "invalid-user-name-exception": {
         "Error": {
@@ -792,7 +792,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_create_service_specific_credential_invalid_service": {
-    "recorded-date": "06-03-2025, 14:27:11",
+    "recorded-date": "06-03-2025, 16:58:38",
     "recorded-content": {
       "create-user-response": {
         "User": {
@@ -843,7 +843,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_list_service_specific_credential_different_service": {
-    "recorded-date": "06-03-2025, 14:27:13",
+    "recorded-date": "06-03-2025, 16:58:39",
     "recorded-content": {
       "create-user-response": {
         "User": {
@@ -873,8 +873,8 @@
         "ServiceSpecificCredential": {
           "CreateDate": "<datetime>",
           "ServiceName": "codecommit.amazonaws.com",
-          "ServicePassword": "<service-password(60):1>",
-          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServicePassword": "<service-password:1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
           "ServiceUserName": "<user-name:1>-at-111111111111",
           "Status": "Active",
           "UserName": "<user-name:1>"
@@ -894,7 +894,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_delete_user_after_service_credential_created": {
-    "recorded-date": "06-03-2025, 14:27:14",
+    "recorded-date": "06-03-2025, 16:58:41",
     "recorded-content": {
       "create-user-response": {
         "User": {
@@ -913,8 +913,8 @@
         "ServiceSpecificCredential": {
           "CreateDate": "<datetime>",
           "ServiceName": "codecommit.amazonaws.com",
-          "ServicePassword": "<service-password(60):1>",
-          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServicePassword": "<service-password:1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
           "ServiceUserName": "<user-name:1>-at-111111111111",
           "Status": "Active",
           "UserName": "<user-name:1>"
@@ -938,7 +938,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_user_match_id_mismatch[totally-wrong-credential-id-with-hyphens]": {
-    "recorded-date": "06-03-2025, 14:27:18",
+    "recorded-date": "06-03-2025, 16:58:45",
     "recorded-content": {
       "create-user-response": {
         "User": {
@@ -957,8 +957,8 @@
         "ServiceSpecificCredential": {
           "CreateDate": "<datetime>",
           "ServiceName": "codecommit.amazonaws.com",
-          "ServicePassword": "<service-password(60):1>",
-          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServicePassword": "<service-password:1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
           "ServiceUserName": "<user-name:1>-at-111111111111",
           "Status": "Active",
           "UserName": "<user-name:1>"
@@ -1004,7 +1004,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_user_match_id_mismatch[satisfiesregexbutstillinvalid]": {
-    "recorded-date": "06-03-2025, 14:27:20",
+    "recorded-date": "06-03-2025, 16:58:47",
     "recorded-content": {
       "create-user-response": {
         "User": {
@@ -1023,8 +1023,8 @@
         "ServiceSpecificCredential": {
           "CreateDate": "<datetime>",
           "ServiceName": "codecommit.amazonaws.com",
-          "ServicePassword": "<service-password(60):1>",
-          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServicePassword": "<service-password:1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
           "ServiceUserName": "<user-name:1>-at-111111111111",
           "Status": "Active",
           "UserName": "<user-name:1>"
@@ -1070,7 +1070,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_id_match_user_mismatch": {
-    "recorded-date": "06-03-2025, 14:27:16",
+    "recorded-date": "06-03-2025, 16:58:43",
     "recorded-content": {
       "create-user-response": {
         "User": {
@@ -1089,8 +1089,8 @@
         "ServiceSpecificCredential": {
           "CreateDate": "<datetime>",
           "ServiceName": "codecommit.amazonaws.com",
-          "ServicePassword": "<service-password(60):1>",
-          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServicePassword": "<service-password:1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
           "ServiceUserName": "<user-name:1>-at-111111111111",
           "Status": "Active",
           "UserName": "<user-name:1>"
@@ -1136,7 +1136,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_invalid_update_parameters": {
-    "recorded-date": "06-03-2025, 16:38:50",
+    "recorded-date": "06-03-2025, 16:58:49",
     "recorded-content": {
       "create-user-response": {
         "User": {
@@ -1155,8 +1155,8 @@
         "ServiceSpecificCredential": {
           "CreateDate": "<datetime>",
           "ServiceName": "codecommit.amazonaws.com",
-          "ServicePassword": "<service-password(60):1>",
-          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServicePassword": "<service-password:1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id:1>",
           "ServiceUserName": "<user-name:1>-at-111111111111",
           "Status": "Active",
           "UserName": "<user-name:1>"

--- a/tests/aws/services/iam/test_iam.snapshot.json
+++ b/tests/aws/services/iam/test_iam.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_update_assume_role_policy": {
-    "recorded-date": "14-09-2023, 17:42:36",
+    "recorded-date": "06-03-2025, 12:24:58",
     "recorded-content": {
       "created_role": {
         "Role": {
@@ -21,7 +21,7 @@
             ],
             "Version": "2012-10-17"
           },
-          "CreateDate": "datetime",
+          "CreateDate": "<datetime>",
           "Path": "/",
           "RoleId": "<role-id:1>",
           "RoleName": "<role-name:1>"
@@ -40,7 +40,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMExtensions::test_create_role_with_malformed_assume_role_policy_document": {
-    "recorded-date": "14-09-2023, 17:07:51",
+    "recorded-date": "06-03-2025, 12:24:44",
     "recorded-content": {
       "invalid-json": {
         "Error": {
@@ -56,7 +56,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_list_roles_with_permission_boundary": {
-    "recorded-date": "14-09-2023, 17:42:39",
+    "recorded-date": "06-03-2025, 12:25:01",
     "recorded-content": {
       "created_role": {
         "Role": {
@@ -73,7 +73,7 @@
             ],
             "Version": "2012-10-17"
           },
-          "CreateDate": "datetime",
+          "CreateDate": "<datetime>",
           "Path": "/<path-prefix>/",
           "RoleId": "<role-id:1>",
           "RoleName": "<role-name:1>"
@@ -100,7 +100,7 @@
               ],
               "Version": "2012-10-17"
             },
-            "CreateDate": "datetime",
+            "CreateDate": "<datetime>",
             "MaxSessionDuration": 3600,
             "Path": "/<path-prefix>/",
             "RoleId": "<role-id:1>",
@@ -115,7 +115,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_create_describe_role": {
-    "recorded-date": "14-09-2023, 17:42:37",
+    "recorded-date": "06-03-2025, 12:24:59",
     "recorded-content": {
       "create_role_result": {
         "Role": {
@@ -132,7 +132,7 @@
             ],
             "Version": "2012-10-17"
           },
-          "CreateDate": "datetime",
+          "CreateDate": "<datetime>",
           "Path": "/<path-prefix>/",
           "RoleId": "<role-id:1>",
           "RoleName": "<role-name:1>"
@@ -157,7 +157,7 @@
             ],
             "Version": "2012-10-17"
           },
-          "CreateDate": "datetime",
+          "CreateDate": "<datetime>",
           "MaxSessionDuration": 3600,
           "Path": "/<path-prefix>/",
           "RoleId": "<role-id:1>",
@@ -186,7 +186,7 @@
               ],
               "Version": "2012-10-17"
             },
-            "CreateDate": "datetime",
+            "CreateDate": "<datetime>",
             "MaxSessionDuration": 3600,
             "Path": "/<path-prefix>/",
             "RoleId": "<role-id:1>",
@@ -201,20 +201,20 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_role_attach_policy": {
-    "recorded-date": "14-09-2023, 17:42:42",
+    "recorded-date": "06-03-2025, 12:25:04",
     "recorded-content": {
       "create_policy_response": {
         "Policy": {
           "Arn": "arn:<partition>:iam::111111111111:policy/<policy-name:1>",
           "AttachmentCount": 0,
-          "CreateDate": "datetime",
+          "CreateDate": "<datetime>",
           "DefaultVersionId": "v1",
           "IsAttachable": true,
           "Path": "/",
           "PermissionsBoundaryUsageCount": 0,
           "PolicyId": "<policy-id:1>",
           "PolicyName": "<policy-name:1>",
-          "UpdateDate": "datetime"
+          "UpdateDate": "<datetime>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -223,8 +223,8 @@
       },
       "non_existent_malformed_policy_arn": {
         "Error": {
-          "Code": "InvalidInput",
-          "Message": "ARN longpolicynamebutnoarn is not valid.",
+          "Code": "ValidationError",
+          "Message": "Invalid ARN:  Could not be parsed!",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -234,8 +234,8 @@
       },
       "existing_policy_name_provided": {
         "Error": {
-          "Code": "InvalidInput",
-          "Message": "ARN <policy-name:1> is not valid.",
+          "Code": "ValidationError",
+          "Message": "Invalid ARN:  Could not be parsed!",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -263,20 +263,20 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_user_attach_policy": {
-    "recorded-date": "14-09-2023, 17:42:45",
+    "recorded-date": "06-03-2025, 12:25:06",
     "recorded-content": {
       "create_policy_response": {
         "Policy": {
           "Arn": "arn:<partition>:iam::111111111111:policy/<policy-name:1>",
           "AttachmentCount": 0,
-          "CreateDate": "datetime",
+          "CreateDate": "<datetime>",
           "DefaultVersionId": "v1",
           "IsAttachable": true,
           "Path": "/",
           "PermissionsBoundaryUsageCount": 0,
           "PolicyId": "<policy-id:1>",
           "PolicyName": "<policy-name:1>",
-          "UpdateDate": "datetime"
+          "UpdateDate": "<datetime>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -285,8 +285,8 @@
       },
       "non_existent_malformed_policy_arn": {
         "Error": {
-          "Code": "InvalidInput",
-          "Message": "ARN longpolicynamebutnoarn is not valid.",
+          "Code": "ValidationError",
+          "Message": "Invalid ARN:  Could not be parsed!",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -296,8 +296,8 @@
       },
       "existing_policy_name_provided": {
         "Error": {
-          "Code": "InvalidInput",
-          "Message": "ARN <policy-name:1> is not valid.",
+          "Code": "ValidationError",
+          "Message": "Invalid ARN:  Could not be parsed!",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -325,7 +325,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMExtensions::test_role_with_path_lifecycle": {
-    "recorded-date": "21-06-2024, 12:13:05",
+    "recorded-date": "06-03-2025, 12:24:45",
     "recorded-content": {
       "create-role-response": {
         "Role": {
@@ -342,7 +342,7 @@
             ],
             "Version": "2012-10-17"
           },
-          "CreateDate": "datetime",
+          "CreateDate": "<datetime>",
           "Path": "<path>",
           "RoleId": "<role-id:1>",
           "RoleName": "<role-name:1>"
@@ -367,7 +367,7 @@
             ],
             "Version": "2012-10-17"
           },
-          "CreateDate": "datetime",
+          "CreateDate": "<datetime>",
           "MaxSessionDuration": 3600,
           "Path": "<path>",
           "RoleId": "<role-id:1>",
@@ -388,7 +388,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_user_policy_encoding": {
-    "recorded-date": "25-09-2024, 15:10:45",
+    "recorded-date": "06-03-2025, 12:25:08",
     "recorded-content": {
       "get-policy-response": {
         "PolicyDocument": {
@@ -415,7 +415,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_role_policy_encoding": {
-    "recorded-date": "30-09-2024, 15:17:42",
+    "recorded-date": "06-03-2025, 12:25:09",
     "recorded-content": {
       "create-role-response": {
         "Role": {
@@ -437,7 +437,7 @@
             ],
             "Version": "2012-10-17"
           },
-          "CreateDate": "datetime",
+          "CreateDate": "<datetime>",
           "Path": "<path:1>",
           "RoleId": "<role-id:1>",
           "RoleName": "<role-name:1>"
@@ -489,7 +489,7 @@
             ],
             "Version": "2012-10-17"
           },
-          "CreateDate": "datetime",
+          "CreateDate": "<datetime>",
           "MaxSessionDuration": 3600,
           "Path": "<path:1>",
           "RoleId": "<role-id:1>",
@@ -523,7 +523,7 @@
               ],
               "Version": "2012-10-17"
             },
-            "CreateDate": "datetime",
+            "CreateDate": "<datetime>",
             "MaxSessionDuration": 3600,
             "Path": "<path:1>",
             "RoleId": "<role-id:1>",
@@ -538,7 +538,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_group_policy_encoding": {
-    "recorded-date": "25-09-2024, 15:10:47",
+    "recorded-date": "06-03-2025, 12:25:10",
     "recorded-content": {
       "get-policy-response": {
         "GroupName": "<group-name:1>",
@@ -560,6 +560,621 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_service_specific_credential_lifecycle[codecommit.amazonaws.com]": {
+    "recorded-date": "06-03-2025, 14:28:04",
+    "recorded-content": {
+      "create-user-response": {
+        "User": {
+          "Arn": "arn:<partition>:iam::111111111111:user/<user-name:1>",
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "UserId": "<user-id:1>",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-service-specific-credential-response": {
+        "ServiceSpecificCredential": {
+          "CreateDate": "<datetime>",
+          "ServiceName": "codecommit.amazonaws.com",
+          "ServicePassword": "<service-password(60):1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServiceUserName": "<user-name:1>-at-111111111111",
+          "Status": "Active",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-service-specific-credentials-response-before-update": {
+        "ServiceSpecificCredentials": [
+          {
+            "CreateDate": "<datetime>",
+            "ServiceName": "codecommit.amazonaws.com",
+            "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+            "ServiceUserName": "<user-name:1>-at-111111111111",
+            "Status": "Active",
+            "UserName": "<user-name:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-service-specific-credential-response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-service-specific-credentials-response-after-update": {
+        "ServiceSpecificCredentials": [
+          {
+            "CreateDate": "<datetime>",
+            "ServiceName": "codecommit.amazonaws.com",
+            "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+            "ServiceUserName": "<user-name:1>-at-111111111111",
+            "Status": "Inactive",
+            "UserName": "<user-name:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "reset-service-specific-credential-response": {
+        "ServiceSpecificCredential": {
+          "CreateDate": "<datetime>",
+          "ServiceName": "codecommit.amazonaws.com",
+          "ServicePassword": "<service-password(60):2>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServiceUserName": "<user-name:1>-at-111111111111",
+          "Status": "Inactive",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-service-specific-credentials-response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_service_specific_credential_lifecycle[cassandra.amazonaws.com]": {
+    "recorded-date": "06-03-2025, 14:28:06",
+    "recorded-content": {
+      "create-user-response": {
+        "User": {
+          "Arn": "arn:<partition>:iam::111111111111:user/<user-name:1>",
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "UserId": "<user-id:1>",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-service-specific-credential-response": {
+        "ServiceSpecificCredential": {
+          "CreateDate": "<datetime>",
+          "ServiceName": "cassandra.amazonaws.com",
+          "ServicePassword": "<service-password(60):1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServiceUserName": "<user-name:1>-at-111111111111",
+          "Status": "Active",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-service-specific-credentials-response-before-update": {
+        "ServiceSpecificCredentials": [
+          {
+            "CreateDate": "<datetime>",
+            "ServiceName": "cassandra.amazonaws.com",
+            "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+            "ServiceUserName": "<user-name:1>-at-111111111111",
+            "Status": "Active",
+            "UserName": "<user-name:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-service-specific-credential-response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-service-specific-credentials-response-after-update": {
+        "ServiceSpecificCredentials": [
+          {
+            "CreateDate": "<datetime>",
+            "ServiceName": "cassandra.amazonaws.com",
+            "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+            "ServiceUserName": "<user-name:1>-at-111111111111",
+            "Status": "Inactive",
+            "UserName": "<user-name:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "reset-service-specific-credential-response": {
+        "ServiceSpecificCredential": {
+          "CreateDate": "<datetime>",
+          "ServiceName": "cassandra.amazonaws.com",
+          "ServicePassword": "<service-password(60):2>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServiceUserName": "<user-name:1>-at-111111111111",
+          "Status": "Inactive",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-service-specific-credentials-response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_delete_non_existent_policy_returns_no_such_entity": {
+    "recorded-date": "06-03-2025, 12:29:55",
+    "recorded-content": {
+      "delete-non-existent-policy-exc": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "Policy arn:<partition>:iam::111111111111:policy/non-existent-policy was not found.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_create_service_specific_credential_invalid_user": {
+    "recorded-date": "06-03-2025, 14:27:10",
+    "recorded-content": {
+      "invalid-user-name-exception": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "The user with name non-existent-user cannot be found.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "invalid-user-and-service-exception": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "The user with name non-existent-user cannot be found.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_create_service_specific_credential_invalid_service": {
+    "recorded-date": "06-03-2025, 14:27:11",
+    "recorded-content": {
+      "create-user-response": {
+        "User": {
+          "Arn": "arn:<partition>:iam::111111111111:user/<user-name:1>",
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "UserId": "<user-id:1>",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invalid-service-exception": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "No such service nonexistentservice.amazonaws.com is supported for Service Specific Credentials",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "invalid-service-completely-malformed-exception": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "No such service o3on3n3onosneo is supported for Service Specific Credentials",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "invalid-service-existing-but-unsupported-exception": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "No such service lambda.amazonaws.com is supported for Service Specific Credentials",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_list_service_specific_credential_different_service": {
+    "recorded-date": "06-03-2025, 14:27:13",
+    "recorded-content": {
+      "create-user-response": {
+        "User": {
+          "Arn": "arn:<partition>:iam::111111111111:user/<user-name:1>",
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "UserId": "<user-id:1>",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-service-specific-credentials-invalid-service": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "No such service nonexistentservice.amazonaws.com is supported for Service Specific Credentials",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "create-service-specific-credential-response": {
+        "ServiceSpecificCredential": {
+          "CreateDate": "<datetime>",
+          "ServiceName": "codecommit.amazonaws.com",
+          "ServicePassword": "<service-password(60):1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServiceUserName": "<user-name:1>-at-111111111111",
+          "Status": "Active",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-service-specific-credentials-response-wrong-service": {
+        "ServiceSpecificCredentials": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_delete_user_after_service_credential_created": {
+    "recorded-date": "06-03-2025, 14:27:14",
+    "recorded-content": {
+      "create-user-response": {
+        "User": {
+          "Arn": "arn:<partition>:iam::111111111111:user/<user-name:1>",
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "UserId": "<user-id:1>",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-service-specific-credential-response": {
+        "ServiceSpecificCredential": {
+          "CreateDate": "<datetime>",
+          "ServiceName": "codecommit.amazonaws.com",
+          "ServicePassword": "<service-password(60):1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServiceUserName": "<user-name:1>-at-111111111111",
+          "Status": "Active",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-user-existing-credential": {
+        "Error": {
+          "Code": "DeleteConflict",
+          "Message": "Cannot delete entity, must remove referenced objects first.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_user_match_id_mismatch[totally-wrong-credential-id-with-hyphens]": {
+    "recorded-date": "06-03-2025, 14:27:18",
+    "recorded-content": {
+      "create-user-response": {
+        "User": {
+          "Arn": "arn:<partition>:iam::111111111111:user/<user-name:1>",
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "UserId": "<user-id:1>",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-service-specific-credential-response": {
+        "ServiceSpecificCredential": {
+          "CreateDate": "<datetime>",
+          "ServiceName": "codecommit.amazonaws.com",
+          "ServicePassword": "<service-password(60):1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServiceUserName": "<user-name:1>-at-111111111111",
+          "Status": "Active",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-wrong-id": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "1 validation error detected: Value at 'serviceSpecificCredentialId' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\w]+",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "reset-wrong-id": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "1 validation error detected: Value at 'serviceSpecificCredentialId' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\w]+",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "delete-wrong-id": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "1 validation error detected: Value at 'serviceSpecificCredentialId' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\w]+",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_user_match_id_mismatch[satisfiesregexbutstillinvalid]": {
+    "recorded-date": "06-03-2025, 14:27:20",
+    "recorded-content": {
+      "create-user-response": {
+        "User": {
+          "Arn": "arn:<partition>:iam::111111111111:user/<user-name:1>",
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "UserId": "<user-id:1>",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-service-specific-credential-response": {
+        "ServiceSpecificCredential": {
+          "CreateDate": "<datetime>",
+          "ServiceName": "codecommit.amazonaws.com",
+          "ServicePassword": "<service-password(60):1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServiceUserName": "<user-name:1>-at-111111111111",
+          "Status": "Active",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-wrong-id": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "No such credential satisfiesregexbutstillinvalid exists",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "reset-wrong-id": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "No such credential satisfiesregexbutstillinvalid exists",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete-wrong-id": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "No such credential satisfiesregexbutstillinvalid exists",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_id_match_user_mismatch": {
+    "recorded-date": "06-03-2025, 14:27:16",
+    "recorded-content": {
+      "create-user-response": {
+        "User": {
+          "Arn": "arn:<partition>:iam::111111111111:user/<user-name:1>",
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "UserId": "<user-id:1>",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-service-specific-credential-response": {
+        "ServiceSpecificCredential": {
+          "CreateDate": "<datetime>",
+          "ServiceName": "codecommit.amazonaws.com",
+          "ServicePassword": "<service-password(60):1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServiceUserName": "<user-name:1>-at-111111111111",
+          "Status": "Active",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-wrong-user-name": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "The user with name wrong-user-name cannot be found.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "reset-wrong-user-name": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "The user with name wrong-user-name cannot be found.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete-wrong-user-name": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "The user with name wrong-user-name cannot be found.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_invalid_update_parameters": {
+    "recorded-date": "06-03-2025, 16:38:50",
+    "recorded-content": {
+      "create-user-response": {
+        "User": {
+          "Arn": "arn:<partition>:iam::111111111111:user/<user-name:1>",
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "UserId": "<user-id:1>",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-service-specific-credential-response": {
+        "ServiceSpecificCredential": {
+          "CreateDate": "<datetime>",
+          "ServiceName": "codecommit.amazonaws.com",
+          "ServicePassword": "<service-password(60):1>",
+          "ServiceSpecificCredentialId": "<service-specific-credential-id(21):1>",
+          "ServiceUserName": "<user-name:1>-at-111111111111",
+          "Status": "Active",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-invalid-status": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "1 validation error detected: Value at 'status' failed to satisfy constraint: Member must satisfy enum value set",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/iam/test_iam.validation.json
+++ b/tests/aws/services/iam/test_iam.validation.json
@@ -1,32 +1,104 @@
 {
   "tests/aws/services/iam/test_iam.py::TestIAMExtensions::test_create_role_with_malformed_assume_role_policy_document": {
-    "last_validated_date": "2023-09-14T15:07:51+00:00"
+    "last_validated_date": "2025-03-06T12:24:44+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMExtensions::test_create_user_add_permission_boundary_afterwards": {
+    "last_validated_date": "2025-03-06T12:24:43+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMExtensions::test_create_user_with_permission_boundary": {
+    "last_validated_date": "2025-03-06T12:24:41+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMExtensions::test_get_user_without_username_as_role": {
+    "last_validated_date": "2025-03-06T12:24:39+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMExtensions::test_get_user_without_username_as_user": {
+    "last_validated_date": "2025-03-06T12:24:26+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMExtensions::test_role_with_path_lifecycle": {
-    "last_validated_date": "2024-06-21T12:13:05+00:00"
+    "last_validated_date": "2025-03-06T12:24:45+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_attach_detach_role_policy": {
+    "last_validated_date": "2025-03-06T12:24:54+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_attach_iam_role_to_new_iam_user": {
+    "last_validated_date": "2025-03-06T12:24:47+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_create_describe_role": {
-    "last_validated_date": "2023-09-14T15:42:37+00:00"
+    "last_validated_date": "2025-03-06T12:24:59+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_create_role_with_assume_role_policy": {
+    "last_validated_date": "2025-03-06T12:24:57+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_create_user_with_tags": {
+    "last_validated_date": "2025-03-06T12:24:52+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_delete_non_existent_policy_returns_no_such_entity": {
+    "last_validated_date": "2025-03-06T12:29:55+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_instance_profile_tags": {
+    "last_validated_date": "2025-03-06T12:24:52+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_list_roles_with_permission_boundary": {
-    "last_validated_date": "2023-09-14T15:42:39+00:00"
+    "last_validated_date": "2025-03-06T12:25:00+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_recreate_iam_role": {
+    "last_validated_date": "2025-03-06T12:24:48+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_role_attach_policy": {
-    "last_validated_date": "2023-09-14T15:42:42+00:00"
+    "last_validated_date": "2025-03-06T12:25:03+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_update_assume_role_policy": {
-    "last_validated_date": "2023-09-14T15:42:36+00:00"
+    "last_validated_date": "2025-03-06T12:24:58+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_user_attach_policy": {
-    "last_validated_date": "2023-09-14T15:42:45+00:00"
+    "last_validated_date": "2025-03-06T12:25:05+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_group_policy_encoding": {
-    "last_validated_date": "2024-09-25T15:12:26+00:00"
+    "last_validated_date": "2025-03-06T12:25:10+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_role_policy_encoding": {
-    "last_validated_date": "2024-09-30T15:17:41+00:00"
+    "last_validated_date": "2025-03-06T12:25:09+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_user_policy_encoding": {
-    "last_validated_date": "2024-09-25T15:12:23+00:00"
+    "last_validated_date": "2025-03-06T12:25:07+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_create_service_specific_credential_invalid_service": {
+    "last_validated_date": "2025-03-06T14:27:11+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_create_service_specific_credential_invalid_user": {
+    "last_validated_date": "2025-03-06T14:27:10+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_delete_user_after_service_credential_created": {
+    "last_validated_date": "2025-03-06T14:27:13+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_id_match_user_mismatch": {
+    "last_validated_date": "2025-03-06T14:27:15+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_invalid_update_parameters": {
+    "last_validated_date": "2025-03-06T16:38:49+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_list_service_specific_credential_different_service": {
+    "last_validated_date": "2025-03-06T14:27:12+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_service_specific_credential_lifecycle": {
+    "last_validated_date": "2025-03-05T17:56:55+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_service_specific_credential_lifecycle[cassandra.amazonaws.com]": {
+    "last_validated_date": "2025-03-06T14:28:06+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_service_specific_credential_lifecycle[codecommit.amazonaws.com]": {
+    "last_validated_date": "2025-03-06T14:28:04+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_user_id_mismatch": {
+    "last_validated_date": "2025-03-06T13:34:01+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_user_match_id_mismatch": {
+    "last_validated_date": "2025-03-06T13:36:53+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_user_match_id_mismatch[satisfiesregexbutstillinvalid]": {
+    "last_validated_date": "2025-03-06T14:27:19+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_user_match_id_mismatch[totally-wrong-credential-id-with-hyphens]": {
+    "last_validated_date": "2025-03-06T14:27:17+00:00"
   }
 }

--- a/tests/aws/services/iam/test_iam.validation.json
+++ b/tests/aws/services/iam/test_iam.validation.json
@@ -63,31 +63,31 @@
     "last_validated_date": "2025-03-06T12:25:07+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_create_service_specific_credential_invalid_service": {
-    "last_validated_date": "2025-03-06T14:27:11+00:00"
+    "last_validated_date": "2025-03-06T16:58:37+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_create_service_specific_credential_invalid_user": {
-    "last_validated_date": "2025-03-06T14:27:10+00:00"
+    "last_validated_date": "2025-03-06T16:58:36+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_delete_user_after_service_credential_created": {
-    "last_validated_date": "2025-03-06T14:27:13+00:00"
+    "last_validated_date": "2025-03-06T16:58:40+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_id_match_user_mismatch": {
-    "last_validated_date": "2025-03-06T14:27:15+00:00"
+    "last_validated_date": "2025-03-06T16:58:42+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_invalid_update_parameters": {
-    "last_validated_date": "2025-03-06T16:38:49+00:00"
+    "last_validated_date": "2025-03-06T16:58:48+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_list_service_specific_credential_different_service": {
-    "last_validated_date": "2025-03-06T14:27:12+00:00"
+    "last_validated_date": "2025-03-06T16:58:39+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_service_specific_credential_lifecycle": {
     "last_validated_date": "2025-03-05T17:56:55+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_service_specific_credential_lifecycle[cassandra.amazonaws.com]": {
-    "last_validated_date": "2025-03-06T14:28:06+00:00"
+    "last_validated_date": "2025-03-06T16:58:35+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_service_specific_credential_lifecycle[codecommit.amazonaws.com]": {
-    "last_validated_date": "2025-03-06T14:28:04+00:00"
+    "last_validated_date": "2025-03-06T16:58:33+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_user_id_mismatch": {
     "last_validated_date": "2025-03-06T13:34:01+00:00"
@@ -96,9 +96,9 @@
     "last_validated_date": "2025-03-06T13:36:53+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_user_match_id_mismatch[satisfiesregexbutstillinvalid]": {
-    "last_validated_date": "2025-03-06T14:27:19+00:00"
+    "last_validated_date": "2025-03-06T16:58:47+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_user_match_id_mismatch[totally-wrong-credential-id-with-hyphens]": {
-    "last_validated_date": "2025-03-06T14:27:17+00:00"
+    "last_validated_date": "2025-03-06T16:58:44+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
IAM users can have service specific credentials assigned to them, they can be used for AWS CodeCommit (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_ssh-keys.html) and Amazon Keyspaces (for Apache Cassandra) (https://docs.aws.amazon.com/keyspaces/latest/devguide/programmatic.credentials.ssc.html).

For now, we need to have an implementation of the CRUD part of this functionality.

This initally depended on localstack/localstack-snapshot#10, but the last commit removes that dependency to avoid this PR being blocked by it.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* LocalStack now supports service specific credential create, list, update, reset and delete operations.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
