### PR TITLE
make counter classes public

### DIFF
--- a/localstack-core/localstack/utils/analytics/metrics.py
+++ b/localstack-core/localstack/utils/analytics/metrics.py
@@ -140,7 +140,7 @@ class BaseCounter:
 class CounterMetric(Metric, BaseCounter):
     """
     A thread-safe counter for tracking occurrences of an event without labels.
-    This class is intended for type hinting only and should not be instantiated directly; use the Counter class instead.
+    This class should not be instantiated directly, use the Counter class instead.
     """
 
     _namespace: Optional[str]
@@ -175,7 +175,7 @@ class CounterMetric(Metric, BaseCounter):
 class LabeledCounterMetric(Metric):
     """
     A labeled counter that tracks occurrences of an event across different label combinations.
-    This class is intended for type hinting only and should not be instantiated directly; use the Counter class instead.
+    This class should not be instantiated directly, use the Counter class instead.
     """
 
     _namespace: Optional[str]

--- a/localstack-core/localstack/utils/analytics/metrics.py
+++ b/localstack-core/localstack/utils/analytics/metrics.py
@@ -260,7 +260,7 @@ class Counter:
     A factory class for creating counter instances.
 
     This class provides a flexible way to create either a simple counter
-    (`_CounterMetric`) or a labeled counter (`_LabeledCounterMetric`) based on
+    (`CounterMetric`) or a labeled counter (`LabeledCounterMetric`) based on
     whether labels are provided.
     """
 

--- a/localstack-core/localstack/utils/analytics/metrics.py
+++ b/localstack-core/localstack/utils/analytics/metrics.py
@@ -99,16 +99,17 @@ class Metric(ABC):
         pass
 
 
-class _Counter:
+class BaseCounter:
     """
     A thread-safe counter for any kind of tracking.
+    This class should not be instantiated directly, use the Counter class instead.
     """
 
     _mutex: threading.Lock
     _count: int
 
     def __init__(self):
-        super(_Counter, self).__init__()
+        super(BaseCounter, self).__init__()
         self._mutex = threading.Lock()
         self._count = 0
 
@@ -136,9 +137,10 @@ class _Counter:
             self._count = 0
 
 
-class CounterMetric(Metric, _Counter):
+class CounterMetric(Metric, BaseCounter):
     """
     A thread-safe counter for tracking occurrences of an event without labels.
+    This class is intended for type hinting only and should not be instantiated directly; use the Counter class instead.
     """
 
     _namespace: Optional[str]
@@ -146,7 +148,7 @@ class CounterMetric(Metric, _Counter):
 
     def __init__(self, name: str, namespace: Optional[str] = ""):
         Metric.__init__(self, name=name)
-        _Counter.__init__(self)
+        BaseCounter.__init__(self)
 
         self._namespace = namespace.strip() if namespace else ""
         self._type = "counter"
@@ -173,6 +175,7 @@ class CounterMetric(Metric, _Counter):
 class LabeledCounterMetric(Metric):
     """
     A labeled counter that tracks occurrences of an event across different label combinations.
+    This class is intended for type hinting only and should not be instantiated directly; use the Counter class instead.
     """
 
     _namespace: Optional[str]
@@ -180,7 +183,7 @@ class LabeledCounterMetric(Metric):
     _unit: str
     _labels: list[str]
     _label_values: Tuple[Optional[Union[str, float]], ...]
-    _counters_by_label_values: defaultdict[Tuple[Optional[Union[str, float]], ...], _Counter]
+    _counters_by_label_values: defaultdict[Tuple[Optional[Union[str, float]], ...], BaseCounter]
 
     def __init__(self, name: str, labels: List[str], namespace: Optional[str] = ""):
         super(LabeledCounterMetric, self).__init__(name=name)
@@ -197,15 +200,15 @@ class LabeledCounterMetric(Metric):
         self._namespace = namespace.strip() if namespace else ""
         self._type = "counter"
         self._labels = labels
-        self._counters_by_label_values = defaultdict(_Counter)
+        self._counters_by_label_values = defaultdict(BaseCounter)
         MetricRegistry().register(self)
 
-    def labels(self, **kwargs: Union[str, float, None]) -> _Counter:
+    def labels(self, **kwargs: Union[str, float, None]) -> BaseCounter:
         """
         Create a scoped counter instance with specific label values.
 
         This method assigns values to the predefined labels of a labeled counter and returns
