### PR TITLE
Cloud Formation: [POC] Update Graph with Template Traversal & Intrinsic Function Resolution

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/entities.py
+++ b/localstack-core/localstack/services/cloudformation/engine/entities.py
@@ -8,6 +8,10 @@ from localstack.services.cloudformation.engine.parameters import (
     mask_no_echo,
     strip_parameter_type,
 )
+from localstack.services.cloudformation.engine.v2.change_set_model import (
+    ChangeSetModel,
+    NodeTemplate,
+)
 from localstack.utils.aws import arns
 from localstack.utils.collections import select_attributes
 from localstack.utils.id_generator import ExistingIds, ResourceIdentifier, Tags, generate_short_uid
@@ -363,7 +367,10 @@ class Stack:
 
 
 # FIXME: remove inheritance
+# TODO: what functionality of the Stack object do we rely on here?
 class StackChangeSet(Stack):
+    update_graph: NodeTemplate | None
+
     def __init__(self, account_id: str, region_name: str, stack: Stack, params=None, template=None):
         if template is None:
             template = {}
@@ -399,3 +406,11 @@ class StackChangeSet(Stack):
     def changes(self):
         result = self.metadata["Changes"] = self.metadata.get("Changes", [])
         return result
+
+    # V2 only
+    def populate_update_graph(self, before_template: dict | None, after_template: dict | None):
+        change_set_model = ChangeSetModel(
+            before_template=before_template,
+            after_template=after_template,
+        )
+        self.update_graph = change_set_model.get_update_model()

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
@@ -219,6 +219,7 @@ class ChangeSetModel:
         self._node_template = self._model(
             before_template=self._before_template, after_template=self._after_template
         )
