### PR TITLE
Lambda: Added Ruby 3.4 Runtime

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -223,6 +223,7 @@ from localstack.services.lambda_.runtimes import (
     DEPRECATED_RUNTIMES,
     DEPRECATED_RUNTIMES_UPGRADES,
     RUNTIMES_AGGREGATED,
+    SNAP_START_SUPPORTED_RUNTIMES,
     VALID_RUNTIMES,
 )
 from localstack.services.lambda_.urlrouter import FunctionUrlRouter
@@ -716,6 +717,11 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         ]:
             raise ValidationException(
                 f"1 validation error detected: Value '{apply_on}' at 'snapStart.applyOn' failed to satisfy constraint: Member must satisfy enum value set: [PublishedVersions, None]"
+            )
+
+        if runtime not in SNAP_START_SUPPORTED_RUNTIMES:
+            raise InvalidParameterValueException(
+                f"{runtime} is not supported for SnapStart enabled functions.", Type="User"
             )
 
     def _validate_layers(self, new_layers: list[str], region: str, account_id: str):

--- a/localstack-core/localstack/services/lambda_/runtimes.py
+++ b/localstack-core/localstack/services/lambda_/runtimes.py
@@ -59,6 +59,7 @@ IMAGE_MAPPING: dict[Runtime, str] = {
     Runtime.dotnet6: "dotnet:6",
     Runtime.dotnetcore3_1: "dotnet:core3.1",  # deprecated Apr 3, 2023 => Apr 3, 2023 => May 3, 2023
     Runtime.go1_x: "go:1",  # deprecated Jan 8, 2024 => Feb 8, 2024 => Mar 12, 2024
+    Runtime.ruby3_4: "ruby:3.4",
     Runtime.ruby3_3: "ruby:3.3",
     Runtime.ruby3_2: "ruby:3.2",
     Runtime.ruby2_7: "ruby:2.7",  # deprecated Dec 7, 2023 => Jan 9, 2024 => Feb 8, 2024
@@ -133,6 +134,7 @@ RUNTIMES_AGGREGATED = {
     "ruby": [
         Runtime.ruby3_2,
         Runtime.ruby3_3,
+        Runtime.ruby3_4,
     ],
     "dotnet": [
         Runtime.dotnet6,
@@ -149,7 +151,18 @@ TESTED_RUNTIMES: list[Runtime] = [
     runtime for runtime_group in RUNTIMES_AGGREGATED.values() for runtime in runtime_group
 ]
 
+# An unordered list of snapstart-enabled runtimes. Related to snapshots in test_snapstart_exceptions
+# https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html
+SNAP_START_SUPPORTED_RUNTIMES = [
+    Runtime.java11,
+    Runtime.java17,
+    Runtime.java21,
+    Runtime.python3_12,
+    Runtime.python3_13,
+    Runtime.dotnet8,
+]
+
 # An ordered list of all Lambda runtimes considered valid by AWS. Matching snapshots in test_create_lambda_exceptions
-VALID_RUNTIMES: str = "[nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]"
+VALID_RUNTIMES: str = "[nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9]"
 # An ordered list of all Lambda runtimes for layers considered valid by AWS. Matching snapshots in test_layer_exceptions
-VALID_LAYER_RUNTIMES: str = "[ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java17, nodejs, nodejs4.3, java8.al2, go1.x, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, nodejs22.x, python3.10, java8, nodejs12.x, python3.11, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, python3.13, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby2.5, python3.6, python2.7]"
+VALID_LAYER_RUNTIMES: str = "[ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java25, java17, nodejs, nodejs4.3, java8.al2, go1.x, dotnet10, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, nodejs22.x, python3.10, java8, nodejs12.x, python3.11, nodejs24.x, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, python3.13, python3.14, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby3.4, ruby2.5, python3.6, python2.7]"

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -38,6 +38,7 @@ from localstack.services.lambda_.provider_utils import LambdaLayerVersionIdentif
 from localstack.services.lambda_.runtimes import (
     ALL_RUNTIMES,
     DEPRECATED_RUNTIMES,
+    SNAP_START_SUPPORTED_RUNTIMES,
 )
 from localstack.testing.aws.lambda_utils import (
     _await_dynamodb_table_active,
@@ -6827,14 +6828,12 @@ class TestLambdaLayer:
 class TestLambdaSnapStart:
     @markers.aws.validated
     @markers.lambda_runtime_update
-    @markers.multiruntime(scenario="echo")
+    @markers.multiruntime(scenario="echo", runtimes=SNAP_START_SUPPORTED_RUNTIMES)
     def test_snapstart_lifecycle(self, multiruntime_lambda, snapshot, aws_client):
         """Test the API of the SnapStart feature. The optimization behavior is not supported in LocalStack.
         Slow (~1-2min) against AWS.
         """
-        create_function_response = multiruntime_lambda.create_function(
-            MemorySize=1024, Timeout=5, SnapStart={"ApplyOn": "PublishedVersions"}
-        )
+        create_function_response = multiruntime_lambda.create_function(MemorySize=1024, Timeout=5)
         function_name = create_function_response["FunctionName"]
         snapshot.match("create_function_response", create_function_response)
 
@@ -6856,7 +6855,7 @@ class TestLambdaSnapStart:
 
     @markers.aws.validated
     @markers.lambda_runtime_update
-    @markers.multiruntime(scenario="echo")
+    @markers.multiruntime(scenario="echo", runtimes=SNAP_START_SUPPORTED_RUNTIMES)
     def test_snapstart_update_function_configuration(
         self, multiruntime_lambda, snapshot, aws_client
     ):

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -7848,7 +7848,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "recorded-date": "26-11-2024, 09:27:31",
+    "recorded-date": "01-04-2025, 13:08:21",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7863,10 +7863,10 @@
       "invalid_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7875,10 +7875,10 @@
       "uppercase_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7920,7 +7920,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "recorded-date": "26-11-2024, 09:27:33",
+    "recorded-date": "01-04-2025, 13:09:51",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7935,10 +7935,10 @@
       "invalid_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7947,10 +7947,10 @@
       "uppercase_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -8260,7 +8260,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_exceptions": {
-    "recorded-date": "26-11-2024, 09:27:46",
+    "recorded-date": "01-04-2025, 13:19:20",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8287,7 +8287,7 @@
       "list_layers_exc_compatibleruntime_invalid": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'runtimedoesnotexist' at 'compatibleRuntime' failed to satisfy constraint: Member must satisfy enum value set: [ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java17, nodejs, nodejs4.3, java8.al2, go1.x, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, nodejs22.x, python3.10, java8, nodejs12.x, python3.11, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, python3.13, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby2.5, python3.6, python2.7]"
+          "Message": "1 validation error detected: Value 'runtimedoesnotexist' at 'compatibleRuntime' failed to satisfy constraint: Member must satisfy enum value set: [ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java25, java17, nodejs, nodejs4.3, java8.al2, go1.x, dotnet10, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, nodejs22.x, python3.10, java8, nodejs12.x, python3.11, nodejs24.x, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, python3.13, python3.14, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby3.4, ruby2.5, python3.6, python2.7]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8438,7 +8438,7 @@
       "publish_layer_version_exc_invalid_runtime_arch": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "2 validation errors detected: Value '[invalidruntime]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
+          "Message": "2 validation errors detected: Value '[invalidruntime]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8448,7 +8448,7 @@
       "publish_layer_version_exc_partially_invalid_values": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "2 validation errors detected: Value '[invalidruntime, invalidruntime2, nodejs20.x]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch, x86_64]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
+          "Message": "2 validation errors detected: Value '[invalidruntime, invalidruntime2, nodejs20.x]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch, x86_64]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -12407,7 +12407,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_exceptions": {
-    "recorded-date": "09-12-2024, 15:23:03",
+    "recorded-date": "31-03-2025, 16:15:53",
     "recorded-content": {
       "create_function_invalid_snapstart_apply": {
         "Error": {
@@ -12881,7 +12881,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java11]": {
-    "recorded-date": "09-12-2024, 15:03:12",
+    "recorded-date": "01-04-2025, 13:30:54",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -12910,7 +12910,7 @@
           "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
         },
         "SnapStart": {
-          "ApplyOn": "PublishedVersions",
+          "ApplyOn": "None",
           "OptimizationStatus": "Off"
         },
         "State": "Pending",
@@ -12959,7 +12959,7 @@
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "PublishedVersions",
+            "ApplyOn": "None",
             "OptimizationStatus": "Off"
           },
           "State": "Active",
@@ -13007,8 +13007,8 @@
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
           },
           "State": "Active",
           "Timeout": 5,
@@ -13025,7 +13025,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java17]": {
-    "recorded-date": "09-12-2024, 15:01:48",
+    "recorded-date": "01-04-2025, 13:30:58",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -13054,7 +13054,7 @@
           "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
         },
         "SnapStart": {
-          "ApplyOn": "PublishedVersions",
+          "ApplyOn": "None",
           "OptimizationStatus": "Off"
         },
         "State": "Pending",
@@ -13103,7 +13103,7 @@
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "PublishedVersions",
+            "ApplyOn": "None",
             "OptimizationStatus": "Off"
           },
           "State": "Active",
@@ -13151,8 +13151,8 @@
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
           },
           "State": "Active",
           "Timeout": 5,
@@ -13161,190 +13161,6 @@
           },
           "Version": "1"
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java11]": {
-    "recorded-date": "09-12-2024, 15:28:21",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "echo.Handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "java11",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "echo.Handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "java11",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java17]": {
-    "recorded-date": "09-12-2024, 15:28:18",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "echo.Handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "java17",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "echo.Handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "java17",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -13705,49 +13521,8 @@
       }
     }
   },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities": {
