### PR TITLE
CloudFormation: Fix LoggingConfiguration Parameter Handling in StepFunctions Resource Provider

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/resource_providers/aws_stepfunctions_statemachine.py
+++ b/localstack-core/localstack/services/stepfunctions/resource_providers/aws_stepfunctions_statemachine.py
@@ -110,6 +110,9 @@ class StepFunctionsStateMachineProvider(ResourceProvider[StepFunctionsStateMachi
             "roleArn": model.get("RoleArn"),
             "type": model.get("StateMachineType", "STANDARD"),
         }
+        logging_configuration = model.get("LoggingConfiguration")
+        if logging_configuration is not None:
+            params["loggingConfiguration"] = logging_configuration
 
         # get definition
         s3_client = request.aws_client_factory.s3
@@ -221,6 +224,9 @@ class StepFunctionsStateMachineProvider(ResourceProvider[StepFunctionsStateMachi
             "stateMachineArn": model["Arn"],
             "definition": definition_str,
         }
+        logging_configuration = model.get("LoggingConfiguration")
+        if logging_configuration is not None:
+            params["loggingConfiguration"] = logging_configuration
 
         step_function.update_state_machine(**params)
 

--- a/tests/aws/services/cloudformation/resources/test_stepfunctions.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_stepfunctions.snapshot.json
@@ -66,5 +66,48 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_stepfunctions.py::test_statemachine_create_with_logging_configuration": {
+    "recorded-date": "24-03-2025, 21:58:55",
+    "recorded-content": {
+      "describe_state_machine_result": {
+        "creationDate": "datetime",
+        "definition": {
+          "StartAt": "S0",
+          "States": {
+            "S0": {
+              "Type": "Pass",
+              "End": true
+            }
+          }
+        },
+        "encryptionConfiguration": {
+          "type": "AWS_OWNED_KEY"
+        },
+        "loggingConfiguration": {
+          "destinations": [
+            {
+              "cloudWatchLogsLogGroup": {
+                "logGroupArn": "<log-group-arn:1>"
+              }
+            }
+          ],
+          "includeExecutionData": true,
+          "level": "ALL"
+        },
+        "name": "<state-machine-name:1>",
+        "roleArn": "<role-arn:1>",
+        "stateMachineArn": "<state-machine-arn:1>",
+        "status": "ACTIVE",
+        "tracingConfiguration": {
+          "enabled": false
+        },
+        "type": "STANDARD",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_stepfunctions.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_stepfunctions.validation.json
@@ -1,5 +1,8 @@
 {
   "tests/aws/services/cloudformation/resources/test_stepfunctions.py::test_cfn_statemachine_default_s3_location": {
     "last_validated_date": "2024-12-17T16:06:46+00:00"
+  },
+  "tests/aws/services/cloudformation/resources/test_stepfunctions.py::test_statemachine_create_with_logging_configuration": {
+    "last_validated_date": "2025-03-24T21:58:55+00:00"
   }
 }

--- a/tests/aws/templates/statemachine_machine_logging_configuration.yml
+++ b/tests/aws/templates/statemachine_machine_logging_configuration.yml
@@ -1,0 +1,52 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Resources:
+  StateMachineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: states.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: StateMachineFullAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: "*"
+                Resource: "*"
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+
+  StateMachine:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineType: STANDARD
+      RoleArn: !GetAtt StateMachineRole.Arn
+      DefinitionString: |
+        {
+          "StartAt": "S0",
+          "States": {
+            "S0": {
+              "Type": "Pass",
+              "End": true
+            }
+          }
+        }
+      LoggingConfiguration:
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt LogGroup.Arn
+        IncludeExecutionData: true
+        Level: ALL
+
+Outputs:
+  StateMachineArnOutput:
+    Value: !Ref StateMachine


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes a limitation in the CloudFormation resource provider for AWS Step Functions where the LoggingConfiguration parameters are not passed through during Create and Delete actions https://github.com/localstack/localstack/issues/11374. These changes address such limitation and add a related positive snapshot test.



<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