+        # TODO: need to do template preprocessing e.g. parameter resolution, conditions etc.
 
     def get_update_model(self) -> NodeTemplate:
         # TODO: rethink naming of this for outer utils

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import abc
+import enum
+from itertools import zip_longest
+from typing import Any, Final, Generator, Optional
+
+
+class ChangeType(enum.Enum):
+    UNCHANGED = "Unchanged"
+    CREATED = "Created"
+    MODIFIED = "Modified"
+    REMOVED = "Removed"
+
+    def __str__(self):
+        return self.value
+
+
+class ChangeSetEntity(abc.ABC):
+    change_type: Final[ChangeType]
+
+    def __init__(self, change_type: ChangeType):
+        self.change_type = change_type
+
+    def get_children(self) -> Generator[ChangeSetEntity]:
+        for child in self.__dict__.values():
+            yield from self._get_children_in(child)
+
+    @staticmethod
+    def _get_children_in(obj: Any) -> Generator[ChangeSetEntity]:
+        # TODO: could avoid the inductive logic here, and check for loops?
+        if isinstance(obj, ChangeSetEntity):
+            yield obj
+        elif isinstance(obj, list):
+            for item in obj:
+                yield from ChangeSetEntity._get_children_in(item)
+        elif isinstance(obj, dict):
+            for item in obj.values():
+                yield from ChangeSetEntity._get_children_in(item)
+
+    def __str__(self):
+        return f"({self.__class__.__name__}| {vars(self)}"
+
+    def __repr__(self):
+        return str(self)
+
+
+class ChangeSetNode(ChangeSetEntity, abc.ABC): ...
+
+
+class ChangeSetTerminal(ChangeSetEntity, abc.ABC): ...
+
+
+class NodeTemplate(ChangeSetNode):
+    resources: Final[NodeResources]
+
+    def __init__(self, change_type: ChangeType, resources: NodeResources):
+        super().__init__(change_type=change_type)
+        self.resources = resources
+
+
+class NodeResources(ChangeSetNode):
+    resources: Final[list[NodeResource]]
+
+    def __init__(self, change_type: ChangeType, resources: list[NodeResource]):
+        super().__init__(change_type=change_type)
+        self.resources = resources
+
+
+class NodeResource(ChangeSetNode):
+    name: Final[str]
+    type_: Final[ChangeSetTerminal]
+    properties: Final[NodeProperties]
+
+    def __init__(
+        self,
+        change_type: ChangeType,
+        name: str,
+        type_: ChangeSetTerminal,
+        properties: NodeProperties,
+    ):
+        super().__init__(change_type=change_type)
+        self.name = name
+        self.type_ = type_
+        self.properties = properties
+
+
+class NodeProperties(ChangeSetNode):
+    properties: Final[list[NodeProperty]]
+
+    def __init__(self, change_type: ChangeType, properties: list[NodeProperty]):
+        super().__init__(change_type=change_type)
+        self.properties = properties
+
+
+class NodeProperty(ChangeSetNode):
+    name: Final[str]
+    value: Final[ChangeSetEntity]
+
+    def __init__(self, change_type: ChangeType, name: str, value: ChangeSetEntity):
+        super().__init__(change_type=change_type)
+        self.name = name
+        self.value = value
+
+
+class NodeObject(ChangeSetNode):
+    bindings: Final[dict[str, ChangeSetEntity]]
+
+    def __init__(self, change_type: ChangeType, bindings: dict[str, ChangeSetEntity]):
+        super().__init__(change_type=change_type)
+        self.bindings = bindings
+
+
+class NodeArray(ChangeSetNode):
+    array: Final[list[ChangeSetEntity]]
+
+    def __init__(self, change_type: ChangeType, array: list[ChangeSetEntity]):
+        super().__init__(change_type=change_type)
+        self.array = array
+
+
+class TerminalValue(ChangeSetTerminal, abc.ABC):
+    value: Final[Any]
+
+    def __init__(self, change_type: ChangeType, value: Any):
+        super().__init__(change_type=change_type)
+        self.value = value
+
+
+class TerminalValueModified(TerminalValue):
+    modified_value: Final[Any]
+
+    def __init__(self, value: Any, modified_value: Any):
+        super().__init__(change_type=ChangeType.MODIFIED, value=value)
+        self.modified_value = modified_value
+
+
+class TerminalValueCreated(TerminalValue):
+    def __init__(self, value: Any):
+        super().__init__(change_type=ChangeType.CREATED, value=value)
+
+
+class TerminalValueRemoved(TerminalValue):
+    def __init__(self, value: Any):
+        super().__init__(change_type=ChangeType.REMOVED, value=value)
+
+
+class TerminalValueUnchanged(TerminalValue):
+    def __init__(self, value: Any):
+        super().__init__(change_type=ChangeType.UNCHANGED, value=value)
+
+
+class NoSuchValue: ...
+
+
+ResourcesKey: Final[str] = "Resources"
+PropertiesKey: Final[str] = "Properties"
+
+
+class ChangeSetModel:
+    # TODO: should this instead be generalised to work on "Stack" objects instead of just "Template"s?
+
+    # TODO: fix type hints in the modeler class, the use of Optional[...] is incorrect, it should reflect
+    #  that the type could be NoSuchValue, like Maybe[innertype] === innertype | NoSuchValue
+
+    # TODO: can probably improve the typehints to use CFN's 'language' eg. dict -> Template|Properties, etc.
+
+    # TODO: typechecks for key-value pairs?
+
+    _before_template: Final[dict]
+    _after_template: Final[dict]
+    _node_template: Final[NodeTemplate]
+
+    def __init__(self, before_template: dict, after_template: dict):
+        self._before_template = before_template
+        self._after_template = after_template
+        self._node_template = self._model(
+            before_template=before_template, after_template=after_template
+        )
+
+    def get_update_model(self) -> NodeTemplate:
+        # TODO: rethink naming of this for outer utils
+        return self._node_template
+
+    # TODO: figure out when and which intrinsic functions are evaluated when.
+    # TODO: dependency evaluation logic needs implementing, this should probably be done in a second pass about the changeset.
+    #
+    #    def _visit_intrinsic_function_fn_get_att(self, before_arguments: Any, after_arguments: Any) -> TerminalValue:
+    #        pass
+    #
+    #    def _visit_intrinsic_function(self, function_name: str, before_arguments: Any, after_arguments: Any) -> TerminalValue:
+    #        reflection_key = function_name.replace("::", "")
+    #        reflection_key = camel_to_snake_case(reflection_key)
+    #        visit_function_name = f"visit_intrinsic_function_{reflection_key}"
+    #        visit_function = getattr(self, visit_function_name)
+    #        # TODO: check and raise unsupported?
+    #        return visit_function(before_arguments, after_arguments)
+
+    def _visit_terminal_value(  # noqa
+        self, before_value: Optional[Any], after_value: Optional[Any]
+    ) -> TerminalValue:
+        if self._is_created(before=before_value, after=after_value):
+            return TerminalValueCreated(value=after_value)
+        if self._is_removed(before=before_value, after=after_value):
+            return TerminalValueRemoved(value=before_value)
+        if before_value == after_value:
+            return TerminalValueUnchanged(value=before_value)
+        return TerminalValueModified(value=before_value, modified_value=after_value)
+
+    def _visit_array(self, before_array: Optional[list], after_array: Optional[list]) -> NodeArray:
+        change_type = ChangeType.UNCHANGED
+        array: list[ChangeSetEntity] = list()
+        for before_value, after_value in zip_longest(
+            before_array, after_array, fillvalue=NoSuchValue()
+        ):
+            value = self._visit_value(before_value=before_value, after_value=after_value)
+            array.append(value)
+            if value.change_type != ChangeType.UNCHANGED:
+                change_type = ChangeType.MODIFIED
+        return NodeArray(change_type=change_type, array=array)
+
+    def _visit_object(
+        self, before_object: Optional[dict], after_object: Optional[dict]
+    ) -> NodeObject:
+        change_type = ChangeType.UNCHANGED
+        binding_names = self._keys_of(before_object, after_object)
+        bindings: dict[str, ChangeSetEntity] = dict()
+        for binding_name in binding_names:
+            # TODO: check the binding names for intrinsic functions and redirect.
+            before_value, after_value = self._sample_from(binding_name, before_object, after_object)
+            value = self._visit_value(before_value=before_value, after_value=after_value)
+            bindings[binding_name] = value
+            if value.change_type != ChangeType.UNCHANGED:
+                change_type = ChangeType.MODIFIED
+        return NodeObject(change_type=change_type, bindings=bindings)
+
+    def _visit_value(
+        self, before_value: Optional[Any], after_value: Optional[Any]
+    ) -> ChangeSetEntity:
+        before_type = type(before_value)
+        after_type = type(after_value)
+
+        if self._is_created(before=before_value, after=after_value):
+            return TerminalValueCreated(value=after_value)
+        if self._is_removed(before=before_value, after=after_value):
+            return TerminalValueRemoved(value=before_value)
+
+        # Case: update on the same type.
+        if before_type == after_type:
+            if self._is_terminal(value=before_value):
+                value = self._visit_terminal_value(
+                    before_value=before_value, after_value=after_value
+                )
+            elif self._is_object(value=before_value):
+                value = self._visit_object(before_object=before_value, after_object=after_value)
+            elif self._is_array(value=before_value):
+                value = self._visit_array(before_array=before_value, after_array=after_value)
+            else:
+                raise RuntimeError(f"Unsupported type {before_type}")
+            return value
+        # Case: update to new type.
+        else:
+            return TerminalValueModified(value=before_value, modified_value=after_value)
+
+    def _visit_property(
+        self, property_name: str, before_property: Optional[Any], after_property: Optional[Any]
+    ) -> NodeProperty:
+        if self._is_created(before=before_property, after=after_property):
+            return NodeProperty(
+                change_type=ChangeType.CREATED,
+                name=property_name,
+                value=TerminalValueCreated(value=after_property),
+            )
+        if self._is_removed(before=before_property, after=after_property):
+            return NodeProperty(
+                change_type=ChangeType.REMOVED,
+                name=property_name,
+                value=TerminalValueRemoved(value=before_property),
+            )
+        value = self._visit_value(before_value=before_property, after_value=after_property)
+        return NodeProperty(change_type=value.change_type, name=property_name, value=value)
+
+    def _visit_properties(
+        self, before_properties: Optional[dict], after_properties: Optional[dict]
+    ) -> NodeProperties:
+        # TODO: double check we are sure not to have this be a NodeObject
+        property_names: set[str] = self._keys_of(before_properties, after_properties)
+        properties: list[NodeProperty] = list()
+        change_type = ChangeType.UNCHANGED
+        for property_name in property_names:
+            before_property, after_property = self._sample_from(
+                property_name, before_properties, after_properties
+            )
+            property_ = self._visit_property(
+                property_name=property_name,
+                before_property=before_property,
+                after_property=after_property,
+            )
+            properties.append(property_)
+            # TODO: compute the properties change type properly.
+            if property_.change_type != ChangeType.UNCHANGED:
+                change_type = change_type.MODIFIED
+        return NodeProperties(change_type=change_type, properties=properties)
+
+    def _visit_resource(
+        self, resource_name: str, before_resource: Optional[dict], after_resource: Optional[dict]
+    ) -> NodeResource:
+        # TODO: fix add/delete/unchanged logic, needs minor rework of node types being update informants
+        before_properties, after_properties = self._sample_from(
+            PropertiesKey, before_resource, after_resource
+        )
+        properties = self._visit_properties(
+            before_properties=before_properties, after_properties=after_properties
+        )
+
+        change_type = properties.change_type
+        if isinstance(before_resource, NoSuchValue) and after_resource:
+            change_type = ChangeType.CREATED
+        elif before_resource and isinstance(after_resource, NoSuchValue):
+            change_type = ChangeType.REMOVED
+
+        return NodeResource(
+            change_type=change_type,
+            name=resource_name,
+            # TODO: investigate behaviour with type changes, for now this is filler code.
+            type_=TerminalValueUnchanged(value="<Type>"),
+            properties=properties,
+        )
+
+    def _visit_resources(self, before_resources: dict, after_resources: dict) -> NodeResources:
+        # TODO: investigate type changes behavior.
+        change_type = ChangeType.UNCHANGED
+        resources: list[NodeResource] = list()
+        resource_names = self._keys_of(before_resources, after_resources)
+        for resource_name in resource_names:
+            before_resource, after_resource = self._sample_from(
+                resource_name, before_resources, after_resources
+            )
+            resource = self._visit_resource(
+                resource_name=resource_name,
+                before_resource=before_resource,
+                after_resource=after_resource,
+            )
+            resources.append(resource)
+            # TODO: compute the properties change type properly.
+            if resource.change_type != ChangeType.UNCHANGED:
+                change_type = ChangeType.MODIFIED
+        return NodeResources(change_type=change_type, resources=resources)
+
+    def _model(self, before_template: dict, after_template: dict) -> NodeTemplate:
+        # TODO: visit other child types
+        before_resources, after_resources = self._sample_from(
+            ResourcesKey, before_template, after_template
+        )
+        resources = self._visit_resources(
+            before_resources=before_resources, after_resources=after_resources
+        )
+        # TODO: what is a change type for templates?
+        return NodeTemplate(change_type=resources.change_type, resources=resources)
+
+    @staticmethod
+    def _sample_from(key: str, *objects: dict | NoSuchValue) -> Any | NoSuchValue:
+        results = list()
+        for obj in objects:
+            # TODO: raise errors if not dict
+            if not isinstance(obj, NoSuchValue):
+                results.append(obj.get(key, NoSuchValue()))
+            else:
+                results.append(obj)
+        return results[0] if len(objects) == 1 else tuple(results)
+
+    @staticmethod
+    def _keys_of(*objects: dict | NoSuchValue) -> set[str]:
+        keys: set[str] = set()
+        for obj in objects:
+            # TODO: raise errors if not dict
+            if isinstance(obj, dict):
+                keys.update(obj.keys())
+        return set(keys)
+
+    @staticmethod
+    def _is_terminal(value: Any) -> bool:
+        return type(value) in {int, float, bool, str, None}
+
+    @staticmethod
+    def _is_object(value: Any) -> bool:
+        return isinstance(value, dict)
+
+    @staticmethod
+    def _is_array(value: Any) -> bool:
+        return isinstance(value, list)
+
+    #    @staticmethod
+    #    def _is_intrinsic_function(function_name: str) -> bool:
+    #        # TODO export set
+    #        # TODO check for scope? are intrinsic function strong or soft string literals?
+    #        return function_name in {"Fn:GetAtt"}
+
+    @staticmethod
+    def _is_created(before: Any | NoSuchValue, after: Any | NoSuchValue) -> bool:
+        return isinstance(before, NoSuchValue) and not isinstance(after, NoSuchValue)
+
+    @staticmethod
+    def _is_removed(before: Any | NoSuchValue, after: Any | NoSuchValue) -> bool:
+        return not isinstance(before, NoSuchValue) and isinstance(after, NoSuchValue)

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import abc
+from typing import Any, Optional
+
+from localstack.aws.api.cloudformation import ChangeAction, ResourceChange
+from localstack.services.cloudformation.engine.v2.change_set_model import (
+    ChangeSetEntity,
+    ChangeType,
+    NodeArray,
+    NodeObject,
+    NodeProperties,
+    NodeResource,
+    NodeResources,
+    TerminalValueCreated,
+    TerminalValueModified,
+    TerminalValueRemoved,
+    TerminalValueUnchanged,
+)
+from localstack.services.cloudformation.engine.v2.change_set_model_visitor import (
+    ChangeSetModelVisitor,
+)
+
+
+class DescribeUnit(abc.ABC):
+    before_context: Optional[Any] = None
+    after_context: Optional[Any] = None
+
+    def __init__(self, before_context: Optional[Any] = None, after_context: Optional[Any] = None):
+        self.before_context = before_context
+        self.after_context = after_context
+
+
+class ChangeSetModelDescriber(ChangeSetModelVisitor):
+    resource_changes: list[ResourceChange] = list()
+
+    def __init__(self):
+        self.resource_changes = list()
+
+    def visit(self, change_set_entity: ChangeSetEntity) -> DescribeUnit:
+        # Overridden for the return type-hints.
+        return super().visit(change_set_entity=change_set_entity)
+
+    def visit_terminal_value_modified(
+        self, terminal_value_modified: TerminalValueModified
+    ) -> DescribeUnit:
+        return DescribeUnit(
+            before_context=terminal_value_modified.value,
+            after_context=terminal_value_modified.modified_value,
+        )
+
+    def visit_terminal_value_created(
+        self, terminal_value_created: TerminalValueCreated
+    ) -> DescribeUnit:
+        return DescribeUnit(before_context=terminal_value_created.value)
+
+    def visit_terminal_value_removed(
+        self, terminal_value_removed: TerminalValueRemoved
+    ) -> DescribeUnit:
+        return DescribeUnit(before_context=terminal_value_removed.value)
+
+    def visit_terminal_value_unchanged(
+        self, terminal_value_unchanged: TerminalValueUnchanged
+    ) -> DescribeUnit:
+        return DescribeUnit(before_context=terminal_value_unchanged.value)
+
+    def visit_node_object(self, node_object: NodeObject) -> DescribeUnit:
+        before_context = dict()
+        after_context = dict()
+        for name, change_set_entity in node_object.bindings.items():
+            describe_unit: DescribeUnit = self.visit(change_set_entity=change_set_entity)
+            match change_set_entity.change_type:
+                case ChangeType.MODIFIED:
+                    before_context[name] = describe_unit.before_context
+                    after_context[name] = describe_unit.after_context
+                case ChangeType.CREATED:
+                    after_context[name] = describe_unit.before_context
+                case ChangeType.REMOVED:
+                    before_context[name] = describe_unit.before_context
+        return DescribeUnit(before_context=before_context, after_context=after_context)
+
+    def visit_node_array(self, node_array: NodeArray) -> DescribeUnit:
+        before_context = list()
+        after_context = list()
+        for change_set_entity in node_array.array:
+            describe_unit: DescribeUnit = self.visit(change_set_entity=change_set_entity)
+            match change_set_entity.change_type:
+                case ChangeType.MODIFIED:
+                    before_context.append(describe_unit.before_context)
+                    after_context.append(describe_unit.after_context)
+                case ChangeType.CREATED:
+                    after_context.append(describe_unit.before_context)
+                case ChangeType.REMOVED:
+                    before_context.append(describe_unit.before_context)
+                case ChangeType.UNCHANGED:
+                    before_context.append(describe_unit.before_context)
+                    after_context.append(describe_unit.before_context)
+        return DescribeUnit(before_context=before_context, after_context=after_context)
+
+    def visit_node_properties(self, node_properties: NodeProperties) -> DescribeUnit:
+        before_context: dict[str, Any] = dict()
+        after_context: dict[str, Any] = dict()
+        for node_property in node_properties.properties:
+            if node_property.change_type == ChangeType.UNCHANGED:
+                continue
+            describe_unit = self.visit(node_property.value)
+            property_name = node_property.name
+            match node_property.change_type:
+                case ChangeType.MODIFIED:
+                    before_context[property_name] = describe_unit.before_context
+                    after_context[property_name] = describe_unit.after_context
+                case ChangeType.CREATED:
+                    after_context[property_name] = describe_unit.before_context
+                case ChangeType.REMOVED:
+                    before_context[property_name] = describe_unit.before_context
+        # TODO: this object can probably be well-typed instead of a free dict(?)
+        before_context = {"Properties": before_context}
+        after_context = {"Properties": after_context}
+        return DescribeUnit(before_context=before_context, after_context=after_context)
+
+    def visit_node_resource(self, node_resource: NodeResource) -> DescribeUnit:
+        resource_change = ResourceChange()
+        resource_change["LogicalResourceId"] = node_resource.name
+
+        # TODO: investigate effects on type changes
+        type_describe_unit = self.visit(node_resource.type_)
+        resource_change["ResourceType"] = (
+            type_describe_unit.before_context or type_describe_unit.after_context
+        )
+
+        properties_describe_unit = self.visit_node_properties(node_resource.properties)
+        # TODO: this should be about the resource itself, fix this in the change set modeler.
+        match node_resource.properties.change_type:
+            case ChangeType.MODIFIED:
+                resource_change["Action"] = ChangeAction.Modify
+                resource_change["BeforeContext"] = properties_describe_unit.before_context
+                resource_change["AfterContext"] = properties_describe_unit.after_context
+            case ChangeType.CREATED:
+                resource_change["Action"] = ChangeAction.Add
+                resource_change["AfterContext"] = properties_describe_unit.before_context
+            case ChangeType.REMOVED:
+                resource_change["Action"] = ChangeAction.Remove
+                resource_change["BeforeContext"] = properties_describe_unit.before_context
+
+        self.resource_changes.append(resource_change)
+
+        # TODO
+        return None
+
+    def visit_node_resources(self, node_resources: NodeResources) -> DescribeUnit:
+        for node_resource in node_resources.resources:
+            if node_resource.change_type != ChangeType.UNCHANGED:
+                self.visit_node_resource(node_resource=node_resource)
+        # TODO
+        return None

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 from typing import Any, Final, Optional
 
