### PR TITLE
[ESM] Reset shards in StreamPoller for DDB Local errors

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
@@ -164,7 +164,7 @@ class EsmWorker:
                 # If the event source is empty, backoff
                 poll_interval_duration = empty_boff.next_backoff()
                 LOG.debug(
-                    "The event source %s is empty. Backing off for %s seconds until next request.",
+                    "The event source %s is empty. Backing off for %.2d seconds until next request.",
                     miss_ex.source_arn,
                     poll_interval_duration,
                 )

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
@@ -164,7 +164,7 @@ class EsmWorker:
                 # If the event source is empty, backoff
                 poll_interval_duration = empty_boff.next_backoff()
                 LOG.debug(
-                    "The event source %s is empty. Backing off for %.2d seconds until next request.",
+                    "The event source %s is empty. Backing off for %.2f seconds until next request.",
                     miss_ex.source_arn,
                     poll_interval_duration,
                 )

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/poller.py
@@ -68,6 +68,8 @@ class Poller(ABC):
         """Return the event source metadata (e.g., aws:sqs)"""
         pass
 
+    # TODO: create an abstract fetch_records method that all children should implement. This will unify how poller's internally retreive data from an event
+    # source and make for much easier error handling.
     @abstractmethod
     def poll_events(self) -> None:
         """Poll events polled from the event source and matching at least one filter criteria and invoke the target processor."""

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -163,6 +163,7 @@ class StreamPoller(Poller):
         get_records_response = self.get_records(shard_iterator)
         records = get_records_response.get("Records", [])
         if not records:
+            self.shards[shard_id] = get_records_response["NextShardIterator"]
             raise EmptyPollResultsException(service=self.event_source(), source_arn=self.source_arn)
 
         polled_events = self.transform_into_events(records, shard_id)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Shards were not being reset when a DynamoDBPoller encountered a `TrimmedDataAccessException` exception, placing the StreamPoller into an unrecoverable state instead of re-initialising and proceeding. 

In addition, when shard/iterator initialisation failed, the subsequent `current_shard_tuple` was set to `None`, failing to be unpacked into the `self.poll_events_from_shard(*current_shard_tuple)` and raising a type exception.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Always propogate an exception from a `StreamPoller::get_records` call to the worker loop -- allowing for back-off between retries.
- Raise an exception when shard and iterator initialisation fails.


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
