### PR TITLE
Deleting a FIFO message with an expired receipt handle should raise an error

### DIFF
--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -30,7 +30,6 @@ from localstack.services.sqs.exceptions import (
 )
 from localstack.services.sqs.queue import InterruptiblePriorityQueue, InterruptibleQueue
 from localstack.services.sqs.utils import (
-    decode_receipt_handle,
     encode_move_task_handle,
     encode_receipt_handle,
     extract_receipt_handle_info,
@@ -446,7 +445,7 @@ class SqsQueue:
         return len(self.delayed)
 
     def validate_receipt_handle(self, receipt_handle: str):
-        if self.arn != decode_receipt_handle(receipt_handle):
+        if self.arn != extract_receipt_handle_info(receipt_handle).queue_arn:
             raise ReceiptHandleIsInvalid(
                 f'The input receipt handle "{receipt_handle}" is not a valid receipt handle.'
             )

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -1019,7 +1019,7 @@ class FifoQueue(SqsQueue):
         _, _, _, last_received = extract_receipt_handle_info(receipt_handle)
         if time.time() - float(last_received) > message.visibility_timeout:
             raise InvalidParameterValueException(
-                f"Value f{receipt_handle} for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired."
+                f"Value {receipt_handle} for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired."
             )
 
     def remove(self, receipt_handle: str):

--- a/localstack-core/localstack/services/sqs/utils.py
+++ b/localstack-core/localstack/services/sqs/utils.py
@@ -131,7 +131,7 @@ def extract_receipt_handle_info(receipt_handle: str) -> list[str]:
     try:
         handle = base64.b64decode(receipt_handle).decode("utf-8")
         return handle.split(" ")
-    except IndexError:
+    except (IndexError, ValueError):
         raise ReceiptHandleIsInvalid(
             f'The input receipt handle "{receipt_handle}" is not a valid receipt handle.'
         )

--- a/localstack-core/localstack/services/sqs/utils.py
+++ b/localstack-core/localstack/services/sqs/utils.py
@@ -118,11 +118,20 @@ def parse_queue_url(queue_url: str) -> Tuple[str, Optional[str], str]:
 
 def decode_receipt_handle(receipt_handle: str) -> str:
     try:
-        handle = base64.b64decode(receipt_handle).decode("utf-8")
-        _, queue_arn, message_id, last_received = handle.split(" ")
+        _, queue_arn, message_id, last_received = extract_receipt_handle_info(receipt_handle)
         parse_arn(queue_arn)  # raises a ValueError if it is not an arn
         return queue_arn
-    except (IndexError, ValueError):
+    except ValueError:
+        raise ReceiptHandleIsInvalid(
+            f'The input receipt handle "{receipt_handle}" is not a valid receipt handle.'
+        )
+
+
+def extract_receipt_handle_info(receipt_handle: str) -> list[str]:
+    try:
+        handle = base64.b64decode(receipt_handle).decode("utf-8")
+        return handle.split(" ")
+    except IndexError:
         raise ReceiptHandleIsInvalid(
             f'The input receipt handle "{receipt_handle}" is not a valid receipt handle.'
         )

--- a/localstack-core/localstack/services/sqs/utils.py
+++ b/localstack-core/localstack/services/sqs/utils.py
@@ -121,7 +121,7 @@ def decode_receipt_handle(receipt_handle: str) -> str:
         _, queue_arn, message_id, last_received = extract_receipt_handle_info(receipt_handle)
         parse_arn(queue_arn)  # raises a ValueError if it is not an arn
         return queue_arn
-    except ValueError:
+    except (IndexError, ValueError):
         raise ReceiptHandleIsInvalid(
             f'The input receipt handle "{receipt_handle}" is not a valid receipt handle.'
         )

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1143,7 +1143,7 @@ class TestSqsProvider:
 
         aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="foobar", MessageGroupId="1")
         # receive the message
