### PR TITLE
CloudFormation: [POC] Support Update Graph Modeling of Mappings and FindInMap

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
@@ -11,6 +11,7 @@ from localstack.services.cloudformation.engine.v2.change_set_model import (
     NodeCondition,
     NodeDivergence,
     NodeIntrinsicFunction,
+    NodeMapping,
     NodeObject,
     NodeParameter,
     NodeProperties,
@@ -74,6 +75,15 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
         # TODO
         raise RuntimeError()
 
+    def _get_node_mapping(self, map_name: str) -> NodeMapping:
+        mappings: list[NodeMapping] = self._node_template.mappings.mappings
+        # TODO: another scenarios suggesting property lookups might be preferable.
+        for mapping in mappings:
+            if mapping.name == map_name:
+                return mapping
+        # TODO
+        raise RuntimeError()
+
     def _get_node_parameter_if_exists(self, parameter_name: str) -> Optional[NodeParameter]:
         parameters: list[NodeParameter] = self._node_template.parameters.parameters
         # TODO: another scenarios suggesting property lookups might be preferable.
@@ -108,6 +118,16 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
         limitation_str = "Cannot yet compute Ref values for Resources"
         resource_unit = DescribeUnit(before_context=limitation_str, after_context=limitation_str)
         return resource_unit
+
+    def _resolve_mapping(self, map_name: str, top_level_key: str, second_level_key) -> DescribeUnit:
+        # TODO: add support for nested intrinsic functions, and KNOWN AFTER APPLY logical ids.
+        node_mapping: NodeMapping = self._get_node_mapping(map_name=map_name)
+        top_level_value = node_mapping.bindings.bindings.get(top_level_key)
+        if not isinstance(top_level_value, NodeObject):
+            raise RuntimeError()
+        second_level_value = top_level_value.bindings.get(second_level_key)
+        mapping_value_unit = self.visit(second_level_value)
+        return mapping_value_unit
 
     def _resolve_reference_binding(
         self, before_logical_id: str, after_logical_id: str
@@ -281,8 +301,31 @@ class ChangeSetModelDescriber(ChangeSetModelVisitor):
         # Implicit change type computation.
         return DescribeUnit(before_context=before_context, after_context=after_context)
 
+    def visit_node_intrinsic_function_fn_find_in_map(
+        self, node_intrinsic_function: NodeIntrinsicFunction
+    ) -> DescribeUnit:
+        # TODO: check for KNOWN AFTER APPLY values for logical ids coming from intrinsic functions as arguments.
+        # TODO: add type checking/validation for result unit?
+        arguments_unit = self.visit(node_intrinsic_function.arguments)
+        before_arguments = arguments_unit.before_context
+        after_arguments = arguments_unit.after_context
+        if before_arguments:
+            before_value_unit = self._resolve_mapping(*before_arguments)
+            before_context = before_value_unit.before_context
+        else:
+            before_context = None
+        if after_arguments:
+            after_value_unit = self._resolve_mapping(*after_arguments)
+            after_context = after_value_unit.after_context
+        else:
+            after_context = None
+        return DescribeUnit(before_context=before_context, after_context=after_context)
+
+    def visit_node_mapping(self, node_mapping: NodeMapping) -> DescribeUnit:
+        bindings_unit = self.visit(node_mapping.bindings)
+        return bindings_unit
+
     def visit_node_parameter(self, node_parameter: NodeParameter) -> DescribeUnit:
-        # TODO: add caching for these operation, parameters may be referenced more than once.
         # TODO: add support for default value sampling
         dynamic_value = node_parameter.dynamic_value
         describe_unit = self.visit(dynamic_value)

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_visitor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_visitor.py
@@ -7,6 +7,8 @@ from localstack.services.cloudformation.engine.v2.change_set_model import (
     NodeConditions,
     NodeDivergence,
     NodeIntrinsicFunction,
+    NodeMapping,
+    NodeMappings,
     NodeObject,
     NodeParameter,
     NodeParameters,
@@ -44,6 +46,12 @@ class ChangeSetModelVisitor(abc.ABC):
 
     def visit_node_template(self, node_template: NodeTemplate):
         self.visit_children(node_template)
+
+    def visit_node_mapping(self, node_mapping: NodeMapping):
+        self.visit_children(node_mapping)
+
+    def visit_node_mappings(self, node_mappings: NodeMappings):
+        self.visit_children(node_mappings)
 
     def visit_node_parameters(self, node_parameters: NodeParameters):
         self.visit_children(node_parameters)
@@ -92,6 +100,11 @@ class ChangeSetModelVisitor(abc.ABC):
         self.visit_children(node_intrinsic_function)
 
     def visit_node_intrinsic_function_fn_not(self, node_intrinsic_function: NodeIntrinsicFunction):
+        self.visit_children(node_intrinsic_function)
+
+    def visit_node_intrinsic_function_fn_find_in_map(
+        self, node_intrinsic_function: NodeIntrinsicFunction
+    ):
         self.visit_children(node_intrinsic_function)
 
     def visit_node_intrinsic_function_ref(self, node_intrinsic_function: NodeIntrinsicFunction):


### PR DESCRIPTION
…indinmap

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, the POC Update Graph approach to modeling CloudFormation templates does not support CloudFormation Mappings. In addition, intrinsic functions that depend on mapping lookups (Fn::FindInMap) is also unsupported in the modeling layer, which restricted the accuracy of the update graph and impacted downstream processes relying on this data. This PR introduces initial support for Mappings and Fn::FindInMap modeling, ensuring that such constructs are correctly parsed, modeled, and propagated through the update graph. The changes also add support for change set describe workflows involving maps. Relevant initial unit tests have been included to validate these enhancements.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added support for modeling CloudFormation Mappings within the Update Graph
- Implemented modeling support for the intrinsic function Fn::FindInMap
- Added support for Update Graph descriptions of changes in mappings through Fn::FindInMap


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
