### PR TITLE
Fix subnet tags going missing

### DIFF
--- a/localstack-core/localstack/services/ec2/patches.py
+++ b/localstack-core/localstack/services/ec2/patches.py
@@ -1,5 +1,4 @@
 import logging
-from re import sub
 from typing import Optional
 
 from moto.ec2 import models as ec2_models

--- a/localstack-core/localstack/services/ec2/patches.py
+++ b/localstack-core/localstack/services/ec2/patches.py
@@ -83,10 +83,15 @@ def apply_patches():
         resource_identifier = SubnetIdentifier(
             self.account_id, self.region_name, vpc_id, cidr_block
         )
-        # tags has the format: {"subnet": {"Key": ..., "Value": ...}}
+
+        # tags has the format: {"subnet": {"Key": ..., "Value": ...}}, but we need
+        # to pass this to the generate method as {"Key": ..., "Value": ...}.  Take
+        # care not to alter the original tags dict otherwise moto will not be able
+        # to understand it.
+        subnetTags = None
         if tags is not None:
-            tags = tags.get("subnet", tags)
-        custom_id = resource_identifier.generate(tags=tags)
+            subnetTags = tags.get("subnet", tags)
+        custom_id = resource_identifier.generate(tags=subnetTags)
 
         if custom_id:
             # Check if custom id is unique within a given VPC

--- a/localstack-core/localstack/services/ec2/patches.py
+++ b/localstack-core/localstack/services/ec2/patches.py
@@ -90,10 +90,10 @@ def apply_patches():
         # to pass this to the generate method as {"Key": ..., "Value": ...}.  Take
         # care not to alter the original tags dict otherwise moto will not be able
         # to understand it.
-        subnetTags = None
+        subnet_tags = None
         if tags is not None:
-            subnetTags = tags.get("subnet", tags)
-        custom_id = resource_identifier.generate(tags=subnetTags)
+            subnet_tags = tags.get("subnet", tags)
+        custom_id = resource_identifier.generate(tags=subnet_tags)
 
         if custom_id:
             # Check if custom id is unique within a given VPC

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -482,7 +482,7 @@ class TestEc2Integrations:
         assert e.value.response["Error"]["Code"] == "InvalidVpc.DuplicateCustomId"
 
     @markers.aws.only_localstack
-    def test_create_subnet_with_tags(self, aws_client, create_vpc):
+    def test_create_subnet_with_tags(self, cleanups, aws_client, create_vpc):
         # Create a VPC.
         vpc: dict = create_vpc(
             cidr_block="10.0.0.0/16",
@@ -525,7 +525,7 @@ class TestEc2Integrations:
         assert subnet["Tags"][0]["Value"] == "main-subnet"
 
     @markers.aws.only_localstack
-    def test_create_subnet_with_custom_id(self, aws_client, create_vpc):
+    def test_create_subnet_with_custom_id(self, cleanups, aws_client, create_vpc):
         custom_id = random_subnet_id()
 
         # Create necessary VPC resource
@@ -545,6 +545,7 @@ class TestEc2Integrations:
                 }
             ],
         )
+        cleanups.append(lambda: aws_client.ec2.delete_subnet(SubnetId=subnet["Subnet"]["SubnetId"]))
         assert subnet["Subnet"]["SubnetId"] == custom_id
 
         # Check if the custom ID is present in the describe_subnets response as well
@@ -572,7 +573,7 @@ class TestEc2Integrations:
         assert e.value.response["Error"]["Code"] == "InvalidSubnet.DuplicateCustomId"
 
     @markers.aws.only_localstack
-    def test_create_subnet_with_custom_id_and_vpc_id(self, aws_client, create_vpc):
+    def test_create_subnet_with_custom_id_and_vpc_id(self, cleanups, aws_client, create_vpc):
         custom_subnet_id = random_subnet_id()
         custom_vpc_id = random_vpc_id()
 
