### PR TITLE
Events: migrate to new Counter type for Event Rule invocation analytics

### DIFF
--- a/localstack-core/localstack/services/events/analytics.py
+++ b/localstack-core/localstack/services/events/analytics.py
@@ -1,0 +1,14 @@
+from enum import StrEnum
+
+from localstack.utils.analytics.metrics import Counter
+
+
+class InvocationStatus(StrEnum):
+    success = "success"
+    error = "error"
+
+
+# number of EventBridge rule invocations per target (e.g., aws:lambda)
+# - status label can be `success` or `error`, see InvocationStatus
+# - service label is the target service name
+rule_invocation = Counter(namespace="events", name="rule_invocations", labels=["status", "service"])

--- a/localstack-core/localstack/services/events/analytics.py
+++ b/localstack-core/localstack/services/events/analytics.py
@@ -11,4 +11,6 @@ class InvocationStatus(StrEnum):
 # number of EventBridge rule invocations per target (e.g., aws:lambda)
 # - status label can be `success` or `error`, see InvocationStatus
 # - service label is the target service name
-rule_invocation = Counter(namespace="events", name="rule_invocations", labels=["status", "service"])
+rule_invocation = Counter(
+    namespace="eventbridge", name="rule_invocations", labels=["status", "service"]
+)

--- a/localstack-core/localstack/services/events/analytics.py
+++ b/localstack-core/localstack/services/events/analytics.py
@@ -11,6 +11,4 @@ class InvocationStatus(StrEnum):
 # number of EventBridge rule invocations per target (e.g., aws:lambda)
 # - status label can be `success` or `error`, see InvocationStatus
 # - service label is the target service name
-rule_invocation = Counter(
-    namespace="eventbridge", name="rule_invocations", labels=["status", "service"]
-)
+rule_invocation = Counter(namespace="events", name="rule_invocations", labels=["status", "service"])

--- a/localstack-core/localstack/services/events/usage.py
+++ b/localstack-core/localstack/services/events/usage.py
@@ -1,7 +1,0 @@
-from localstack.utils.analytics.usage import UsageSetCounter
-
-# number of successful EventBridge rule invocations per target (e.g., aws:lambda)
-rule_invocation = UsageSetCounter("events:rule:invocation")
-
-# number of EventBridge rule errors per target (e.g., aws:lambda)
-rule_error = UsageSetCounter("events:rule:error")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR replaces the analytics Counter used for tracking usage of Event rule invocations. We merge both Counter for success and failure into one, and use the new labels instead. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- merge the 2 counters into one with more labels

## Testing
To test the changes:

- run a LocalStack in host mode with this branch checked out
- run the `tests.aws.services.events.test_events_targets.TestEventsTargetSqs.test_put_events_with_target_sqs` integration test with `TEST_SKIP_LOCALSTACK_START=1` set, to avoid trying to start LocalStack with the test
- shutdown LocalStack

I've tried without sending the events but only printing the collected metrics and this is what I got:
```json
{
  "metrics": [
    {
      "namespace": "events",
      "name": "rule_invocations",
      "value": 1,
      "type": "counter",
      "label_1_value": "success",
      "label_2_value": "sqs",
      "label_1": "status",
      "label_2": "service"
    }
  ]
}
```


<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
