### PR TITLE
APIGW: fix rendering of $input.body when empty

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -227,6 +227,9 @@ class VelocityInput:
 
     @property
     def body(self):
+        if not self.value:
+            return "{}"
+
         return self.value
 
     def params(self, name=None):

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -887,10 +887,6 @@ class TestApiGatewayCommon:
         # create a special lambda URL returning exactly what it got as a body
         handler_code = handler_code = textwrap.dedent("""
         def handler(event, context):
-            # response = {"statusCode": 200}
-            # body = event.get("body", "")
-            # if body:
-            #     response["body"] = body
             return event.get("body", "")
         """)
         func_name = f"echo-http-{short_uid()}"

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -1,4 +1,5 @@
 import json
+import textwrap
 import time
 from operator import itemgetter
 
@@ -876,6 +877,150 @@ class TestApiGatewayCommon:
 
         response = requests.post(to_string, json={"list": [{"foo": "bar"}]})
         snapshot.match("list-to-string", response.text)
+
+    @markers.aws.validated
+    def test_input_body_formatting(
+        self, aws_client, create_lambda_function, create_rest_apigw, snapshot
+    ):
+        api_id, _, root_id = create_rest_apigw()
+
+        # create a special lambda URL returning exactly what it got as a body
+        handler_code = handler_code = textwrap.dedent("""
+        def handler(event, context):
+            # response = {"statusCode": 200}
+            # body = event.get("body", "")
+            # if body:
+            #     response["body"] = body
+            return event.get("body", "")
+        """)
+        func_name = f"echo-http-{short_uid()}"
+        create_lambda_function(
+            func_name=func_name,
+            handler_file=handler_code,
+            runtime=Runtime.python3_12,
+        )
+        url_response = aws_client.lambda_.create_function_url_config(
+            FunctionName=func_name, AuthType="NONE"
+        )
+        aws_client.lambda_.add_permission(
+            FunctionName=func_name,
+            StatementId="urlPermission",
+            Action="lambda:InvokeFunctionUrl",
+            Principal="*",
+            FunctionUrlAuthType="NONE",
+        )
+        echo_endpoint_url = url_response["FunctionUrl"]
+
+        def _create_route(path: str, request_template: str, response_template: str):
+            resource_id = aws_client.apigateway.create_resource(
+                restApiId=api_id, parentId=root_id, pathPart=path
+            )["id"]
+            aws_client.apigateway.put_method(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod="POST",
+                authorizationType="NONE",
+                apiKeyRequired=False,
+            )
+
+            aws_client.apigateway.put_method_response(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod="POST",
+                statusCode="200",
+            )
+
+            aws_client.apigateway.put_integration(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod="POST",
+                integrationHttpMethod="POST",
+                type="HTTP",
+                uri=echo_endpoint_url,
+                requestTemplates={"application/json": request_template},
+            )
+
+            aws_client.apigateway.put_integration_response(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod="POST",
+                statusCode="200",
+                selectionPattern="",
+                responseTemplates={"application/json": response_template},
+            )
+
+        raw_body = "#set($result = $input.body)$result"
+        body_in_str = "Action=SendMessage&MessageBody=$input.body"
+        input_body_attr_access = "#set($result = $input.body.testAccess)$result"
+        url_encode_body = "EncodedBody=$util.urlEncode($input.body)&EncodedBodyAccess=$util.urlEncode($input.body.testAccess)"
+        _create_route(
+            "raw-body",
+            request_template=raw_body,
+            response_template=raw_body,
+        )
+        _create_route(
+            "str-body-input",
+            request_template=body_in_str,
+            response_template=raw_body,
+        )
+        _create_route(
+            "str-body-output",
+            request_template=raw_body,
+            response_template=body_in_str,
+        )
+        _create_route(
+            "str-body-all",
+            request_template=body_in_str,
+            response_template=body_in_str,
+        )
+        _create_route(
+            "body-attr-access",
+            request_template=input_body_attr_access,
+            response_template=raw_body,
+        )
+        _create_route(
+            "url-encode",
+            request_template=url_encode_body,
+            response_template=raw_body,
+        )
+
+        stage_name = "dev"
+        aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
+
+        url = api_invoke_url(api_id=api_id, stage=stage_name, path="/")
+
+        route_types = [
+            "raw-body",
+            "str-body-input",
+            "str-body-output",
+            "str-body-all",
+            "body-attr-access",
+            "url-encode",
+        ]
+        for route_type in route_types:
+            route_url = url + route_type
+            # we are using `response.content` on purpose in snapshot to have text response prefixed with `b''` to avoid
+            # auto decoding of the possible JSON responses
+            # TODO: remove headers parameter, this is due to issue in our Lambda URL parity, it B64 encodes data when
+            #  AWS does not
+
+            empty_body_response = requests.post(
+                route_url, headers={"Content-Type": "application/json"}
+            )
+            json_body_response = requests.post(route_url, json={"some": "value"})
+            str_body_response = requests.post(
+                route_url, data=b"some raw data", headers={"Content-Type": "application/json"}
+            )
+
+            # keep the snapshot in one object to group related tests together
+            snapshot.match(
+                f"response-{route_type}",
+                {
+                    "empty-body": empty_body_response.content,
+                    "json-body": json_body_response.content,
+                    "str-body": str_body_response.content,
+                },
+            )
 
 
 class TestUsagePlans:

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -1391,5 +1391,40 @@
       "to-string": "{foo=bar}",
       "list-to-string": "{list=[{\"foo\":\"bar\"}]}"
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_body_formatting": {
+    "recorded-date": "19-03-2025, 17:03:40",
+    "recorded-content": {
+      "response-raw-body": {
+        "empty-body": "b'{}'",
+        "json-body": "b'{\"some\": \"value\"}'",
+        "str-body": "b'some raw data'"
+      },
+      "response-str-body-input": {
+        "empty-body": "b'Action=SendMessage&MessageBody={}'",
+        "json-body": "b'Action=SendMessage&MessageBody={\"some\": \"value\"}'",
+        "str-body": "b'Action=SendMessage&MessageBody=some raw data'"
+      },
+      "response-str-body-output": {
+        "empty-body": "b'Action=SendMessage&MessageBody={}'",
+        "json-body": "b'Action=SendMessage&MessageBody={\"some\": \"value\"}'",
+        "str-body": "b'Action=SendMessage&MessageBody=some raw data'"
+      },
+      "response-str-body-all": {
+        "empty-body": "b'Action=SendMessage&MessageBody=Action=SendMessage&MessageBody={}'",
+        "json-body": "b'Action=SendMessage&MessageBody=Action=SendMessage&MessageBody={\"some\": \"value\"}'",
+        "str-body": "b'Action=SendMessage&MessageBody=Action=SendMessage&MessageBody=some raw data'"
+      },
+      "response-body-attr-access": {
+        "empty-body": "b'{}'",
+        "json-body": "b'{}'",
+        "str-body": "b'{}'"
+      },
+      "response-url-encode": {
+        "empty-body": "b'EncodedBody=%7B%7D&EncodedBodyAccess='",
+        "json-body": "b'EncodedBody=%7B%22some%22%3A+%22value%22%7D&EncodedBodyAccess='",
+        "str-body": "b'EncodedBody=some+raw+data&EncodedBodyAccess='"
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -8,6 +8,9 @@
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator_with_ref_one_ofmodels": {
     "last_validated_date": "2024-10-28T23:12:21+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_body_formatting": {
+    "last_validated_date": "2025-03-19T17:03:40+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_path_template_formatting": {
     "last_validated_date": "2025-03-12T21:18:25+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_sqs.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_sqs.snapshot.json
@@ -1,15 +1,4 @@
 {
-  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration": {
-    "recorded-date": "30-05-2024, 17:27:58",
-    "recorded-content": {
-      "sqs-aws-integration": {
-        "message": "great success!"
-      },
-      "sqs-message": {
-        "foo": "bar"
-      }
-    }
-  },
   "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_request_and_response_xml_templates_integration": {
     "recorded-date": "12-07-2024, 16:27:03",
     "recorded-content": {
@@ -44,6 +33,36 @@
           "DataType": "String",
           "StringValue": "BAR-Header"
         }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration[payload0]": {
+    "recorded-date": "19-03-2025, 13:11:14",
+    "recorded-content": {
+      "sqs-aws-integration": {
+        "message": "great success!"
+      },
+      "sqs-message": {
+        "Body": {
+          "foo": "bar"
+        },
+        "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+        "MessageId": "<uuid:1>",
+        "ReceiptHandle": "<receipt-handle:1>"
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration[None]": {
+    "recorded-date": "19-03-2025, 13:11:24",
+    "recorded-content": {
+      "sqs-aws-integration": {
+        "message": "great success!"
+      },
+      "sqs-message": {
+        "Body": {},
+        "MD5OfBody": "99914b932bd37a50b983c5e7c90ae93b",
+        "MessageId": "<uuid:1>",
+        "ReceiptHandle": "<receipt-handle:1>"
       }
     }
   }

--- a/tests/aws/services/apigateway/test_apigateway_sqs.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_sqs.snapshot.json
@@ -36,34 +36,31 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration[payload0]": {
-    "recorded-date": "19-03-2025, 13:11:14",
+  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration": {
+    "recorded-date": "19-03-2025, 13:27:52",
     "recorded-content": {
-      "sqs-aws-integration": {
+      "sqs-aws-integration-with-payload": {
         "message": "great success!"
       },
-      "sqs-message": {
-        "Body": {
-          "foo": "bar"
+      "sqs-aws-integration-without-payload": {
+        "message": "great success!"
+      },
+      "sqs-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+          "Body": {
+            "foo": "bar"
+          }
         },
-        "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
-        "MessageId": "<uuid:1>",
-        "ReceiptHandle": "<receipt-handle:1>"
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration[None]": {
-    "recorded-date": "19-03-2025, 13:11:24",
-    "recorded-content": {
-      "sqs-aws-integration": {
-        "message": "great success!"
-      },
-      "sqs-message": {
-        "Body": {},
-        "MD5OfBody": "99914b932bd37a50b983c5e7c90ae93b",
-        "MessageId": "<uuid:1>",
-        "ReceiptHandle": "<receipt-handle:1>"
-      }
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "99914b932bd37a50b983c5e7c90ae93b",
+          "Body": {}
+        }
+      ]
     }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_sqs.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_sqs.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration": {
-    "last_validated_date": "2024-05-30T17:27:58+00:00"
+    "last_validated_date": "2025-03-19T13:27:52+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration[None]": {
     "last_validated_date": "2025-03-19T13:11:24+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_sqs.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_sqs.validation.json
@@ -2,6 +2,12 @@
   "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration": {
     "last_validated_date": "2024-05-30T17:27:58+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration[None]": {
+    "last_validated_date": "2025-03-19T13:11:24+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration[payload0]": {
+    "last_validated_date": "2025-03-19T13:11:14+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration_with_message_attribute[MessageAttribute]": {
     "last_validated_date": "2024-06-06T00:38:25+00:00"
   },

--- a/tests/unit/services/apigateway/test_template_mapping.py
+++ b/tests/unit/services/apigateway/test_template_mapping.py
@@ -234,53 +234,26 @@ class TestApiGatewayVtlTemplate:
             "status": 400,
         }
 
-    # TODO The test below are making failing assumption if the returned value isn't of valid type
-    #  for the `Accept`. But AWS doesn't seem to be raising any error.
-    #  Once properly confirmed, we should delete
-    # def test_error_when_render_invalid_json(self):
-    #     api_context = ApiInvocationContext(
-    #         method="POST",
-    #         path="/foo/bar?baz=test",
-    #         data=b"<root></root>",
-    #         headers={},
-    #     )
-    #     api_context.integration = {
-    #         "integrationResponses": {
-    #             "200": {"responseTemplates": {APPLICATION_JSON: RESPONSE_TEMPLATE_WRONG_JSON}}
-    #         },
-    #     }
-    #     api_context.response = requests_response({"spam": "eggs"})
-    #     api_context.context = {}
-    #     api_context.stage_variables = {}
-    #
-    #     template = ResponseTemplates()
-    #     with pytest.raises(JSONDecodeError):
-    #         template.render(api_context=api_context)
-    #
+    def test_input_empty_body(self):
+        variables = MappingTemplateVariables(input=MappingTemplateInput(body=""))
 
+        template = "$input.body"
+        rendered_request = ApiGatewayVtlTemplate().render_vtl(
+            template=template, variables=variables
+        )
 
-#
-#     def test_error_when_render_invalid_xml(self):
-#         api_context = ApiInvocationContext(
-#             method="POST",
-#             path="/foo/bar?baz=test",
-#             data=b"<root></root>",
-#             headers={"content-type": APPLICATION_XML, "accept": APPLICATION_XML},
-#             stage="local",
-#         )
-#         api_context.integration = {
-#             "integrationResponses": {
-#                 "200": {"responseTemplates": {APPLICATION_XML: RESPONSE_TEMPLATE_WRONG_XML}}
-#             },
-#         }
-#         api_context.resource_path = "/{proxy+}"
-#         api_context.response = requests_response({"spam": "eggs"})
-#         api_context.context = {}
-#         api_context.stage_variables = {}
-#
-#         template = ResponseTemplates()
-#         with pytest.raises(xml.parsers.expat.ExpatError):
-#             template.render(api_context=api_context, template_key=APPLICATION_XML)
+        assert rendered_request == "{}"
+
+    def test_input_url_encode_empty_body(self):
+        variables = MappingTemplateVariables(input=MappingTemplateInput(body=""))
+
+        template = "$util.urlEncode($input.body)"
+        rendered_request = ApiGatewayVtlTemplate().render_vtl(
+            template=template, variables=variables
+        )
+
+        assert rendered_request == "%7B%7D"
+
 
 TEMPLATE_JSON = """
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We broke an upstream integration test following #12322, because API Gateway would forward an empty body to the SQS integration, and SQS disallows that.

This is because API Gateway will replace an empty body with `{}` when using `$input.body` in a VTL template.

I've added a few tests validating the assumption, and @dfangl added the SQS regression test to make sure we don't break upstream anymore. He also added some changes in the retry mechanism for deleting REST APIs, and I've updated it to use the Boto config in both creation and deletion of REST APIs. 

note: I've also tried with a request template set with `text/html` and the empty body is still `{}` so it's not dependent on the content-type. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- return a `{}` string if the body is empty for `$input.body` (so that it can be passed to function like `$util.urlEncode`)
- add a test with multiple cases
- add an SQS AWS integration test with empty body

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