-        a _Counter object (``) that allows tracking metrics for that specific
+        a BaseCounter object that allows tracking metrics for that specific
         combination of label values.
 
         :raises ValueError:

--- a/localstack-core/localstack/utils/analytics/metrics.py
+++ b/localstack-core/localstack/utils/analytics/metrics.py
@@ -136,7 +136,7 @@ class _Counter:
             self._count = 0
 
 
-class _CounterMetric(Metric, _Counter):
+class CounterMetric(Metric, _Counter):
     """
     A thread-safe counter for tracking occurrences of an event without labels.
     """
@@ -170,7 +170,7 @@ class _CounterMetric(Metric, _Counter):
         ]
 
 
-class _LabeledCounterMetric(Metric):
+class LabeledCounterMetric(Metric):
     """
     A labeled counter that tracks occurrences of an event across different label combinations.
     """
@@ -183,7 +183,7 @@ class _LabeledCounterMetric(Metric):
     _counters_by_label_values: defaultdict[Tuple[Optional[Union[str, float]], ...], _Counter]
 
     def __init__(self, name: str, labels: List[str], namespace: Optional[str] = ""):
-        super(_LabeledCounterMetric, self).__init__(name=name)
+        super(LabeledCounterMetric, self).__init__(name=name)
 
         if not labels:
             raise ValueError("At least one label is required; the labels list cannot be empty.")
@@ -260,26 +260,26 @@ class Counter:
     A factory class for creating counter instances.
 
     This class provides a flexible way to create either a simple counter
-    (`_SimpleCounter`) or a labeled counter (`_LabeledCounter`) based on
+    (`_CounterMetric`) or a labeled counter (`_LabeledCounterMetric`) based on
     whether labels are provided.
     """
 
     @overload
-    def __new__(cls, name: str, namespace: Optional[str] = "") -> _CounterMetric:
-        return _CounterMetric(namespace=namespace, name=name)
+    def __new__(cls, name: str, namespace: Optional[str] = "") -> CounterMetric:
+        return CounterMetric(namespace=namespace, name=name)
 
     @overload
     def __new__(
         cls, name: str, labels: List[str], namespace: Optional[str] = ""
-    ) -> _LabeledCounterMetric:
-        return _LabeledCounterMetric(namespace=namespace, name=name, labels=labels)
+    ) -> LabeledCounterMetric:
+        return LabeledCounterMetric(namespace=namespace, name=name, labels=labels)
 
     def __new__(
         cls, name: str, namespace: Optional[str] = "", labels: Optional[List[str]] = None
-    ) -> Union[_CounterMetric, _LabeledCounterMetric]:
+    ) -> Union[CounterMetric, LabeledCounterMetric]:
         if labels is not None:
-            return _LabeledCounterMetric(namespace=namespace, name=name, labels=labels)
-        return _CounterMetric(namespace=namespace, name=name)
+            return LabeledCounterMetric(namespace=namespace, name=name, labels=labels)
+        return CounterMetric(namespace=namespace, name=name)
 
 
 @hooks.on_infra_shutdown()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
@bentsku noticed this behavior while working on this [PR](https://github.com/localstack/localstack/pull/12383), thanks for the heads-up! 🚀 
Before this change, the classes `_CounterMetric` and `_LabeledCounterMetric` were "protected", which made it inappropriate to use them directly for static typing. This caused type hinting issues, particularly in cases where a Counter instance was assigned to a class attribute: 
```python
class TestClass:
    counter: Counter

    def __init__(self, counter: Counter):
        self.counter = counter or Counter(name="test", labels=["l1"])

        self.counter.labels(l1="test_value").increment()
```
![Screenshot 2025-03-13 at 15 38 49](https://github.com/user-attachments/assets/85802df0-51a7-40da-88db-ca4736ae2165)


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
The `CounterMetric` and `LabeledCounterMetric` classes have been made public, allowing clients to use them directly for typing. The use of TypeVar and [Protocol](https://peps.python.org/pep-0544/) was also considered, but it may not be necessary to rely on them in this specific case.
```python
class TestClass:
    counter: LabeledCounterMetric

    def __init__(self, counter: LabeledCounterMetric):
        self.counter = counter or Counter(name="test", labels=["l1"])

        self.counter.labels(l1="test_value").increment()
```

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
