### PR TITLE
KMS: fix RSA PSS signing issue for salt length

### DIFF
--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -476,7 +476,7 @@ class KmsKey:
             if "PKCS" in signing_algorithm:
                 return padding.PKCS1v15()
             elif "PSS" in signing_algorithm:
-                return padding.PSS(mgf=padding.MGF1(hasher), salt_length=padding.PSS.MAX_LENGTH)
+                return padding.PSS(mgf=padding.MGF1(hasher), salt_length=padding.PSS.DIGEST_LENGTH)
             else:
                 LOG.warning("Unsupported padding in SigningAlgorithm '%s'", signing_algorithm)
 

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -2152,5 +2152,37 @@
         }
       }
     }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[RSA_2048-RSASSA_PSS_SHA_256]": {
+    "recorded-date": "02-04-2025, 06:06:52",
+    "recorded-content": {}
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[RSA_2048-RSASSA_PSS_SHA_384]": {
+    "recorded-date": "02-04-2025, 06:06:54",
+    "recorded-content": {}
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[RSA_2048-RSASSA_PSS_SHA_512]": {
+    "recorded-date": "02-04-2025, 06:06:57",
+    "recorded-content": {}
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[RSA_4096-RSASSA_PKCS1_V1_5_SHA_256]": {
+    "recorded-date": "02-04-2025, 06:06:59",
+    "recorded-content": {}
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[RSA_4096-RSASSA_PKCS1_V1_5_SHA_512]": {
+    "recorded-date": "02-04-2025, 06:07:01",
+    "recorded-content": {}
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[ECC_NIST_P256-ECDSA_SHA_256]": {
+    "recorded-date": "02-04-2025, 06:07:03",
+    "recorded-content": {}
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[ECC_NIST_P384-ECDSA_SHA_384]": {
+    "recorded-date": "02-04-2025, 06:07:06",
+    "recorded-content": {}
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[ECC_SECG_P256K1-ECDSA_SHA_256]": {
+    "recorded-date": "02-04-2025, 06:07:08",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -275,6 +275,30 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_update_key_description": {
     "last_validated_date": "2024-04-11T15:53:46+00:00"
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[ECC_NIST_P256-ECDSA_SHA_256]": {
+    "last_validated_date": "2025-04-02T06:07:03+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[ECC_NIST_P384-ECDSA_SHA_384]": {
+    "last_validated_date": "2025-04-02T06:07:05+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[ECC_SECG_P256K1-ECDSA_SHA_256]": {
+    "last_validated_date": "2025-04-02T06:07:08+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[RSA_2048-RSASSA_PSS_SHA_256]": {
+    "last_validated_date": "2025-04-02T06:06:52+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[RSA_2048-RSASSA_PSS_SHA_384]": {
+    "last_validated_date": "2025-04-02T06:06:54+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[RSA_2048-RSASSA_PSS_SHA_512]": {
+    "last_validated_date": "2025-04-02T06:06:56+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[RSA_4096-RSASSA_PKCS1_V1_5_SHA_256]": {
+    "last_validated_date": "2025-04-02T06:06:58+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[RSA_4096-RSASSA_PKCS1_V1_5_SHA_512]": {
+    "last_validated_date": "2025-04-02T06:07:01+00:00"
+  },
   "tests/aws/services/kms/test_kms.py::TestKMSGenerateKeys::test_encryption_context_generate_data_key": {
     "last_validated_date": "2024-04-11T15:54:32+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using an RSA key to sign with PSS algorithm, currently the salt length is set to be `MAX_LENGTH`, which is not in accordance with the ones required by RFC 4055 making making it difficult to verify such signatures across platforms: https://datatracker.ietf.org/doc/html/rfc4055#section-3.3. 

Closes https://github.com/localstack/localstack/issues/9602

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This PR: 
- sets the salt length appropriately for the signing algorithm being used.
- adds an AWS validated test to validate the changes to sign with an aws client and verify the signature using `cryptography` library. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