-import localstack.aws.api.cloudformation as cfn
+from localstack.aws.api.cloudformation import ChangeAction, ResourceChange
 from localstack.services.cloudformation.engine.v2.change_set_model import (
     ChangeSetEntity,
     ChangeType,
@@ -39,18 +39,17 @@ class DescribeUnit(abc.ABC):
 
 
 class ChangeSetModelDescriber(ChangeSetModelVisitor):
-    # TODO: add support for tracking the 'scope' and 'details' (field in the ResourceChange response)
-
     _node_template: Final[NodeTemplate]
-    _changes: Final[list[cfn.Change]]
+    _resource_changes: Final[list[ResourceChange]]
 
     def __init__(self, node_template: NodeTemplate):
         self._node_template = node_template
-        self._changes = list()
+        self._resource_changes = list()
         self.visit(self._node_template)
 
-    def get_changes(self) -> list[cfn.Change]:
-        return self._changes
+    def get_resource_changes(self) -> list[ResourceChange]:
+        # TODO return 'list[Change]' instead.
+        return [{"ResourceChange": change, "Type": "Resource"} for change in self._resource_changes]
 
     def visit(self, change_set_entity: ChangeSetEntity) -> DescribeUnit:
         # Overridden for the return type-hints.
@@ -128,28 +127,23 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
     def visit_node_intrinsic_function_fn_get_att(
         self, node_intrinsic_function: NodeIntrinsicFunction
     ) -> DescribeUnit:
-        # TODO: validate the return value according to the spec.
-
         arguments_unit = self.visit(node_intrinsic_function.arguments)
-
+        # TODO: validate the return value according to the spec.
         before_argument_list = arguments_unit.before_context
         before_logical_name_of_resource = before_argument_list[0]
         before_attribute_name = before_argument_list[1]
         before_node_resource = self._get_node_resource_for(
             resource_name=before_logical_name_of_resource, node_template=self._node_template
         )
-        node_property = self._get_node_property_for(
+        node_property: TerminalValue = self._get_node_property_for(
             property_name=before_attribute_name, node_resource=before_node_resource
         )
-        node_property_value = node_property.value
-        if not isinstance(node_property_value, TerminalValue):
-            raise RuntimeError()
 
-        before_context = node_property_value.value
-        if node_property_value.change_type != ChangeType.UNCHANGED:
+        before_context = node_property.value.value
+        if node_property.change_type != ChangeType.UNCHANGED:
             after_context = CHANGESET_KNOWN_AFTER_APPLY
         else:
-            after_context = node_property_value.value
+            after_context = node_property.value.value
 
         match node_intrinsic_function.change_type:
             case ChangeType.MODIFIED:
@@ -203,7 +197,7 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
         return DescribeUnit(before_context=before_context, after_context=after_context)
 
     def visit_node_resource(self, node_resource: NodeResource) -> DescribeUnit:
-        resource_change = cfn.ResourceChange()
+        resource_change = ResourceChange()
         resource_change["LogicalResourceId"] = node_resource.name
 
         # TODO: investigate effects on type changes
@@ -215,18 +209,17 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
         properties_describe_unit = self.visit_node_properties(node_resource.properties)
         match node_resource.change_type:
             case ChangeType.MODIFIED:
-                resource_change["Action"] = cfn.ChangeAction.Modify
+                resource_change["Action"] = ChangeAction.Modify
                 resource_change["BeforeContext"] = properties_describe_unit.before_context
                 resource_change["AfterContext"] = properties_describe_unit.after_context
             case ChangeType.CREATED:
-                resource_change["Action"] = cfn.ChangeAction.Add
+                resource_change["Action"] = ChangeAction.Add
                 resource_change["AfterContext"] = properties_describe_unit.after_context
             case ChangeType.REMOVED:
-                resource_change["Action"] = cfn.ChangeAction.Remove
+                resource_change["Action"] = ChangeAction.Remove
                 resource_change["BeforeContext"] = properties_describe_unit.before_context
 
-        change = cfn.Change(ResourceChange=resource_change, Type=cfn.ChangeType.Resource)
-        self._changes.append(change)
+        self._resource_changes.append(resource_change)
 
         # TODO
         return None

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
@@ -52,7 +52,7 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
     def visit_terminal_value_created(
         self, terminal_value_created: TerminalValueCreated
     ) -> DescribeUnit:
-        return DescribeUnit(before_context=terminal_value_created.value)
+        return DescribeUnit(after_context=terminal_value_created.value)
 
     def visit_terminal_value_removed(
         self, terminal_value_removed: TerminalValueRemoved
@@ -74,7 +74,7 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
                     before_context[name] = describe_unit.before_context
                     after_context[name] = describe_unit.after_context
                 case ChangeType.CREATED:
-                    after_context[name] = describe_unit.before_context
+                    after_context[name] = describe_unit.after_context
                 case ChangeType.REMOVED:
                     before_context[name] = describe_unit.before_context
         return DescribeUnit(before_context=before_context, after_context=after_context)
@@ -89,7 +89,7 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
                     before_context.append(describe_unit.before_context)
                     after_context.append(describe_unit.after_context)
                 case ChangeType.CREATED:
-                    after_context.append(describe_unit.before_context)
+                    after_context.append(describe_unit.after_context)
                 case ChangeType.REMOVED:
                     before_context.append(describe_unit.before_context)
                 case ChangeType.UNCHANGED:
@@ -110,7 +110,7 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
                     before_context[property_name] = describe_unit.before_context
                     after_context[property_name] = describe_unit.after_context
                 case ChangeType.CREATED:
-                    after_context[property_name] = describe_unit.before_context
+                    after_context[property_name] = describe_unit.after_context
                 case ChangeType.REMOVED:
                     before_context[property_name] = describe_unit.before_context
         # TODO: this object can probably be well-typed instead of a free dict(?)

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
@@ -129,15 +129,14 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
         )
 
         properties_describe_unit = self.visit_node_properties(node_resource.properties)
-        # TODO: this should be about the resource itself, fix this in the change set modeler.
-        match node_resource.properties.change_type:
+        match node_resource.change_type:
             case ChangeType.MODIFIED:
                 resource_change["Action"] = ChangeAction.Modify
                 resource_change["BeforeContext"] = properties_describe_unit.before_context
                 resource_change["AfterContext"] = properties_describe_unit.after_context
             case ChangeType.CREATED:
                 resource_change["Action"] = ChangeAction.Add
-                resource_change["AfterContext"] = properties_describe_unit.before_context
+                resource_change["AfterContext"] = properties_describe_unit.after_context
             case ChangeType.REMOVED:
                 resource_change["Action"] = ChangeAction.Remove
                 resource_change["BeforeContext"] = properties_describe_unit.before_context

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, Optional
+from typing import Any, Final, Optional
 
 from localstack.aws.api.cloudformation import ChangeAction, ResourceChange
 from localstack.services.cloudformation.engine.v2.change_set_model import (
     ChangeSetEntity,
     ChangeType,
     NodeArray,
+    NodeIntrinsicFunction,
     NodeObject,
     NodeProperties,
+    NodeProperty,
     NodeResource,
-    NodeResources,
+    NodeTemplate,
+    TerminalValue,
     TerminalValueCreated,
     TerminalValueModified,
     TerminalValueRemoved,
@@ -20,6 +23,8 @@ from localstack.services.cloudformation.engine.v2.change_set_model import (
 from localstack.services.cloudformation.engine.v2.change_set_model_visitor import (
     ChangeSetModelVisitor,
 )
+
+CHANGESET_KNOWN_AFTER_APPLY: Final[str] = "{{changeSet:KNOWN_AFTER_APPLY}}"
 
 
 class DescribeUnit(abc.ABC):
@@ -32,10 +37,17 @@ class DescribeUnit(abc.ABC):
 
 
 class ChangeSetModelDescriber(ChangeSetModelVisitor):
-    resource_changes: list[ResourceChange] = list()
+    _node_template: Final[NodeTemplate]
+    _resource_changes: Final[list[ResourceChange]]
 
-    def __init__(self):
-        self.resource_changes = list()
+    def __init__(self, node_template: NodeTemplate):
+        self._node_template = node_template
+        self._resource_changes = list()
+        self.visit(self._node_template)
+
+    def get_resource_changes(self) -> list[ResourceChange]:
+        # TODO return 'list[Change]' instead.
+        return self._resource_changes
 
     def visit(self, change_set_entity: ChangeSetEntity) -> DescribeUnit:
         # Overridden for the return type-hints.
@@ -62,9 +74,19 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
     def visit_terminal_value_unchanged(
         self, terminal_value_unchanged: TerminalValueUnchanged
     ) -> DescribeUnit:
-        return DescribeUnit(before_context=terminal_value_unchanged.value)
+        return DescribeUnit(
+            before_context=terminal_value_unchanged.value,
+            after_context=terminal_value_unchanged.value,
+        )
 
     def visit_node_object(self, node_object: NodeObject) -> DescribeUnit:
+        # TODO: improve check syntax
+        if len(node_object.bindings) == 1:
+            binding_values = list(node_object.bindings.values())
+            unique_value = binding_values[0]
+            if isinstance(unique_value, NodeIntrinsicFunction):
+                return self.visit(unique_value)
+
         before_context = dict()
         after_context = dict()
         for name, change_set_entity in node_object.bindings.items():
@@ -77,7 +99,58 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
                     after_context[name] = describe_unit.after_context
                 case ChangeType.REMOVED:
                     before_context[name] = describe_unit.before_context
+                case ChangeType.UNCHANGED:
+                    before_context[name] = describe_unit.before_context
+                    after_context[name] = describe_unit.after_context
         return DescribeUnit(before_context=before_context, after_context=after_context)
+
+    @staticmethod
+    def _get_node_resource_for(resource_name: str, node_template: NodeTemplate) -> NodeResource:
+        # TODO: this could be improved with hashmap lookups if the Node contained bindings and not lists.
+        for node_resource in node_template.resources.resources:
+            if node_resource.name == resource_name:
+                return node_resource
+        # TODO
+        raise RuntimeError()
+
+    @staticmethod
+    def _get_node_property_for(property_name: str, node_resource: NodeResource) -> NodeProperty:
+        # TODO: this could be improved with hashmap lookups if the Node contained bindings and not lists.
+        for node_property in node_resource.properties.properties:
+            if node_property.name == property_name:
+                return node_property
+        # TODO
+        raise RuntimeError()
+
+    def visit_node_intrinsic_function_fn_get_att(
+        self, node_intrinsic_function: NodeIntrinsicFunction
+    ) -> DescribeUnit:
+        arguments_unit = self.visit(node_intrinsic_function.arguments)
+        # TODO: validate the return value according to the spec.
+        before_argument_list = arguments_unit.before_context
+        before_logical_name_of_resource = before_argument_list[0]
+        before_attribute_name = before_argument_list[1]
+        before_node_resource = self._get_node_resource_for(
+            resource_name=before_logical_name_of_resource, node_template=self._node_template
+        )
+        node_property: TerminalValue = self._get_node_property_for(
+            property_name=before_attribute_name, node_resource=before_node_resource
+        )
+        before_attribute_value = node_property.value.value
+
+        match node_intrinsic_function.change_type:
+            case ChangeType.MODIFIED:
+                return DescribeUnit(
+                    before_context=before_attribute_value, after_context=CHANGESET_KNOWN_AFTER_APPLY
+                )
+            case ChangeType.CREATED:
+                return DescribeUnit(after_context=CHANGESET_KNOWN_AFTER_APPLY)
+            case ChangeType.REMOVED:
+                return DescribeUnit(before_context=before_attribute_value)
+        # Unchanged
+        return DescribeUnit(
+            before_context=before_attribute_value, after_context=before_attribute_value
+        )
 
     def visit_node_array(self, node_array: NodeArray) -> DescribeUnit:
         before_context = list()
@@ -141,14 +214,14 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
                 resource_change["Action"] = ChangeAction.Remove
                 resource_change["BeforeContext"] = properties_describe_unit.before_context
 
-        self.resource_changes.append(resource_change)
+        self._resource_changes.append(resource_change)
 
         # TODO
         return None
 
-    def visit_node_resources(self, node_resources: NodeResources) -> DescribeUnit:
-        for node_resource in node_resources.resources:
-            if node_resource.change_type != ChangeType.UNCHANGED:
-                self.visit_node_resource(node_resource=node_resource)
-        # TODO
-        return None
+    # def visit_node_resources(self, node_resources: NodeResources) -> DescribeUnit:
+    # for node_resource in node_resources.resources:
+    #    if node_resource.change_type != ChangeType.UNCHANGED:
+    #        self.visit_node_resource(node_resource=node_resource)
+    # TODO
+    # return None

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_visitor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_visitor.py
@@ -1,0 +1,70 @@
+import abc
+
+from localstack.services.cloudformation.engine.v2.change_set_model import (
+    ChangeSetEntity,
+    NodeArray,
+    NodeObject,
+    NodeProperties,
+    NodeProperty,
+    NodeResource,
+    NodeResources,
+    NodeTemplate,
+    TerminalValueCreated,
+    TerminalValueModified,
+    TerminalValueRemoved,
+    TerminalValueUnchanged,
+)
+from localstack.utils.strings import camel_to_snake_case
+
+
+class ChangeSetModelVisitor(abc.ABC):
+    # TODO: this class should be auto generated.
+
+    # TODO: add visitors for abstract classes so shared logic can be implemented
+    #  just once in classes extending this.
+
+    def visit(self, change_set_entity: ChangeSetEntity):
+        # TODO: speed up this lookup logic
+        type_str = change_set_entity.__class__.__name__
+        type_str = camel_to_snake_case(type_str)
+        visit_function_name = f"visit_{type_str}"
+        visit_function = getattr(self, visit_function_name)
+        return visit_function(change_set_entity)
+
+    def visit_children(self, change_set_entity: ChangeSetEntity):
+        children = change_set_entity.get_children()
+        for child in children:
+            self.visit(child)
+
+    def visit_node_template(self, node_template: NodeTemplate):
+        self.visit_children(node_template)
+
+    def visit_node_resources(self, node_resources: NodeResources):
+        self.visit_children(node_resources)
+
+    def visit_node_resource(self, node_resource: NodeResource):
+        self.visit_children(node_resource)
+
+    def visit_node_properties(self, node_properties: NodeProperties):
+        self.visit_children(node_properties)
+
+    def visit_node_property(self, node_property: NodeProperty):
+        self.visit_children(node_property)
+
+    def visit_node_object(self, node_object: NodeObject):
+        self.visit_children(node_object)
+
+    def visit_node_array(self, node_array: NodeArray):
+        self.visit_children(node_array)
+
+    def visit_terminal_value_modified(self, terminal_value_modified: TerminalValueModified):
+        self.visit_children(terminal_value_modified)
+
+    def visit_terminal_value_created(self, terminal_value_created: TerminalValueCreated):
+        self.visit_children(terminal_value_created)
+
+    def visit_terminal_value_removed(self, terminal_value_removed: TerminalValueRemoved):
+        self.visit_children(terminal_value_removed)
+
+    def visit_terminal_value_unchanged(self, terminal_value_unchanged: TerminalValueUnchanged):
+        self.visit_children(terminal_value_unchanged)

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_visitor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_visitor.py
@@ -3,6 +3,7 @@ import abc
 from localstack.services.cloudformation.engine.v2.change_set_model import (
     ChangeSetEntity,
     NodeArray,
+    NodeIntrinsicFunction,
     NodeObject,
     NodeProperties,
     NodeProperty,
@@ -50,6 +51,20 @@ class ChangeSetModelVisitor(abc.ABC):
 
     def visit_node_property(self, node_property: NodeProperty):
         self.visit_children(node_property)
+
+    def visit_node_intrinsic_function(self, node_intrinsic_function: NodeIntrinsicFunction):
+        # TODO: speed up this lookup logic
+        function_name = node_intrinsic_function.intrinsic_function
+        function_name = function_name.replace("::", "_")
+        function_name = camel_to_snake_case(function_name)
+        visit_function_name = f"visit_node_intrinsic_function_{function_name}"
+        visit_function = getattr(self, visit_function_name)
+        return visit_function(node_intrinsic_function)
+
+    def visit_node_intrinsic_function_fn_get_att(
+        self, node_intrinsic_function: NodeIntrinsicFunction
+    ):
+        self.visit_children(node_intrinsic_function)
 
     def visit_node_object(self, node_object: NodeObject):
         self.visit_children(node_object)

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -1,5 +1,281 @@
-from localstack.services.cloudformation.provider import CloudformationProvider
+from copy import deepcopy
+
+from localstack.aws.api import RequestContext, handler
+from localstack.aws.api.cloudformation import (
+    ChangeSetNameOrId,
+    ChangeSetNotFoundException,
+    ChangeSetType,
+    CreateChangeSetInput,
+    CreateChangeSetOutput,
+    DescribeChangeSetOutput,
+    IncludePropertyValues,
+    NextToken,
+    Parameter,
+    StackNameOrId,
+    StackStatus,
+)
+from localstack.services.cloudformation import api_utils
+from localstack.services.cloudformation.engine import parameters as param_resolver
+from localstack.services.cloudformation.engine import template_deployer, template_preparer
+from localstack.services.cloudformation.engine.entities import Stack, StackChangeSet
+from localstack.services.cloudformation.engine.parameters import mask_no_echo, strip_parameter_type
+from localstack.services.cloudformation.engine.resource_ordering import (
+    NoResourceInStack,
+    order_resources,
+)
+from localstack.services.cloudformation.engine.template_utils import resolve_stack_conditions
+from localstack.services.cloudformation.engine.v2.change_set_model_describer import (
+    ChangeSetModelDescriber,
+)
+from localstack.services.cloudformation.engine.validations import ValidationError
+from localstack.services.cloudformation.provider import (
+    ARN_CHANGESET_REGEX,
+    ARN_STACK_REGEX,
+    CloudformationProvider,
+    clone_stack_params,
+)
+from localstack.services.cloudformation.stores import (
+    find_change_set,
+    find_stack,
+    get_cloudformation_store,
+)
+from localstack.utils.collections import remove_attributes
 
 
 class CloudformationProviderV2(CloudformationProvider):
-    pass
+    @handler("CreateChangeSet", expand=False)
+    def create_change_set(
+        self, context: RequestContext, request: CreateChangeSetInput
+    ) -> CreateChangeSetOutput:
+        state = get_cloudformation_store(context.account_id, context.region)
+
+        req_params = request
+        change_set_type = req_params.get("ChangeSetType", "UPDATE")
+        stack_name = req_params.get("StackName")
+        change_set_name = req_params.get("ChangeSetName")
+        template_body = req_params.get("TemplateBody")
+        # s3 or secretsmanager url
+        template_url = req_params.get("TemplateURL")
+
+        # validate and resolve template
+        if template_body and template_url:
+            raise ValidationError(
+                "Specify exactly one of 'TemplateBody' or 'TemplateUrl'"
+            )  # TODO: check proper message
+
+        if not template_body and not template_url:
+            raise ValidationError(
+                "Specify exactly one of 'TemplateBody' or 'TemplateUrl'"
+            )  # TODO: check proper message
+
+        api_utils.prepare_template_body(
+            req_params
+        )  # TODO: function has too many unclear responsibilities
+        if not template_body:
+            template_body = req_params[
+                "TemplateBody"
+            ]  # should then have been set by prepare_template_body
+        template = template_preparer.parse_template(req_params["TemplateBody"])
+
+        del req_params["TemplateBody"]  # TODO: stop mutating req_params
+        template["StackName"] = stack_name
+        # TODO: validate with AWS what this is actually doing?
+        template["ChangeSetName"] = change_set_name
+
+        # this is intentionally not in a util yet. Let's first see how the different operations deal with these before generalizing
+        # handle ARN stack_name here (not valid for initial CREATE, since stack doesn't exist yet)
+        if ARN_STACK_REGEX.match(stack_name):
+            if not (stack := state.stacks.get(stack_name)):
+                raise ValidationError(f"Stack '{stack_name}' does not exist.")
+        else:
+            # stack name specified, so fetch the stack by name
+            stack_candidates: list[Stack] = [
+                s for stack_arn, s in state.stacks.items() if s.stack_name == stack_name
+            ]
+            active_stack_candidates = [
+                s for s in stack_candidates if self._stack_status_is_active(s.status)
+            ]
+
+            # on a CREATE an empty Stack should be generated if we didn't find an active one
+            if not active_stack_candidates and change_set_type == ChangeSetType.CREATE:
+                empty_stack_template = dict(template)
+                empty_stack_template["Resources"] = {}
+                req_params_copy = clone_stack_params(req_params)
+                stack = Stack(
+                    context.account_id,
+                    context.region,
+                    req_params_copy,
+                    empty_stack_template,
+                    template_body=template_body,
+                )
+                state.stacks[stack.stack_id] = stack
+                stack.set_stack_status("REVIEW_IN_PROGRESS")
+            else:
+                if not active_stack_candidates:
+                    raise ValidationError(f"Stack '{stack_name}' does not exist.")
+                stack = active_stack_candidates[0]
+
+        # TODO: test if rollback status is allowed as well
+        if (
+            change_set_type == ChangeSetType.CREATE
+            and stack.status != StackStatus.REVIEW_IN_PROGRESS
+        ):
+            raise ValidationError(
+                f"Stack [{stack_name}] already exists and cannot be created again with the changeSet [{change_set_name}]."
+            )
+
+        old_parameters: dict[str, Parameter] = {}
+        match change_set_type:
+            case ChangeSetType.UPDATE:
+                # add changeset to existing stack
+                old_parameters = {
+                    k: mask_no_echo(strip_parameter_type(v))
+                    for k, v in stack.resolved_parameters.items()
+                }
+            case ChangeSetType.IMPORT:
+                raise NotImplementedError()  # TODO: implement importing resources
+            case ChangeSetType.CREATE:
+                pass
+            case _:
+                msg = (
+                    f"1 validation error detected: Value '{change_set_type}' at 'changeSetType' failed to satisfy "
+                    f"constraint: Member must satisfy enum value set: [IMPORT, UPDATE, CREATE] "
+                )
+                raise ValidationError(msg)
+
+        # resolve parameters
+        new_parameters: dict[str, Parameter] = param_resolver.convert_stack_parameters_to_dict(
+            request.get("Parameters")
+        )
+        parameter_declarations = param_resolver.extract_stack_parameter_declarations(template)
+        resolved_parameters = param_resolver.resolve_parameters(
+            account_id=context.account_id,
+            region_name=context.region,
+            parameter_declarations=parameter_declarations,
+            new_parameters=new_parameters,
+            old_parameters=old_parameters,
+        )
+
+        # TODO: remove this when fixing Stack.resources and transformation order
+        #   currently we need to create a stack with existing resources + parameters so that resolve refs recursively in here will work.
+        #   The correct way to do it would be at a later stage anyway just like a normal intrinsic function
+        req_params_copy = clone_stack_params(req_params)
+        temp_stack = Stack(context.account_id, context.region, req_params_copy, template)
+        temp_stack.set_resolved_parameters(resolved_parameters)
+
+        # TODO: everything below should be async
+        # apply template transformations
+        transformed_template = template_preparer.transform_template(
+            context.account_id,
+            context.region,
+            template,
+            stack_name=temp_stack.stack_name,
+            resources=temp_stack.resources,
+            mappings=temp_stack.mappings,
+            conditions={},  # TODO: we don't have any resolved conditions yet at this point but we need the conditions because of the samtranslator...
+            resolved_parameters=resolved_parameters,
+        )
+
+        # create change set for the stack and apply changes
+        change_set = StackChangeSet(
+            context.account_id, context.region, stack, req_params, transformed_template
+        )
+        # only set parameters for the changeset, then switch to stack on execute_change_set
+        change_set.template_body = template_body
+        change_set.populate_update_graph(stack.template, transformed_template)
+
+        # TODO: evaluate conditions
+        raw_conditions = transformed_template.get("Conditions", {})
+        resolved_stack_conditions = resolve_stack_conditions(
+            account_id=context.account_id,
+            region_name=context.region,
+            conditions=raw_conditions,
+            parameters=resolved_parameters,
+            mappings=temp_stack.mappings,
+            stack_name=stack_name,
+        )
+        change_set.set_resolved_stack_conditions(resolved_stack_conditions)
+
+        # a bit gross but use the template ordering to validate missing resources
+        try:
+            order_resources(
+                transformed_template["Resources"],
+                resolved_parameters=resolved_parameters,
+                resolved_conditions=resolved_stack_conditions,
+            )
+        except NoResourceInStack as e:
+            raise ValidationError(str(e)) from e
+
+        deployer = template_deployer.TemplateDeployer(
+            context.account_id, context.region, change_set
+        )
+        changes = deployer.construct_changes(
+            stack,
+            change_set,
+            change_set_id=change_set.change_set_id,
+            append_to_changeset=True,
+            filter_unchanged_resources=True,
+        )
+        stack.change_sets.append(change_set)
+        if not changes:
+            change_set.metadata["Status"] = "FAILED"
+            change_set.metadata["ExecutionStatus"] = "UNAVAILABLE"
+            change_set.metadata["StatusReason"] = (
+                "The submitted information didn't contain changes. Submit different information to create a change set."
+            )
+        else:
+            change_set.metadata["Status"] = (
+                "CREATE_COMPLETE"  # technically for some time this should first be CREATE_PENDING
+            )
+            change_set.metadata["ExecutionStatus"] = (
+                "AVAILABLE"  # technically for some time this should first be UNAVAILABLE
+            )
+
+        return CreateChangeSetOutput(StackId=change_set.stack_id, Id=change_set.change_set_id)
+
+    @handler("DescribeChangeSet")
+    def describe_change_set(
+        self,
+        context: RequestContext,
+        change_set_name: ChangeSetNameOrId,
+        stack_name: StackNameOrId = None,
+        next_token: NextToken = None,
+        include_property_values: IncludePropertyValues = None,
+        **kwargs,
+    ) -> DescribeChangeSetOutput:
+        # TODO add support for include_property_values
+        # only relevant if change_set_name isn't an ARN
+        if not ARN_CHANGESET_REGEX.match(change_set_name):
+            if not stack_name:
+                raise ValidationError(
+                    "StackName must be specified if ChangeSetName is not specified as an ARN."
+                )
+
+            stack = find_stack(context.account_id, context.region, stack_name)
+            if not stack:
+                raise ValidationError(f"Stack [{stack_name}] does not exist")
+
+        change_set = find_change_set(
+            context.account_id, context.region, change_set_name, stack_name=stack_name
+        )
+        if not change_set:
+            raise ChangeSetNotFoundException(f"ChangeSet [{change_set_name}] does not exist")
+
+        change_set_describer = ChangeSetModelDescriber(node_template=change_set.update_graph)
+        resource_changes = change_set_describer.get_resource_changes()
+
+        attrs = [
+            "ChangeSetType",
+            "StackStatus",
+            "LastUpdatedTime",
+            "DisableRollback",
+            "EnableTerminationProtection",
+            "Transform",
+        ]
+        result = remove_attributes(deepcopy(change_set.metadata), attrs)
+        # TODO: replace this patch with a better solution
+        result["Parameters"] = [
+            mask_no_echo(strip_parameter_type(p)) for p in result.get("Parameters", [])
+        ]
+        result["Changes"] = resource_changes
+        return result

--- a/tests/unit/services/cloudformation/test_change_set_describe_details.py
+++ b/tests/unit/services/cloudformation/test_change_set_describe_details.py
@@ -22,7 +22,7 @@ class TestChangeSetDescribeDetails:
         )
         update_model: NodeTemplate = change_set_model.get_update_model()
         change_set_describer = ChangeSetModelDescriber(node_template=update_model)
-        changes = change_set_describer.get_changes()
+        changes = change_set_describer.get_resource_changes()
         # TODO
         json_str = json.dumps(changes)
         return json.loads(json_str)

--- a/tests/unit/services/cloudformation/test_change_set_describe_details.py
+++ b/tests/unit/services/cloudformation/test_change_set_describe_details.py
@@ -1,0 +1,245 @@
+import json
+
+from localstack.aws.api.cloudformation import ResourceChange
+from localstack.services.cloudformation.engine.v2.change_set_model import (
+    ChangeSetModel,
+    NodeTemplate,
+)
+from localstack.services.cloudformation.engine.v2.change_set_model_describer import (
+    ChangeSetModelDescriber,
+)
+
+
+# TODO: this is a temporary test suite for the v2 CFN update engine change set description logic.
+#  should be replaced in favour of v2 integration tests.
+class TestChangeSetDescribeDetails:
+    @staticmethod
+    def eval_change_set(before_template: dict, after_template: dict) -> list[ResourceChange]:
+        change_set_model = ChangeSetModel(
+            before_template=before_template, after_template=after_template
+        )
+        update_model: NodeTemplate = change_set_model.get_update_model()
+        change_set_describer = ChangeSetModelDescriber(node_template=update_model)
+        resource_changes = change_set_describer.get_resource_changes()
+        # TODO
+        json_str = json.dumps(resource_changes)
+        return json.loads(json_str)
+
+    def test_direct_update(self):
+        t1 = {
+            "Resources": {
+                "Foo": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": "topic-1",
+                    },
+                },
+            },
+        }
+        t2 = {
+            "Resources": {
+                "Foo": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": "topic-2",
+                    },
+                },
+            },
+        }
+        resource_changes = self.eval_change_set(t1, t2)
+        target = [
+            {
+                "Action": "Modify",
+                "AfterContext": {"Properties": {"TopicName": "topic-2"}},
+                "BeforeContext": {"Properties": {"TopicName": "topic-1"}},
+                "LogicalResourceId": "Foo",
+                "ResourceType": "AWS::SNS::Topic",
+            },
+        ]
+        assert resource_changes == target
+
+    def test_dynamic_update(self):
+        t1 = {
+            "Resources": {
+                "Foo": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": "topic-1",
+                    },
+                },
+                "Parameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Type": "String",
+                        "Value": {
+                            "Fn::GetAtt": ["Foo", "TopicName"],
+                        },
+                    },
+                },
+            },
+        }
+        t2 = {
+            "Resources": {
+                "Foo": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": "topic-2",
+                    },
+                },
+                "Parameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Type": "String",
+                        "Value": {
+                            "Fn::GetAtt": ["Foo", "TopicName"],
+                        },
+                    },
+                },
+            },
+        }
+        resource_changes = self.eval_change_set(t1, t2)
+        target = [
+            {
+                "Action": "Modify",
+                "AfterContext": {"Properties": {"TopicName": "topic-2"}},
+                "BeforeContext": {"Properties": {"TopicName": "topic-1"}},
+                "LogicalResourceId": "Foo",
+                "ResourceType": "AWS::SNS::Topic",
+            },
+            {
+                "Action": "Modify",
+                "AfterContext": {
+                    "Properties": {"Value": "{{changeSet:KNOWN_AFTER_APPLY}}", "Type": "String"}
+                },
+                "BeforeContext": {"Properties": {"Value": "topic-1", "Type": "String"}},
+                "LogicalResourceId": "Parameter",
+                "ResourceType": "AWS::SSM::Parameter",
+            },
+        ]
+        assert resource_changes == target
+
+    def test_unrelated_changes_update_propagation(self):
+        t1 = {
+            "Resources": {
+                "Parameter1": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Type": "String",
+                        "Value": "topic_name",
+                        "Description": "original",
+                    },
+                },
+                "Parameter2": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Type": "String",
+                        "Value": {"Fn::GetAtt": ["Parameter1", "Value"]},
+                    },
+                },
+            },
+        }
+        t2 = {
+            "Resources": {
+                "Parameter1": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Type": "String",
+                        "Value": "topic_name",
+                        "Description": "changed",
+                    },
+                },
+                "Parameter2": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Type": "String",
+                        "Value": {"Fn::GetAtt": ["Parameter1", "Value"]},
+                    },
+                },
+            },
+        }
+        resource_changes = self.eval_change_set(t1, t2)
+        target = [
+            {
+                "Action": "Modify",
+                "AfterContext": {
+                    "Properties": {
+                        "Value": "topic_name",
+                        "Type": "String",
+                        "Description": "changed",
+                    }
+                },
+                "BeforeContext": {
+                    "Properties": {
+                        "Value": "topic_name",
+                        "Type": "String",
+                        "Description": "original",
+                    }
+                },
+            }
+        ]
+        assert resource_changes == target
+
+    def test_unrelated_changes_requires_replacement(self):
+        t1 = {
+            "Resources": {
+                "Parameter1": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Name": "MyParameter-1",
+                        "Type": "String",
+                        "Value": "value",
+                    },
+                },
+                "Parameter2": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Type": "String",
+                        "Value": {"Fn::GetAtt": ["Parameter1", "Value"]},
+                    },
+                },
+            },
+        }
+        t2 = {
+            "Resources": {
+                "Parameter1": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Name": "MyParameter-2",
+                        "Type": "String",
+                        "Value": "value",
+                    },
+                },
+                "Parameter2": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Type": "String",
+                        "Value": {"Fn::GetAtt": ["Parameter1", "Value"]},
+                    },
+                },
+            },
+        }
+        resource_changes = self.eval_change_set(t1, t2)
+        target = [
+            {
+                "Action": "Modify",
+                "AfterContext": {
+                    "Properties": {"Value": "value", "Type": "String", "Name": "MyParameter-2"}
+                },
+                "BeforeContext": {
+                    "Properties": {"Value": "value", "Type": "String", "Name": "MyParameter-1"}
+                },
+                "LogicalResourceId": "Parameter1",
+                "ResourceType": "AWS::SSM::Parameter",
+            },
+            {
+                "Action": "Modify",
+                "AfterContext": {
+                    "Properties": {"Value": "{{changeSet:KNOWN_AFTER_APPLY}}", "Type": "String"}
+                },
+                "BeforeContext": {"Properties": {"Value": "value", "Type": "String"}},
+                "LogicalResourceId": "Parameter2",
+                "Replacement": "False",
+                "ResourceType": "AWS::SSM::Parameter",
+            },
+        ]
+        assert resource_changes == target

