### PR TITLE
CFn: switch to new usage counters

### DIFF
--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -514,7 +514,7 @@ class ResourceProviderExecutor:
         match change_type:
             case "Add":
                 # replicate previous event emitting behaviour
-                usage.resource_type.record(request.resource_type)
+                usage.resource_types.labels(resource_type=request.resource_type).increment()
 
                 return resource_provider.create(request)
             case "Dynamic" | "Modify":
@@ -604,7 +604,7 @@ class ResourceProviderExecutor:
             f'No resource provider found for "{resource_type}"',
         )
 
-        usage.missing_resource_types.record(resource_type)
+        usage.missing_resource_types.labels(missing_resource_type=resource_type).increment()
 
         if config.CFN_IGNORE_UNSUPPORTED_RESOURCE_TYPES:
             # TODO: figure out a better way to handle non-implemented here?

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -513,9 +513,6 @@ class ResourceProviderExecutor:
 
         match change_type:
             case "Add":
-                # replicate previous event emitting behaviour
-                usage.resource_types.labels(resource_type=request.resource_type).increment()
-
                 return resource_provider.create(request)
             case "Dynamic" | "Modify":
                 try:
@@ -586,6 +583,7 @@ class ResourceProviderExecutor:
         # 2. try to load community resource provider
         try:
             plugin = plugin_manager.load(resource_type)
+            usage.resources.labels(resource_type=resource_type, missing=False).increment()
             return plugin.factory()
         except ValueError:
             # could not find a plugin for that name
@@ -604,7 +602,7 @@ class ResourceProviderExecutor:
             f'No resource provider found for "{resource_type}"',
         )
 
-        usage.missing_resource_types.labels(missing_resource_type=resource_type).increment()
+        usage.resources.labels(resource_type=resource_type, missing=True).increment()
 
         if config.CFN_IGNORE_UNSUPPORTED_RESOURCE_TYPES:
             # TODO: figure out a better way to handle non-implemented here?

--- a/localstack-core/localstack/services/cloudformation/usage.py
+++ b/localstack-core/localstack/services/cloudformation/usage.py
@@ -2,10 +2,6 @@ from localstack.utils.analytics.metrics import Counter
 
 COUNTER_NAMESPACE = "cloudformation"
 
-# XXX the name is resourcetype to maintain backwards compatibility with the previous counters (when using UsageSetCounter)
-resource_types = Counter(namespace=COUNTER_NAMESPACE, name="resourcetype", labels=["resource_type"])
-
-# XXX the name is missingresourcetypes to maintain backwards compatibility with the previous counters (when using UsageSetCounter)
-missing_resource_types = Counter(
-    namespace=COUNTER_NAMESPACE, name="missingresourcetypes", labels=["missing_resource_type"]
+resources = Counter(
+    namespace=COUNTER_NAMESPACE, name="resources", labels=["resource_type", "missing"]
 )

--- a/localstack-core/localstack/services/cloudformation/usage.py
+++ b/localstack-core/localstack/services/cloudformation/usage.py
@@ -1,4 +1,11 @@
-from localstack.utils.analytics.usage import UsageSetCounter
+from localstack.utils.analytics.metrics import Counter
 
-resource_type = UsageSetCounter("cloudformation:resourcetype")
-missing_resource_types = UsageSetCounter("cloudformation:missingresourcetypes")
+COUNTER_NAMESPACE = "cloudformation"
+
+# XXX the name is resourcetype to maintain backwards compatibility with the previous counters (when using UsageSetCounter)
+resource_types = Counter(namespace=COUNTER_NAMESPACE, name="resourcetype", labels=["resource_type"])
+
+# XXX the name is missingresourcetypes to maintain backwards compatibility with the previous counters (when using UsageSetCounter)
+missing_resource_types = Counter(
+    namespace=COUNTER_NAMESPACE, name="missingresourcetypes", labels=["missing_resource_type"]
+)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We are standardising on our metrics counters. This PR updates CloudFormation to use the new API rather than our own (non-standardised) `UsageSetCounter` API.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Use the new counters
## Testing

1. Start LocalStack with `DISABLE_EVENTS=0`
2. Deploy the following template with `awslocal cloudformation deploy --template-file <filename> --stack-name mystack`:

```yaml
Resources:
  MyParameter:
    Type: AWS::SSM::Parameter
    Properties:
      Type: String
      Value: my-parameter

  NonSupportedResource:
    Type: AWS::Logs::ResourcePolicy
    Properties:
      PolicyName: "MyResourcePolicy"
      PolicyDocument: "{ \"Version\": \"2012-10-17\", \"Statement\": [ { \"Sid\": \"Route53LogsToCloudWatchLogs\", \"Effect\": \"Allow\", \"Principal\": { \"Service\": [ \"route53.amazonaws.com\" ] }, \"Action\":\"logs:PutLogEvents\", \"Resource\": \"logArn\" } ] }"
```

3. put a breakpoint in `localstack.utils.analytics.metrics.publish_metrics`) and evaluate the `collected_metrics` variable. It should contain:

```json
{
  "metrics": [
    {
      "label_1": "latency",
      "label_1_value": 0,
      "name": "network_effect",
      "namespace": "chaos",
      "type": "counter",
      "value": 8
    },
    {
      "label_1": "resource_type",
      "label_1_value": "AWS::SSM::Parameter",
      "name": "resourcetype",
      "namespace": "cloudformation",
      "type": "counter",
      "value": 1
    },
    {
      "label_1": "missing_resource_type",
      "label_1_value": "AWS::Logs::ResourcePolicy",
      "name": "missingresourcetypes",
      "namespace": "cloudformation",
      "type": "counter",
      "value": 1
    }
  ]
}
```
(the first event is unrelated)

Or... evaluate the analytics events once they have reached the platform.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
