### PR TITLE
CFn updates: create new v2 provider for new engine

### DIFF
--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -1,0 +1,5 @@
+from localstack.services.cloudformation.provider import CloudformationProvider
+
+
+class CloudformationProviderV2(CloudformationProvider):
+    pass

--- a/localstack-core/localstack/services/providers.py
+++ b/localstack-core/localstack/services/providers.py
@@ -49,6 +49,14 @@ def cloudformation():
     return Service.for_provider(provider)
 
 
+@aws_provider(api="cloudformation", name="engine-v2")
+def cloudformation_v2():
+    from localstack.services.cloudformation.v2.provider import CloudformationProviderV2
+
+    provider = CloudformationProviderV2()
+    return Service.for_provider(provider)
+
+
 @aws_provider(api="config")
 def awsconfig():
     from localstack.services.configservice.provider import ConfigProvider


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In order to make improvements to the CFn engine, we have decided to add a new provider to update the functionality. It is useful to be able to update the provider methods for specific operations (typically around change sets) to change the template preprocessing etc.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Add a new provider under the name `engine-v2`. This can be enabled with `PROVIDER_OVERRIDE_CLOUDFORMATION=engine-v2`. There is no implementation for now.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
