### PR TITLE
Step Functions: Migrate Usage Metrics to New Counter Standards

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/usage_metrics_static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/usage_metrics_static_analyser.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import logging
+from typing import Final
 
 import localstack.services.stepfunctions.usage as UsageMetrics
 from localstack.services.stepfunctions.asl.antlr.runtime.ASLParser import ASLParser
@@ -10,20 +13,36 @@ from localstack.services.stepfunctions.asl.static_analyser.static_analyser impor
 LOG = logging.getLogger(__name__)
 
 
+class QueryLanguage(str):
+    JSONPath = QueryLanguageMode.JSONPath.name
+    JSONata = QueryLanguageMode.JSONata.name
+    Both = "JSONPath+JSONata"
+
+
 class UsageMetricsStaticAnalyser(StaticAnalyser):
     @staticmethod
-    def process(definition: str) -> "UsageMetricsStaticAnalyser":
+    def process(definition: str) -> UsageMetricsStaticAnalyser:
         analyser = UsageMetricsStaticAnalyser()
         try:
+            # Run the static analyser.
             analyser.analyse(definition=definition)
 
-            if analyser.has_jsonata:
-                UsageMetrics.jsonata_create_counter.increment()
+            # Determine which query language is being used in this state machine.
+            query_modes = analyser._query_language_modes
+            if len(query_modes) == 2:
+                language_used = QueryLanguage.Both
+            elif QueryLanguageMode.JSONata in query_modes:
+                language_used = QueryLanguage.JSONata
             else:
-                UsageMetrics.jsonpath_create_counter.increment()
+                language_used = QueryLanguage.JSONPath
 
-            if analyser.has_variable_sampling:
-                UsageMetrics.variables_create_counter.increment()
+            # Determine is the state machine uses the variables feature.
+            uses_variables = analyser._uses_variables
+
+            # Count.
+            UsageMetrics.language_features_counter.labels(
+                query_language=language_used, variables=uses_variables
+            ).increment()
         except Exception as e:
             LOG.warning(
                 "Failed to record Step Functions metrics from static analysis",
@@ -31,26 +50,28 @@ class UsageMetricsStaticAnalyser(StaticAnalyser):
             )
         return analyser
 
+    _query_language_modes: Final[set[QueryLanguageMode]]
+    _uses_variables: bool
+
     def __init__(self):
         super().__init__()
-        self.has_jsonata: bool = False
-        self.has_variable_sampling = False
+        self._query_language_modes = set()
+        self._uses_variables = False
 
     def visitQuery_language_decl(self, ctx: ASLParser.Query_language_declContext):
-        if self.has_jsonata:
+        if len(self._query_language_modes) == 2:
+            # Both query language modes have been confirmed to be in use.
             return
-
         query_language_mode_int = ctx.children[-1].getSymbol().type
         query_language_mode = QueryLanguageMode(value=query_language_mode_int)
-        if query_language_mode == QueryLanguageMode.JSONata:
-            self.has_jsonata = True
+        self._query_language_modes.add(query_language_mode)
 
     def visitString_literal(self, ctx: ASLParser.String_literalContext):
         # Prune everything parsed as a string literal.
         return
 
     def visitString_variable_sample(self, ctx: ASLParser.String_variable_sampleContext):
-        self.has_variable_sampling = True
+        self._uses_variables = True
 
     def visitAssign_decl(self, ctx: ASLParser.Assign_declContext):
-        self.has_variable_sampling = True
+        self._uses_variables = True

