### PR TITLE
S3: fix MA/MR test

### DIFF
--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -10304,12 +10304,18 @@ class TestS3PresignedPost:
         assert "PostResponse" in json_response
         json_response = json_response["PostResponse"]
 
-        location = f"{_bucket_url_vhost(s3_bucket, region_name)}/key-my-file"
         etag = '"43281e21fce675ac3bcb3524b38ca4ed"'
         assert response.headers["ETag"] == etag
-        assert response.headers["Location"] == location
 
+        location = f"{_bucket_url_vhost(s3_bucket, region_name)}/key-my-file"
+        if region_name != "us-east-1":
+            # the format is a bit different for non-default regions, we don't return the region as part of the
+            # `Location` to avoid SSL issue, but we still want to test it works with `_bucket_url_vhost`
+            location = location.replace(f".{region_name}.", ".")
+
+        assert response.headers["Location"] == location
         assert json_response["Location"] == location
+
         assert json_response["Bucket"] == s3_bucket
         assert json_response["Key"] == "key-my-file"
         assert json_response["ETag"] == etag


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following this failure: https://app.circleci.com/pipelines/github/localstack/localstack/31762/workflows/19bde378-af5b-4fd4-af79-79f829da2482/jobs/283732

We need a bit of custom logic because there is a difference between what we want to test with `_bucket_url_vhost` (that the bucket is reachable even with the region in the host) and the `Location` we return (without the region in the host because the URL returned would not be covered by our SSL certs). 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update the `Location` assert to remove the region from the wanted value 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
