### PR TITLE
APIGW: migrate to new Counter type for REST API analytics

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/analytics.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/analytics.py
@@ -1,7 +1,7 @@
 import logging
 
 from localstack.http import Response
-from localstack.utils.analytics.metrics import Counter, _LabeledCounterMetric
+from localstack.utils.analytics.metrics import Counter
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import RestApiInvocationContext
@@ -10,9 +10,7 @@ LOG = logging.getLogger(__name__)
 
 
 class IntegrationUsageCounter(RestApiGatewayHandler):
-    counter: _LabeledCounterMetric
-
-    def __init__(self, counter: _LabeledCounterMetric = None):
+    def __init__(self, counter: Counter = None):
         self.counter = counter or Counter(
             namespace="apigateway", name="rest_api_execute", labels=["invocation_type"]
         )

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/analytics.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/analytics.py
@@ -1,7 +1,7 @@
 import logging
 
 from localstack.http import Response
-from localstack.utils.analytics.metrics import Counter
+from localstack.utils.analytics.metrics import Counter, LabeledCounterMetric
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import RestApiInvocationContext
@@ -10,7 +10,9 @@ LOG = logging.getLogger(__name__)
 
 
 class IntegrationUsageCounter(RestApiGatewayHandler):
-    def __init__(self, counter: Counter = None):
+    counter: LabeledCounterMetric
+
+    def __init__(self, counter: LabeledCounterMetric = None):
         self.counter = counter or Counter(
             namespace="apigateway", name="rest_api_execute", labels=["invocation_type"]
         )

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/analytics.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/analytics.py
@@ -43,4 +43,8 @@ class IntegrationUsageCounter(RestApiGatewayHandler):
         if len(split_arn := integration_uri.split(":", maxsplit=5)) < 4:
             return "null"
 
-        return split_arn[4]
+        service = split_arn[4]
+        # the URI can also contain some <api-id>.<service>-api kind of route like `execute-api` or `appsync-api`
+        # we need to make sure we do not pass the full value back
+        service = service.split(".")[-1]
+        return service


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR replaces the analytics Counter used for tracking usage of `execute-api` routes for API Gateway REST APIs.

<!-- What notable changes does this PR make? -->
## Changes
- replace the previous UsageSetCounter with the new Counter with labels

## Testing

To test the changes:

- run a LocalStack in host mode with this branch checked out
- run the `tests.aws.services.apigateway.test_apigateway_http.test_http_integration_method` integration test with `TEST_SKIP_LOCALSTACK_START=1` set, to avoid trying to start LocalStack with the test
shutdown LocalStack
- I've tried without sending the events but only printing the collected metrics and this is what I got:

```json
{
  "metrics": [
    {
      "namespace": "apigateway",
      "name": "rest_api_execute",
      "value": 3,
      "type": "counter",
      "label_1_value": "HTTP",
      "label_1": "invocation_type"
    },
    {
      "namespace": "apigateway",
      "name": "rest_api_execute",
      "value": 3,
      "type": "counter",
      "label_1_value": "HTTP_PROXY",
      "label_1": "invocation_type"
    }
  ]
}
```

Now, with more tests:
- `apigateway.test_apigateway_eventbridge.test_apigateway_to_eventbridge`
- `apigateway.test_apigateway_lambda.test_lambda_aws_proxy_integration`
- `apigateway.test_apigateway_sqs.test_sqs_aws_integration`

```json
{
  "metrics": [
    {
      "namespace": "apigateway",
      "name": "rest_api_execute",
      "value": 11,
      "type": "counter",
      "label_1_value": "AWS_PROXY",
      "label_1": "invocation_type"
    },
    {
      "namespace": "apigateway",
      "name": "rest_api_execute",
      "value": 1,
      "type": "counter",
      "label_1_value": "AWS:sqs",
      "label_1": "invocation_type"
    },
    {
      "namespace": "apigateway",
      "name": "rest_api_execute",
      "value": 1,
      "type": "counter",
      "label_1_value": "AWS:events",
      "label_1": "invocation_type"
    }
  ]
}
```

<!-- The following sections are optional, but can be useful!
## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->