--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/usage_metrics_static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/usage_metrics_static_analyser.py
@@ -41,7 +41,7 @@ class UsageMetricsStaticAnalyser(StaticAnalyser):
 
             # Count.
             UsageMetrics.language_features_counter.labels(
-                query_language=language_used, variables=uses_variables
+                query_language=language_used, uses_variables=uses_variables
             ).increment()
         except Exception as e:
             LOG.warning(

--- a/localstack-core/localstack/services/stepfunctions/usage.py
+++ b/localstack-core/localstack/services/stepfunctions/usage.py
@@ -6,5 +6,7 @@ from localstack.utils.analytics.metrics import Counter
 
 # Initialize a counter to record the usage of language features for each state machine.
 language_features_counter = Counter(
-    namespace="stepfunctions", name="language_features_used", labels=["query_language", "variables"]
+    namespace="stepfunctions",
+    name="language_features_used",
+    labels=["query_language", "uses_variables"],
 )

--- a/localstack-core/localstack/services/stepfunctions/usage.py
+++ b/localstack-core/localstack/services/stepfunctions/usage.py
@@ -2,19 +2,9 @@
 Usage reporting for StepFunctions service
 """
 
-from localstack.utils.analytics.usage import UsageCounter
+from localstack.utils.analytics.metrics import Counter
 
-# Count of StepFunctions being created with JSONata QueryLanguage
-jsonata_create_counter = UsageCounter("stepfunctions:jsonata:create")
-
-# Count of StepFunctions being created with JSONPath QueryLanguage
-jsonpath_create_counter = UsageCounter("stepfunctions:jsonpath:create")
-
-# Count of StepFunctions being created that use Variable Sampling or the Assign block
-variables_create_counter = UsageCounter("stepfunctions:variables:create")
-
-# Successful invocations (also including expected error cases in line with AWS behaviour)
-invocation_counter = UsageCounter("stepfunctions:invocation")
-
-# Unexpected errors that we do not account for
-error_counter = UsageCounter("stepfunctions:error")
+# Initialize a counter to record the usage of language features for each state machine.
+language_features_counter = Counter(
+    namespace="stepfunctions", name="language_features_used", labels=["query_language", "variables"]
+)

--- a/tests/unit/services/stepfunctions/test_usage_metrics_static_analyser.py
+++ b/tests/unit/services/stepfunctions/test_usage_metrics_static_analyser.py
@@ -136,6 +136,7 @@ class TestUsageMetricsStaticAnalyser:
     )
     def test_jsonata_and_variable_sampling(self, definition):
         analyser = UsageMetricsStaticAnalyser.process(definition)
+        assert QueryLanguageMode.JSONPath in analyser.query_language_modes
         assert QueryLanguageMode.JSONata in analyser.query_language_modes
         assert analyser.uses_variables
 

--- a/tests/unit/services/stepfunctions/test_usage_metrics_static_analyser.py
+++ b/tests/unit/services/stepfunctions/test_usage_metrics_static_analyser.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from localstack.services.stepfunctions.asl.component.common.query_language import QueryLanguageMode
 from localstack.services.stepfunctions.asl.static_analyser.usage_metrics_static_analyser import (
     UsageMetricsStaticAnalyser,
 )
@@ -104,22 +105,39 @@ class TestUsageMetricsStaticAnalyser:
     )
     def test_jsonata(self, definition):
         analyser = UsageMetricsStaticAnalyser.process(definition)
-        assert analyser.has_jsonata
-        assert not analyser.has_variable_sampling
+        assert not analyser.uses_variables
+        assert QueryLanguageMode.JSONata in analyser.query_language_modes
+
+    @pytest.mark.parametrize(
+        "definition",
+        [
+            BASE_PASS_JSONATA_OVERRIDE,
+            BASE_PASS_JSONATA_OVERRIDE_DEFAULT,
+        ],
+        ids=[
+            "BASE_PASS_JSONATA_OVERRIDE",
+            "BASE_PASS_JSONATA_OVERRIDE_DEFAULT",
+        ],
+    )
+    def test_both_query_languages(self, definition):
+        analyser = UsageMetricsStaticAnalyser.process(definition)
+        assert not analyser.uses_variables
+        assert QueryLanguageMode.JSONata in analyser.query_language_modes
+        assert QueryLanguageMode.JSONPath in analyser.query_language_modes
 
     @pytest.mark.parametrize("definition", [BASE_PASS_JSONPATH], ids=["BASE_PASS_JSONPATH"])
     def test_jsonpath(self, definition):
         analyser = UsageMetricsStaticAnalyser.process(definition)
-        assert not analyser.has_jsonata
-        assert not analyser.has_variable_sampling
+        assert QueryLanguageMode.JSONata not in analyser.query_language_modes
+        assert not analyser.uses_variables
 
     @pytest.mark.parametrize(
         "definition", [JSONPATH_TO_JSONATA_DATAFLOW], ids=["JSONPATH_TO_JSONATA_DATAFLOW"]
     )
     def test_jsonata_and_variable_sampling(self, definition):
         analyser = UsageMetricsStaticAnalyser.process(definition)
-        assert analyser.has_jsonata
-        assert analyser.has_variable_sampling
+        assert QueryLanguageMode.JSONata in analyser.query_language_modes
+        assert analyser.uses_variables
 
     @pytest.mark.parametrize(
         "definition",
@@ -134,5 +152,5 @@ class TestUsageMetricsStaticAnalyser:
     )
     def test_jsonpath_and_variable_sampling(self, definition):
         analyser = UsageMetricsStaticAnalyser.process(definition)
-        assert not analyser.has_jsonata
-        assert analyser.has_variable_sampling
+        assert QueryLanguageMode.JSONata not in analyser.query_language_modes
+        assert analyser.uses_variables


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR migrates our step functions usage metrics to the new Counter standards. It increases transparency by accurately reflecting the query language usage within each state machine. Previously, JSONata was always counted as used—even when combined with JSONPath. Since interleaved usage of both modes is critical for testing the shared memory model and understanding user reliance on this mechanism, the updated metrics now provide a clearer picture.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
-  Migrated step functions usage metrics to the new Counter standards
- Consolidated tracking of language features into a single Counter per state machine on creation
- Updated query language detection logic to differentiate between exclusive and interleaved usage of JSONPath and JSONata

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
