### PR TITLE
Admin: Improve license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dynamic = ["version"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
-    "License :: OSI Approved :: Apache Software License",
+    "License-Expression :: OSI Approved :: Apache Software License",
     "Topic :: Internet",
     "Topic :: Software Development :: Testing",
     "Topic :: System :: Emulators",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With [PEP 639](https://peps.python.org/pep-0639/), the latest setuptools (>= 77.0) throws a warning when building projects with a deprecated license-format. This PR updates the format to the latest recommended format, removing all warnings.

The [Python Packaging docs](https://packaging.python.org/en/latest/specifications/core-metadata/#classifier-multiple-use) now also explicitly states that this is the recommended format:

| The use of License :: classifiers is deprecated as of Metadata 2.4, use License-Expression instead. See [PEP 639](https://peps.python.org/pep-0639/#deprecate-license-classifiers).
