### PR TITLE
Secret Manager: Solve the issue for rotate secret after sub-sequent r…

### DIFF
--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -738,7 +738,7 @@ def backend_rotate_secret(
     # Resolve rotation_lambda_arn and fallback to previous value if its missing
     # from the current request
     rotation_lambda_arn = rotation_lambda_arn or secret.rotation_lambda_arn
-
+    rotation_period = 0
     if rotation_lambda_arn:
         if len(rotation_lambda_arn) > 2048:
             msg = "RotationLambdaARN must <= 2048 characters long."
@@ -788,7 +788,7 @@ def backend_rotate_secret(
         pass
 
     secret.rotation_lambda_arn = rotation_lambda_arn
-    secret.auto_rotate_after_days = rotation_period
+    secret.auto_rotate_after_days = rotation_period or 0
     if secret.auto_rotate_after_days > 0:
         wait_interval_s = int(rotation_period) * 86400
         secret.next_rotation_date = int(time.time()) + wait_interval_s

--- a/localstack-core/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack-core/localstack/testing/snapshots/transformer_utility.py
@@ -648,6 +648,19 @@ class TransformerUtility:
                 ),
                 "version_uuid",
             ),
+            KeyValueBasedTransformer(
+                lambda k, v: (
+                    v
+                    if (
+                        isinstance(k, str)
+                        and k == "RotationLambdaARN"
+                        and isinstance(v, str)
+                        and re.match(PATTERN_ARN, v)
+                    )
+                    else None
+                ),
+                "lambda-arn",
+            ),
             SortingTransformer("VersionStages"),
             SortingTransformer("Versions", lambda e: e.get("CreatedDate")),
         ]

--- a/tests/aws/services/secretsmanager/functions/lambda_rotate_secret.py
+++ b/tests/aws/services/secretsmanager/functions/lambda_rotate_secret.py
@@ -224,3 +224,14 @@ def finish_secret(service_client, arn, token):
         token,
         arn,
     )
+    if "AWSPENDING" in metadata["VersionIdsToStages"].get(token, []):
+        service_client.update_secret_version_stage(
+            SecretId=arn,
+            VersionStage="AWSPENDING",
+            RemoveFromVersionId=token,
+        )
+        logger.info(
+            "finishSecret: Successfully removed AWSPENDING stage from version %s for secret %s.",
+            token,
+            arn,
+        )

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -3687,12 +3687,12 @@
     }
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[True]": {
-    "recorded-date": "16-03-2025, 07:41:39",
+    "recorded-date": "25-03-2025, 03:33:11",
     "recorded-content": {
       "rotate_secret_immediately_1": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "Name": "<SecretId-0idx>",
-        "VersionId": "<version_uuid:2>",
+        "VersionId": "<version_uuid:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3714,10 +3714,10 @@
         },
         "VersionIdsToStages": {
           "<version_uuid:1>": [
-            "AWSPREVIOUS"
+            "AWSCURRENT"
           ],
           "<version_uuid:2>": [
-            "AWSCURRENT"
+            "AWSPREVIOUS"
           ]
         },
         "ResponseMetadata": {
@@ -3735,7 +3735,7 @@
               "DefaultEncryptionKey"
             ],
             "LastAccessedDate": "datetime",
-            "VersionId": "<version_uuid:1>",
+            "VersionId": "<version_uuid:2>",
             "VersionStages": [
               "AWSPREVIOUS"
             ]
@@ -3745,7 +3745,7 @@
             "KmsKeyIds": [
               "DefaultEncryptionKey"
             ],
-            "VersionId": "<version_uuid:2>",
+            "VersionId": "<version_uuid:1>",
             "VersionStages": [
               "AWSCURRENT"
             ]
@@ -3759,12 +3759,12 @@
     }
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[None]": {
-    "recorded-date": "16-03-2025, 07:41:47",
+    "recorded-date": "25-03-2025, 03:33:20",
     "recorded-content": {
       "rotate_secret_immediately_1": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "Name": "<SecretId-0idx>",
-        "VersionId": "<version_uuid:2>",
+        "VersionId": "<version_uuid:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3786,10 +3786,10 @@
         },
         "VersionIdsToStages": {
           "<version_uuid:1>": [
-            "AWSPREVIOUS"
+            "AWSCURRENT"
           ],
           "<version_uuid:2>": [
-            "AWSCURRENT"
+            "AWSPREVIOUS"
           ]
         },
         "ResponseMetadata": {
@@ -3807,7 +3807,7 @@
               "DefaultEncryptionKey"
             ],
             "LastAccessedDate": "datetime",
