### PR TITLE
Fix ssm list parameter tags

### DIFF
--- a/localstack-core/localstack/services/ssm/patches.py
+++ b/localstack-core/localstack/services/ssm/patches.py
@@ -1,0 +1,15 @@
+from moto.ssm.models import SimpleSystemManagerBackend
+
+from localstack.utils.patch import patch
+
+
+def apply_all_patches():
+    @patch(SimpleSystemManagerBackend.list_tags_for_resource)
+    def ssm_validate_resource_type_and_id(fn, self, resource_type: str, resource_id: str):
+        if resource_type != "Parameter":
+            return fn(self, resource_type, resource_id)
+
+        if resource_id.startswith("/") and resource_id.count("/") == 1:
+            resource_id = resource_id.lstrip("/")
+
+        return fn(self, resource_type, resource_id)

--- a/localstack-core/localstack/services/ssm/provider.py
+++ b/localstack-core/localstack/services/ssm/provider.py
@@ -2,7 +2,6 @@ import copy
 import json
 import logging
 import time
-from abc import ABC
 from typing import Dict, Optional
 
 from localstack.aws.api import CommonServiceException, RequestContext
@@ -78,6 +77,7 @@ from localstack.aws.api.ssm import (
 )
 from localstack.aws.connect import connect_to
 from localstack.services.moto import call_moto, call_moto_with_request
+from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.ssm.patches import apply_all_patches
 from localstack.utils.aws.arns import extract_resource_from_arn, is_arn
 from localstack.utils.bootstrap import is_api_enabled
@@ -105,7 +105,7 @@ class InvalidParameterNameException(ValidationException):
 
 
 # TODO: check if _normalize_name(..) calls are still required here
-class SsmProvider(SsmApi, ABC):
+class SsmProvider(SsmApi, ServiceLifecycleHook):
     def on_after_init(self):
         apply_all_patches()
 

--- a/localstack-core/localstack/services/ssm/provider.py
+++ b/localstack-core/localstack/services/ssm/provider.py
@@ -107,6 +107,10 @@ class InvalidParameterNameException(ValidationException):
 # TODO: check if _normalize_name(..) calls are still required here
 class SsmProvider(SsmApi, ServiceLifecycleHook):
     def on_after_init(self):
+        self.apply_patches()
+
+    @staticmethod
+    def apply_patches():
         apply_all_patches()
 
     def get_parameters(

--- a/localstack-core/localstack/services/ssm/provider.py
+++ b/localstack-core/localstack/services/ssm/provider.py
@@ -78,6 +78,7 @@ from localstack.aws.api.ssm import (
 )
 from localstack.aws.connect import connect_to
 from localstack.services.moto import call_moto, call_moto_with_request
+from localstack.services.ssm.patches import apply_all_patches
 from localstack.utils.aws.arns import extract_resource_from_arn, is_arn
 from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.collections import remove_attributes
@@ -105,6 +106,9 @@ class InvalidParameterNameException(ValidationException):
 
 # TODO: check if _normalize_name(..) calls are still required here
 class SsmProvider(SsmApi, ABC):
+    def on_after_init(self):
+        apply_all_patches()
+
     def get_parameters(
         self,
         context: RequestContext,

--- a/tests/aws/services/ssm/test_ssm.snapshot.json
+++ b/tests/aws/services/ssm/test_ssm.snapshot.json
@@ -91,5 +91,81 @@
         }
       }
     }
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_list_tags_for_parameter": {
+    "recorded-date": "19-03-2025, 02:18:23",
+    "recorded-content": {
+      "list-tags": {
+        "TagList": [
+          {
+            "Key": "my-tags",
+            "Value": "123"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-tags-with-leading-slash": {
+        "TagList": [
+          {
+            "Key": "my-tags",
+            "Value": "123"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invalid-resource-with-two-slashes": {
+        "Error": {
+          "Code": "InvalidResourceId",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_list_tags_for_nested_parameter": {
+    "recorded-date": "19-03-2025, 02:20:27",
+    "recorded-content": {
+      "list-tags": {
+        "TagList": [
+          {
+            "Key": "my-tags",
+            "Value": "123"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-nested-tags-missing-leading-slash": {
+        "Error": {
+          "Code": "InvalidResourceId",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-resource-with-two-slashes": {
+        "Error": {
+          "Code": "InvalidResourceId",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/ssm/test_ssm.validation.json
+++ b/tests/aws/services/ssm/test_ssm.validation.json
@@ -2,6 +2,12 @@
   "tests/aws/services/ssm/test_ssm.py::TestSSM::test_get_parameter_by_arn": {
     "last_validated_date": "2024-07-16T17:17:40+00:00"
   },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_list_tags_for_nested_parameter": {
+    "last_validated_date": "2025-03-19T02:20:27+00:00"
+  },
+  "tests/aws/services/ssm/test_ssm.py::TestSSM::test_list_tags_for_parameter": {
+    "last_validated_date": "2025-03-19T02:18:23+00:00"
+  },
   "tests/aws/services/ssm/test_ssm.py::TestSSM::test_parameters_with_path": {
     "last_validated_date": "2025-01-08T17:04:53+00:00"
   }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This pr fixes an issue where attempting to list tags for a parameter that starts with a `/` would fail if the parameter was not created with the leading slash.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- patch moto to remove the leading slash for a non-nested parameter when attempting to list the tags
- added test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
