### PR TITLE
Add CIDR reservation support for subnets

### DIFF
--- a/localstack-core/localstack/services/ec2/exceptions.py
+++ b/localstack-core/localstack/services/ec2/exceptions.py
@@ -78,3 +78,11 @@ class InvalidVpcDuplicateCustomIdError(CommonServiceException):
             code="InvalidVpc.DuplicateCustomId",
             message=f"VPC with custom id '{custom_id}' already exists",
         )
+
+
+class CidrBlockReservationError(CommonServiceException):
+    def __init__(self, message):
+        super().__init__(
+            code="CidrBlockReservationError",
+            message=message,
+        )

--- a/localstack-core/localstack/services/ec2/models.py
+++ b/localstack-core/localstack/services/ec2/models.py
@@ -25,3 +25,18 @@ def get_state(self):
 
 Subnet.__setstate__ = set_state
 Subnet.__getstate__ = get_state
+
+
+def reserve_cidr_block(self, subnet_id: str, cidr_block: str):
+    subnet = self.get_subnet(subnet_id)
+    if not subnet:
+        raise ValueError(f"Subnet with ID {subnet_id} not found")
+    if not subnet.cidr_block:
+        raise ValueError(f"Subnet with ID {subnet_id} does not have a CIDR block")
+    if cidr_block in subnet.reserved_cidr_blocks:
+        raise ValueError(f"CIDR block {cidr_block} is already reserved in subnet {subnet_id}")
+    subnet.reserved_cidr_blocks.append(cidr_block)
+    return {"SubnetId": subnet_id, "CidrBlock": cidr_block}
+
+
+Subnet.reserve_cidr_block = reserve_cidr_block

--- a/localstack-core/localstack/services/ec2/patches.py
+++ b/localstack-core/localstack/services/ec2/patches.py
@@ -197,3 +197,20 @@ def apply_patches():
                 )
 
         return result
+
+    @patch(ec2_models.subnets.Subnet.reserve_cidr_block)
+    def patch_reserve_cidr_block(
+        fn: ec2_models.subnets.Subnet.reserve_cidr_block,
+        self: ec2_models.subnets.Subnet,
+        subnet_id: str,
+        cidr_block: str,
+    ):
+        subnet = self.get_subnet(subnet_id)
+        if not subnet:
+            raise ValueError(f"Subnet with ID {subnet_id} not found")
+        if not subnet.cidr_block:
+            raise ValueError(f"Subnet with ID {subnet_id} does not have a CIDR block")
+        if cidr_block in subnet.reserved_cidr_blocks:
+            raise ValueError(f"CIDR block {cidr_block} is already reserved in subnet {subnet_id}")
+        subnet.reserved_cidr_blocks.append(cidr_block)
+        return {"SubnetId": subnet_id, "CidrBlock": cidr_block}

--- a/localstack-core/localstack/services/ec2/provider.py
+++ b/localstack-core/localstack/services/ec2/provider.py
@@ -27,6 +27,8 @@ from localstack.aws.api.ec2 import (
     CreateFlowLogsResult,
     CreateLaunchTemplateRequest,
     CreateLaunchTemplateResult,
+    CreateSubnetCidrReservationRequest,
+    CreateSubnetCidrReservationResult,
     CreateSubnetRequest,
     CreateSubnetResult,
     CreateTransitGatewayRequest,
@@ -301,6 +303,16 @@ class Ec2Provider(Ec2Api, ABC, ServiceLifecycleHook):
         value = {"HostnameType": host_type}
         backend.modify_subnet_attribute(subnet_id, attr_name, value)
         return response
+
+    @handler("CreateSubnetCidrReservation", expand=False)
+    def create_subnet_cidr_reservation(
+        self, context: RequestContext, request: CreateSubnetCidrReservationRequest
+    ) -> CreateSubnetCidrReservationResult:
+        backend = get_ec2_backend(context.account_id, context.region)
+        subnet_id = request["SubnetId"]
+        cidr_block = request["CidrBlock"]
+        reservation = backend.reserve_cidr_block(subnet_id, cidr_block)
+        return CreateSubnetCidrReservationResult(Reservation=reservation)
 
     @handler("RevokeSecurityGroupEgress", expand=False)
     def revoke_security_group_egress(


### PR DESCRIPTION
Related to #12207

Add support for `create-subnet-cidr-reservation` command to reserve CIDR blocks within a subnet.

* **Provider Implementation**
  - Add `create_subnet_cidr_reservation` handler method in `localstack-core/localstack/services/ec2/provider.py`.
  - Implement logic to reserve CIDR blocks within a subnet in the `create_subnet_cidr_reservation` method.
  - Update `Ec2Provider` class to include the new handler method.

* **Model Changes**
  - Add `reserve_cidr_block` method to the `Subnet` class in `localstack-core/localstack/services/ec2/models.py`.
  - Update `get_ec2_backend` function to include the new `reserve_cidr_block` method.

* **Patch Changes**
  - Add `patch_reserve_cidr_block` method in `localstack-core/localstack/services/ec2/patches.py`.
  - Update `apply_patches` function to include the new `patch_reserve_cidr_block` method.

* **Exception Handling**
  - Add `CidrBlockReservationError` exception class in `localstack-core/localstack/services/ec2/exceptions.py`.


I have read the CLA Document and I hereby sign the CLA

