### PR TITLE
chore: improve test snapshot

### DIFF
--- a/tests/aws/services/route53resolver/test_route53resolver.py
+++ b/tests/aws/services/route53resolver/test_route53resolver.py
@@ -570,7 +570,7 @@ class TestRoute53Resolver:
             aws_client.route53resolver.disassociate_resolver_rule(
                 ResolverRuleId="rslvr-123", VPCId="vpc-123"
             )
-        snapshot.match("resource_not_found_res", resource_not_found)
+        snapshot.match("resource_not_found_res", resource_not_found.value.response)
 
     @markers.snapshot.skip_snapshot_verify(
         paths=[

--- a/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
@@ -516,9 +516,19 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_disassociate_non_existent_association": {
-    "recorded-date": "08-09-2023, 10:22:56",
+    "recorded-date": "11-03-2025, 17:07:33",
     "recorded-content": {
-      "resource_not_found_res": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DisassociateResolverRule operation: [RSLVR-00703] Resolver rule with ID \"rslvr-123\" does not exist.') tblen=3>"
+      "resource_not_found_res": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "[RSLVR-00703] Resolver rule with ID \"rslvr-123\" does not exist."
+        },
+        "Message": "[RSLVR-00703] Resolver rule with ID \"rslvr-123\" does not exist.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_create_resolver_query_log_config": {

--- a/tests/aws/services/route53resolver/test_route53resolver.validation.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.validation.json
@@ -30,7 +30,7 @@
     "last_validated_date": "2023-09-08T06:42:35+00:00"
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_disassociate_non_existent_association": {
-    "last_validated_date": "2023-09-08T08:22:56+00:00"
+    "last_validated_date": "2025-03-11T17:07:33+00:00"
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_domain_lists": {
     "last_validated_date": "2023-09-01T08:05:46+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When snapshotting an exception, the best practice is to snapshot the actual response of the exception, instead of the `ExceptionInfo` object. In this way we can capture the proper code, message, and status code.
In addition, the test becomes more stable (e.g., [here](https://github.com/localstack/localstack/actions/runs/13791616449/job/38572719566?pr=12365) the test fails for a different traceback level).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Improve the snapshot as described.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