-            "VersionId": "<version_uuid:1>",
+            "VersionId": "<version_uuid:2>",
             "VersionStages": [
               "AWSPREVIOUS"
             ]
@@ -3817,7 +3817,7 @@
             "KmsKeyIds": [
               "DefaultEncryptionKey"
             ],
-            "VersionId": "<version_uuid:2>",
+            "VersionId": "<version_uuid:1>",
             "VersionStages": [
               "AWSCURRENT"
             ]
@@ -4576,62 +4576,6 @@
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "DeletionDate": "datetime",
         "Name": "<SecretId-0idx>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[False]": {
-    "recorded-date": "15-03-2025, 08:34:38",
-    "recorded-content": {
-      "rotate_secret_immediately_1": {
-        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
-        "Name": "<SecretId-0idx>",
-        "VersionId": "<version_uuid:2>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe_secret_rotated_1": {
-        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
-        "CreatedDate": "datetime",
-        "Description": "testing rotation of secrets",
-        "LastChangedDate": "datetime",
-        "Name": "<SecretId-0idx>",
-        "NextRotationDate": "datetime",
-        "RotationEnabled": true,
-        "RotationLambdaARN": "<lambda-arn:1>",
-        "RotationRules": {
-          "AutomaticallyAfterDays": 1
-        },
-        "VersionIdsToStages": {
-          "<version_uuid:1>": [
-            "AWSCURRENT"
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list_secret_versions_rotated_1_1": {
-        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
-        "Name": "<SecretId-0idx>",
-        "Versions": [
-          {
-            "CreatedDate": "datetime",
-            "KmsKeyIds": [
-              "DefaultEncryptionKey"
-            ],
-            "VersionId": "<version_uuid:1>",
-            "VersionStages": [
-              "AWSCURRENT"
-            ]
-          }
-        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -3687,18 +3687,18 @@
     }
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[True]": {
-    "recorded-date": "25-03-2025, 03:33:11",
+    "recorded-date": "30-03-2025, 11:45:42",
     "recorded-content": {
-      "rotate_secret_immediately_1": {
+      "rotate_secret_immediately": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "Name": "<SecretId-0idx>",
-        "VersionId": "<version_uuid:1>",
+        "VersionId": "<version_uuid:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
-      "describe_secret_rotated_1": {
+      "describe_secret_rotated": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "CreatedDate": "datetime",
         "Description": "testing rotation of secrets",
@@ -3714,10 +3714,10 @@
         },
         "VersionIdsToStages": {
           "<version_uuid:1>": [
-            "AWSCURRENT"
+            "AWSPREVIOUS"
           ],
           "<version_uuid:2>": [
-            "AWSPREVIOUS"
+            "AWSCURRENT"
           ]
         },
         "ResponseMetadata": {
@@ -3725,7 +3725,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "list_secret_versions_rotated_1_1": {
+      "list_secret_versions_rotated_1": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "Name": "<SecretId-0idx>",
         "Versions": [
@@ -3735,7 +3735,7 @@
               "DefaultEncryptionKey"
             ],
             "LastAccessedDate": "datetime",
-            "VersionId": "<version_uuid:2>",
+            "VersionId": "<version_uuid:1>",
             "VersionStages": [
               "AWSPREVIOUS"
             ]
@@ -3745,7 +3745,7 @@
             "KmsKeyIds": [
               "DefaultEncryptionKey"
             ],
-            "VersionId": "<version_uuid:1>",
+            "VersionId": "<version_uuid:2>",
             "VersionStages": [
               "AWSCURRENT"
             ]
@@ -3759,18 +3759,18 @@
     }
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[None]": {
-    "recorded-date": "25-03-2025, 03:33:20",
+    "recorded-date": "30-03-2025, 11:45:54",
     "recorded-content": {
-      "rotate_secret_immediately_1": {
+      "rotate_secret_immediately": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "Name": "<SecretId-0idx>",
-        "VersionId": "<version_uuid:1>",
+        "VersionId": "<version_uuid:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
-      "describe_secret_rotated_1": {
+      "describe_secret_rotated": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "CreatedDate": "datetime",
         "Description": "testing rotation of secrets",
@@ -3786,10 +3786,10 @@
         },
         "VersionIdsToStages": {
           "<version_uuid:1>": [
-            "AWSCURRENT"
+            "AWSPREVIOUS"
           ],
           "<version_uuid:2>": [
-            "AWSPREVIOUS"
+            "AWSCURRENT"
           ]
         },
         "ResponseMetadata": {
@@ -3797,7 +3797,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "list_secret_versions_rotated_1_1": {
+      "list_secret_versions_rotated_1": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "Name": "<SecretId-0idx>",
         "Versions": [
@@ -3807,7 +3807,7 @@
               "DefaultEncryptionKey"
             ],
             "LastAccessedDate": "datetime",
-            "VersionId": "<version_uuid:2>",
+            "VersionId": "<version_uuid:1>",
             "VersionStages": [
               "AWSPREVIOUS"
             ]
@@ -3817,7 +3817,7 @@
             "KmsKeyIds": [
               "DefaultEncryptionKey"
             ],
-            "VersionId": "<version_uuid:1>",
+            "VersionId": "<version_uuid:2>",
             "VersionStages": [
               "AWSCURRENT"
             ]
@@ -4583,8 +4583,48 @@
       }
     }
   },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_multiple_times_with_lambda_success[True]": {
-    "recorded-date": "16-03-2025, 07:43:09",
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_first_rotate_secret_with_missing_lambda_arn": {
+    "recorded-date": "27-03-2025, 16:33:46",
+    "recorded-content": {
+      "create_secret": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "rotate_secret_no_arn_exc": {
+        "Error": {
+          "Code": "InvalidRequestException",
+          "Message": "No Lambda rotation function ARN is associated with this secret."
+        },
+        "Message": "No Lambda rotation function ARN is associated with this secret.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "describe_secret": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "CreatedDate": "datetime",
+        "LastChangedDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "VersionIdsToStages": {
+          "<version_uuid:1>": [
+            "AWSCURRENT"
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_multiple_times_with_lambda_success": {
+    "recorded-date": "29-03-2025, 09:40:15",
     "recorded-content": {
       "rotate_secret_immediately_1": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
@@ -4677,11 +4717,11 @@
           "AutomaticallyAfterDays": 1
         },
         "VersionIdsToStages": {
-          "<version_uuid:3>": [
-            "AWSCURRENT"
-          ],
           "<version_uuid:2>": [
             "AWSPREVIOUS"
+          ],
+          "<version_uuid:3>": [
+            "AWSCURRENT"
           ]
         },
         "ResponseMetadata": {
@@ -4715,185 +4755,6 @@
             ]
           }
         ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_multiple_times_with_lambda_success[False]": {
-    "recorded-date": "16-03-2025, 07:42:51",
-    "recorded-content": {
-      "rotate_secret_immediately_1": {
-        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
-        "Name": "<SecretId-0idx>",
-        "VersionId": "<version_uuid:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe_secret_rotated_1": {
-        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
-        "CreatedDate": "datetime",
-        "Description": "testing rotation of secrets",
-        "LastAccessedDate": "datetime",
-        "LastChangedDate": "datetime",
-        "LastRotatedDate": "datetime",
-        "Name": "<SecretId-0idx>",
-        "NextRotationDate": "datetime",
-        "RotationEnabled": true,
-        "RotationLambdaARN": "<lambda-arn:1>",
-        "RotationRules": {
-          "AutomaticallyAfterDays": 1
-        },
-        "VersionIdsToStages": {
-          "<version_uuid:1>": [
-            "AWSCURRENT"
-          ],
-          "<version_uuid:2>": [
-            "AWSPREVIOUS"
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list_secret_versions_rotated_1_1": {
-        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
-        "Name": "<SecretId-0idx>",
-        "Versions": [
-          {
-            "CreatedDate": "datetime",
-            "KmsKeyIds": [
-              "DefaultEncryptionKey"
-            ],
-            "LastAccessedDate": "datetime",
-            "VersionId": "<version_uuid:2>",
-            "VersionStages": [
-              "AWSPREVIOUS"
-            ]
-          },
-          {
-            "CreatedDate": "datetime",
-            "KmsKeyIds": [
-              "DefaultEncryptionKey"
-            ],
-            "VersionId": "<version_uuid:1>",
-            "VersionStages": [
-              "AWSCURRENT"
-            ]
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "rotate_secret_immediately_2": {
-        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
-        "Name": "<SecretId-0idx>",
-        "VersionId": "<version_uuid:3>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe_secret_rotated_2": {
-        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
-        "CreatedDate": "datetime",
-        "Description": "testing rotation of secrets",
-        "LastAccessedDate": "datetime",
-        "LastChangedDate": "datetime",
-        "LastRotatedDate": "datetime",
-        "Name": "<SecretId-0idx>",
-        "NextRotationDate": "datetime",
-        "RotationEnabled": true,
-        "RotationLambdaARN": "<lambda-arn:1>",
-        "RotationRules": {
-          "AutomaticallyAfterDays": 1
-        },
-        "VersionIdsToStages": {
-          "<version_uuid:1>": [
-            "AWSPREVIOUS"
-          ],
-          "<version_uuid:3>": [
-            "AWSCURRENT"
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list_secret_versions_rotated_1_2": {
-        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
-        "Name": "<SecretId-0idx>",
-        "Versions": [
-          {
-            "CreatedDate": "datetime",
-            "KmsKeyIds": [
-              "DefaultEncryptionKey"
-            ],
-            "LastAccessedDate": "datetime",
-            "VersionId": "<version_uuid:1>",
-            "VersionStages": [
-              "AWSPREVIOUS"
-            ]
-          },
-          {
-            "CreatedDate": "datetime",
-            "KmsKeyIds": [
-              "DefaultEncryptionKey"
-            ],
-            "VersionId": "<version_uuid:3>",
-            "VersionStages": [
-              "AWSCURRENT"
-            ]
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_first_rotate_secret_with_missing_lambda_arn": {
-    "recorded-date": "27-03-2025, 16:33:46",
-    "recorded-content": {
-      "create_secret": {
-        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
-        "Name": "<SecretId-0idx>",
-        "VersionId": "<version_uuid:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "rotate_secret_no_arn_exc": {
-        "Error": {
-          "Code": "InvalidRequestException",
-          "Message": "No Lambda rotation function ARN is associated with this secret."
-        },
-        "Message": "No Lambda rotation function ARN is associated with this secret.",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "describe_secret": {
-        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
-        "CreatedDate": "datetime",
-        "LastChangedDate": "datetime",
-        "Name": "<SecretId-0idx>",
-        "VersionIdsToStages": {
-          "<version_uuid:1>": [
-            "AWSCURRENT"
-          ]
-        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -3687,18 +3687,18 @@
     }
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[True]": {
-    "recorded-date": "28-03-2024, 06:58:46",
+    "recorded-date": "16-03-2025, 07:41:39",
     "recorded-content": {
-      "rotate_secret_immediately": {
+      "rotate_secret_immediately_1": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "Name": "<SecretId-0idx>",
-        "VersionId": "<version_uuid:1>",
+        "VersionId": "<version_uuid:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
-      "describe_secret_rotated": {
+      "describe_secret_rotated_1": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "CreatedDate": "datetime",
         "Description": "testing rotation of secrets",
@@ -3714,11 +3714,10 @@
         },
         "VersionIdsToStages": {
           "<version_uuid:1>": [
-            "AWSCURRENT",
-            "AWSPENDING"
+            "AWSPREVIOUS"
           ],
           "<version_uuid:2>": [
-            "AWSPREVIOUS"
+            "AWSCURRENT"
           ]
         },
         "ResponseMetadata": {
@@ -3726,7 +3725,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "list_secret_versions_rotated_1": {
+      "list_secret_versions_rotated_1_1": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "Name": "<SecretId-0idx>",
         "Versions": [
@@ -3736,7 +3735,7 @@
               "DefaultEncryptionKey"
             ],
             "LastAccessedDate": "datetime",
-            "VersionId": "<version_uuid:2>",
+            "VersionId": "<version_uuid:1>",
             "VersionStages": [
               "AWSPREVIOUS"
             ]
@@ -3746,10 +3745,9 @@
             "KmsKeyIds": [
               "DefaultEncryptionKey"
             ],
-            "VersionId": "<version_uuid:1>",
+            "VersionId": "<version_uuid:2>",
             "VersionStages": [
-              "AWSCURRENT",
-              "AWSPENDING"
+              "AWSCURRENT"
             ]
           }
         ],
@@ -3761,9 +3759,9 @@
     }
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[None]": {
-    "recorded-date": "28-03-2024, 06:58:58",
+    "recorded-date": "16-03-2025, 07:41:47",
     "recorded-content": {
-      "rotate_secret_immediately": {
+      "rotate_secret_immediately_1": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "Name": "<SecretId-0idx>",
         "VersionId": "<version_uuid:2>",
@@ -3772,7 +3770,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "describe_secret_rotated": {
+      "describe_secret_rotated_1": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "CreatedDate": "datetime",
         "Description": "testing rotation of secrets",
@@ -3791,8 +3789,7 @@
             "AWSPREVIOUS"
           ],
           "<version_uuid:2>": [
-            "AWSCURRENT",
-            "AWSPENDING"
+            "AWSCURRENT"
           ]
         },
         "ResponseMetadata": {
@@ -3800,7 +3797,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "list_secret_versions_rotated_1": {
+      "list_secret_versions_rotated_1_1": {
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "Name": "<SecretId-0idx>",
         "Versions": [
@@ -3822,8 +3819,7 @@
             ],
             "VersionId": "<version_uuid:2>",
             "VersionStages": [
-              "AWSCURRENT",
-              "AWSPENDING"
+              "AWSCURRENT"
             ]
           }
         ],
@@ -4580,6 +4576,340 @@
         "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
         "DeletionDate": "datetime",
         "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[False]": {
+    "recorded-date": "15-03-2025, 08:34:38",
+    "recorded-content": {
+      "rotate_secret_immediately_1": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_secret_rotated_1": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "CreatedDate": "datetime",
+        "Description": "testing rotation of secrets",
+        "LastChangedDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "NextRotationDate": "datetime",
+        "RotationEnabled": true,
+        "RotationLambdaARN": "<lambda-arn:1>",
+        "RotationRules": {
+          "AutomaticallyAfterDays": 1
+        },
+        "VersionIdsToStages": {
+          "<version_uuid:1>": [
+            "AWSCURRENT"
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_versions_rotated_1_1": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:1>",
+            "VersionStages": [
+              "AWSCURRENT"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_multiple_times_with_lambda_success[True]": {
+    "recorded-date": "16-03-2025, 07:43:09",
+    "recorded-content": {
+      "rotate_secret_immediately_1": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_secret_rotated_1": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "CreatedDate": "datetime",
+        "Description": "testing rotation of secrets",
+        "LastAccessedDate": "datetime",
+        "LastChangedDate": "datetime",
+        "LastRotatedDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "NextRotationDate": "datetime",
+        "RotationEnabled": true,
+        "RotationLambdaARN": "<lambda-arn:1>",
+        "RotationRules": {
+          "AutomaticallyAfterDays": 1
+        },
+        "VersionIdsToStages": {
+          "<version_uuid:1>": [
+            "AWSPREVIOUS"
+          ],
+          "<version_uuid:2>": [
+            "AWSCURRENT"
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_versions_rotated_1_1": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "LastAccessedDate": "datetime",
+            "VersionId": "<version_uuid:1>",
+            "VersionStages": [
+              "AWSPREVIOUS"
+            ]
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:2>",
+            "VersionStages": [
+              "AWSCURRENT"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "rotate_secret_immediately_2": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_secret_rotated_2": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "CreatedDate": "datetime",
+        "Description": "testing rotation of secrets",
+        "LastAccessedDate": "datetime",
+        "LastChangedDate": "datetime",
+        "LastRotatedDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "NextRotationDate": "datetime",
+        "RotationEnabled": true,
+        "RotationLambdaARN": "<lambda-arn:1>",
+        "RotationRules": {
+          "AutomaticallyAfterDays": 1
+        },
+        "VersionIdsToStages": {
+          "<version_uuid:3>": [
+            "AWSCURRENT"
+          ],
+          "<version_uuid:2>": [
+            "AWSPREVIOUS"
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_versions_rotated_1_2": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "LastAccessedDate": "datetime",
+            "VersionId": "<version_uuid:2>",
+            "VersionStages": [
+              "AWSPREVIOUS"
+            ]
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:3>",
+            "VersionStages": [
+              "AWSCURRENT"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_multiple_times_with_lambda_success[False]": {
+    "recorded-date": "16-03-2025, 07:42:51",
+    "recorded-content": {
+      "rotate_secret_immediately_1": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_secret_rotated_1": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "CreatedDate": "datetime",
+        "Description": "testing rotation of secrets",
+        "LastAccessedDate": "datetime",
+        "LastChangedDate": "datetime",
+        "LastRotatedDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "NextRotationDate": "datetime",
+        "RotationEnabled": true,
+        "RotationLambdaARN": "<lambda-arn:1>",
+        "RotationRules": {
+          "AutomaticallyAfterDays": 1
+        },
+        "VersionIdsToStages": {
+          "<version_uuid:1>": [
+            "AWSCURRENT"
+          ],
+          "<version_uuid:2>": [
+            "AWSPREVIOUS"
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_versions_rotated_1_1": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "LastAccessedDate": "datetime",
+            "VersionId": "<version_uuid:2>",
+            "VersionStages": [
+              "AWSPREVIOUS"
+            ]
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:1>",
+            "VersionStages": [
+              "AWSCURRENT"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "rotate_secret_immediately_2": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_secret_rotated_2": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "CreatedDate": "datetime",
+        "Description": "testing rotation of secrets",
+        "LastAccessedDate": "datetime",
+        "LastChangedDate": "datetime",
+        "LastRotatedDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "NextRotationDate": "datetime",
+        "RotationEnabled": true,
+        "RotationLambdaARN": "<lambda-arn:1>",
+        "RotationRules": {
+          "AutomaticallyAfterDays": 1
+        },
+        "VersionIdsToStages": {
+          "<version_uuid:1>": [
+            "AWSPREVIOUS"
+          ],
+          "<version_uuid:3>": [
+            "AWSCURRENT"
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_versions_rotated_1_2": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "LastAccessedDate": "datetime",
+            "VersionId": "<version_uuid:1>",
+            "VersionStages": [
+              "AWSPREVIOUS"
+            ]
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:3>",
+            "VersionStages": [
+              "AWSCURRENT"
+            ]
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4860,5 +4860,45 @@
         }
       }
     }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_first_rotate_secret_with_missing_lambda_arn": {
+    "recorded-date": "27-03-2025, 16:33:46",
+    "recorded-content": {
+      "create_secret": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "rotate_secret_no_arn_exc": {
+        "Error": {
+          "Code": "InvalidRequestException",
+          "Message": "No Lambda rotation function ARN is associated with this secret."
+        },
+        "Message": "No Lambda rotation function ARN is associated with this secret.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "describe_secret": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "CreatedDate": "datetime",
+        "LastChangedDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "VersionIdsToStages": {
+          "<version_uuid:1>": [
+            "AWSCURRENT"
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -41,6 +41,9 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_exp_raised_on_creation_of_secret_scheduled_for_deletion": {
     "last_validated_date": "2024-03-15T08:13:16+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_first_rotate_secret_with_missing_lambda_arn": {
+    "last_validated_date": "2025-03-27T16:33:46+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_force_delete_deleted_secret": {
     "last_validated_date": "2024-10-11T14:33:45+00:00"
   },

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -110,14 +110,11 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success": {
     "last_validated_date": "2024-03-15T08:12:22+00:00"
   },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[False]": {
-    "last_validated_date": "2025-03-15T08:34:38+00:00"
-  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[None]": {
-    "last_validated_date": "2025-03-16T07:41:47+00:00"
+    "last_validated_date": "2025-03-25T03:33:19+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[True]": {
-    "last_validated_date": "2025-03-16T07:41:39+00:00"
+    "last_validated_date": "2025-03-25T03:33:10+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_exists": {
     "last_validated_date": "2024-03-15T08:14:33+00:00"

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -101,14 +101,23 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_invalid_lambda_arn": {
     "last_validated_date": "2024-03-15T10:11:13+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_multiple_times_with_lambda_success[False]": {
+    "last_validated_date": "2025-03-16T07:42:50+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_multiple_times_with_lambda_success[True]": {
+    "last_validated_date": "2025-03-16T07:43:08+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success": {
     "last_validated_date": "2024-03-15T08:12:22+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[False]": {
+    "last_validated_date": "2025-03-15T08:34:38+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[None]": {
-    "last_validated_date": "2024-03-28T06:58:56+00:00"
+    "last_validated_date": "2025-03-16T07:41:47+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[True]": {
-    "last_validated_date": "2024-03-28T06:58:44+00:00"
+    "last_validated_date": "2025-03-16T07:41:39+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_exists": {
     "last_validated_date": "2024-03-15T08:14:33+00:00"

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -104,20 +104,17 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_invalid_lambda_arn": {
     "last_validated_date": "2024-03-15T10:11:13+00:00"
   },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_multiple_times_with_lambda_success[False]": {
-    "last_validated_date": "2025-03-16T07:42:50+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_multiple_times_with_lambda_success[True]": {
-    "last_validated_date": "2025-03-16T07:43:08+00:00"
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_multiple_times_with_lambda_success": {
+    "last_validated_date": "2025-03-29T09:40:15+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success": {
     "last_validated_date": "2024-03-15T08:12:22+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[None]": {
-    "last_validated_date": "2025-03-25T03:33:19+00:00"
+    "last_validated_date": "2025-03-30T11:45:54+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[True]": {
-    "last_validated_date": "2025-03-25T03:33:10+00:00"
+    "last_validated_date": "2025-03-30T11:45:41+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_exists": {
     "last_validated_date": "2024-03-15T08:14:33+00:00"


### PR DESCRIPTION
## Motivation

This PR is added in order to address the issue raised by our community [12144](https://github.com/localstack/localstack/issues/12144). The issue happens when making subsequent rotate-secret calls without specifying RotationLambdaARN and RotationRules cause ResourceNotFoundException 


## Changes

- Read from rotation configurations for a given secret from the secret store when they are not provided by user
- Reading from secret store (current rotation configuration) before rotation happened helped us to fetch these configuration in order to invoke the target lambda function 

## Testing

In order to test this you can run localstack locally and run the following command

# Create role for lambda function
```
awslocal iam create-role --role-name lambda-rotation-role --assume-role-policy-document '{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": { "Service": "lambda.amazonaws.com" },
      "Action": "sts:AssumeRole"
    }
  ]
}'
```

#### Attach policy to role
```
awslocal iam put-role-policy --role-name lambda-rotation-role --policy-name secret-rotation-policy --policy-document '{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "secretsmanager:GetSecretValue",
        "secretsmanager:PutSecretValue"
      ],
      "Resource": "*"
    }
  ]
}'
```

#### Create lambda function
```bash 
awslocal lambda create-function --function-name rotate-secret-function --runtime python3.9 --role arn:aws:iam::000000000000:role/lambda-rotation-role --handler rotate_function.lambda_handler --timeout 30 --zip-file fileb://rotate_function.zip
```


#### Create secret
```
bash
awslocal secretsmanager create-secret --name MySecretKey --secret-string "initialValue"
```

#### First rotation 
```bash
awslocal secretsmanager rotate-secret --secret-id MySecretKey --rotation-lambda-arn arn:aws:lambda:us-east-1:000000000000:function:rotate-secret-function --rotation-rules AutomaticallyAfterDays=1
```


#### Second rotation
```bash 
awslocal secretsmanager rotate-secret --secret-id MySecretKey
```




