### PR TITLE
Fix apigw input path formatting

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -54,7 +54,7 @@ def get_java_formatter(value):
     if isinstance(value, dict):
         return JavaDictFormatter(value)
     if isinstance(value, list):
-        return [JavaDictFormatter(item) for item in value]
+        return [get_java_formatter(item) for item in value]
     return value
 
 
@@ -68,13 +68,14 @@ def get_input_path_formatter(value: any) -> any:
 
 class JavaDictFormatter(dict):
     # TODO apply this class more generally through the template mappings
-    @staticmethod
-    def formatter_factory(value: any) -> any:
-        return get_java_formatter(value)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.update(*args, **kwargs)
+
+    @staticmethod
+    def formatter_factory(value: any) -> any:
+        return get_java_formatter(value)
 
     def update(self, *args, **kwargs):
         for k, v in self.items():

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -209,15 +209,18 @@ class VelocityInput:
         self.parameters = params or {}
         self.value = body
 
-    def path(self, path):
+    def _extract_json_path(self, path):
         if not self.value:
             return {}
         value = self.value if isinstance(self.value, dict) else json.loads(self.value)
-        return cast_to_vtl_json_object(extract_jsonpath(value, path))
+        return extract_jsonpath(value, path)
+
+    def path(self, path):
+        return cast_to_vtl_json_object(self._extract_json_path(path))
 
     def json(self, path):
         path = path or "$"
-        matching = self.path(path)
+        matching = self._extract_json_path(path)
         if isinstance(matching, (list, dict)):
             matching = json_safe(matching)
         return json.dumps(matching)

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -2175,6 +2175,7 @@ def echo_http_server(httpserver: HTTPServer):
             "headers": dict(request.headers),
             "url": request.url,
             "method": request.method,
+            "json": request.json if request.is_json else None,
         }
         response_body = json.dumps(json_safe(result))
         return Response(response_body, status=200)

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -2170,12 +2170,16 @@ def echo_http_server(httpserver: HTTPServer):
     """Spins up a local HTTP echo server and returns the endpoint URL"""
 
     def _echo(request: Request) -> Response:
+        request_json = None
+        if request.is_json:
+            with contextlib.suppress(ValueError):
+                request_json = json.loads(request.data)
         result = {
             "data": request.data or "{}",
             "headers": dict(request.headers),
             "url": request.url,
             "method": request.method,
-            "json": request.json if request.is_json else None,
+            "json": request_json,
         }
         response_body = json.dumps(json_safe(result))
         return Response(response_body, status=200)

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -788,6 +788,87 @@ class TestApiGatewayCommon:
         # assert that AWS populated the parent part of the trace with a generated one
         assert split_trace[1] != hardcoded_parent
 
+    @markers.aws.validated
+    def test_input_path_template_formatting(
+        self, aws_client, create_rest_apigw, echo_http_server_post, snapshot
+    ):
+        api_id, _, root_id = create_rest_apigw()
+
+        def _create_route(path: str, response_templates):
+            resource_id = aws_client.apigateway.create_resource(
+                restApiId=api_id, parentId=root_id, pathPart=path
+            )["id"]
+            aws_client.apigateway.put_method(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod="POST",
+                authorizationType="NONE",
+                apiKeyRequired=False,
+            )
+
+            aws_client.apigateway.put_method_response(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod="POST",
+                statusCode="200",
+            )
+
+            aws_client.apigateway.put_integration(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod="POST",
+                integrationHttpMethod="POST",
+                type="HTTP",
+                uri=echo_http_server_post,
+            )
+
+            aws_client.apigateway.put_integration_response(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod="POST",
+                statusCode="200",
+                selectionPattern="",
+                responseTemplates={"application/json": response_templates},
+            )
+
+        _create_route("path", '#set($result = $input.path("$.json"))$result')
+        _create_route("nested", '#set($result = $input.path("$.json"))$result.nested')
+        _create_route("list", '#set($result = $input.path("$.json"))$result[0]')
+
+        stage_name = "dev"
+        aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
+
+        url = api_invoke_url(api_id=api_id, stage=stage_name, path="/")
+        path_url = url + "path"
+        nested_url = url + "nested"
+        list_url = url + "list"
+
+        response = requests.post(path_url, json={"foo": "bar"})
+        snapshot.match("dict-response", response.text)
+
+        response = requests.post(path_url, json=[{"foo": "bar"}])
+        snapshot.match("json-list", response.text)
+
+        response = requests.post(nested_url, json={"nested": {"foo": "bar"}})
+        snapshot.match("nested-dict", response.text)
+
+        response = requests.post(nested_url, json={"nested": [{"foo": "bar"}]})
+        snapshot.match("nested-list", response.text)
+
+        response = requests.post(list_url, json=[{"foo": "bar"}])
+        snapshot.match("dict-in-list", response.text)
+
+        response = requests.post(list_url, json=[[{"foo": "bar"}]])
+        snapshot.match("list-with-nested-list", response.text)
+
+        response = requests.post(path_url, json={"foo": [{"nested": "bar"}]})
+        snapshot.match("dict-with-nested-list", response.text)
+
+        response = requests.post(
+            path_url, json={"bigger": "dict", "to": "test", "with": "separators"}
+        )
+        snapshot.match("bigger-dict", response.text)
+
 
 class TestUsagePlans:
     @markers.aws.validated

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -834,6 +834,7 @@ class TestApiGatewayCommon:
         _create_route("path", '#set($result = $input.path("$.json"))$result')
         _create_route("nested", '#set($result = $input.path("$.json"))$result.nested')
         _create_route("list", '#set($result = $input.path("$.json"))$result[0]')
