### PR TITLE
[ESM] Add configurable poll frequency and log shard info

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1071,6 +1071,24 @@ LAMBDA_INIT_POST_INVOKE_WAIT_MS = os.environ.get("LAMBDA_INIT_POST_INVOKE_WAIT_M
 # DEV: sbx_user1051 (default when not provided) Alternative system user or empty string to skip dropping privileges.
 LAMBDA_INIT_USER = os.environ.get("LAMBDA_INIT_USER")
 
+# INTERNAL: 1 (default)
+# The duration (in seconds) to wait between each poll call to an event source.
+LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC = float(
+    os.environ.get("LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC") or 1
+)
+
+# INTERNAL: 60 (default)
+# Maximum duration (in seconds) to wait between retries when an event source poll fails.
+LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC = float(
+    os.environ.get("LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC") or 60
+)
+
+# INTERNAL: 10 (default)
+# Maximum duration (in seconds) to wait between polls when an event source returns empty results.
+LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC = float(
+    os.environ.get("LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC") or 10
+)
+
 # Adding Stepfunctions default port
 LOCAL_PORT_STEPFUNCTIONS = int(os.environ.get("LOCAL_PORT_STEPFUNCTIONS") or 8083)
 # Stepfunctions lambda endpoint override

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
@@ -19,11 +19,6 @@ from localstack.services.lambda_.provider_utils import get_function_version_from
 from localstack.utils.backoff import ExponentialBackoff
 from localstack.utils.threads import FuncThread
 
-POLL_INTERVAL_SEC: float = LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC
-MAX_BACKOFF_POLL_EMPTY_SEC: float = LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC
-MAX_BACKOFF_POLL_ERROR_SEC: float = LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC
-
-
 LOG = logging.getLogger(__name__)
 
 
@@ -149,10 +144,15 @@ class EsmWorker:
             self.update_esm_state_in_store(EsmState.ENABLED)
             self.state_transition_reason = self.user_state_reason
 
-        error_boff = ExponentialBackoff(initial_interval=2, max_interval=MAX_BACKOFF_POLL_ERROR_SEC)
-        empty_boff = ExponentialBackoff(initial_interval=1, max_interval=MAX_BACKOFF_POLL_EMPTY_SEC)
+        error_boff = ExponentialBackoff(
+            initial_interval=2, max_interval=LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC
+        )
+        empty_boff = ExponentialBackoff(
+            initial_interval=1,
+            max_interval=LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC,
+        )
 
-        poll_interval_duration = POLL_INTERVAL_SEC
+        poll_interval_duration = LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC
 
         while not self._shutdown_event.is_set():
             try:
@@ -164,7 +164,7 @@ class EsmWorker:
                 empty_boff.reset()
 
                 # Set the poll frequency back to the default
-                poll_interval_duration = POLL_INTERVAL_SEC
+                poll_interval_duration = LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC
             except EmptyPollResultsException as miss_ex:
                 # If the event source is empty, backoff
                 poll_interval_duration = empty_boff.next_backoff()

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker.py
@@ -5,6 +5,11 @@ from enum import StrEnum
 from localstack.aws.api.lambda_ import (
     EventSourceMappingConfiguration,
 )
+from localstack.config import (
+    LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC,
+    LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC,
+    LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC,
+)
 from localstack.services.lambda_.event_source_mapping.pollers.poller import (
     EmptyPollResultsException,
     Poller,
@@ -14,9 +19,9 @@ from localstack.services.lambda_.provider_utils import get_function_version_from
 from localstack.utils.backoff import ExponentialBackoff
 from localstack.utils.threads import FuncThread
 
-POLL_INTERVAL_SEC: float = 1
-MAX_BACKOFF_POLL_EMPTY_SEC: float = 10
-MAX_BACKOFF_POLL_ERROR_SEC: float = 60
+POLL_INTERVAL_SEC: float = LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC
+MAX_BACKOFF_POLL_EMPTY_SEC: float = LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC
+MAX_BACKOFF_POLL_ERROR_SEC: float = LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC
 
 
 LOG = logging.getLogger(__name__)

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -169,6 +169,9 @@ class StreamPoller(Poller):
         get_records_response = self.get_records(shard_iterator)
         records = get_records_response.get("Records", [])
         if not records:
+            # We cannot reliably back-off when no records found since an iterator
+            # may have to move multiple times until records are returned.
+            # See https://docs.aws.amazon.com/streams/latest/dev/troubleshooting-consumers.html#getrecords-returns-empty
             self.shards[shard_id] = get_records_response["NextShardIterator"]
             return
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
In order to address performance shortcomings, we should allow for a user to configure their poller frequency as well as their maximum backoff on error/empty polls.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- `StreamPollers` no longer back-off when a `GetRecords` call is empty
- `StreamPollers` back-off when no shards have been initialised.
- More debug logs have been added to show shard count.
- Adds the following config varibales:
   - `LAMBDA_EVENT_SOURCE_MAPPING_POLL_INTERVAL_SEC` -> set all poller's per-second frequency.
   - `LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_ERROR_SEC` -> set maximum backoff on poller exception.
   - `LAMBDA_EVENT_SOURCE_MAPPING_MAX_BACKOFF_ON_EMPTY_POLL_SEC` -> set maximum backoff on empty polls.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
