### PR TITLE
Use per-file-target-version to define Python 3.9 for CLI code

### DIFF
--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -282,7 +282,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                     "Timestamp": timestamp,
                     "Value": value,
                 }
-                for timestamp, value in zip(timestamps, values)
+                for timestamp, value in zip(timestamps, values, strict=False)
             ]
 
             pagination = PaginatedList(timestamp_value_dicts)

--- a/localstack-core/localstack/utils/analytics/usage.py
+++ b/localstack-core/localstack/utils/analytics/usage.py
@@ -17,6 +17,7 @@ from localstack.utils.analytics.publisher import AnalyticsClientPublisher
 # Counters have to register with the registry
 collector_registry: dict[str, Any] = dict()
 
+
 # TODO: introduce some base abstraction for the counters after gather some initial experience working with it
 #  we could probably do intermediate aggregations over time to avoid unbounded counters for very long LS sessions
 #  for now, we can recommend to use config.DISABLE_EVENTS=1
@@ -119,22 +120,21 @@ class TimingStats:
         result = {}
         if self.state:
             for aggregation in self.aggregations:
-                match aggregation:
-                    case "sum":
-                        result[aggregation] = sum(self.state)
-                    case "min":
-                        result[aggregation] = min(self.state)
-                    case "max":
-                        result[aggregation] = max(self.state)
-                    case "mean":
-                        result[aggregation] = sum(self.state) / len(self.state)
-                    case "median":
-                        median_index = math.floor(len(self.state) / 2)
-                        result[aggregation] = sorted(self.state)[median_index]
-                    case "count":
-                        result[aggregation] = len(self.state)
-                    case _:
-                        raise Exception(f"Unsupported aggregation: {aggregation}")
+                if aggregation == "sum":
+                    result[aggregation] = sum(self.state)
+                elif aggregation == "min":
+                    result[aggregation] = min(self.state)
+                elif aggregation == "max":
+                    result[aggregation] = max(self.state)
+                elif aggregation == "mean":
+                    result[aggregation] = sum(self.state) / len(self.state)
+                elif aggregation == "median":
+                    median_index = math.floor(len(self.state) / 2)
+                    result[aggregation] = sorted(self.state)[median_index]
+                elif aggregation == "count":
+                    result[aggregation] = len(self.state)
+                else:
+                    raise Exception(f"Unsupported aggregation: {aggregation}")
         return result
 
 

--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -297,7 +297,9 @@ class PortMappings:
                     bind_port(bind_address, host_port),
                 )
                 for container_port, host_port in zip(
-                    range(to_range[0], to_range[1] + 1), range(from_range[0], from_range[1] + 1)
+                    range(to_range[0], to_range[1] + 1),
+                    range(from_range[0], from_range[1] + 1),
+                    strict=False,
                 )
             ]
 

--- a/localstack-core/localstack/utils/functions.py
+++ b/localstack-core/localstack/utils/functions.py
@@ -70,7 +70,7 @@ def prevent_stack_overflow(match_parameters=False):
 
                 # construct dict of arguments the original function has been called with
                 sig = inspect.signature(wrapped)
-                this_call_args = dict(zip(sig.parameters.keys(), args))
+                this_call_args = dict(zip(sig.parameters.keys(), args, strict=False))
                 this_call_args.update(kwargs)
 
                 return prev_call_args == this_call_args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "localstack-core"
 authors = [
-        { name = "LocalStack Contributors", email = "info@localstack.cloud" }
+    { name = "LocalStack Contributors", email = "info@localstack.cloud" }
 ]
 description = "The core library and runtime of LocalStack"
 requires-python = ">=3.9"
@@ -149,10 +149,10 @@ script-files = [
     "bin/localstack.bat",
     "bin/localstack-supervisor",
 ]
-package-dir = { "" = "localstack-core"}
+package-dir = { "" = "localstack-core" }
 
 [tool.setuptools.dynamic]
-readme = { file = ["README.md"], content-type = "text/markdown"}
+readme = { file = ["README.md"], content-type = "text/markdown" }
 
 [tool.setuptools.packages.find]
 where = ["localstack-core/"]
@@ -174,8 +174,8 @@ exclude = ["tests*"]
 ]
 
 [tool.ruff]