-    "recorded-date": "30-08-2023, 09:57:12",
-    "recorded-content": {
-      "publish_result": {
-        "CompatibleArchitectures": [
-          "arm64",
-          "x86_64"
-        ],
-        "CompatibleRuntimes": [
-          "nodejs12.x",
-          "nodejs14.x",
-          "nodejs16.x",
-          "nodejs18.x",
-          "python3.7",
-          "python3.8",
-          "python3.9",
-          "python3.10",
-          "python3.11",
-          "ruby2.7",
-          "ruby3.2",
-          "java8",
-          "java8.al2",
-          "java11"
-        ],
-        "Content": {
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Location": "<layer-location>"
-        },
-        "CreatedDate": "date",
-        "Description": "",
-        "LayerArn": "arn:<partition>:lambda:<region>:111111111111:layer:<resource:1>",
-        "LayerVersionArn": "arn:<partition>:lambda:<region>:111111111111:layer:<resource:1>:1",
-        "Version": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      }
-    }
-  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes0]": {
-    "recorded-date": "26-11-2024, 09:27:34",
+    "recorded-date": "01-04-2025, 13:12:59",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -13788,7 +13563,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes1]": {
-    "recorded-date": "26-11-2024, 09:27:38",
+    "recorded-date": "01-04-2025, 13:13:03",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -13804,6 +13579,7 @@
           "dotnet6",
           "dotnetcore3.1",
           "go1.x",
+          "ruby3.4",
           "ruby3.3",
           "ruby3.2",
           "ruby2.7",
@@ -13883,7 +13659,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java21]": {
-    "recorded-date": "09-12-2024, 15:00:20",
+    "recorded-date": "01-04-2025, 13:31:02",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -13912,7 +13688,7 @@
           "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
         },
         "SnapStart": {
-          "ApplyOn": "PublishedVersions",
+          "ApplyOn": "None",
           "OptimizationStatus": "Off"
         },
         "State": "Pending",
@@ -13961,7 +13737,7 @@
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "PublishedVersions",
+            "ApplyOn": "None",
             "OptimizationStatus": "Off"
           },
           "State": "Active",
@@ -14009,8 +13785,8 @@
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
           },
           "State": "Active",
           "Timeout": 5,
@@ -14458,98 +14234,6 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java21]": {
-    "recorded-date": "09-12-2024, 15:28:16",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "echo.Handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "java21",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "echo.Handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "java21",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
         }
       }
     }
@@ -16254,25 +15938,8 @@
     "recorded-date": "05-06-2024, 11:49:05",
     "recorded-content": {}
   },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled": {
-    "recorded-date": "12-06-2024, 14:19:11",
-    "recorded-content": {
-      "deprecation_error": {
-        "Error": {
-          "Code": "InvalidParameterValueException",
-          "Message": "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions."
-        },
-        "Type": "User",
-        "message": "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions.",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[java8]": {
-    "recorded-date": "26-11-2024, 09:27:29",
+    "recorded-date": "01-04-2025, 13:02:29",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16289,7 +15956,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[go1.x]": {
-    "recorded-date": "26-11-2024, 09:27:29",
+    "recorded-date": "01-04-2025, 13:02:29",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16306,7 +15973,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[provided]": {
-    "recorded-date": "26-11-2024, 09:27:30",
+    "recorded-date": "01-04-2025, 13:02:30",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16323,7 +15990,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[ruby2.7]": {
-    "recorded-date": "26-11-2024, 09:27:30",
+    "recorded-date": "01-04-2025, 13:02:30",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16340,7 +16007,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs14.x]": {
-    "recorded-date": "26-11-2024, 09:27:30",
+    "recorded-date": "01-04-2025, 13:02:30",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16357,7 +16024,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[python3.7]": {
-    "recorded-date": "26-11-2024, 09:27:30",
+    "recorded-date": "01-04-2025, 13:02:30",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16374,7 +16041,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[dotnetcore3.1]": {
-    "recorded-date": "26-11-2024, 09:27:30",
+    "recorded-date": "01-04-2025, 13:02:31",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16391,7 +16058,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs12.x]": {
-    "recorded-date": "26-11-2024, 09:27:30",
+    "recorded-date": "01-04-2025, 13:02:31",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -18269,584 +17936,8 @@
       }
     }
   },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[nodejs22.x]": {
-    "recorded-date": "09-12-2024, 14:45:02",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "index.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "nodejs22.x",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "index.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "nodejs22.x",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "index.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "nodejs22.x",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[nodejs20.x]": {
-    "recorded-date": "09-12-2024, 14:46:41",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "index.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "nodejs20.x",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "index.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "nodejs20.x",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "index.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "nodejs20.x",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[nodejs18.x]": {
-    "recorded-date": "09-12-2024, 14:48:09",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "index.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "nodejs18.x",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "index.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "nodejs18.x",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "index.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "nodejs18.x",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[nodejs16.x]": {
-    "recorded-date": "09-12-2024, 14:49:37",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "index.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "nodejs16.x",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "index.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "nodejs16.x",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "index.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "nodejs16.x",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.13]": {
-    "recorded-date": "09-12-2024, 14:51:06",
+    "recorded-date": "01-04-2025, 13:31:11",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -18875,7 +17966,7 @@
           "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
         },
         "SnapStart": {
-          "ApplyOn": "PublishedVersions",
+          "ApplyOn": "None",
           "OptimizationStatus": "Off"
         },
         "State": "Pending",
@@ -18924,7 +18015,7 @@
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "PublishedVersions",
+            "ApplyOn": "None",
             "OptimizationStatus": "Off"
           },
           "State": "Active",
@@ -18972,8 +18063,8 @@
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
           },
           "State": "Active",
           "Timeout": 5,
@@ -18990,7 +18081,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.12]": {
-    "recorded-date": "09-12-2024, 14:52:34",
+    "recorded-date": "01-04-2025, 13:31:07",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -19019,7 +18110,7 @@
           "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
         },
         "SnapStart": {
-          "ApplyOn": "PublishedVersions",
+          "ApplyOn": "None",
           "OptimizationStatus": "Off"
         },
         "State": "Pending",
