### PR TITLE
Step Functions: Lazy Initialization of JVM for JSONata Evaluation 

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/jsonata/jsonata.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/jsonata/jsonata.py
@@ -86,11 +86,16 @@ class _JSONataJVMBridge:
             raise JSONataException("UNKNOWN", str(ex))
 
 
-# Final reference to the java evaluation function.
-_eval_jsonata: Final[Callable[[JSONataExpression], Any]] = _JSONataJVMBridge.get().eval_jsonata
+# Lazy initialization of the `eval_jsonata` function pointer.
+# This ensures the JVM is only started when JSONata functionality is needed.
+_eval_jsonata: Optional[Callable[[JSONataExpression], Any]] = None
 
 
 def eval_jsonata_expression(jsonata_expression: JSONataExpression) -> Any:
+    global _eval_jsonata
+    if _eval_jsonata is None:
+        # Initialize _eval_jsonata only when invoked for the first time using the Singleton pattern.
+        _eval_jsonata = _JSONataJVMBridge.get().eval_jsonata
     return _eval_jsonata(jsonata_expression)
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The current implementation starts the JVM during module import, which interferes with unrelated processes like generating entrypoints—especially on Windows machines, where it may break the entrypoint generation process entirely. This PR defers the startup of the JVM until the JSONata evaluation feature is actually needed first, ensuring that other processes remain unaffected by premature JVM initialization.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Delay JVM instantiation until the first JSONata evaluation call, then cache the function reference to ensure fast, persistent access throughout the application’s runtime.

\* Known Limitation: The first invocation in a state with tight timeouts might trigger a timeout error in the evaluation of the state machine due to the JVM installation overhead. This edge case is rare, does not result in abrupt terminations (the state machine will terminate gracefully), and does not affect future executions. Future refinements to the installer behavior may address this further.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