-        initial_receive = aws_sqs_client.receive_message(QueueUrl=queue_url)
+        initial_receive = aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=5)
         snapshot.match("received_sqs_message", initial_receive)
         receipt_handle = initial_receive["Messages"][0]["ReceiptHandle"]
 

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3890,5 +3890,61 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_after_visibility_timeout[sqs]": {
+    "recorded-date": "26-03-2025, 12:53:35",
+    "recorded-content": {
+      "delete_after_timeout": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_after_visibility_timeout[sqs_query]": {
+    "recorded-date": "26-03-2025, 12:53:38",
+    "recorded-content": {
+      "delete_after_timeout": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs]": {
+    "recorded-date": "26-03-2025, 13:04:37",
+    "recorded-content": {
+      "delete_after_timeout_fifo": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value AQEB4DZ0eAE/vl+coiMhAZZk8AWqkX/XIzhg6iIBAD6Mk/CKAsbsoyD5DQ4PaLGJFG5wAiIhVdj7B9DOSt1Tsa/I+WFqjSnCblg7R+mZIhFReS/k7b8fordB0gMIG6DqSBlgx2QnC3DLITKds1jjOugYDCeo+dz7yHhmCByJv2QWirSGDetAac7HX1kuv/zx5aZOcfVH3tZ0ohNN/sqGRSTDip3hBsBxqpfyEl3EavWgPuIPiNiEdahb9OFykOMGML/nY/xTxESP7jETo+WhtLLgiS7ofDjYDtYQH/kWU0D8poc= for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs_query]": {
+    "recorded-date": "26-03-2025, 13:04:40",
+    "recorded-content": {
+      "delete_after_timeout_fifo": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value AQEBaRWJUHD60JoHEy1+MiGtyl0qM45VE4mZWsI+Kkf5iNxORJkxRxVbNtwqeON3Hv4RMUF0u3j/SUU3Qq25aQVnp1cg3DvY7SpnUQhQEzn/2MynzcvEEsx4BuQs+mLjBnTO7A78bwW5caD6Rnbj4uNI3jZ2If+Ce/FdHpePbhuJ7rjS6Sio2gp1UBg0tDdEmbpEZB3Sg3g3BRJEyQzM+V+IJ8Y8RmUoj35UZnQmrlN0ei+YYOxOOuYFmL2gbh9hdtwzPm6C9CmC0jEzXqviflJAHOyQ3rWhMI5jGP3dPftn0SA= for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3892,9 +3892,9 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_after_visibility_timeout[sqs]": {
-    "recorded-date": "26-03-2025, 12:53:35",
+    "recorded-date": "28-03-2025, 13:46:28",
     "recorded-content": {
-      "delete_after_timeout": {
+      "delete_after_timeout_queue_empty": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3903,9 +3903,9 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_after_visibility_timeout[sqs_query]": {
-    "recorded-date": "26-03-2025, 12:53:38",
+    "recorded-date": "28-03-2025, 13:46:31",
     "recorded-content": {
-      "delete_after_timeout": {
+      "delete_after_timeout_queue_empty": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3914,12 +3914,26 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs]": {
-    "recorded-date": "26-03-2025, 14:10:59",
+    "recorded-date": "28-03-2025, 13:28:19",
     "recorded-content": {
+      "received_sqs_message": {
+        "Messages": [
+          {
+            "Body": "foobar",
+            "MD5OfBody": "3858f62230ac3c915f300c664312c63f",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "delete_after_timeout_fifo": {
         "Error": {
           "Code": "InvalidParameterValue",
-          "Message": "Value <RECEIPT_HANDLE> for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
+          "Message": "Value <receipt-handle:1> for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
           "QueryErrorCode": "InvalidParameterValueException",
           "Type": "Sender"
         },
@@ -3931,13 +3945,27 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs_query]": {
-    "recorded-date": "26-03-2025, 14:11:02",
+    "recorded-date": "28-03-2025, 13:28:23",
     "recorded-content": {
+      "received_sqs_message": {
+        "Messages": [
+          {
+            "Body": "foobar",
+            "MD5OfBody": "3858f62230ac3c915f300c664312c63f",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "delete_after_timeout_fifo": {
         "Error": {
           "Code": "InvalidParameterValue",
           "Detail": null,
-          "Message": "Value <RECEIPT_HANDLE> for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
+          "Message": "Value <receipt-handle:1> for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
           "Type": "Sender"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3914,12 +3914,12 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs]": {
-    "recorded-date": "26-03-2025, 13:04:37",
+    "recorded-date": "26-03-2025, 14:10:59",
     "recorded-content": {
       "delete_after_timeout_fifo": {
         "Error": {
           "Code": "InvalidParameterValue",
-          "Message": "Value AQEB4DZ0eAE/vl+coiMhAZZk8AWqkX/XIzhg6iIBAD6Mk/CKAsbsoyD5DQ4PaLGJFG5wAiIhVdj7B9DOSt1Tsa/I+WFqjSnCblg7R+mZIhFReS/k7b8fordB0gMIG6DqSBlgx2QnC3DLITKds1jjOugYDCeo+dz7yHhmCByJv2QWirSGDetAac7HX1kuv/zx5aZOcfVH3tZ0ohNN/sqGRSTDip3hBsBxqpfyEl3EavWgPuIPiNiEdahb9OFykOMGML/nY/xTxESP7jETo+WhtLLgiS7ofDjYDtYQH/kWU0D8poc= for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
+          "Message": "Value <RECEIPT_HANDLE> for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
           "QueryErrorCode": "InvalidParameterValueException",
           "Type": "Sender"
         },
@@ -3931,13 +3931,13 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs_query]": {
-    "recorded-date": "26-03-2025, 13:04:40",
+    "recorded-date": "26-03-2025, 14:11:02",
     "recorded-content": {
       "delete_after_timeout_fifo": {
         "Error": {
           "Code": "InvalidParameterValue",
           "Detail": null,
-          "Message": "Value AQEBaRWJUHD60JoHEy1+MiGtyl0qM45VE4mZWsI+Kkf5iNxORJkxRxVbNtwqeON3Hv4RMUF0u3j/SUU3Qq25aQVnp1cg3DvY7SpnUQhQEzn/2MynzcvEEsx4BuQs+mLjBnTO7A78bwW5caD6Rnbj4uNI3jZ2If+Ce/FdHpePbhuJ7rjS6Sio2gp1UBg0tDdEmbpEZB3Sg3g3BRJEyQzM+V+IJ8Y8RmUoj35UZnQmrlN0ei+YYOxOOuYFmL2gbh9hdtwzPm6C9CmC0jEzXqviflJAHOyQ3rWhMI5jGP3dPftn0SA= for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
+          "Message": "Value <RECEIPT_HANDLE> for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
           "Type": "Sender"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -135,10 +135,10 @@
     "last_validated_date": "2024-04-30T13:34:17+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs]": {
-    "last_validated_date": "2025-03-26T13:04:37+00:00"
+    "last_validated_date": "2025-03-26T14:10:59+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs_query]": {
-    "last_validated_date": "2025-03-26T13:04:39+00:00"
+    "last_validated_date": "2025-03-26T14:11:02+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_empty_message_groups_added_back_to_queue[sqs]": {
     "last_validated_date": "2024-04-30T13:46:32+00:00"

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -68,6 +68,12 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_deduplication_interval[sqs_query]": {
     "last_validated_date": "2024-05-29T13:47:36+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_after_visibility_timeout[sqs]": {
+    "last_validated_date": "2025-03-26T12:53:35+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_after_visibility_timeout[sqs_query]": {
+    "last_validated_date": "2025-03-26T12:53:37+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[sqs-]": {
     "last_validated_date": "2024-04-30T13:48:34+00:00"
   },
@@ -127,6 +133,12 @@
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_not_on_message_group_id[sqs_query-True]": {
     "last_validated_date": "2024-04-30T13:34:17+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs]": {
+    "last_validated_date": "2025-03-26T13:04:37+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs_query]": {
+    "last_validated_date": "2025-03-26T13:04:39+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_empty_message_groups_added_back_to_queue[sqs]": {
     "last_validated_date": "2024-04-30T13:46:32+00:00"

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -69,10 +69,10 @@
     "last_validated_date": "2024-05-29T13:47:36+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_after_visibility_timeout[sqs]": {
-    "last_validated_date": "2025-03-26T12:53:35+00:00"
+    "last_validated_date": "2025-03-28T13:46:27+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_after_visibility_timeout[sqs_query]": {
-    "last_validated_date": "2025-03-26T12:53:37+00:00"
+    "last_validated_date": "2025-03-28T13:46:31+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[sqs-]": {
     "last_validated_date": "2024-04-30T13:48:34+00:00"
@@ -135,10 +135,10 @@
     "last_validated_date": "2024-04-30T13:34:17+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs]": {
-    "last_validated_date": "2025-03-26T14:10:59+00:00"
+    "last_validated_date": "2025-03-28T13:37:10+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs_query]": {
-    "last_validated_date": "2025-03-26T14:11:02+00:00"
+    "last_validated_date": "2025-03-28T13:37:13+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_empty_message_groups_added_back_to_queue[sqs]": {
     "last_validated_date": "2024-04-30T13:46:32+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As per title. FIFO messages should not be deleted if the provided receipt handle has expired, tests against AWS failed consistently. Reversely, the same test succeeded consistently on standard queues, making fifo specific code necessary.
fixes https://github.com/localstack/localstack/issues/12278

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- adds tests to confirm the issue
- adds new methods to decouple some of the extraction steps for the receipt handle to access time-related information
- adds `_pre_delete_checks` hook when removing messages, because this behaviour is fifo specific, and a complete remodel of the delete method to separate standard and fifo behaviour to make this cleaner was out of scope for this PR.
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