+        _create_route("to-string", '#set($result = $input.path("$.json"))$result.toString()')
 
         stage_name = "dev"
         aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
@@ -842,6 +843,7 @@ class TestApiGatewayCommon:
         path_url = url + "path"
         nested_url = url + "nested"
         list_url = url + "list"
+        to_string = url + "to-string"
 
         response = requests.post(path_url, json={"foo": "bar"})
         snapshot.match("dict-response", response.text)
@@ -868,6 +870,12 @@ class TestApiGatewayCommon:
             path_url, json={"bigger": "dict", "to": "test", "with": "separators"}
         )
         snapshot.match("bigger-dict", response.text)
+
+        response = requests.post(to_string, json={"foo": "bar"})
+        snapshot.match("to-string", response.text)
+
+        response = requests.post(to_string, json={"list": [{"foo": "bar"}]})
+        snapshot.match("list-to-string", response.text)
 
 
 class TestUsagePlans:

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -1376,5 +1376,18 @@
         "message": "Invalid request body"
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_path_template_formatting": {
+    "recorded-date": "12-03-2025, 18:47:52",
+    "recorded-content": {
+      "dict-response": "{foo=bar}",
+      "json-list": "[{\"foo\":\"bar\"}]",
+      "nested-dict": "{foo=bar}",
+      "nested-list": "[{\"foo\":\"bar\"}]",
+      "dict-in-list": "{foo=bar}",
+      "list-with-nested-list": "[{\"foo\":\"bar\"}]",
+      "dict-with-nested-list": "{foo=[{\"nested\":\"bar\"}]}",
+      "bigger-dict": "{bigger=dict, to=test, with=separators}"
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -1378,7 +1378,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_path_template_formatting": {
-    "recorded-date": "12-03-2025, 18:47:52",
+    "recorded-date": "12-03-2025, 21:18:25",
     "recorded-content": {
       "dict-response": "{foo=bar}",
       "json-list": "[{\"foo\":\"bar\"}]",
@@ -1387,7 +1387,9 @@
       "dict-in-list": "{foo=bar}",
       "list-with-nested-list": "[{\"foo\":\"bar\"}]",
       "dict-with-nested-list": "{foo=[{\"nested\":\"bar\"}]}",
-      "bigger-dict": "{bigger=dict, to=test, with=separators}"
+      "bigger-dict": "{bigger=dict, to=test, with=separators}",
+      "to-string": "{foo=bar}",
+      "list-to-string": "{list=[{\"foo\":\"bar\"}]}"
     }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -14,6 +14,9 @@
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_invocation_trace_id": {
     "last_validated_date": "2024-08-07T20:24:17+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_path_template_formatting": {
+    "last_validated_date": "2025-03-12T18:47:52+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApigatewayRouting::test_proxy_routing_with_hardcoded_resource_sibling": {
     "last_validated_date": "2024-07-23T17:41:36+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -8,14 +8,14 @@
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator_with_ref_one_ofmodels": {
     "last_validated_date": "2024-10-28T23:12:21+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_path_template_formatting": {
+    "last_validated_date": "2025-03-12T21:18:25+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_integration_request_parameters_mapping": {
     "last_validated_date": "2024-02-05T19:37:03+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_invocation_trace_id": {
     "last_validated_date": "2024-08-07T20:24:17+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_path_template_formatting": {
-    "last_validated_date": "2025-03-12T18:47:52+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApigatewayRouting::test_proxy_routing_with_hardcoded_resource_sibling": {
     "last_validated_date": "2024-07-23T17:41:36+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When using VTL template for apigateway, AWS generally returns a java object string representation `{foo=bar}`. But when accessing a list through `$input.path('$')`, it returns a valid json string, even if there are dict inside. A nested list inside a dict will cause the encapsulated object to be json encoded as well `{list=[{"foo":"bar"}]}`.

This pr implements java representation for result of `$input.path` and proper list formatting. Follow ups will be required to implement the Java formatting over more results in the VTL template.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Introduces `JavaDictFormatter` to return Java like object
- Implements `InputPathDictFormatter` and `InputPathListFormatter` to manage string formatting of children of `$input.path`
- Add tests

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
