### PR TITLE
CI/CD: More informative linter output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ test-coverage: test	  ## Run automated tests and create coverage report
 
 lint:              		  ## Run code linter to check code style, check if formatter would make changes and check if dependency pins need to be updated
 	@[ -f localstack-core/localstack/__init__.py ] && echo "localstack-core/localstack/__init__.py will break packaging." && exit 1 || :
-	($(VENV_RUN); python -m ruff check --output-format=full . && python -m ruff format --check .)
+	($(VENV_RUN); python -m ruff check --output-format=full . && python -m ruff format --check --diff .)
 	$(VENV_RUN); pre-commit run check-pinned-deps-for-needed-upgrade --files pyproject.toml # run pre-commit hook manually here to ensure that this check runs in CI as well
 	$(VENV_RUN); openapi-spec-validator localstack-core/localstack/openapi.yaml
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

First time or sporadic contributors may have missed installing the `pre-commit` hook. In this situation, un-formatted code may be accidentally pushed. In such case, [the output of the linter](https://app.circleci.com/pipelines/github/localstack/localstack/31434/workflows/8d86be97-dbae-4d85-81a0-224258118466/jobs/280447) is not very informative:

```
Would reformat: tests/aws/services/kms/test_kms.py
1 file would be reformatted, 1815 files already formatted
make: *** [Makefile:121: lint] Error 1

Exited with code exit status 2
```

The goal is to make the output of the linter more informative, so the actual cause of the problem is clearer which could result in a better developer experience.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Adding the `--diff` option to the [`python -m ruff format --check .` command](https://github.com/localstack/localstack/blob/e9777b7068f19275bfb80e34aaa292b28294a7b4/Makefile#L138-L139).

So the output would show the difference between the current file and how the formatted file would look like. For instance, the previous example would look like this:

```
python -m ruff format --check --diff .
--- tests/aws/services/kms/test_kms.py
+++ tests/aws/services/kms/test_kms.py
@@ -1099,7 +1099,9 @@
         assert aws_client.kms.get_key_rotation_status(KeyId=key_id)["KeyRotationEnabled"] is False
 
     @markers.aws.validated
-    def test_rotate_key_on_demand_succeeds_given_symmetric_key_preserving_automatic_rotation_schedules(self, kms_key, aws_client):
+    def test_rotate_key_on_demand_succeeds_given_symmetric_key_preserving_automatic_rotation_schedules(
+        self, kms_key, aws_client
+    ):
         key_id = kms_key["KeyId"]
 
         rotation_status_response_before = aws_client.kms.get_key_rotation_status(KeyId=key_id)
```

If the output is too verbose, `| top 10` could be added to trim the output while still being informative.

Unfortunately `ruff` doesn't seem to have a less verbose output as other linters may have, `--diff` seems the only option available to get feedback of the problems found.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