@@ -19068,7 +18159,7 @@
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "PublishedVersions",
+            "ApplyOn": "None",
             "OptimizationStatus": "Off"
           },
           "State": "Active",
@@ -19116,103 +18207,7 @@
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.11]": {
-    "recorded-date": "09-12-2024, 14:54:02",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.11",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "handler.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.11",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
+            "ApplyOn": "None",
             "OptimizationStatus": "Off"
           },
           "State": "Active",
@@ -19220,3060 +18215,8 @@
           "TracingConfig": {
             "Mode": "PassThrough"
           },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "handler.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.11",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
           "Version": "1"
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.10]": {
-    "recorded-date": "09-12-2024, 14:55:31",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.10",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "handler.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.10",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "handler.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.10",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.9]": {
-    "recorded-date": "09-12-2024, 14:56:58",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "handler.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.9",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "handler.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.9",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.8]": {
-    "recorded-date": "09-12-2024, 14:58:27",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.8",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "handler.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.8",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "handler.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.8",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java8.al2]": {
-    "recorded-date": "09-12-2024, 15:04:41",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "echo.Handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "java8.al2",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "echo.Handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "java8.al2",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "echo.Handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "java8.al2",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[ruby3.2]": {
-    "recorded-date": "09-12-2024, 15:06:09",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "function.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "ruby3.2",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "function.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "ruby3.2",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "function.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "ruby3.2",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[ruby3.3]": {
-    "recorded-date": "09-12-2024, 15:07:48",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "function.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "ruby3.3",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "function.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "ruby3.3",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "function.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "ruby3.3",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[dotnet6]": {
-    "recorded-date": "09-12-2024, 15:10:39",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "dotnet::Dotnet.Function::FunctionHandler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "dotnet6",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "dotnet::Dotnet.Function::FunctionHandler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "dotnet6",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "dotnet::Dotnet.Function::FunctionHandler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "dotnet6",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[dotnet8]": {
-    "recorded-date": "09-12-2024, 15:12:14",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "dotnet::Dotnet.Function::FunctionHandler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "dotnet8",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "dotnet::Dotnet.Function::FunctionHandler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "dotnet8",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "dotnet::Dotnet.Function::FunctionHandler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "dotnet8",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[provided.al2023]": {
-    "recorded-date": "09-12-2024, 15:13:42",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "function.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "provided.al2023",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "function.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "provided.al2023",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "function.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "provided.al2023",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[provided.al2]": {
-    "recorded-date": "09-12-2024, 15:15:16",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "function.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "provided.al2",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "function.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "provided.al2",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "function.handler",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "LoggingConfig": {
-            "LogFormat": "Text",
-            "LogGroup": "/aws/lambda/<function-name:1>"
-          },
-          "MemorySize": 1024,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "provided.al2",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 5,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[nodejs22.x]": {
-    "recorded-date": "09-12-2024, 15:27:51",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "index.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "nodejs22.x",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "index.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "nodejs22.x",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[nodejs20.x]": {
-    "recorded-date": "09-12-2024, 15:27:54",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "index.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "nodejs20.x",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "index.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "nodejs20.x",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[nodejs18.x]": {
-    "recorded-date": "09-12-2024, 15:27:57",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "index.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "nodejs18.x",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "index.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "nodejs18.x",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[nodejs16.x]": {
-    "recorded-date": "09-12-2024, 15:27:59",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "index.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "nodejs16.x",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "index.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "nodejs16.x",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.13]": {
-    "recorded-date": "09-12-2024, 15:28:02",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.13",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.13",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.12]": {
-    "recorded-date": "09-12-2024, 15:28:04",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.12",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.12",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.11]": {
-    "recorded-date": "09-12-2024, 15:28:06",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.11",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.11",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.10]": {
-    "recorded-date": "09-12-2024, 15:28:09",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.10",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.10",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.9]": {
-    "recorded-date": "09-12-2024, 15:28:11",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.8]": {
-    "recorded-date": "09-12-2024, 15:28:13",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.8",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "handler.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.8",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java8.al2]": {
-    "recorded-date": "09-12-2024, 15:28:24",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "echo.Handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "java8.al2",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "echo.Handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "java8.al2",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[ruby3.2]": {
-    "recorded-date": "09-12-2024, 15:28:26",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "function.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "ruby3.2",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "function.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "ruby3.2",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[ruby3.3]": {
-    "recorded-date": "09-12-2024, 15:28:29",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "function.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "ruby3.3",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "function.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "ruby3.3",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[dotnet6]": {
-    "recorded-date": "09-12-2024, 15:28:31",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "dotnet::Dotnet.Function::FunctionHandler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "dotnet6",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "dotnet::Dotnet.Function::FunctionHandler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "dotnet6",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[dotnet8]": {
-    "recorded-date": "09-12-2024, 15:28:33",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "dotnet::Dotnet.Function::FunctionHandler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "dotnet8",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "dotnet::Dotnet.Function::FunctionHandler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "dotnet8",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[provided.al2023]": {
-    "recorded-date": "09-12-2024, 15:28:36",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "function.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "provided.al2023",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "function.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "provided.al2023",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[provided.al2]": {
-    "recorded-date": "09-12-2024, 15:28:38",
-    "recorded-content": {
-      "create_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "function.handler",
-        "LastModified": "date",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "provided.al2",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "None",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Pending",
-        "StateReason": "The function is being created.",
-        "StateReasonCode": "Creating",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "function.handler",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "LoggingConfig": {
-          "LogFormat": "Text",
-          "LogGroup": "/aws/lambda/<function-name:1>"
-        },
-        "MemorySize": 1024,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-        "Runtime": "provided.al2",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 5,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -22358,6 +18301,702 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[dotnet8]": {
+    "recorded-date": "01-04-2025, 13:31:15",
+    "recorded-content": {
+      "create_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "dotnet::Dotnet.Function::FunctionHandler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "dotnet8",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get_function_response_latest": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "dotnet::Dotnet.Function::FunctionHandler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 1024,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+          "Runtime": "dotnet8",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 5,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_response_version_1": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "version1",
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
+          "FunctionName": "<function-name:1>",
+          "Handler": "dotnet::Dotnet.Function::FunctionHandler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 1024,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:3>",
+          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+          "Runtime": "dotnet8",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 5,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java11]": {
+    "recorded-date": "01-04-2025, 13:40:26",
+    "recorded-content": {
+      "create_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "java11",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "java11",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "PublishedVersions",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java17]": {
+    "recorded-date": "01-04-2025, 13:40:32",
+    "recorded-content": {
+      "create_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "java17",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "java17",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "PublishedVersions",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java21]": {
+    "recorded-date": "01-04-2025, 13:40:35",
+    "recorded-content": {
+      "create_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "java21",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "java21",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "PublishedVersions",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.12]": {
+    "recorded-date": "01-04-2025, 13:40:40",
+    "recorded-content": {
+      "create_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.12",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.12",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "PublishedVersions",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.13]": {
+    "recorded-date": "01-04-2025, 13:40:44",
+    "recorded-content": {
+      "create_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.13",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.13",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "PublishedVersions",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[dotnet8]": {
+    "recorded-date": "01-04-2025, 13:40:47",
+    "recorded-content": {
+      "create_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "dotnet::Dotnet.Function::FunctionHandler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "dotnet8",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "dotnet::Dotnet.Function::FunctionHandler",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "dotnet8",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "PublishedVersions",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -63,7 +63,7 @@
     "last_validated_date": "2024-04-10T08:58:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "last_validated_date": "2024-11-26T09:27:31+00:00"
+    "last_validated_date": "2025-04-01T13:08:49+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_delete_on_nonexisting_version": {
     "last_validated_date": "2024-09-12T11:29:32+00:00"
@@ -426,7 +426,7 @@
     "last_validated_date": "2024-09-12T11:29:23+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "last_validated_date": "2024-11-26T09:27:33+00:00"
+    "last_validated_date": "2025-04-01T13:10:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_vpc_config": {
     "last_validated_date": "2024-09-12T11:34:40+00:00"
@@ -444,13 +444,13 @@
     "last_validated_date": "2024-04-10T09:10:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes0]": {
-    "last_validated_date": "2024-11-26T09:27:34+00:00"
+    "last_validated_date": "2025-04-01T13:14:56+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes1]": {
-    "last_validated_date": "2024-11-26T09:27:38+00:00"
+    "last_validated_date": "2025-04-01T13:15:00+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_exceptions": {
-    "last_validated_date": "2024-11-26T09:27:46+00:00"
+    "last_validated_date": "2025-04-01T13:19:40+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_function_exceptions": {
     "last_validated_date": "2024-04-10T09:23:18+00:00"
@@ -546,127 +546,43 @@
     "last_validated_date": "2024-04-10T09:17:26+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_exceptions": {
-    "last_validated_date": "2024-12-09T15:23:03+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[dotnet6]": {
-    "last_validated_date": "2024-12-09T15:10:39+00:00"
+    "last_validated_date": "2025-03-31T16:15:53+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[dotnet8]": {
-    "last_validated_date": "2024-12-09T15:12:13+00:00"
+    "last_validated_date": "2025-04-01T13:31:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java11]": {
-    "last_validated_date": "2024-12-09T15:03:11+00:00"
+    "last_validated_date": "2025-04-01T13:30:54+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java17]": {
-    "last_validated_date": "2024-12-09T15:01:47+00:00"
+    "last_validated_date": "2025-04-01T13:30:57+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java21]": {
-    "last_validated_date": "2024-12-09T15:00:19+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java8.al2]": {
-    "last_validated_date": "2024-12-09T15:04:40+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[nodejs16.x]": {
-    "last_validated_date": "2024-12-09T14:49:37+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[nodejs18.x]": {
-    "last_validated_date": "2024-12-09T14:48:09+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[nodejs20.x]": {
-    "last_validated_date": "2024-12-09T14:46:41+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[nodejs22.x]": {
-    "last_validated_date": "2024-12-09T14:45:02+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[provided.al2023]": {
-    "last_validated_date": "2024-12-09T15:13:42+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[provided.al2]": {
-    "last_validated_date": "2024-12-09T15:15:16+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.10]": {
-    "last_validated_date": "2024-12-09T14:55:30+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.11]": {
-    "last_validated_date": "2024-12-09T14:54:02+00:00"
+    "last_validated_date": "2025-04-01T13:31:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.12]": {
-    "last_validated_date": "2024-12-09T14:52:34+00:00"
+    "last_validated_date": "2025-04-01T13:31:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.13]": {
-    "last_validated_date": "2024-12-09T14:51:05+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.8]": {
-    "last_validated_date": "2024-12-09T14:58:27+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.9]": {
-    "last_validated_date": "2024-12-09T14:56:58+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[ruby3.2]": {
-    "last_validated_date": "2024-12-09T15:06:09+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[ruby3.3]": {
-    "last_validated_date": "2024-12-09T15:07:48+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[dotnet6]": {
-    "last_validated_date": "2024-12-09T15:28:31+00:00"
+    "last_validated_date": "2025-04-01T13:31:10+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[dotnet8]": {
-    "last_validated_date": "2024-12-09T15:28:33+00:00"
+    "last_validated_date": "2025-04-01T13:42:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java11]": {
-    "last_validated_date": "2024-12-09T15:28:20+00:00"
+    "last_validated_date": "2025-04-01T13:41:52+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java17]": {
-    "last_validated_date": "2024-12-09T15:28:18+00:00"
+    "last_validated_date": "2025-04-01T13:41:56+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java21]": {
-    "last_validated_date": "2024-12-09T15:28:15+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java8.al2]": {
-    "last_validated_date": "2024-12-09T15:28:24+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[nodejs16.x]": {
-    "last_validated_date": "2024-12-09T15:27:59+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[nodejs18.x]": {
-    "last_validated_date": "2024-12-09T15:27:57+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[nodejs20.x]": {
-    "last_validated_date": "2024-12-09T15:27:53+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[nodejs22.x]": {
-    "last_validated_date": "2024-12-09T15:27:51+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[provided.al2023]": {
-    "last_validated_date": "2024-12-09T15:28:36+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[provided.al2]": {
-    "last_validated_date": "2024-12-09T15:28:38+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.10]": {
-    "last_validated_date": "2024-12-09T15:28:09+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.11]": {
-    "last_validated_date": "2024-12-09T15:28:06+00:00"
+    "last_validated_date": "2025-04-01T13:42:01+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.12]": {
-    "last_validated_date": "2024-12-09T15:28:03+00:00"
+    "last_validated_date": "2025-04-01T13:42:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.13]": {
-    "last_validated_date": "2024-12-09T15:28:01+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.8]": {
-    "last_validated_date": "2024-12-09T15:28:13+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.9]": {
-    "last_validated_date": "2024-12-09T15:28:11+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[ruby3.2]": {
-    "last_validated_date": "2024-12-09T15:28:26+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[ruby3.3]": {
-    "last_validated_date": "2024-12-09T15:28:29+00:00"
+    "last_validated_date": "2025-04-01T13:42:08+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_create_tag_on_esm_create": {
     "last_validated_date": "2024-10-24T14:16:05+00:00"
@@ -752,31 +668,28 @@
   "tests/aws/services/lambda_/test_lambda_api.py::TestPartialARNMatching::test_update_function_configuration_full_arn": {
     "last_validated_date": "2024-06-05T11:49:05+00:00"
   },
-  "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled": {
-    "last_validated_date": "2024-06-12T14:19:11+00:00"
-  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[dotnetcore3.1]": {
-    "last_validated_date": "2024-11-26T09:27:30+00:00"
+    "last_validated_date": "2025-04-01T13:06:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[go1.x]": {
-    "last_validated_date": "2024-11-26T09:27:29+00:00"
+    "last_validated_date": "2025-04-01T13:06:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[java8]": {
-    "last_validated_date": "2024-11-26T09:27:29+00:00"
+    "last_validated_date": "2025-04-01T13:06:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs12.x]": {
-    "last_validated_date": "2024-11-26T09:27:30+00:00"
+    "last_validated_date": "2025-04-01T13:06:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs14.x]": {
-    "last_validated_date": "2024-11-26T09:27:30+00:00"
+    "last_validated_date": "2025-04-01T13:06:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[provided]": {
-    "last_validated_date": "2024-11-26T09:27:30+00:00"
+    "last_validated_date": "2025-04-01T13:06:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[python3.7]": {
-    "last_validated_date": "2024-11-26T09:27:30+00:00"
+    "last_validated_date": "2025-04-01T13:06:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[ruby2.7]": {
-    "last_validated_date": "2024-11-26T09:27:30+00:00"
+    "last_validated_date": "2025-04-01T13:06:04+00:00"
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_common.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_common.snapshot.json
@@ -1,70 +1,70 @@
 {
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.8]": {
-    "recorded-date": "26-11-2024, 09:28:27",
+    "recorded-date": "31-03-2025, 12:14:56",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java11]": {
-    "recorded-date": "26-11-2024, 09:29:13",
+    "recorded-date": "31-03-2025, 12:15:23",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2]": {
-    "recorded-date": "26-11-2024, 09:31:05",
+    "recorded-date": "31-03-2025, 12:17:30",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8.al2]": {
-    "recorded-date": "26-11-2024, 09:29:18",
+    "recorded-date": "31-03-2025, 12:15:42",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.2]": {
-    "recorded-date": "26-11-2024, 09:29:22",
+    "recorded-date": "31-03-2025, 12:15:54",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.11]": {
-    "recorded-date": "26-11-2024, 09:28:14",
+    "recorded-date": "31-03-2025, 12:14:05",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java17]": {
-    "recorded-date": "26-11-2024, 09:29:09",
+    "recorded-date": "31-03-2025, 12:15:14",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs18.x]": {
-    "recorded-date": "26-11-2024, 09:27:58",
+    "recorded-date": "31-03-2025, 12:13:11",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java21]": {
-    "recorded-date": "26-11-2024, 09:29:04",
+    "recorded-date": "31-03-2025, 12:15:05",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2023]": {
-    "recorded-date": "26-11-2024, 09:30:57",
+    "recorded-date": "31-03-2025, 12:17:17",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.9]": {
-    "recorded-date": "26-11-2024, 09:28:22",
+    "recorded-date": "31-03-2025, 12:14:39",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.10]": {
-    "recorded-date": "26-11-2024, 09:28:18",
+    "recorded-date": "31-03-2025, 12:14:20",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.12]": {
-    "recorded-date": "26-11-2024, 09:28:11",
+    "recorded-date": "31-03-2025, 12:13:57",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs20.x]": {
-    "recorded-date": "26-11-2024, 09:27:54",
+    "recorded-date": "31-03-2025, 12:12:59",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet6]": {
-    "recorded-date": "26-11-2024, 09:30:41",
+    "recorded-date": "31-03-2025, 12:16:46",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs16.x]": {
-    "recorded-date": "26-11-2024, 09:28:02",
+    "recorded-date": "31-03-2025, 12:13:31",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.8]": {
-    "recorded-date": "26-11-2024, 09:31:29",
+    "recorded-date": "31-03-2025, 12:18:00",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -205,7 +205,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java11]": {
-    "recorded-date": "26-11-2024, 09:31:44",
+    "recorded-date": "31-03-2025, 12:18:12",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -344,7 +344,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2]": {
-    "recorded-date": "26-11-2024, 09:33:29",
+    "recorded-date": "31-03-2025, 12:21:46",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -477,7 +477,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8.al2]": {
-    "recorded-date": "26-11-2024, 09:31:47",
+    "recorded-date": "31-03-2025, 12:18:15",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -616,7 +616,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.2]": {
-    "recorded-date": "26-11-2024, 09:31:49",
+    "recorded-date": "31-03-2025, 12:18:19",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -761,7 +761,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.11]": {
-    "recorded-date": "26-11-2024, 09:31:22",
+    "recorded-date": "31-03-2025, 12:17:51",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -902,7 +902,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java17]": {
-    "recorded-date": "26-11-2024, 09:31:41",
+    "recorded-date": "31-03-2025, 12:18:08",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1037,7 +1037,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs18.x]": {
-    "recorded-date": "26-11-2024, 09:31:13",
+    "recorded-date": "31-03-2025, 12:17:39",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1178,7 +1178,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java21]": {
-    "recorded-date": "26-11-2024, 09:31:38",
+    "recorded-date": "31-03-2025, 12:18:04",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1313,7 +1313,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2023]": {
-    "recorded-date": "26-11-2024, 09:33:25",
+    "recorded-date": "31-03-2025, 12:21:36",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1446,7 +1446,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.9]": {
-    "recorded-date": "26-11-2024, 09:31:26",
+    "recorded-date": "31-03-2025, 12:17:57",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1587,7 +1587,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.10]": {
-    "recorded-date": "26-11-2024, 09:31:24",
+    "recorded-date": "31-03-2025, 12:17:54",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1728,7 +1728,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.12]": {
-    "recorded-date": "26-11-2024, 09:31:20",
+    "recorded-date": "31-03-2025, 12:17:48",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1871,7 +1871,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs20.x]": {
-    "recorded-date": "26-11-2024, 09:31:10",
+    "recorded-date": "31-03-2025, 12:17:36",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2010,7 +2010,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet6]": {
-    "recorded-date": "26-11-2024, 09:32:01",
+    "recorded-date": "31-03-2025, 12:18:32",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2155,7 +2155,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs16.x]": {
-    "recorded-date": "26-11-2024, 09:31:15",
+    "recorded-date": "31-03-2025, 12:17:42",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2296,7 +2296,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.8]": {
-    "recorded-date": "26-11-2024, 09:33:50",
+    "recorded-date": "31-03-2025, 12:22:12",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2358,7 +2358,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java11]": {
-    "recorded-date": "26-11-2024, 09:34:06",
+    "recorded-date": "31-03-2025, 12:22:27",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2420,7 +2420,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2]": {
-    "recorded-date": "26-11-2024, 09:35:05",
+    "recorded-date": "31-03-2025, 12:26:16",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2481,7 +2481,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8.al2]": {
-    "recorded-date": "26-11-2024, 09:34:09",
+    "recorded-date": "31-03-2025, 12:22:31",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2543,7 +2543,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.2]": {
-    "recorded-date": "26-11-2024, 09:34:11",
+    "recorded-date": "31-03-2025, 12:22:34",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2605,7 +2605,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.11]": {
-    "recorded-date": "26-11-2024, 09:33:44",
+    "recorded-date": "31-03-2025, 12:22:04",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2668,7 +2668,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java17]": {
-    "recorded-date": "26-11-2024, 09:34:03",
+    "recorded-date": "31-03-2025, 12:22:24",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2730,7 +2730,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs18.x]": {
-    "recorded-date": "26-11-2024, 09:33:36",
+    "recorded-date": "31-03-2025, 12:21:54",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2792,7 +2792,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java21]": {
-    "recorded-date": "26-11-2024, 09:34:00",
+    "recorded-date": "31-03-2025, 12:22:21",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2854,7 +2854,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2023]": {
-    "recorded-date": "26-11-2024, 09:35:00",
+    "recorded-date": "31-03-2025, 12:26:03",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2915,7 +2915,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.9]": {
-    "recorded-date": "26-11-2024, 09:33:48",
+    "recorded-date": "31-03-2025, 12:22:09",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2978,7 +2978,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.10]": {
-    "recorded-date": "26-11-2024, 09:33:46",
+    "recorded-date": "31-03-2025, 12:22:07",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3041,7 +3041,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.12]": {
-    "recorded-date": "26-11-2024, 09:33:42",
+    "recorded-date": "31-03-2025, 12:22:02",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3104,7 +3104,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs20.x]": {
-    "recorded-date": "26-11-2024, 09:33:34",
+    "recorded-date": "31-03-2025, 12:21:51",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3166,7 +3166,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet6]": {
-    "recorded-date": "26-11-2024, 09:34:22",
+    "recorded-date": "31-03-2025, 12:22:49",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3228,7 +3228,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs16.x]": {
-    "recorded-date": "26-11-2024, 09:33:38",
+    "recorded-date": "31-03-2025, 12:21:57",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3290,7 +3290,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.8]": {
-    "recorded-date": "26-11-2024, 09:35:17",
+    "recorded-date": "31-03-2025, 12:26:39",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3343,7 +3343,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java11]": {
-    "recorded-date": "26-11-2024, 09:35:23",
+    "recorded-date": "31-03-2025, 12:26:57",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3396,7 +3396,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java8.al2]": {
-    "recorded-date": "26-11-2024, 09:35:33",
+    "recorded-date": "31-03-2025, 12:27:11",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3449,7 +3449,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.2]": {
-    "recorded-date": "26-11-2024, 09:35:20",
+    "recorded-date": "31-03-2025, 12:26:45",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3502,7 +3502,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.11]": {
-    "recorded-date": "26-11-2024, 09:35:49",
+    "recorded-date": "31-03-2025, 12:26:19",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3555,7 +3555,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java17]": {
-    "recorded-date": "26-11-2024, 09:35:45",
+    "recorded-date": "31-03-2025, 12:26:29",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3608,7 +3608,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs18.x]": {
-    "recorded-date": "26-11-2024, 09:35:35",
+    "recorded-date": "31-03-2025, 12:26:41",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3661,7 +3661,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java21]": {
-    "recorded-date": "26-11-2024, 09:35:30",
+    "recorded-date": "31-03-2025, 12:27:07",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3714,7 +3714,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.9]": {
-    "recorded-date": "26-11-2024, 09:35:37",
+    "recorded-date": "31-03-2025, 12:27:16",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3767,7 +3767,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.10]": {
-    "recorded-date": "26-11-2024, 09:35:11",
+    "recorded-date": "31-03-2025, 12:27:14",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3820,7 +3820,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.12]": {
-    "recorded-date": "26-11-2024, 09:35:25",
+    "recorded-date": "31-03-2025, 12:27:00",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3873,7 +3873,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs20.x]": {
-    "recorded-date": "26-11-2024, 09:35:47",
+    "recorded-date": "31-03-2025, 12:26:50",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3926,7 +3926,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet6]": {
-    "recorded-date": "26-11-2024, 09:35:40",
+    "recorded-date": "31-03-2025, 12:26:33",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3979,7 +3979,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs16.x]": {
-    "recorded-date": "26-11-2024, 09:35:27",
+    "recorded-date": "31-03-2025, 12:26:25",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4032,47 +4032,47 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs20.x]": {
-    "recorded-date": "26-11-2024, 09:38:09",
+    "recorded-date": "31-03-2025, 17:43:04",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs18.x]": {
-    "recorded-date": "26-11-2024, 09:37:43",
+    "recorded-date": "31-03-2025, 17:42:22",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs16.x]": {
-    "recorded-date": "26-11-2024, 09:36:44",
+    "recorded-date": "31-03-2025, 17:44:41",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.8]": {
-    "recorded-date": "26-11-2024, 09:36:15",
+    "recorded-date": "31-03-2025, 17:43:58",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.9]": {
-    "recorded-date": "26-11-2024, 09:37:45",
+    "recorded-date": "31-03-2025, 17:44:04",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.10]": {
-    "recorded-date": "26-11-2024, 09:35:56",
+    "recorded-date": "31-03-2025, 17:42:25",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.11]": {
-    "recorded-date": "26-11-2024, 09:38:12",
+    "recorded-date": "31-03-2025, 17:43:22",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.12]": {
-    "recorded-date": "26-11-2024, 09:36:40",
+    "recorded-date": "31-03-2025, 17:44:01",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.2]": {
-    "recorded-date": "26-11-2024, 09:36:18",
+    "recorded-date": "31-03-2025, 17:43:19",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet8]": {
-    "recorded-date": "26-11-2024, 09:30:52",
+    "recorded-date": "31-03-2025, 12:17:03",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet8]": {
-    "recorded-date": "26-11-2024, 09:32:13",
+    "recorded-date": "31-03-2025, 12:18:36",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4219,7 +4219,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet8]": {
-    "recorded-date": "26-11-2024, 09:34:30",
+    "recorded-date": "31-03-2025, 12:22:56",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4281,7 +4281,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet8]": {
-    "recorded-date": "26-11-2024, 09:35:15",
+    "recorded-date": "31-03-2025, 12:27:03",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4334,35 +4334,35 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java17]": {
-    "recorded-date": "26-11-2024, 09:38:07",
+    "recorded-date": "31-03-2025, 17:42:41",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java21]": {
-    "recorded-date": "26-11-2024, 09:36:54",
+    "recorded-date": "31-03-2025, 17:43:01",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java11]": {
-    "recorded-date": "26-11-2024, 09:36:37",
+    "recorded-date": "31-03-2025, 17:44:31",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java8.al2]": {
-    "recorded-date": "26-11-2024, 09:37:40",
+    "recorded-date": "31-03-2025, 17:43:50",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet6]": {
-    "recorded-date": "26-11-2024, 09:37:55",
+    "recorded-date": "31-03-2025, 17:43:15",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet8]": {
-    "recorded-date": "26-11-2024, 09:36:12",
+    "recorded-date": "31-03-2025, 17:43:54",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.3]": {
-    "recorded-date": "26-11-2024, 09:29:26",
+    "recorded-date": "31-03-2025, 12:16:02",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.3]": {
-    "recorded-date": "26-11-2024, 09:31:52",
+    "recorded-date": "31-03-2025, 12:18:22",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4507,7 +4507,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.3]": {
-    "recorded-date": "26-11-2024, 09:34:14",
+    "recorded-date": "31-03-2025, 12:22:37",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4569,7 +4569,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.3]": {
-    "recorded-date": "26-11-2024, 09:35:08",
+    "recorded-date": "31-03-2025, 12:26:22",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4622,15 +4622,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.3]": {
-    "recorded-date": "26-11-2024, 09:35:53",
+    "recorded-date": "31-03-2025, 17:44:35",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.13]": {
-    "recorded-date": "26-11-2024, 09:28:06",
+    "recorded-date": "31-03-2025, 12:13:46",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.13]": {
-    "recorded-date": "26-11-2024, 09:31:18",
+    "recorded-date": "31-03-2025, 12:17:45",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4773,7 +4773,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.13]": {
-    "recorded-date": "26-11-2024, 09:33:40",
+    "recorded-date": "31-03-2025, 12:21:59",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4836,7 +4836,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.13]": {
-    "recorded-date": "26-11-2024, 09:35:13",
+    "recorded-date": "31-03-2025, 12:26:53",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4889,15 +4889,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.13]": {
-    "recorded-date": "26-11-2024, 09:35:58",
+    "recorded-date": "31-03-2025, 17:44:38",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs22.x]": {
-    "recorded-date": "26-11-2024, 09:27:50",
+    "recorded-date": "31-03-2025, 12:12:50",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs22.x]": {
-    "recorded-date": "26-11-2024, 09:31:08",
+    "recorded-date": "31-03-2025, 12:17:33",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -5036,7 +5036,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs22.x]": {
-    "recorded-date": "26-11-2024, 09:33:31",
+    "recorded-date": "31-03-2025, 12:21:49",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -5098,7 +5098,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs22.x]": {
-    "recorded-date": "26-11-2024, 09:35:42",
+    "recorded-date": "31-03-2025, 12:26:36",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -5151,7 +5151,275 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs22.x]": {
-    "recorded-date": "26-11-2024, 09:37:57",
+    "recorded-date": "31-03-2025, 17:42:44",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.4]": {
+    "recorded-date": "31-03-2025, 12:16:24",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.4]": {
+    "recorded-date": "31-03-2025, 12:18:27",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "TEST_KEY": "TEST_VAL"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "function.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "ruby3.4",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "invocation_result_payload": {
+        "ctx": {
+          "aws_request_id": "<uuid:2>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "memory_limit_in_mb": "1024",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_ruby3.4",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
+          "GEM_HOME": "/var/runtime",
+          "GEM_PATH": "/var/task/vendor/bundle/ruby/3.4.0:/opt/ruby/gems/3.4.0:/var/runtime:/var/runtime/ruby/3.4.0",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "PATH": "/var/lang/bin:/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "PWD": "/var/task",
+          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.0.0/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
+          "SHLVL": "0",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "function.handler",
+          "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
+        },
+        "packages": []
+      },
+      "invocation_result_payload_qualified": {
+        "ctx": {
+          "aws_request_id": "<uuid:3>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:$LATEST",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "memory_limit_in_mb": "1024",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_ruby3.4",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
+          "GEM_HOME": "/var/runtime",
+          "GEM_PATH": "/var/task/vendor/bundle/ruby/3.4.0:/opt/ruby/gems/3.4.0:/var/runtime:/var/runtime/ruby/3.4.0",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "PATH": "/var/lang/bin:/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "PWD": "/var/task",
+          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.0.0/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
+          "SHLVL": "0",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "function.handler",
+          "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
+        },
+        "packages": []
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.4]": {
+    "recorded-date": "31-03-2025, 12:22:40",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "function.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "ruby3.4",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "error_result": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorMessage": "Error: some_error_msg",
+          "errorType": "Function<RuntimeError>",
+          "stackTrace": "<stack-trace>"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.4]": {
+    "recorded-date": "31-03-2025, 12:26:47",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "AWS_LAMBDA_EXEC_WRAPPER": "/var/task/environment_wrapper"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "function.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "ruby3.4",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.4]": {
+    "recorded-date": "31-03-2025, 17:43:08",
     "recorded-content": {}
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_common.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_common.validation.json
@@ -1,290 +1,305 @@
 {
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet6]": {
-    "last_validated_date": "2024-11-26T09:37:54+00:00"
+    "last_validated_date": "2025-03-31T17:43:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet8]": {
-    "last_validated_date": "2024-11-26T09:36:12+00:00"
+    "last_validated_date": "2025-03-31T17:43:54+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java11]": {
-    "last_validated_date": "2024-11-26T09:36:37+00:00"
+    "last_validated_date": "2025-03-31T17:44:30+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java17]": {
-    "last_validated_date": "2024-11-26T09:38:07+00:00"
+    "last_validated_date": "2025-03-31T17:42:41+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java21]": {
-    "last_validated_date": "2024-11-26T09:36:53+00:00"
+    "last_validated_date": "2025-03-31T17:43:00+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java8.al2]": {
-    "last_validated_date": "2024-11-26T09:37:40+00:00"
+    "last_validated_date": "2025-03-31T17:43:49+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs16.x]": {
-    "last_validated_date": "2024-11-26T09:36:43+00:00"
+    "last_validated_date": "2025-03-31T17:44:41+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs18.x]": {
-    "last_validated_date": "2024-11-26T09:37:42+00:00"
+    "last_validated_date": "2025-03-31T17:42:21+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs20.x]": {
-    "last_validated_date": "2024-11-26T09:38:09+00:00"
+    "last_validated_date": "2025-03-31T17:43:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs22.x]": {
-    "last_validated_date": "2024-11-26T09:37:57+00:00"
+    "last_validated_date": "2025-03-31T17:42:44+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.10]": {
-    "last_validated_date": "2024-11-26T09:35:55+00:00"
+    "last_validated_date": "2025-03-31T17:42:24+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.11]": {
-    "last_validated_date": "2024-11-26T09:38:12+00:00"
+    "last_validated_date": "2025-03-31T17:43:21+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.12]": {
-    "last_validated_date": "2024-11-26T09:36:40+00:00"
+    "last_validated_date": "2025-03-31T17:44:00+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.13]": {
-    "last_validated_date": "2024-11-26T09:35:58+00:00"
+    "last_validated_date": "2025-03-31T17:44:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.8]": {
-    "last_validated_date": "2024-11-26T09:36:14+00:00"
+    "last_validated_date": "2025-03-31T17:43:57+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.9]": {
-    "last_validated_date": "2024-11-26T09:37:45+00:00"
+    "last_validated_date": "2025-03-31T17:44:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.2]": {
-    "last_validated_date": "2024-11-26T09:36:18+00:00"
+    "last_validated_date": "2025-03-31T17:43:18+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.3]": {
-    "last_validated_date": "2024-11-26T09:35:53+00:00"
+    "last_validated_date": "2025-03-31T17:44:34+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.4]": {
+    "last_validated_date": "2025-03-31T17:43:07+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet6]": {
-    "last_validated_date": "2024-11-26T09:30:41+00:00"
+    "last_validated_date": "2025-03-31T12:16:46+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet8]": {
-    "last_validated_date": "2024-11-26T09:30:52+00:00"
+    "last_validated_date": "2025-03-31T12:17:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java11]": {
-    "last_validated_date": "2024-11-26T09:29:13+00:00"
+    "last_validated_date": "2025-03-31T12:15:22+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java17]": {
-    "last_validated_date": "2024-11-26T09:29:09+00:00"
+    "last_validated_date": "2025-03-31T12:15:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java21]": {
-    "last_validated_date": "2024-11-26T09:29:04+00:00"
+    "last_validated_date": "2025-03-31T12:15:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8.al2]": {
-    "last_validated_date": "2024-11-26T09:29:18+00:00"
+    "last_validated_date": "2025-03-31T12:15:42+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs16.x]": {
-    "last_validated_date": "2024-11-26T09:28:02+00:00"
+    "last_validated_date": "2025-03-31T12:13:31+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs18.x]": {
-    "last_validated_date": "2024-11-26T09:27:58+00:00"
+    "last_validated_date": "2025-03-31T12:13:11+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs20.x]": {
-    "last_validated_date": "2024-11-26T09:27:54+00:00"
+    "last_validated_date": "2025-03-31T12:12:59+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs22.x]": {
-    "last_validated_date": "2024-11-26T09:27:50+00:00"
+    "last_validated_date": "2025-03-31T12:12:50+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2023]": {
-    "last_validated_date": "2024-11-26T09:30:57+00:00"
+    "last_validated_date": "2025-03-31T12:17:17+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2]": {
-    "last_validated_date": "2024-11-26T09:31:05+00:00"
+    "last_validated_date": "2025-03-31T12:17:30+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.10]": {
-    "last_validated_date": "2024-11-26T09:28:18+00:00"
+    "last_validated_date": "2025-03-31T12:14:20+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.11]": {
-    "last_validated_date": "2024-11-26T09:28:14+00:00"
+    "last_validated_date": "2025-03-31T12:14:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.12]": {
-    "last_validated_date": "2024-11-26T09:28:10+00:00"
+    "last_validated_date": "2025-03-31T12:13:57+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.13]": {
-    "last_validated_date": "2024-11-26T09:28:06+00:00"
+    "last_validated_date": "2025-03-31T12:13:45+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.8]": {
-    "last_validated_date": "2024-11-26T09:28:27+00:00"
+    "last_validated_date": "2025-03-31T12:14:56+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.9]": {
-    "last_validated_date": "2024-11-26T09:28:22+00:00"
+    "last_validated_date": "2025-03-31T12:14:39+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.2]": {
-    "last_validated_date": "2024-11-26T09:29:22+00:00"
+    "last_validated_date": "2025-03-31T12:15:53+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.3]": {
-    "last_validated_date": "2024-11-26T09:29:26+00:00"
+    "last_validated_date": "2025-03-31T12:16:02+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.4]": {
+    "last_validated_date": "2025-03-31T12:16:24+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet6]": {
-    "last_validated_date": "2024-11-26T09:32:01+00:00"
+    "last_validated_date": "2025-03-31T12:18:32+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet8]": {
-    "last_validated_date": "2024-11-26T09:32:13+00:00"
+    "last_validated_date": "2025-03-31T12:18:35+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java11]": {
-    "last_validated_date": "2024-11-26T09:31:43+00:00"
+    "last_validated_date": "2025-03-31T12:18:11+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java17]": {
-    "last_validated_date": "2024-11-26T09:31:40+00:00"
+    "last_validated_date": "2025-03-31T12:18:07+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java21]": {
-    "last_validated_date": "2024-11-26T09:31:38+00:00"
+    "last_validated_date": "2025-03-31T12:18:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8.al2]": {
-    "last_validated_date": "2024-11-26T09:31:46+00:00"
+    "last_validated_date": "2025-03-31T12:18:15+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs16.x]": {
-    "last_validated_date": "2024-11-26T09:31:15+00:00"
+    "last_validated_date": "2025-03-31T12:17:42+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs18.x]": {
-    "last_validated_date": "2024-11-26T09:31:12+00:00"
+    "last_validated_date": "2025-03-31T12:17:39+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs20.x]": {
-    "last_validated_date": "2024-11-26T09:31:10+00:00"
+    "last_validated_date": "2025-03-31T12:17:36+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs22.x]": {
-    "last_validated_date": "2024-11-26T09:31:08+00:00"
+    "last_validated_date": "2025-03-31T12:17:33+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2023]": {
-    "last_validated_date": "2024-11-26T09:33:24+00:00"
+    "last_validated_date": "2025-03-31T12:21:35+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2]": {
-    "last_validated_date": "2024-11-26T09:33:29+00:00"
+    "last_validated_date": "2025-03-31T12:21:46+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.10]": {
-    "last_validated_date": "2024-11-26T09:31:24+00:00"
+    "last_validated_date": "2025-03-31T12:17:54+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.11]": {
-    "last_validated_date": "2024-11-26T09:31:22+00:00"
+    "last_validated_date": "2025-03-31T12:17:51+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.12]": {
-    "last_validated_date": "2024-11-26T09:31:20+00:00"
+    "last_validated_date": "2025-03-31T12:17:48+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.13]": {
-    "last_validated_date": "2024-11-26T09:31:17+00:00"
+    "last_validated_date": "2025-03-31T12:17:45+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.8]": {
-    "last_validated_date": "2024-11-26T09:31:28+00:00"
+    "last_validated_date": "2025-03-31T12:18:00+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.9]": {
-    "last_validated_date": "2024-11-26T09:31:26+00:00"
+    "last_validated_date": "2025-03-31T12:17:56+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.2]": {
-    "last_validated_date": "2024-11-26T09:31:49+00:00"
+    "last_validated_date": "2025-03-31T12:18:18+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.3]": {
-    "last_validated_date": "2024-11-26T09:31:51+00:00"
+    "last_validated_date": "2025-03-31T12:18:21+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.4]": {
+    "last_validated_date": "2025-03-31T12:18:26+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet6]": {
-    "last_validated_date": "2024-11-26T09:35:40+00:00"
+    "last_validated_date": "2025-03-31T12:26:32+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet8]": {
-    "last_validated_date": "2024-11-26T09:35:15+00:00"
+    "last_validated_date": "2025-03-31T12:27:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java11]": {
-    "last_validated_date": "2024-11-26T09:35:22+00:00"
+    "last_validated_date": "2025-03-31T12:26:57+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java17]": {
-    "last_validated_date": "2024-11-26T09:35:45+00:00"
+    "last_validated_date": "2025-03-31T12:26:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java21]": {
-    "last_validated_date": "2024-11-26T09:35:29+00:00"
+    "last_validated_date": "2025-03-31T12:27:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java8.al2]": {
-    "last_validated_date": "2024-11-26T09:35:33+00:00"
+    "last_validated_date": "2025-03-31T12:27:10+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs16.x]": {
-    "last_validated_date": "2024-11-26T09:35:27+00:00"
+    "last_validated_date": "2025-03-31T12:26:24+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs18.x]": {
-    "last_validated_date": "2024-11-26T09:35:35+00:00"
+    "last_validated_date": "2025-03-31T12:26:41+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs20.x]": {
-    "last_validated_date": "2024-11-26T09:35:47+00:00"
+    "last_validated_date": "2025-03-31T12:26:50+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs22.x]": {
-    "last_validated_date": "2024-11-26T09:35:42+00:00"
+    "last_validated_date": "2025-03-31T12:26:35+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.10]": {
-    "last_validated_date": "2024-11-26T09:35:10+00:00"
+    "last_validated_date": "2025-03-31T12:27:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.11]": {
-    "last_validated_date": "2024-11-26T09:35:49+00:00"
+    "last_validated_date": "2025-03-31T12:26:18+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.12]": {
-    "last_validated_date": "2024-11-26T09:35:24+00:00"
+    "last_validated_date": "2025-03-31T12:27:00+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.13]": {
-    "last_validated_date": "2024-11-26T09:35:12+00:00"
+    "last_validated_date": "2025-03-31T12:26:53+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.8]": {
-    "last_validated_date": "2024-11-26T09:35:17+00:00"
+    "last_validated_date": "2025-03-31T12:26:38+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.9]": {
-    "last_validated_date": "2024-11-26T09:35:37+00:00"
+    "last_validated_date": "2025-03-31T12:27:16+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.2]": {
-    "last_validated_date": "2024-11-26T09:35:20+00:00"
+    "last_validated_date": "2025-03-31T12:26:44+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.3]": {
-    "last_validated_date": "2024-11-26T09:35:08+00:00"
+    "last_validated_date": "2025-03-31T12:26:21+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.4]": {
+    "last_validated_date": "2025-03-31T12:26:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet6]": {
-    "last_validated_date": "2024-11-26T09:34:21+00:00"
+    "last_validated_date": "2025-03-31T12:22:48+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet8]": {
-    "last_validated_date": "2024-11-26T09:34:30+00:00"
+    "last_validated_date": "2025-03-31T12:22:56+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java11]": {
-    "last_validated_date": "2024-11-26T09:34:06+00:00"
+    "last_validated_date": "2025-03-31T12:22:27+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java17]": {
-    "last_validated_date": "2024-11-26T09:34:03+00:00"
+    "last_validated_date": "2025-03-31T12:22:23+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java21]": {
-    "last_validated_date": "2024-11-26T09:34:00+00:00"
+    "last_validated_date": "2025-03-31T12:22:21+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8.al2]": {
-    "last_validated_date": "2024-11-26T09:34:09+00:00"
+    "last_validated_date": "2025-03-31T12:22:31+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs16.x]": {
-    "last_validated_date": "2024-11-26T09:33:37+00:00"
+    "last_validated_date": "2025-03-31T12:21:56+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs18.x]": {
-    "last_validated_date": "2024-11-26T09:33:35+00:00"
+    "last_validated_date": "2025-03-31T12:21:54+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs20.x]": {
-    "last_validated_date": "2024-11-26T09:33:33+00:00"
+    "last_validated_date": "2025-03-31T12:21:51+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs22.x]": {
-    "last_validated_date": "2024-11-26T09:33:31+00:00"
+    "last_validated_date": "2025-03-31T12:21:48+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2023]": {
-    "last_validated_date": "2024-11-26T09:35:00+00:00"
+    "last_validated_date": "2025-03-31T12:26:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2]": {
-    "last_validated_date": "2024-11-26T09:35:05+00:00"
+    "last_validated_date": "2025-03-31T12:26:16+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.10]": {
-    "last_validated_date": "2024-11-26T09:33:46+00:00"
+    "last_validated_date": "2025-03-31T12:22:07+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.11]": {
-    "last_validated_date": "2024-11-26T09:33:44+00:00"
+    "last_validated_date": "2025-03-31T12:22:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.12]": {
-    "last_validated_date": "2024-11-26T09:33:42+00:00"
+    "last_validated_date": "2025-03-31T12:22:02+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.13]": {
-    "last_validated_date": "2024-11-26T09:33:40+00:00"
+    "last_validated_date": "2025-03-31T12:21:59+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.8]": {
-    "last_validated_date": "2024-11-26T09:33:50+00:00"
+    "last_validated_date": "2025-03-31T12:22:12+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.9]": {
-    "last_validated_date": "2024-11-26T09:33:48+00:00"
+    "last_validated_date": "2025-03-31T12:22:09+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.2]": {
-    "last_validated_date": "2024-11-26T09:34:11+00:00"
+    "last_validated_date": "2025-03-31T12:22:34+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.3]": {
-    "last_validated_date": "2024-11-26T09:34:13+00:00"
+    "last_validated_date": "2025-03-31T12:22:37+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.4]": {
+    "last_validated_date": "2025-03-31T12:22:40+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
AWS announced support for Ruby 3.4 Lambda runtime on March 27th and we want to support it quickly.
https://aws.amazon.com/about-aws/whats-new/2025/03/aws-lambda-support-ruby-3-4/

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added support for the new Lambda runtime Ruby 3.4
- Updated snapshots
- Reverted some of the (temporary?) changes introduced in this PR for `test_snapstart_lifecycle`  and `test_snapstart_update_function_configuration`: https://github.com/localstack/localstack/pull/12006/ because AWS seems to not support snapstart enabled functions for many runtimes anymore (they seems to temporarily allow them 🤷🏼 ).
**`botocore.errorfactory.InvalidParameterValueException: An error occurred (InvalidParameterValueException) when calling the CreateFunction operation: nodejs22.x is not supported for SnapStart enabled functions.`**
![Screenshot 2025-03-31 at 14 52 30](https://github.com/user-attachments/assets/0573d8fd-2615-4d2c-b37a-0258d88e0244)


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
