### PR TITLE
fix APIGW binary media types

### DIFF
--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -255,6 +255,9 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         result = call_moto(context)
         rest_api = get_moto_rest_api(context, rest_api_id=result["id"])
         rest_api.version = request.get("version")
+        if binary_media_types := request.get("binaryMediaTypes"):
+            rest_api.binaryMediaTypes = binary_media_types
+
         response: RestApi = rest_api.to_dict()
         remove_empty_attributes_from_rest_api(response)
         store = get_apigateway_store(context=context)

--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -174,6 +174,14 @@ class TestApiGatewayApiRestApi:
         snapshot.match("string-compression-size", e.value.response)
 
     @markers.aws.validated
+    def test_create_rest_api_with_binary_media_types(self, apigw_create_rest_api, snapshot):
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}",
+            binaryMediaTypes=["image/png"],
+        )
+        snapshot.match("create-with-binary-media", response)
+
+    @markers.aws.validated
     def test_create_rest_api_with_tags(self, apigw_create_rest_api, snapshot, aws_client):
         response = apigw_create_rest_api(
             name=f"test-api-{short_uid()}",

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -3604,5 +3604,30 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_create_rest_api_with_binary_media_types": {
+    "recorded-date": "11-03-2025, 22:33:05",
+    "recorded-content": {
+      "create-with-binary-media": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/png"
+        ],
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -92,6 +92,9 @@
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_update_resource_behaviour": {
     "last_validated_date": "2024-04-15T17:29:08+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_create_rest_api_with_binary_media_types": {
+    "last_validated_date": "2025-03-11T22:32:34+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_create_rest_api_with_optional_params": {
     "last_validated_date": "2024-04-15T15:10:32+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by https://github.com/localstack/localstack/issues/12115#issuecomment-2715763423, we had an issue with binary media types and CDK, which led to finding out Moto was not considering `binaryMediaTypes` in the `CreateRestAPI` operation

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add `binaryMediaTypes` to the REST API model

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
