### PR TITLE
[ESM] Support Stream Poller batching

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
@@ -168,6 +168,9 @@ class EsmWorkerFactory:
                         self.esm_config["StartingPosition"]
                     ],
                     BatchSize=self.esm_config["BatchSize"],
+                    MaximumBatchingWindowInSeconds=self.esm_config[
+                        "MaximumBatchingWindowInSeconds"
+                    ],
                     MaximumRetryAttempts=self.esm_config["MaximumRetryAttempts"],
                     **optional_params,
                 ),
@@ -196,6 +199,9 @@ class EsmWorkerFactory:
                         self.esm_config["StartingPosition"]
                     ],
                     BatchSize=self.esm_config["BatchSize"],
+                    MaximumBatchingWindowInSeconds=self.esm_config[
+                        "MaximumBatchingWindowInSeconds"
+                    ],
                     MaximumRetryAttempts=self.esm_config["MaximumRetryAttempts"],
                     **optional_params,
                 ),

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -202,6 +202,7 @@ class StreamPoller(Poller):
         for batch in batched(collected_records, self.stream_parameters.get("BatchSize")):
             # This could potentially lead to data loss if forward_events_to_target raises an exception after a flush
             # which would otherwise be solved with checkpointing.
+            # TODO: Implement checkpointing, leasing, etc. from https://docs.aws.amazon.com/streams/latest/dev/kcl-concepts.html
             self.forward_events_to_target(shard_id, next_shard_iterator, batch)
 
     def forward_events_to_target(self, shard_id, next_shard_iterator, records):

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -80,8 +80,8 @@ class StreamPoller(Poller):
 
         self.shard_batcher = defaultdict(
             lambda: Batcher(
-                max_count=self.stream_parameters.get("BatchSize"),
-                max_window=self.stream_parameters.get("MaximumBatchingWindowInSeconds"),
+                max_count=self.stream_parameters.get("BatchSize", 100),
+                max_window=self.stream_parameters.get("MaximumBatchingWindowInSeconds", 0),
             )
         )
 

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -2,6 +2,7 @@ import json
 import logging
 import threading
 from abc import abstractmethod
+from collections import defaultdict
 from datetime import datetime
 from typing import Iterator
 
@@ -29,8 +30,12 @@ from localstack.services.lambda_.event_source_mapping.pollers.poller import (
     get_batch_item_failures,
 )
 from localstack.services.lambda_.event_source_mapping.pollers.sqs_poller import get_queue_url
+from localstack.services.lambda_.event_source_mapping.senders.sender_utils import (
+    batched,
+)
 from localstack.utils.aws.arns import parse_arn, s3_bucket_name
 from localstack.utils.backoff import ExponentialBackoff
+from localstack.utils.batch_policy import Batcher
 from localstack.utils.strings import long_uid
 
 LOG = logging.getLogger(__name__)
@@ -53,6 +58,9 @@ class StreamPoller(Poller):
     # Used for backing-off between retries and breaking the retry loop
     _is_shutdown: threading.Event
 
