### PR TITLE
SNS: fix Subscribe idempotency due to RawMessageDelivery casing

### DIFF
--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -1045,7 +1045,7 @@ class TestSNSSubscriptionCrud:
 
         subscribe_resp = subscribe_queue_to_topic(
             {
-                "RawMessageDelivery": "true",
+                "RawMessageDelivery": "True",
             }
         )
         snapshot.match("subscribe", subscribe_resp)

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -3721,7 +3721,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_subscribe_idempotency": {
-    "recorded-date": "15-09-2023, 17:29:11",
+    "recorded-date": "20-03-2025, 17:16:39",
     "recorded-content": {
       "subscribe": {
         "SubscriptionArn": "arn:<partition>:sns:<region>:111111111111:<resource:4>:<resource:1>",

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -69,7 +69,7 @@
     "last_validated_date": "2023-08-24T21:27:58+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_subscribe_idempotency": {
-    "last_validated_date": "2023-09-15T15:29:11+00:00"
+    "last_validated_date": "2025-03-20T17:16:39+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_subscribe_with_invalid_protocol": {
     "last_validated_date": "2023-08-24T21:27:50+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #12419, we had an issue with Subscribe idempotency due to `RawMessageDelivery` casing, value like `True` and `true` are consider equal as they should be lower-cased before comparison. 

This PR fixes the issue by lower-casing the attribute before comparison


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- adapt a test to cover the casing issue
- lower case the attribute before comparison

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
