### PR TITLE
CFn: validate resource names are alphanumeric

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/validations.py
+++ b/localstack-core/localstack/services/cloudformation/engine/validations.py
@@ -2,6 +2,7 @@
 Provide validations for use within the CFn engine
 """
 
+import re
 from typing import Protocol
 
 from localstack.aws.api import CommonServiceException
@@ -76,6 +77,20 @@ def resources_top_level_keys(template: dict):
                 raise ValidationError(f"Invalid template resource property '{key}'")
 
 
+def alphanumeric_resources(template: dict):
+    # validate that all resource names are alphanumeric
+
+    # XXX I don't think these resource # names can be transformed by later template
+    # processing since in our implementation we # have applied the global transforms,
+    # and only local transforms (affecting resource # properties) are left to do
+    alpha_regex = re.compile(r"^[a-zA-Z0-9]+$")
+    for resource_name in template["Resources"]:
+        if not alpha_regex.match(resource_name):
+            raise ValidationError(
+                f"Template format error: Resource name {resource_name} is non alphanumeric."
+            )
+
+
 DEFAULT_TEMPLATE_VALIDATIONS: list[TemplateValidationStep] = [
     # FIXME: disabled for now due to the template validation not fitting well with the template that we use here.
     #  We don't have access to a "raw" processed template here and it's questionable if we should have it at all,
@@ -83,4 +98,5 @@ DEFAULT_TEMPLATE_VALIDATIONS: list[TemplateValidationStep] = [
     #   => Reevaluate this when reworking how we mutate the template dict in the provider
     # outputs_have_values,
     # resources_top_level_keys,
+    alphanumeric_resources,
 ]

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -833,9 +833,9 @@ def test_name_conflicts(aws_client, snapshot, cleanups):
         pytest.param("with_underscores", id="with-underscores"),
     ],
 )
+# TODO: test update stack
 @pytest.mark.parametrize("deploy_method", ["create_change_set", "create_stack"])
 @markers.aws.validated
-@pytest.mark.skipif(condition=not is_aws_cloud(), reason="WIP")
 def test_validate_resource_names(aws_client, snapshot, resource_name, deploy_method):
     template = {
         "Resources": {

--- a/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
@@ -2286,5 +2286,149 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[with-hyphens]": {
+    "recorded-date": "02-04-2025, 08:38:32",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Resource name invalid-resource-name is non alphanumeric.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[with-colons]": {
+    "recorded-date": "02-04-2025, 08:38:32",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Resource name with:colons is non alphanumeric.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[with-underscores]": {
+    "recorded-date": "02-04-2025, 08:38:32",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Resource name with_underscores is non alphanumeric.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[create_change_set-with-hyphens]": {
+    "recorded-date": "02-04-2025, 08:41:35",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Resource name invalid-resource-name is non alphanumeric.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[create_change_set-with-colons]": {
+    "recorded-date": "02-04-2025, 08:41:36",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Resource name with:colons is non alphanumeric.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[create_change_set-with-underscores]": {
+    "recorded-date": "02-04-2025, 08:41:36",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Resource name with_underscores is non alphanumeric.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[create_stack-with-hyphens]": {
+    "recorded-date": "02-04-2025, 08:41:36",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Resource name invalid-resource-name is non alphanumeric.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[create_stack-with-colons]": {
+    "recorded-date": "02-04-2025, 08:41:36",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Resource name with:colons is non alphanumeric.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[create_stack-with-underscores]": {
+    "recorded-date": "02-04-2025, 08:41:36",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Resource name with_underscores is non alphanumeric.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_stacks.validation.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.validation.json
@@ -127,5 +127,32 @@
   },
   "tests/aws/services/cloudformation/api/test_stacks.py::test_updating_an_updated_stack_sets_status": {
     "last_validated_date": "2022-12-02T10:19:41+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[create_change_set-with-colons]": {
+    "last_validated_date": "2025-04-02T08:41:36+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[create_change_set-with-hyphens]": {
+    "last_validated_date": "2025-04-02T08:41:35+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[create_change_set-with-underscores]": {
+    "last_validated_date": "2025-04-02T08:41:36+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[create_stack-with-colons]": {
+    "last_validated_date": "2025-04-02T08:41:36+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[create_stack-with-hyphens]": {
+    "last_validated_date": "2025-04-02T08:41:36+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[create_stack-with-underscores]": {
+    "last_validated_date": "2025-04-02T08:41:36+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[with-colons]": {
+    "last_validated_date": "2025-04-02T08:38:32+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[with-hyphens]": {
+    "last_validated_date": "2025-04-02T08:38:32+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_validate_resource_names[with-underscores]": {
+    "last_validated_date": "2025-04-02T08:38:32+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

CloudFormation logical resource names must be alphanumeric on AWS, however we don't support this same restriction. This extra validation reduces the chance that an invalid template deploys correctly against LocalStack.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Validate that all resource names must be alphanumeric in 
    - `create_change_set`
    - `create_stack`
    - `update_stack`

- Add validated test capturing the error message

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