-# Always generate Python 3.9-compatible code.
-target-version = "py39"
+# Generate code compatible with version defined in .python-version
+target-version = "py311"
 line-length = 100
 src = ["localstack-core", "tests"]
 exclude = [
@@ -190,7 +190,18 @@ exclude = [
     "localstack-core/.filesystem",
     ".git",
     "localstack-core/localstack/services/stepfunctions/asl/antlr/runtime"
-    ]
+]
+
+[tool.ruff.per-file-target-version]
+# Only allow minimum version for code used in the CLI
+"localstack-core/localstack/cli/**" = "py39"
+"localstack-core/localstack/packages/**" = "py39"
+"localstack-core/localstack/config.py" = "py39"
+"localstack-core/localstack/constants.py" = "py39"
+"localstack-core/localstack/utils/analytics/**" = "py39"
+"localstack/utils/bootstrap.py" = "py39"
+"localstack-core/localstack/utils/json.py" = "py39"
+
 
 [tool.ruff.lint]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,7 @@ exclude = [
 "localstack-core/localstack/config.py" = "py39"
 "localstack-core/localstack/constants.py" = "py39"
 "localstack-core/localstack/utils/analytics/**" = "py39"
-"localstack/utils/bootstrap.py" = "py39"
+"localstack-core/localstack/utils/bootstrap.py" = "py39"
 "localstack-core/localstack/utils/json.py" = "py39"
 
 

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -1588,7 +1588,7 @@ class TestEventRule:
 
         # create rules
         sources = ["source-one", "source-two", "source-three"]
-        for i, source in zip(range(3), sources):
+        for i, source in zip(range(3), sources, strict=False):
             rule_name = f"test-rule-{i}-{short_uid()}"
             rule = events_put_rule(
                 Name=rule_name,
@@ -1613,7 +1613,7 @@ class TestEventRule:
                 Targets=[{"Id": target_id, "Arn": lambda_function_arn}],
             )
 
-        for i, source in zip(range(3), sources):
+        for i, source in zip(range(3), sources, strict=False):
             num_events = i + 1
             aws_client.events.put_events(
                 Entries=[
@@ -1681,7 +1681,9 @@ class TestEventRule:
                 "InputTemplate": '{"detail-with-id": <detail>}',
             },
         ]
-        for i, pattern, input_transformer in zip(range(2), patterns, input_transformers):
+        for i, pattern, input_transformer in zip(
+            range(2), patterns, input_transformers, strict=False
+        ):
             rule_name = f"test-rule-{i}-{short_uid()}"
             rule = events_put_rule(
                 Name=rule_name,
@@ -1716,7 +1718,7 @@ class TestEventRule:
             {"payload": {"id": "123"}},
             {"id": "123"},
         ]
-        for i, detail in zip(range(2), details):
+        for i, detail in zip(range(2), details, strict=False):
             num_events = i + 1
             aws_client.events.put_events(
                 Entries=[

--- a/tests/aws/services/route53resolver/test_route53resolver.py
+++ b/tests/aws/services/route53resolver/test_route53resolver.py
@@ -818,7 +818,7 @@ class TestRoute53Resolver:
         priorities = [1, 2, 3, 4]
         actions = [Action.ALLOW, Action.ALERT, Action.ALERT, Action.ALLOW]
 
-        for action, priority in zip(actions, priorities):
+        for action, priority in zip(actions, priorities, strict=False):
             domain_list_response = aws_client.route53resolver.create_firewall_domain_list(
                 Name=f"fw-domain-list-{short_uid()}"
             )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

As in dependent repositories, we have an issue with the ASF updates since the latest `ruff` update. The definition of the Python 3.9 target version in linting/formatting leads to syntax errors when enabling preview features like we do in the ASF update action.

To fix that, we need to define our versions correctly depending on if the code runs in the CLI or in the runtime (container)

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Set target version to `py311` matching our `.python-version`
- Set `per-file-target-version` to `py39` for all code accessed in the CLI matching our minimum required version
- Apply changes that are made necessary by upgrading the target version to `py311`
- Make code that can be reached by the CLI `py39` compatible (remove match statement from `usage.py`)

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
