### PR TITLE
S3: fix casing of PreSignedPost validation

### DIFF
--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -710,6 +710,12 @@
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_default_checksum": {
     "last_validated_date": "2025-03-17T21:46:24+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_casing[s3]": {
+    "last_validated_date": "2025-03-28T19:11:34+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_casing[s3v4]": {
+    "last_validated_date": "2025-03-28T19:11:36+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
     "last_validated_date": "2025-03-17T20:16:55+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #12448, we had an issue with the JS AWS SDK v3 accepting some conditions that shouldn't have been validated. This is because we skipped validating the request if the request did not have a `policy` field, lower-cased. But the JS SDK sends it as `Policy`. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update the logic to be case insensitive while validating certain fields of the Post request

_fixes #12448_
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
