### PR TITLE
DDBStreams: skip flaky test

### DIFF
--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -1459,6 +1459,7 @@ class TestDynamoDB:
         retry(lambda: _get_records_amount(4), sleep=1, retries=3)
         snapshot.match("get-records", {"Records": records})
 
+    @pytest.mark.skip(reason="Flaky in CI")
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Skips a flaky DDB Streams test: `test_dynamodb_stream_records_with_update_item`

We've been seeing this test flake intermittently for a while now, and just happened today again:
https://app.circleci.com/pipelines/github/localstack/localstack/31682/workflows/bf8c139e-1007-4aaa-a6ed-a30970d79c25/jobs/282982

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- skip `test_dynamodb_stream_records_with_update_item`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
