### PR TITLE
Hyphen to snake-case util function

### DIFF
--- a/localstack-core/localstack/utils/strings.py
+++ b/localstack-core/localstack/utils/strings.py
@@ -78,6 +78,10 @@ def snake_to_camel_case(string: str, capitalize_first: bool = True) -> str:
     return "".join(components)
 
 
+def hyphen_to_snake_case(string: str) -> str:
+    return string.replace("-", "_")
+
+
 def canonicalize_bool_to_str(val: bool) -> str:
     return "true" if str(val).lower() == "true" else "false"
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When working with file names, I've encountered scenarios where hyphenated strings (for example: file-name) need to be converted into snake_case (for example: file_name) representations. To standardize processing and improve consistency, I added a simple util function that does that.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Added `hyphen_to_snake_case` function

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
