### PR TITLE
Fix lambda timeout race condition

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/assignment.py
+++ b/localstack-core/localstack/services/lambda_/invocation/assignment.py
@@ -86,7 +86,9 @@ class AssignmentService(OtherServiceEndpoint):
         except InvalidStatusException as invalid_e:
             LOG.error("InvalidStatusException: %s", invalid_e)
         except Exception as e:
-            LOG.error("Failed invocation %s", e)
+            LOG.error(
+                "Failed invocation <%s>: %s", type(e), e, exc_info=LOG.isEnabledFor(logging.DEBUG)
+            )
             self.stop_environment(execution_environment)
             raise e
 

--- a/localstack-core/localstack/services/lambda_/invocation/assignment.py
+++ b/localstack-core/localstack/services/lambda_/invocation/assignment.py
@@ -109,7 +109,7 @@ class AssignmentService(OtherServiceEndpoint):
         except EnvironmentStartupTimeoutException:
             raise
         except Exception as e:
-            message = f"Could not start new environment: {e}"
+            message = f"Could not start new environment: {type(e).__name__}:{e}"
             raise AssignmentException(message) from e
         return execution_environment
 

--- a/localstack-core/localstack/services/lambda_/invocation/execution_environment.py
+++ b/localstack-core/localstack/services/lambda_/invocation/execution_environment.py
@@ -275,6 +275,9 @@ class ExecutionEnvironment:
             self.id,
             self.function_version.qualified_arn,
         )
+        # The stop() method allows to interrupt invocations (on purpose), which might cancel running invocations
+        # which we should not do when the keepalive timer passed.
+        # The new TIMING_OUT state prevents this race condition
         with self.status_lock:
             if self.status != RuntimeStatus.READY:
                 LOG.debug(

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1608,7 +1608,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
             raise LambdaServiceException(
-                f"[{context.request_id}] Internal error while executing lambda {function_name}:{qualifier}. Cause: {type(e)}"
+                f"[{context.request_id}] Internal error while executing lambda {function_name}:{qualifier}. Caused by {type(e).__name__}: {e}"
             ) from e
 
         if invocation_type == InvocationType.Event:

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1597,10 +1597,19 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         except ServiceException:
             raise
         except EnvironmentStartupTimeoutException as e:
-            raise LambdaServiceException("Internal error while executing lambda") from e
+            raise LambdaServiceException(
+                f"[{context.request_id}] Timeout while starting up lambda environment for function {function_name}:{qualifier}"
+            ) from e
         except Exception as e:
-            LOG.error("Error while invoking lambda", exc_info=e)
-            raise LambdaServiceException("Internal error while executing lambda") from e
+            LOG.error(
+                "[%s] Error while invoking lambda %s",
+                context.request_id,
+                function_name,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
+            )
+            raise LambdaServiceException(
+                f"[{context.request_id}] Internal error while executing lambda {function_name}:{qualifier}. Cause: {type(e)}"
+            ) from e
 
         if invocation_type == InvocationType.Event:
             # This happens when invocation type is event


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We recently discovered that a race condition is possible, killing in-progress invocations of lambda functions if the environment is scheduled for removal due to inactivity at the same time.

This will lead to different errors (depending on the phase of the execution), and has to be fixed.

Also, the error messages we return to the caller in case of internal errors during invocations do not convey the actual error - making it harder to trace the error, especially for internal calls.
Here we fix this, to clearly communicate the error to the caller.

Old error message:
```
Internal error while executing lambda
```

New error message (containing request id and function name + qualifier):

```
[fd2d870e-827c-44a2-b365-2eb7efc38e86] Internal error while executing lambda test-function-28f7fd59:None. Caused by AssignmentException: Could not start new environment: NoSuchImage:public.ecr.aws/lambda/python:3.12
```

The error logging in various places has also been improved to log the exception type as well as the message.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Fix race condition during environment timeout
* Improve error messages

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
