### PR TITLE
SNS: migrate to new Counter type for analytics

### DIFF
--- a/localstack-core/localstack/services/sns/analytics.py
+++ b/localstack-core/localstack/services/sns/analytics.py
@@ -1,0 +1,9 @@
+"""
+Usage analytics for SNS internal endpoints
+"""
+
+from localstack.utils.analytics.metrics import Counter
+
+# number of times SNS internal endpoint per resource types
+# (e.g. PlatformMessage invoked 10x times, SMSMessage invoked 3x times, SubscriptionToken...)
+internal_api_calls = Counter(namespace="sns", name="internal_api_call", labels=["resource_type"])

--- a/localstack-core/localstack/services/sns/provider.py
+++ b/localstack-core/localstack/services/sns/provider.py
@@ -61,7 +61,6 @@ from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.sns import constants as sns_constants
-from localstack.services.sns import usage
 from localstack.services.sns.certificate import SNS_SERVER_CERT
 from localstack.services.sns.filter import FilterPolicyValidator
 from localstack.services.sns.models import (
@@ -85,6 +84,8 @@ from localstack.utils.aws.arns import (
 )
 from localstack.utils.collections import PaginatedList, select_from_typed_dict
 from localstack.utils.strings import short_uid, to_bytes, to_str
+
+from .analytics import internal_api_calls
 
 # set up logger
 LOG = logging.getLogger(__name__)
@@ -1134,7 +1135,7 @@ class SNSInternalResource:
     """Base class with helper to properly track usage of internal endpoints"""
 
     def count_usage(self):
-        usage.internalapi.record(f"{self.resource_type}")
+        internal_api_calls.labels(resource_type=self.resource_type).increment()
 
 
 def count_usage(f):

--- a/localstack-core/localstack/services/sns/usage.py
+++ b/localstack-core/localstack/services/sns/usage.py
@@ -1,9 +1,0 @@
-"""
-Usage reporting for SNS internal endpoints
-"""
-
-from localstack.utils.analytics.usage import UsageSetCounter
-
-# number of times SNS internal endpoint per resource types
-# (e.g. PlatformMessage:get invoked 10x times, SMSMessage:get invoked 3x times, SubscriptionToken...)
-internalapi = UsageSetCounter("sns:internalapi")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR replaces the analytics Counter used for tracking usage of internal SNS APIs. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- replace the previous `UsageSetCounter` with the new `Counter` with labels
- rename the `usage.py` file in `analytics.py`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
