### PR TITLE
chore: improve remaining tests snapshots

### DIFF
--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -420,15 +420,15 @@ def test_execute_change_set(
 @markers.aws.validated
 def test_delete_change_set_exception(snapshot, aws_client):
     """test error cases when trying to delete a change set"""
-    with pytest.raises(Exception) as e1:
+    with pytest.raises(ClientError) as e1:
         aws_client.cloudformation.delete_change_set(
             StackName="nostack", ChangeSetName="DoesNotExist"
         )
-    snapshot.match("e1", e1)
+    snapshot.match("e1", e1.value.response)
 
-    with pytest.raises(Exception) as e2:
+    with pytest.raises(ClientError) as e2:
         aws_client.cloudformation.delete_change_set(ChangeSetName="DoesNotExist")
-    snapshot.match("e2", e2)
+    snapshot.match("e2", e2.value.response)
 
 
 @markers.aws.validated

--- a/tests/aws/services/cloudformation/api/test_changesets.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_changesets.snapshot.json
@@ -166,16 +166,36 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_changesets.py::test_describe_change_set_nonexisting": {
-    "recorded-date": "11-08-2022, 13:22:01",
+    "recorded-date": "11-03-2025, 19:12:57",
     "recorded-content": {
       "exception": "An error occurred (ValidationError) when calling the DescribeChangeSet operation: Stack [somestack] does not exist"
     }
   },
   "tests/aws/services/cloudformation/api/test_changesets.py::test_delete_change_set_exception": {
-    "recorded-date": "11-08-2022, 14:07:38",
+    "recorded-date": "11-03-2025, 19:13:48",
     "recorded-content": {
-      "e1": "<ExceptionInfo ClientError('An error occurred (ValidationError) when calling the DeleteChangeSet operation: Stack [nostack] does not exist') tblen=3>",
-      "e2": "<ExceptionInfo ClientError('An error occurred (ValidationError) when calling the DeleteChangeSet operation: StackName must be specified if ChangeSetName is not specified as an ARN.') tblen=3>"
+      "e1": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Stack [nostack] does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "e2": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "StackName must be specified if ChangeSetName is not specified as an ARN.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/cloudformation/api/test_changesets.py::test_name_conflicts": {

--- a/tests/aws/services/cloudformation/api/test_changesets.validation.json
+++ b/tests/aws/services/cloudformation/api/test_changesets.validation.json
@@ -12,13 +12,13 @@
     "last_validated_date": "2023-11-22T07:49:15+00:00"
   },
   "tests/aws/services/cloudformation/api/test_changesets.py::test_delete_change_set_exception": {
-    "last_validated_date": "2022-08-11T12:07:38+00:00"
+    "last_validated_date": "2025-03-11T19:13:48+00:00"
   },
   "tests/aws/services/cloudformation/api/test_changesets.py::test_deleted_changeset": {
     "last_validated_date": "2022-08-11T09:11:47+00:00"
   },
   "tests/aws/services/cloudformation/api/test_changesets.py::test_describe_change_set_nonexisting": {
-    "last_validated_date": "2022-08-11T11:22:01+00:00"
+    "last_validated_date": "2025-03-11T19:12:57+00:00"
   },
   "tests/aws/services/cloudformation/api/test_changesets.py::test_describe_change_set_with_similarly_named_stacks": {
     "last_validated_date": "2024-03-06T13:56:47+00:00"

--- a/tests/aws/services/events/test_archive_and_replay.snapshot.json
+++ b/tests/aws/services/events/test_archive_and_replay.snapshot.json
@@ -148,27 +148,63 @@
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_create_archive_error_unknown_event_bus": {
-    "recorded-date": "17-05-2024, 15:15:32",
+    "recorded-date": "11-03-2025, 19:45:47",
     "recorded-content": {
-      "create-archive-unknown-event-bus-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the CreateArchive operation: Event bus <event-bus-name> does not exist.') tblen=3>"
+      "create-archive-unknown-event-bus-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <event-bus-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_create_archive_error_duplicate[default]": {
-    "recorded-date": "17-05-2024, 16:15:51",
+    "recorded-date": "11-03-2025, 19:46:51",
     "recorded-content": {
-      "create-archive-duplicate-error": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateArchive operation: Archive <archive-name> already exists.') tblen=3>"
+      "create-archive-duplicate-error": {
+        "Error": {
+          "Code": "ResourceAlreadyExistsException",
+          "Message": "Archive <archive-name> already exists."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_create_archive_error_duplicate[custom]": {
-    "recorded-date": "17-05-2024, 16:15:53",
+    "recorded-date": "11-03-2025, 19:46:53",
     "recorded-content": {
-      "create-archive-duplicate-error": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateArchive operation: Archive <archive-name> already exists.') tblen=3>"
+      "create-archive-duplicate-error": {
+        "Error": {
+          "Code": "ResourceAlreadyExistsException",
+          "Message": "Archive <archive-name> already exists."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_describe_archive_error_unknown_archive": {
-    "recorded-date": "17-05-2024, 16:19:03",
+    "recorded-date": "11-03-2025, 19:47:23",
     "recorded-content": {
-      "describe-archive-unknown-archive-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeArchive operation: Archive <archive-name> does not exist.') tblen=3>"
+      "describe-archive-unknown-archive-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Archive <archive-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_list_archive_with_name_prefix[default]": {
@@ -308,21 +344,48 @@
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_list_archive_error_unknown_source_arn": {
-    "recorded-date": "17-05-2024, 16:34:48",
+    "recorded-date": "11-03-2025, 19:47:46",
     "recorded-content": {
-      "list-archives-unknown-event-bus-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListArchives operation: Event bus <event-bus-name> does not exist.') tblen=3>"
+      "list-archives-unknown-event-bus-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <event-bus-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_update_archive_error_unknown_archive": {
-    "recorded-date": "17-05-2024, 16:44:35",
+    "recorded-date": "11-03-2025, 19:49:00",
     "recorded-content": {
-      "update-archive-unknown-archive-error": "<ExceptionInfo InternalException('An error occurred (InternalException) when calling the UpdateArchive operation (reached max retries: 4): Service encountered unexpected problem. Please try again.') tblen=3>"
+      "update-archive-unknown-archive-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "At least one of EventPattern, RetentionDays or Description must be provided."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_delete_archive_error_unknown_archive": {
-    "recorded-date": "17-05-2024, 16:46:11",
+    "recorded-date": "11-03-2025, 19:49:18",
     "recorded-content": {
-      "delete-archive-unknown-archive-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DeleteArchive operation: Archive <archive-name> does not exist.') tblen=3>"
+      "delete-archive-unknown-archive-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Archive <archive-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_list_archive_state_enabled[default]": {
@@ -862,10 +925,28 @@
     "recorded-content": {}
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_start_replay_error_unknown_event_bus": {
-    "recorded-date": "22-05-2024, 12:49:01",
+    "recorded-date": "11-03-2025, 19:50:55",
     "recorded-content": {
-      "start-replay-unknown-event-bus-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the StartReplay operation: Event bus <event-bus-name> does not exist.') tblen=3>",
-      "start-replay-wrong-event-bus-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the StartReplay operation: Parameter Destination.Arn is not valid. Reason: Cross event bus replay is not permitted.') tblen=3>"
+      "start-replay-unknown-event-bus-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <event-bus-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "start-replay-wrong-event-bus-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Parameter Destination.Arn is not valid. Reason: Cross event bus replay is not permitted."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_list_replays_with_prefix": {
@@ -984,39 +1065,93 @@
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_start_replay_error_unknown_archive": {
-    "recorded-date": "22-05-2024, 15:09:07",
+    "recorded-date": "11-03-2025, 19:55:13",
     "recorded-content": {
-      "start-replay-unknown-archive-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the StartReplay operation: Parameter EventSourceArn is not valid. Reason: Archive <archive-name> does not exist.') tblen=3>"
+      "start-replay-unknown-archive-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Parameter EventSourceArn is not valid. Reason: Archive <archive-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_start_replay_error_duplicate_name_same_archive": {
-    "recorded-date": "22-05-2024, 15:15:36",
+    "recorded-date": "11-03-2025, 19:54:57",
     "recorded-content": {
-      "start-replay-duplicate-error": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the StartReplay operation: Replay <replay-name> already exists.') tblen=3>"
+      "start-replay-duplicate-error": {
+        "Error": {
+          "Code": "ResourceAlreadyExistsException",
+          "Message": "Replay <replay-name> already exists."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_start_replay_error_invalid_end_time[0]": {
-    "recorded-date": "22-05-2024, 15:17:36",
+    "recorded-date": "11-03-2025, 19:55:05",
     "recorded-content": {
-      "start-replay-invalid-end-time-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the StartReplay operation: Parameter EventEndTime is not valid. Reason: EventStartTime must be before EventEndTime.') tblen=3>"
+      "start-replay-invalid-end-time-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Parameter EventEndTime is not valid. Reason: EventStartTime must be before EventEndTime."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_start_replay_error_invalid_end_time[10]": {
-    "recorded-date": "22-05-2024, 15:17:38",
+    "recorded-date": "11-03-2025, 19:55:07",
     "recorded-content": {
-      "start-replay-invalid-end-time-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the StartReplay operation: Parameter EventEndTime is not valid. Reason: EventStartTime must be before EventEndTime.') tblen=3>"
+      "start-replay-invalid-end-time-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Parameter EventEndTime is not valid. Reason: EventStartTime must be before EventEndTime."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_describe_replay_error_unknown_replay": {
-    "recorded-date": "22-05-2024, 15:20:45",
+    "recorded-date": "11-03-2025, 19:55:20",
     "recorded-content": {
-      "describe-replay-unknown-replay-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeReplay operation: Replay <replay-name> does not exist.') tblen=3>"
+      "describe-replay-unknown-replay-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Replay <replay-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::tests_concurrency_error_too_many_active_replays": {
-    "recorded-date": "22-05-2024, 15:34:28",
+    "recorded-date": "11-03-2025, 19:55:54",
     "recorded-content": {
-      "list-replays-with-limit": "<ExceptionInfo LimitExceededException('An error occurred (LimitExceededException) when calling the StartReplay operation: The requested resource exceeds the maximum number allowed.') tblen=3>"
+      "list-replays-with-limit": {
+        "Error": {
+          "Code": "LimitExceededException",
+          "Message": "The requested resource exceeds the maximum number allowed."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_list_replays_with_event_source_arn": {
@@ -1042,9 +1177,18 @@
     }
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_start_replay_error_duplicate_different_archive": {
-    "recorded-date": "27-05-2024, 10:41:42",
+    "recorded-date": "11-03-2025, 19:57:07",
     "recorded-content": {
-      "start-replay-duplicate-error": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the StartReplay operation: Replay <replay-name> already exists.') tblen=3>"
+      "start-replay-duplicate-error": {
+        "Error": {
+          "Code": "ResourceAlreadyExistsException",
+          "Message": "Replay <replay-name> already exists."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   }
 }

--- a/tests/aws/services/events/test_archive_and_replay.validation.json
+++ b/tests/aws/services/events/test_archive_and_replay.validation.json
@@ -1,12 +1,12 @@
 {
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_create_archive_error_duplicate[custom]": {
-    "last_validated_date": "2024-05-17T16:15:53+00:00"
+    "last_validated_date": "2025-03-11T19:46:53+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_create_archive_error_duplicate[default]": {
-    "last_validated_date": "2024-05-17T16:15:51+00:00"
+    "last_validated_date": "2025-03-11T19:46:51+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_create_archive_error_unknown_event_bus": {
-    "last_validated_date": "2024-05-17T15:15:32+00:00"
+    "last_validated_date": "2025-03-11T19:45:47+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_create_list_describe_update_delete_archive[custom]": {
     "last_validated_date": "2024-05-17T15:15:32+00:00"
@@ -15,13 +15,13 @@
     "last_validated_date": "2024-05-17T15:15:31+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_delete_archive_error_unknown_archive": {
-    "last_validated_date": "2024-05-17T16:46:11+00:00"
+    "last_validated_date": "2025-03-11T19:49:18+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_describe_archive_error_unknown_archive": {
-    "last_validated_date": "2024-05-17T16:19:03+00:00"
+    "last_validated_date": "2025-03-11T19:47:23+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_list_archive_error_unknown_source_arn": {
-    "last_validated_date": "2024-05-17T16:34:48+00:00"
+    "last_validated_date": "2025-03-11T19:47:46+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_list_archive_state_enabled[custom]": {
     "last_validated_date": "2024-05-17T16:51:14+00:00"
@@ -60,10 +60,10 @@
     "last_validated_date": "2024-05-17T16:32:51+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestArchive::test_update_archive_error_unknown_archive": {
-    "last_validated_date": "2024-05-17T16:44:35+00:00"
+    "last_validated_date": "2025-03-11T19:49:00+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_describe_replay_error_unknown_replay": {
-    "last_validated_date": "2024-05-22T15:20:45+00:00"
+    "last_validated_date": "2025-03-11T19:55:20+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_list_replay_with_limit": {
     "last_validated_date": "2024-05-22T13:43:13+00:00"
@@ -81,24 +81,24 @@
     "last_validated_date": "2024-05-27T13:17:56+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_start_replay_error_duplicate_different_archive": {
-    "last_validated_date": "2024-05-27T10:41:42+00:00"
+    "last_validated_date": "2025-03-11T19:57:07+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_start_replay_error_duplicate_name_same_archive": {
-    "last_validated_date": "2024-05-22T15:15:36+00:00"
+    "last_validated_date": "2025-03-11T19:54:57+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_start_replay_error_invalid_end_time[0]": {
-    "last_validated_date": "2024-05-22T15:17:36+00:00"
+    "last_validated_date": "2025-03-11T19:55:05+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_start_replay_error_invalid_end_time[10]": {
-    "last_validated_date": "2024-05-22T15:17:38+00:00"
+    "last_validated_date": "2025-03-11T19:55:07+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_start_replay_error_unknown_archive": {
-    "last_validated_date": "2024-05-22T15:09:07+00:00"
+    "last_validated_date": "2025-03-11T19:55:13+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::test_start_replay_error_unknown_event_bus": {
-    "last_validated_date": "2024-05-22T12:49:01+00:00"
+    "last_validated_date": "2025-03-11T19:50:55+00:00"
   },
   "tests/aws/services/events/test_archive_and_replay.py::TestReplay::tests_concurrency_error_too_many_active_replays": {
-    "last_validated_date": "2024-05-22T15:34:28+00:00"
+    "last_validated_date": "2025-03-11T19:55:54+00:00"
   }
 }

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -561,7 +561,7 @@ class TestEventBus:
 
         with pytest.raises(aws_client.events.exceptions.ResourceAlreadyExistsException) as e:
             events_create_event_bus(Name=bus_name)
-        snapshot.match("create-multiple-event-buses-same-name", e)
+        snapshot.match("create-multiple-event-buses-same-name", e.value.response)
 
     @markers.aws.validated
     def test_describe_delete_not_existing_event_bus(self, aws_client, snapshot):
@@ -570,16 +570,16 @@ class TestEventBus:
 
         with pytest.raises(aws_client.events.exceptions.ResourceNotFoundException) as e:
             aws_client.events.describe_event_bus(Name=bus_name)
-        snapshot.match("describe-not-existing-event-bus-error", e)
+        snapshot.match("describe-not-existing-event-bus-error", e.value.response)
 
         aws_client.events.delete_event_bus(Name=bus_name)
-        snapshot.match("delete-not-existing-event-bus", e)
+        snapshot.match("delete-not-existing-event-bus", e.value.response)
 
     @markers.aws.validated
     def test_delete_default_event_bus(self, aws_client, snapshot):
         with pytest.raises(aws_client.events.exceptions.ClientError) as e:
             aws_client.events.delete_event_bus(Name="default")
-        snapshot.match("delete-default-event-bus-error", e)
+        snapshot.match("delete-default-event-bus-error", e.value.response)
 
     @markers.aws.validated
     @pytest.mark.skipif(
@@ -757,7 +757,7 @@ class TestEventBus:
                 Principal="*",
                 StatementId="statement-id",
             )
-        snapshot.match("remove-permission-non-existing-sid-error", e)
+        snapshot.match("remove-permission-non-existing-sid-error", e.value.response)
 
     @markers.aws.validated
     @pytest.mark.skipif(
@@ -865,7 +865,7 @@ class TestEventBus:
             aws_client.events.remove_permission(
                 EventBusName=bus_name, StatementId="non-existing-sid"
             )
-        snapshot.match("remove-permission-non-existing-sid-error", e)
+        snapshot.match("remove-permission-non-existing-sid-error", e.value.response)
 
     @markers.aws.validated
     # TODO move to test targets
@@ -1304,7 +1304,7 @@ class TestEventRule:
 
         with pytest.raises(aws_client.events.exceptions.ResourceNotFoundException) as e:
             aws_client.events.describe_rule(Name=rule_name)
-        snapshot.match("describe-not-existing-rule-error", e)
+        snapshot.match("describe-not-existing-rule-error", e.value.response)
 
     @markers.aws.validated
     @pytest.mark.parametrize("bus_name", ["custom", "default"])
@@ -1366,7 +1366,7 @@ class TestEventRule:
 
         with pytest.raises(aws_client.events.exceptions.ClientError) as e:
             aws_client.events.delete_rule(Name=rule_name)
-        snapshot.match("delete-rule-with-targets-error", e)
+        snapshot.match("delete-rule-with-targets-error", e.value.response)
 
     @markers.aws.validated
     def test_update_rule_with_targets(
@@ -1900,7 +1900,7 @@ class TestEventTarget:
 
         with pytest.raises(aws_client.events.exceptions.LimitExceededException) as error:
             aws_client.events.put_targets(Rule=rule_name, Targets=targets)
-        snapshot.match("put-targets-client-error", error)
+        snapshot.match("put-targets-client-error", error.value.response)
 
     @markers.aws.validated
     @pytest.mark.skipif(

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -740,22 +740,58 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
-    "recorded-date": "08-01-2025, 15:27:09",
+    "recorded-date": "11-03-2025, 19:59:23",
     "recorded-content": {
-      "create-multiple-event-buses-same-name": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateEventBus operation: Event bus <bus-name> already exists.') tblen=4>"
+      "create-multiple-event-buses-same-name": {
+        "Error": {
+          "Code": "ResourceAlreadyExistsException",
+          "Message": "Event bus <bus-name> already exists."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
-    "recorded-date": "08-01-2025, 15:27:10",
+    "recorded-date": "11-03-2025, 19:59:55",
     "recorded-content": {
-      "describe-not-existing-event-bus-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>",
-      "delete-not-existing-event-bus": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>"
+      "describe-not-existing-event-bus-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <bus-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "delete-not-existing-event-bus": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <bus-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
-    "recorded-date": "08-01-2025, 15:27:11",
+    "recorded-date": "11-03-2025, 20:01:03",
     "recorded-content": {
-      "delete-default-event-bus-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the DeleteEventBus operation: Cannot delete event bus default.') tblen=3>"
+      "delete-default-event-bus-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Cannot delete event bus default."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_prefix": {
@@ -1114,9 +1150,18 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission_non_existing_event_bus": {
-    "recorded-date": "08-01-2025, 15:27:22",
+    "recorded-date": "11-03-2025, 20:01:53",
     "recorded-content": {
-      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the PutPermission operation: Event bus <bus-name> does not exist.') tblen=3>"
+      "remove-permission-non-existing-sid-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <bus-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[custom]": {
@@ -1222,27 +1267,63 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-custom]": {
-    "recorded-date": "08-01-2025, 15:27:25",
+    "recorded-date": "11-03-2025, 20:10:01",
     "recorded-content": {
-      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+      "remove-permission-non-existing-sid-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Statement with the provided id does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-default]": {
-    "recorded-date": "08-01-2025, 15:27:26",
+    "recorded-date": "11-03-2025, 20:10:02",
     "recorded-content": {
-      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+      "remove-permission-non-existing-sid-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Statement with the provided id does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-custom]": {
-    "recorded-date": "08-01-2025, 15:27:27",
+    "recorded-date": "11-03-2025, 20:10:03",
     "recorded-content": {
-      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+      "remove-permission-non-existing-sid-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Statement with the provided id does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-default]": {
-    "recorded-date": "08-01-2025, 15:27:28",
+    "recorded-date": "11-03-2025, 20:10:05",
     "recorded-content": {
-      "remove-permission-non-existing-sid-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the RemovePermission operation: Statement with the provided id does not exist.') tblen=3>"
+      "remove-permission-non-existing-sid-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Statement with the provided id does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_bus_to_bus[standard]": {
@@ -1796,9 +1877,18 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
-    "recorded-date": "08-01-2025, 15:28:53",
+    "recorded-date": "11-03-2025, 20:04:49",
     "recorded-content": {
-      "describe-not-existing-rule-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeRule operation: Rule <rule-name> does not exist on EventBus default.') tblen=3>"
+      "describe-not-existing-rule-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Rule <rule-name> does not exist on EventBus default."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[custom]": {
@@ -1932,9 +2022,18 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
-    "recorded-date": "08-01-2025, 15:28:57",
+    "recorded-date": "11-03-2025, 20:05:07",
     "recorded-content": {
-      "delete-rule-with-targets-error": "<ExceptionInfo ClientError(\"An error occurred (ValidationException) when calling the DeleteRule operation: Rule can't be deleted since it has targets.\") tblen=3>"
+      "delete-rule-with-targets-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Rule can't be deleted since it has targets."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_update_rule_with_targets": {
@@ -2291,9 +2390,18 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
-    "recorded-date": "08-01-2025, 15:30:54",
+    "recorded-date": "11-03-2025, 20:11:11",
     "recorded-content": {
-      "put-targets-client-error": "<ExceptionInfo LimitExceededException('An error occurred (LimitExceededException) when calling the PutTargets operation: The requested resource exceeds the maximum number allowed.') tblen=3>"
+      "put-targets-client-error": {
+        "Error": {
+          "Code": "LimitExceededException",
+          "Message": "The requested resource exceeds the maximum number allowed."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_list_target_by_rule_limit": {

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -12,13 +12,13 @@
     "last_validated_date": "2025-01-08T15:27:06+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
-    "last_validated_date": "2025-01-08T15:27:09+00:00"
+    "last_validated_date": "2025-03-11T19:59:23+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
-    "last_validated_date": "2025-01-08T15:27:11+00:00"
+    "last_validated_date": "2025-03-11T20:01:03+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
-    "last_validated_date": "2025-01-08T15:27:10+00:00"
+    "last_validated_date": "2025-03-11T19:59:55+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_limit": {
     "last_validated_date": "2025-01-08T15:27:14+00:00"
@@ -48,7 +48,7 @@
     "last_validated_date": "2025-01-08T15:27:22+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_permission_non_existing_event_bus": {
-    "last_validated_date": "2025-01-08T15:27:22+00:00"
+    "last_validated_date": "2025-03-11T20:01:53+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission[custom]": {
     "last_validated_date": "2025-01-08T15:27:23+00:00"
@@ -57,16 +57,16 @@
     "last_validated_date": "2025-01-08T15:27:25+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-custom]": {
-    "last_validated_date": "2025-01-08T15:27:27+00:00"
+    "last_validated_date": "2025-03-11T20:10:03+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[False-default]": {
-    "last_validated_date": "2025-01-08T15:27:28+00:00"
+    "last_validated_date": "2025-03-11T20:10:05+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-custom]": {
-    "last_validated_date": "2025-01-08T15:27:25+00:00"
+    "last_validated_date": "2025-03-11T20:10:01+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_remove_permission_non_existing_sid[True-default]": {
-    "last_validated_date": "2025-01-08T15:27:26+00:00"
+    "last_validated_date": "2025-03-11T20:10:02+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_nested": {
     "last_validated_date": "2025-01-08T15:30:49+00:00"
@@ -75,10 +75,10 @@
     "last_validated_date": "2025-01-08T15:30:36+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
-    "last_validated_date": "2025-01-08T15:28:57+00:00"
+    "last_validated_date": "2025-03-11T20:05:07+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
-    "last_validated_date": "2025-01-08T15:28:53+00:00"
+    "last_validated_date": "2025-03-11T20:04:49+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[custom]": {
     "last_validated_date": "2025-01-08T15:28:55+00:00"
@@ -114,7 +114,7 @@
     "last_validated_date": "2025-01-08T15:28:59+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
-    "last_validated_date": "2025-01-08T15:30:54+00:00"
+    "last_validated_date": "2025-03-11T20:11:11+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_list_target_by_rule_limit": {
     "last_validated_date": "2025-01-08T15:30:56+00:00"

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 from botocore.client import Config
+from botocore.exceptions import ClientError
 
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
@@ -57,7 +58,7 @@ def test_put_event_input_path_and_input_transformer(
         "InputPathsMap": input_path_map,
         "InputTemplate": input_template,
     }
-    with pytest.raises(Exception) as exception:
+    with pytest.raises(ClientError) as exception:
         aws_client.events.put_targets(
             Rule=rule_name,
             EventBusName=bus_name,
@@ -72,7 +73,7 @@ def test_put_event_input_path_and_input_transformer(
         )
 
     snapshot.add_transformer(snapshot.transform.regex(target_id, "<target-id>"))
-    snapshot.match("duplicated-input-operations-error", exception)
+    snapshot.match("duplicated-input-operations-error", exception.value.response)
 
 
 class TestInputPath:
@@ -380,7 +381,7 @@ class TestInputTransformer:
             "InputTemplate": input_template,
         }
 
-        with pytest.raises(Exception) as exception:
+        with pytest.raises(ClientError) as exception:
             events_client.put_targets(
                 Rule=rule_name,
                 EventBusName=bus_name,
@@ -390,7 +391,7 @@ class TestInputTransformer:
             )
 
         snapshot.add_transformer(snapshot.transform.regex(target_id, "<target-id>"))
-        snapshot.match("missing-key-exception-error", exception)
+        snapshot.match("missing-key-exception-error", exception.value.response)
 
     # TODO test wrong input template
     # '{"userId": "users/<userId>/profile/<type>"}',

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -160,9 +160,18 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_missing_keys": {
-    "recorded-date": "11-06-2024, 08:33:07",
+    "recorded-date": "11-03-2025, 19:01:17",
     "recorded-content": {
-      "missing-key-exception-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the PutTargets operation: InputTemplate for target <target-id> contains invalid placeholder notdefinedkey.') tblen=3>"
+      "missing-key-exception-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "InputTemplate for target <target-id> contains invalid placeholder notdefinedkey."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
@@ -220,9 +229,18 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::test_put_event_input_path_and_input_transformer": {
-    "recorded-date": "13-05-2024, 13:01:15",
+    "recorded-date": "11-03-2025, 19:03:54",
     "recorded-content": {
-      "duplicated-input-operations-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the PutTargets operation: Only one of Input, InputPath, or InputTransformer must be provided for target <target-id>.') tblen=3>"
+      "duplicated-input-operations-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Only one of Input, InputPath, or InputTransformer must be provided for target <target-id>."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_string[\"Event of <detail-type> type, at time <timestamp>, info extracted from detail <command>\"]": {

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -96,9 +96,9 @@
     "last_validated_date": "2024-06-11T08:33:00+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_missing_keys": {
-    "last_validated_date": "2024-06-11T08:33:07+00:00"
+    "last_validated_date": "2025-03-11T19:01:17+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::test_put_event_input_path_and_input_transformer": {
-    "last_validated_date": "2024-05-13T13:01:15+00:00"
+    "last_validated_date": "2025-03-11T19:03:54+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_schedule.py
+++ b/tests/aws/services/events/test_events_schedule.py
@@ -45,7 +45,7 @@ class TestScheduleRate:
             aws_client.events.put_rule(
                 Name=rule_name, EventBusName=bus_name, ScheduleExpression="rate(1 minute)"
             )
-        snapshot.match("put-rule-with-custom-event-bus-error", e)
+        snapshot.match("put-rule-with-custom-event-bus-error", e.value.response)
 
     @markers.aws.validated
     @pytest.mark.parametrize(

--- a/tests/aws/services/events/test_events_schedule.snapshot.json
+++ b/tests/aws/services/events/test_events_schedule.snapshot.json
@@ -31,9 +31,18 @@
     "recorded-content": {}
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleRate::tests_put_rule_with_schedule_custom_event_bus": {
-    "recorded-date": "14-05-2024, 11:38:21",
+    "recorded-date": "11-03-2025, 19:05:36",
     "recorded-content": {
-      "put-rule-with-custom-event-bus-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the PutRule operation: ScheduleExpression is supported only on the default event bus.') tblen=3>"
+      "put-rule-with-custom-event-bus-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "ScheduleExpression is supported only on the default event bus."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleRate::tests_schedule_rate_target_sqs": {

--- a/tests/aws/services/events/test_events_schedule.validation.json
+++ b/tests/aws/services/events/test_events_schedule.validation.json
@@ -123,7 +123,7 @@
     "last_validated_date": "2024-05-14T11:23:22+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleRate::tests_put_rule_with_schedule_custom_event_bus": {
-    "last_validated_date": "2024-05-14T11:38:21+00:00"
+    "last_validated_date": "2025-03-11T19:05:36+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleRate::tests_schedule_rate_custom_input_target_sqs": {
     "last_validated_date": "2024-05-15T09:31:53+00:00"

--- a/tests/aws/services/events/test_events_tags.py
+++ b/tests/aws/services/events/test_events_tags.py
@@ -107,21 +107,21 @@ def tests_tag_list_untag_not_existing_resource(
             ],
         )
 
-    snapshot.match("tag_not_existing_resource_error", error)
+    snapshot.match("tag_not_existing_resource_error", error.value.response)
 
     snapshot.add_transformer(
         snapshot.transform.regex(resource_name, "<not-existing-resource-name>")
     )
     with pytest.raises(aws_client.events.exceptions.ResourceNotFoundException) as error:
         aws_client.events.list_tags_for_resource(ResourceARN=resource_arn)
-    snapshot.match("list_tags_for_not_existing_resource_error", error)
+    snapshot.match("list_tags_for_not_existing_resource_error", error.value.response)
 
     with pytest.raises(aws_client.events.exceptions.ResourceNotFoundException) as error:
         aws_client.events.untag_resource(
             ResourceARN=resource_arn,
             TagKeys=[tag_key_1],
         )
-    snapshot.match("untag_not_existing_resource_error", error)
+    snapshot.match("untag_not_existing_resource_error", error.value.response)
 
 
 @markers.aws.validated
@@ -243,7 +243,7 @@ class TestRuleTags:
                 snapshot.transform.regex(bus_name, "<bus_name>"),
             ]
         )
-        snapshot.match("list_tags_for_deleted_rule_error", error)
+        snapshot.match("list_tags_for_deleted_rule_error", error.value.response)
 
 
 class TestEventBusTags:
@@ -286,4 +286,4 @@ class TestEventBusTags:
             aws_client.events.list_tags_for_resource(ResourceARN=bus_arn)
 
         snapshot.add_transformer(snapshot.transform.regex(bus_name, "<bus_name>"))
-        snapshot.match("list_tags_for_deleted_rule_error", error)
+        snapshot.match("list_tags_for_deleted_rule_error", error.value.response)

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -90,19 +90,73 @@
     }
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_rule]": {
-    "recorded-date": "15-05-2024, 14:57:57",
+    "recorded-date": "12-03-2025, 06:03:11",
     "recorded-content": {
-      "tag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the TagResource operation: Rule <not-existing-resource-name> does not exist on EventBus default.') tblen=3>",
-      "list_tags_for_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Rule <not-existing-resource-name> does not exist on EventBus default.') tblen=3>",
-      "untag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the UntagResource operation: Rule <not-existing-resource-name> does not exist on EventBus default.') tblen=3>"
+      "tag_not_existing_resource_error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Rule <not-existing-resource-name> does not exist on EventBus default."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "list_tags_for_not_existing_resource_error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Rule <not-existing-resource-name> does not exist on EventBus default."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "untag_not_existing_resource_error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Rule <not-existing-resource-name> does not exist on EventBus default."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_event_bus]": {
-    "recorded-date": "15-05-2024, 14:58:00",
+    "recorded-date": "12-03-2025, 06:03:13",
     "recorded-content": {
-      "tag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the TagResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>",
-      "list_tags_for_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>",
-      "untag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the UntagResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>"
+      "tag_not_existing_resource_error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <not-existing-resource-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "list_tags_for_not_existing_resource_error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <not-existing-resource-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "untag_not_existing_resource_error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <not-existing-resource-name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_put_rule_with_tags": {
@@ -134,9 +188,18 @@
     }
   },
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_list_tags_for_deleted_rule": {
-    "recorded-date": "15-05-2024, 14:58:02",
+    "recorded-date": "12-03-2025, 06:04:45",
     "recorded-content": {
-      "list_tags_for_deleted_rule_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Rule <rule_name> does not exist on EventBus <bus_name>.') tblen=3>"
+      "list_tags_for_deleted_rule_error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Rule <rule_name> does not exist on EventBus <bus_name>."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_create_event_bus_with_tags": {
@@ -168,9 +231,18 @@
     }
   },
   "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_list_tags_for_deleted_event_bus": {
-    "recorded-date": "15-05-2024, 14:58:05",
+    "recorded-date": "12-03-2025, 06:06:48",
     "recorded-content": {
-      "list_tags_for_deleted_rule_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Event bus <bus_name> does not exist.') tblen=3>"
+      "list_tags_for_deleted_rule_error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <bus_name> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus-event_bus_default]": {

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -3,10 +3,10 @@
     "last_validated_date": "2024-05-15T14:58:04+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_list_tags_for_deleted_event_bus": {
-    "last_validated_date": "2024-05-15T14:58:05+00:00"
+    "last_validated_date": "2025-03-12T06:06:48+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_list_tags_for_deleted_rule": {
-    "last_validated_date": "2024-05-15T14:58:02+00:00"
+    "last_validated_date": "2025-03-12T06:04:45+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_put_rule_with_tags": {
     "last_validated_date": "2024-05-15T14:58:01+00:00"
@@ -24,10 +24,10 @@
     "last_validated_date": "2024-05-16T12:13:18+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_event_bus]": {
-    "last_validated_date": "2024-05-15T14:58:00+00:00"
+    "last_validated_date": "2025-03-12T06:03:13+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_rule]": {
-    "last_validated_date": "2024-05-15T14:57:57+00:00"
+    "last_validated_date": "2025-03-12T06:03:11+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus-event_bus_custom]": {
     "last_validated_date": "2024-05-16T11:45:31+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As we fixed a snapshot leading to a test failure in https://github.com/localstack/localstack/pull/12367, I thought it was worth briefly going all over the repository and doing the same.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Improve snapshots by matching the response instead of the exception info object.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
