### PR TITLE
Remove version attribute from docker compose files

### DIFF
--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The `version` top-level element in docker compose files is obsolete in docker compose v2 (https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete).

It will print a warning when used, like this:

```
WARN[0000] /path/to/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

It is only used for docker compose v1, which stopped receiving updates and is considered EOL since July 2023 (https://docs.docker.com/compose/releases/migrate/).

It was marked deprecated already in 2021 (https://github.com/compose-spec/compose-spec/commit/85d1bcfc07462fbfc645882a4ca1901012075cf6).
It should also be supported by later docker compose v1 versions (1.27.0+), after the compose format merging (https://docs.docker.com/compose/releases/release-notes/#1270).

Users with an old docker compose version who cannot upgrade, can still manually add the version tag `version: 3.8`.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Users should no longer get a warning about the obsolete version attribute when running our docker compose files.
* Remove version attributes.

<!-- Optional section: What's left to do before it can be merged? -->
## TODO

What's left to do:

- [ ] Update docs in a similar fashion.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->
