### PR TITLE
Make Lambda reusable for CloudFront Lambda@Edge

### DIFF
--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -10,6 +10,7 @@ LOG = logging.getLogger(__name__)
 TRACKED_ENV_VAR = [
     "ALLOW_NONSTANDARD_REGIONS",
     "BEDROCK_PREWARM",
+    "CLOUDFRONT_LAMBDA_EDGE",
     "CONTAINER_RUNTIME",
     "DEBUG",
     "DEFAULT_REGION",  # Not functional; deprecated in 0.12.7, removed in 3.0.0

--- a/localstack-core/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack-core/localstack/services/lambda_/invocation/lambda_service.py
@@ -279,7 +279,6 @@ class LambdaService:
         except ValueError as e:
             version = function.versions.get(version_qualifier)
             state = version and version.config.state.state
-            # TODO: make such developer hints optional or remove after initial v2 transition period
             if state == State.Failed:
                 HINT_LOG.error(
                     f"Failed to create the runtime executor for the function {function_name}. "

--- a/localstack-core/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack-core/localstack/services/lambda_/invocation/version_manager.py
@@ -219,18 +219,18 @@ class LambdaVersionManager:
         if invocation_result.is_error:
             start_thread(
                 lambda *args, **kwargs: record_cw_metric_error(
-                    function_name=self.function.function_name,
-                    account_id=self.function_version.id.account,
-                    region_name=self.function_version.id.region,
+                    function_name=function_id.function_name,
+                    account_id=function_id.account,
+                    region_name=function_id.region,
                 ),
                 name=f"record-cloudwatch-metric-error-{function_id.function_name}:{function_id.qualifier}",
             )
         else:
             start_thread(
                 lambda *args, **kwargs: record_cw_metric_invocation(
-                    function_name=self.function.function_name,
-                    account_id=self.function_version.id.account,
-                    region_name=self.function_version.id.region,
+                    function_name=function_id.function_name,
+                    account_id=function_id.account,
+                    region_name=function_id.region,
                 ),
                 name=f"record-cloudwatch-metric-{function_id.function_name}:{function_id.qualifier}",
             )

--- a/localstack-core/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack-core/localstack/services/lambda_/invocation/version_manager.py
@@ -56,7 +56,8 @@ class LambdaVersionManager:
         self,
         function_arn: str,
         function_version: FunctionVersion,
-        function: Function,
+        # HACK allowing None for Lambda@Edge; only used in invoke for get_invocation_lease
+        function: Function | None,
         counting_service: CountingService,
         assignment_service: AssignmentService,
     ):

--- a/localstack-core/localstack/services/lambda_/lambda_utils.py
+++ b/localstack-core/localstack/services/lambda_/lambda_utils.py
@@ -7,7 +7,7 @@ import os
 
 from localstack.aws.api.lambda_ import Runtime
 
-# Custom logger for proactive deprecation hints related to the migration from the old to the new lambda provider
+# Custom logger for proactive advice
 HINT_LOG = logging.getLogger("localstack.services.lambda_.hints")
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

CloudFront Lambda@Edge requires some changes in Lambda to be able to re-use the existing Lambda infrastructure.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Make the Lambda `Function` object optional in `counting_service::get_invocation_lease` such that we can re-use the counting service for Lambda@Edge, and skip reserved and provisioned concurrency
* Track version state in the version manager (i.e., fix unused self.state field)
* Refactor version manager such that the optional `function` is only used for the counting service