@@ -603,6 +604,7 @@ class TestEc2Integrations:
                 }
             ],
         )
+        cleanups.append(lambda: aws_client.ec2.delete_subnet(SubnetId=custom_subnet_id))
         assert subnet["Subnet"]["SubnetId"] == custom_subnet_id
 
         # Check if the custom ID is present in the describe_subnets response as well
@@ -616,7 +618,7 @@ class TestEc2Integrations:
         assert subnet["Tags"][0]["Value"] == custom_subnet_id
 
     @markers.aws.only_localstack
-    def test_create_security_group_with_custom_id(self, aws_client, create_vpc):
+    def test_create_security_group_with_custom_id(self, cleanups, aws_client, create_vpc):
         custom_id = random_security_group_id()
 
         # Create necessary VPC resource
@@ -639,6 +641,7 @@ class TestEc2Integrations:
                 }
             ],
         )
+        cleanups.append(lambda: aws_client.ec2.delete_security_group(GroupId=custom_id))
         assert security_group["GroupId"] == custom_id, (
             f"Security group ID does not match custom ID: {security_group}"
         )

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -510,6 +510,7 @@ class TestEc2Integrations:
                 }
             ],
         )
+        cleanups.append(lambda: aws_client.ec2.delete_subnet(SubnetId=subnet["Subnet"]["SubnetId"]))
         assert subnet["Subnet"]["VpcId"] == vpc_id
         subnet_id: str = subnet["Subnet"]["SubnetId"]
 

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -460,6 +460,9 @@ class TestEc2Integrations:
         # Check if the custom ID is present in the describe_vpcs response as well
         vpc: dict = aws_client.ec2.describe_vpcs(VpcIds=[custom_id])["Vpcs"][0]
         assert vpc["VpcId"] == custom_id
+        assert len(vpc["Tags"]) == 1
+        assert vpc["Tags"][0]["Key"] == TAG_KEY_CUSTOM_ID
+        assert vpc["Tags"][0]["Value"] == custom_id
 
         # Check if an duplicate custom ID exception is thrown if we try to recreate the VPC with the same custom ID
         with pytest.raises(ClientError) as e:
@@ -607,6 +610,9 @@ class TestEc2Integrations:
         )["Subnets"][0]
         assert subnet["SubnetId"] == custom_subnet_id
         assert subnet["VpcId"] == custom_vpc_id
+        assert len(subnet["Tags"]) == 1
+        assert subnet["Tags"][0]["Key"] == TAG_KEY_CUSTOM_ID
+        assert subnet["Tags"][0]["Value"] == custom_subnet_id
 
     @markers.aws.only_localstack
     def test_create_security_group_with_custom_id(self, aws_client, create_vpc):
@@ -646,6 +652,9 @@ class TestEc2Integrations:
             (sg for sg in security_groups if sg["VpcId"] == vpc["Vpc"]["VpcId"]), None
         )
         assert security_group["GroupId"] == custom_id
+        assert len(security_group["Tags"]) == 1
+        assert security_group["Tags"][0]["Key"] == TAG_KEY_CUSTOM_ID
+        assert security_group["Tags"][0]["Value"] == custom_id
 
         # Check if a duplicate custom ID exception is thrown if we try to recreate the security group with the same custom ID
         with pytest.raises(ClientError) as e:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
#11853 introduced a regression whereby the structure of the tags dict was altered before passing through to moto.  This was reported in #12377 and is fixed by this PR.

Whilst fixing this PR, I noticed that the tags were also lost when creating a subnet, SG or VPC with a custom ID.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Pass the original tags dict through to moto on subnet creation, rather than the modified one.
* Because tags are not stored within the subnet, VPC or SG objects within moto, but instead in a separate tags dict, the tags needed to be reindexed in that dict when using a custom id.

<!-- Optional section: How to test these changes? -->
<!--
## Testing
* Tested subnet change manually using the AWS CLI.
* Added UTs.
-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