--- a/tests/unit/services/cloudformation/test_change_set_describe_details.py
+++ b/tests/unit/services/cloudformation/test_change_set_describe_details.py
@@ -175,6 +175,8 @@ class TestChangeSetDescribeDetails:
                         "Description": "original",
                     }
                 },
+                "LogicalResourceId": "Parameter1",
+                "ResourceType": "AWS::SSM::Parameter",
             }
         ]
         assert resource_changes == target


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With the recent changes in https://github.com/localstack/localstack/pull/12355, we introduced a new design pattern for representing CloudFormation templates. However, that design did not account for deeper intra-template relationships, preventing accurate detection of indirect resource changes driven by dependencies or intrinsic functions. This PR addresses those limitations by introducing logic to traverse and resolve template elements and intrinsic functions, ensuring that updates and dependencies are correctly captured. It also resolves issues comparing null or empty template versions.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Add logic to lazily traverse template files during update graph construction, capturing indirect changes driven by dependencies and intrinsic function evaluations.
- Introduce a pattern for resolving intrinsic functions, applied both while building the update graph and during ChangeSetDescribe operations.
- Improve comparison logic for null or empty template versions, ensuring changes are accurately detected.
- Integrate new provider (if `PROVIDER_OVERRIDE_CLOUDFORMATION=engine-v2` is supplied) with create and describe change set

## Testing
- Includes temporary unit tests for the describe functionality, set for removal once the update graph POC is integrated in the CFN engine-v2 provide.


<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
