### PR TITLE
update kinesis-mock from 0.4.8 to 0.4.9

### DIFF
--- a/localstack-core/localstack/services/kinesis/packages.py
+++ b/localstack-core/localstack/services/kinesis/packages.py
@@ -5,7 +5,7 @@ from typing import List
 from localstack.packages import Package, PackageInstaller
 from localstack.packages.core import NodePackageInstaller
 
-_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.8"
+_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.9"
 
 
 class KinesisMockPackage(Package):


### PR DESCRIPTION
## Motivation
@etspaceman released a new patch version of `kinesis-mock` yesterday: [`0.4.9`](https://github.com/etspaceman/kinesis-mock/releases/tag/v0.4.9)
This PR upgrades `kinesis-mock` from `0.4.8` to `0.4.9`.
See https://github.com/localstack/localstack/pull/12178 for the last upgrade.

## Changes
- Changes the default version of the `kinesis-mock` package from `0.4.8` to `0.4.9`.