+    # Collects and flushes a batch of records based on a batching policy
+    shard_batcher: dict[str, Batcher[dict]]
+
     def __init__(
         self,
         source_arn: str,
@@ -69,6 +77,13 @@ class StreamPoller(Poller):
         self.iterator_over_shards = None
 
         self._is_shutdown = threading.Event()
+
+        self.shard_batcher = defaultdict(
+            lambda: Batcher(
+                max_count=self.stream_parameters.get("BatchSize"),
+                max_window=self.stream_parameters.get("MaximumBatchingWindowInSeconds"),
+            )
+        )
 
     @abstractmethod
     def transform_into_events(self, records: list[dict], shard_id) -> list[dict]:
@@ -140,6 +155,9 @@ class StreamPoller(Poller):
             raise EmptyPollResultsException(service=self.event_source(), source_arn=self.source_arn)
         else:
             LOG.debug("Event source %s has %d shards.", self.source_arn, len(self.shards))
+            # Remove all shard batchers without corresponding shards
+            for shard_id in self.shard_batcher.keys() - self.shards.keys():
+                self.shard_batcher.pop(shard_id, None)
 
         # TODO: improve efficiency because this currently limits the throughput to at most batch size per poll interval
         # Handle shards round-robin. Re-initialize current shard iterator once all shards are handled.
@@ -165,18 +183,31 @@ class StreamPoller(Poller):
             pass
 
     def poll_events_from_shard(self, shard_id: str, shard_iterator: str):
-        abort_condition = None
         get_records_response = self.get_records(shard_iterator)
-        records = get_records_response.get("Records", [])
-        if not records:
-            # We cannot reliably back-off when no records found since an iterator
-            # may have to move multiple times until records are returned.
-            # See https://docs.aws.amazon.com/streams/latest/dev/troubleshooting-consumers.html#getrecords-returns-empty
-            self.shards[shard_id] = get_records_response["NextShardIterator"]
+        records: list[dict] = get_records_response.get("Records", [])
+        next_shard_iterator = get_records_response["NextShardIterator"]
+
+        # We cannot reliably back-off when no records found since an iterator
+        # may have to move multiple times until records are returned.
+        # See https://docs.aws.amazon.com/streams/latest/dev/troubleshooting-consumers.html#getrecords-returns-empty
+        # However, we still need to check if batcher should be triggered due to time-based batching.
+        should_flush = self.shard_batcher[shard_id].add(records)
+        if not should_flush:
+            self.shards[shard_id] = next_shard_iterator
             return
 
+        # Retrieve and drain all events in batcher
+        collected_records = self.shard_batcher[shard_id].flush()
+        # If there is overflow (i.e 1k BatchSize and 1.2K returned in flush), further split up the batch.
+        for batch in batched(collected_records, self.stream_parameters.get("BatchSize")):
+            # This could potentially lead to data loss if forward_events_to_target raises an exception after a flush
+            # which would otherwise be solved with checkpointing.
+            self.forward_events_to_target(shard_id, next_shard_iterator, batch)
+
+    def forward_events_to_target(self, shard_id, next_shard_iterator, records):
         polled_events = self.transform_into_events(records, shard_id)
 
+        abort_condition = None
         # Check MaximumRecordAgeInSeconds
         if maximum_record_age_in_seconds := self.stream_parameters.get("MaximumRecordAgeInSeconds"):
             arrival_timestamp_of_last_event = polled_events[-1]["approximateArrivalTimestamp"]
@@ -205,7 +236,7 @@ class StreamPoller(Poller):
         # Don't trigger upon empty events
         if len(matching_events_post_filter) == 0:
             # Update shard iterator if no records match the filter
-            self.shards[shard_id] = get_records_response["NextShardIterator"]
+            self.shards[shard_id] = next_shard_iterator
             return
         events = self.add_source_metadata(matching_events_post_filter)
         LOG.debug("Polled %d events from %s in shard %s", len(events), self.source_arn, shard_id)
@@ -237,7 +268,7 @@ class StreamPoller(Poller):
                 boff.reset()
 
                 # Update shard iterator if execution is successful
-                self.shards[shard_id] = get_records_response["NextShardIterator"]
+                self.shards[shard_id] = next_shard_iterator
                 return
             except PartialBatchFailureError as ex:
                 # TODO: add tests for partial batch failure scenarios
@@ -303,7 +334,7 @@ class StreamPoller(Poller):
         )
         self.send_events_to_dlq(shard_id, events, context=failure_context)
         # Update shard iterator if the execution failed but the events are sent to a DLQ
-        self.shards[shard_id] = get_records_response["NextShardIterator"]
+        self.shards[shard_id] = next_shard_iterator
 
     def get_records(self, shard_iterator: str) -> dict:
         """Returns a GetRecordsOutput from the GetRecords endpoint of streaming services such as Kinesis or DynamoDB"""


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
In order to reduce pressure on the LocalStack internal gateway, events being collected by ESM/Pipes pollers should be properly collected and and sent onto a target as a batch.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Uses new `Batcher` utility that allows us to collect and batch records based on an ESM's `MaximumBatchingWindowInSeconds` and `BatchSize` configuration.
- Adds a `shard_batcher` dictionary to the `StreamPoller` that implements a batcher for each shard -- removing those batchers that do not correspond to shards each poll_event iteration.

## Performance

We ran some performance tests comparing baseline LocalStack with implemented **Batching** and **Parallelised** invocations.

### Batching

- Proper batching was implemented such that we only invoke a function when a `BatchSize` is met or a `MaximumBatchingWindowInSeconds` is reached

### Parallelised

- Polling of each shard was done in parallel
- `ParallelizationFactor` allowed for batches to be split by partition key and sent onto a target lambdas concurrently

### Experiments

- Batch Size = 100
- Batch Window = 20s
- No. Streams/Functions/ESMs = 20/20/20
- No. Partition Keys = 2
- No. Shards per Stream = 2

<details>
<summary>Expand for graph of average latency per `Lambda::Invoke` and `Kinesis::GetRecords`</summary>

![image](https://github.com/user-attachments/assets/f9361b76-9473-446e-a5bc-c9780cb794f8)

</details>

### Results

Batching showed improved lambda invocation performance against baseline LocalStack -- with the average latency of `Invoke` both:
- Improving over baseline and parallel and;
- Seemingly not increasing as more locust clients were added -- indicating that batching assists the scalability of adding multiple producer clients to LocalStack.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
