### PR TITLE
Docker Utils: Expose the build logs

### DIFF
--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -701,13 +701,14 @@ class ContainerClient(metaclass=ABCMeta):
         image_name: str,
         context_path: str = None,
         platform: Optional[DockerPlatform] = None,
-    ) -> None:
+    ) -> str:
         """Builds an image from the given Dockerfile
 
         :param dockerfile_path: Path to Dockerfile, or a directory that contains a Dockerfile
         :param image_name: Name of the image to be built
         :param context_path: Path for build context (defaults to dirname of Dockerfile)
         :param platform: Target platform for build (defaults to platform of Docker host)
+        :return: Build logs as a string.
         """
 
     @abstractmethod

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -412,7 +412,7 @@ class CmdDockerClient(ContainerClient):
         cmd += [context_path]
         LOG.debug("Building Docker image: %s", cmd)
         try:
-            run(cmd)
+            return run(cmd)
         except subprocess.CalledProcessError as e:
             raise ContainerException(
                 f"Docker build process returned with error code {e.returncode}", e.stdout, e.stderr

--- a/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
@@ -380,13 +380,23 @@ class SdkDockerClient(ContainerClient):
             dockerfile_path = Util.resolve_dockerfile_path(dockerfile_path)
             context_path = context_path or os.path.dirname(dockerfile_path)
             LOG.debug("Building Docker image %s from %s", image_name, dockerfile_path)
-            self.client().images.build(
+            _, logs_iterator = self.client().images.build(
                 path=context_path,
                 dockerfile=dockerfile_path,
                 tag=image_name,
                 rm=True,
                 platform=platform,
             )
+            # logs_iterator is a stream of dicts. Example content:
+            # {'stream': 'Step 1/4 : FROM alpine'}
+            # ... other build steps
+            # {'aux': {'ID': 'sha256:4dcf90e87fb963e898f9c7a0451a40e36f8e7137454c65ae4561277081747825'}}
+            # {'stream': 'Successfully tagged img-5201f3e1:latest\n'}
+            output = ""
+            for log in logs_iterator:
+                if isinstance(log, dict) and ("stream" in log or "error" in log):
+                    output += log.get("stream") or log["error"]
+            return output
         except APIError as e:
             raise ContainerException("Unable to build Docker image") from e
 

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1240,7 +1240,15 @@ class TestDockerClient:
         dockerfile_ref = str(dockerfile_dir) if dockerfile_as_dir else dockerfile_path
 
         image_name = f"img-{short_uid()}"
-        docker_client.build_image(dockerfile_path=dockerfile_ref, image_name=image_name, **kwargs)
+        build_logs = docker_client.build_image(
+            dockerfile_path=dockerfile_ref, image_name=image_name, **kwargs
+        )
+        # The exact log files are very different between the CMD and SDK
+        # We just run some smoke tests
+        assert build_logs
+        assert isinstance(build_logs, str)
+        assert "ADD" in build_logs
+
         cleanups.append(lambda: docker_client.remove_image(image_name, force=True))
 
         assert image_name in docker_client.get_docker_image_names()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When building a Docker image in the background, it is sometimes necessary for API parity to also expose the build log to the user.

This PR changes the internal Docker-utils class to return the logs, so that we have the option to expose them where necessary.

Note that the previous method signature was to return `None`, so this is a non-breaking change.

## Testing
The exact build logs are very different between the SDK and CMD.
An example output from the SDK:
> Step 1/4 : FROM alpine
 ---> b0c9d60fc5e3
Step 2/4 : ADD 57334505 .
 ---> 82c44d1fd396
Step 3/4 : ENV foo=bar
 ---> Running in 3ff9e2fc6af8
 ---> Removed intermediate container 3ff9e2fc6af8
 ---> 527b181ed9b6
Step 4/4 : EXPOSE 45329
 ---> Running in 3add7fb13f81
 ---> Removed intermediate container 3add7fb13f81
 ---> b81d80655ebb
Successfully built b81d80655ebb
Successfully tagged img-69707aab:latest

Building the same image from the CMD:
> #0 building with "default" instance using docker driver
> 
> #1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 130B done
#1 DONE 0.0s
> 
> #2 [internal] load metadata for docker.io/library/alpine:latest
#2 DONE 0.0s
>
> #3 [internal] load .dockerignore
#3 transferring context: 2B done
#3 DONE 0.0s
>
> #4 [1/2] FROM docker.io/library/alpine:latest
#4 CACHED
>
> #5 [internal] load build context
#5 transferring context: 51B done
#5 DONE 0.0s
>
> #6 [2/2] ADD d95b6ab2 .
#6 DONE 0.0s
>
> #7 exporting to image
#7 exporting layers done
#7 writing image sha256:47ab3fb99ad2840d878e69ce94dcf5430bf6de50dc3c8bab644e91c517f598a1 done
#7 naming to docker.io/library/img-69007ebf done
#7 DONE 0.0s

That's why the test assertions are kept simple. In fairness, I don't think we should make the assertions too strict anyway - what the Docker Engine exactly returns is not relevant, as long as there is some output.