### PR TITLE
fix redshift tests if not in docker

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_redshift.py
+++ b/tests/aws/services/cloudformation/resources/test_redshift.py
@@ -3,6 +3,8 @@ import os
 from localstack.testing.pytest import markers
 
 
+# only runs in Docker when run against Pro (since it needs postgres on the system)
+@markers.only_in_docker
 @markers.aws.validated
 def test_redshift_cluster(deploy_cfn_template, aws_client):
     stack = deploy_cfn_template(

--- a/tests/aws/services/redshift/test_redshift.py
+++ b/tests/aws/services/redshift/test_redshift.py
@@ -7,6 +7,8 @@ from localstack.utils.sync import retry
 
 
 class TestRedshift:
+    # only runs in Docker when run against Pro (since it needs postgres on the system)
+    @markers.only_in_docker
     @markers.aws.validated
     def test_create_clusters(self, aws_client):
         # create


### PR DESCRIPTION
## Motivation
Redshift in LocalStack Pro now fails when it cannot install a database (fail fast).
This breaks two RedShift CloudFormation tests, when not executed against LocalStack in the Docker container.
This PR adds markers to avoid the execution of these tests if executed outside of Docker.

## Changes
- Add `only_in_docker` marker to:
  - `test_redshift_cluster (tests.aws.services.cloudformation.resources.test_redshift)`
  - `test_create_clusters (tests.aws.services.redshift.test_redshift.TestRedshift)`