### PR TITLE
Reapply reduce requests necessary for log publishing from lambda to cloudwatch logs

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/logs.py
+++ b/localstack-core/localstack/services/lambda_/invocation/logs.py
@@ -50,7 +50,9 @@ class LogHandler:
             log_item = self.log_queue.get()
             if log_item is QUEUE_SHUTDOWN:
                 return
-            logs = log_item.logs.splitlines()
+            # we need to split by newline - but keep the newlines in the strings
+            # strips empty lines, as they are not accepted by cloudwatch
+            logs = [line + "\n" for line in log_item.logs.split("\n") if line]
             # until we have a better way to have timestamps, log events have the same time for a single invocation
             log_events = [
                 {"timestamp": int(time.time() * 1000), "message": log_line} for log_line in logs

--- a/tests/aws/services/lambda_/functions/lambda_cloudwatch_logs.py
+++ b/tests/aws/services/lambda_/functions/lambda_cloudwatch_logs.py
@@ -1,0 +1,10 @@
+"""
+A simple handler which does a print on the "body" key of the event passed in.
+Can be used to log different payloads, to check for the correct format in cloudwatch logs
+"""
+
+
+def handler(event, context):
+    # Just print the log line that was passed to lambda
+    print(event["body"])
+    return event

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -127,6 +127,7 @@ TEST_LAMBDA_PYTHON_MULTIPLE_HANDLERS = os.path.join(
     THIS_FOLDER, "functions/lambda_multiple_handlers.py"
 )
 TEST_LAMBDA_NOTIFIER = os.path.join(THIS_FOLDER, "functions/lambda_notifier.py")
+TEST_LAMBDA_CLOUDWATCH_LOGS = os.path.join(THIS_FOLDER, "functions/lambda_cloudwatch_logs.py")
 
 PYTHON_TEST_RUNTIMES = RUNTIMES_AGGREGATED["python"]
 NODE_TEST_RUNTIMES = RUNTIMES_AGGREGATED["nodejs"]

--- a/tests/aws/services/lambda_/test_lambda_runtimes.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_runtimes.snapshot.json
@@ -1208,5 +1208,68 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestCloudwatchLogs::test_multi_line_prints": {
+    "recorded-date": "02-04-2025, 12:35:33",
+    "recorded-content": {
+      "log-events": [
+        {
+          "logStreamName": "<log-stream-name:1>",
+          "timestamp": "timestamp",
+          "message": "INIT_START Runtime Version: python:3.13.v<version>\tRuntime Version ARN: arn:<partition>:lambda:<region>::runtime:<runtime-id>\n",
+          "ingestionTime": "timestamp",
+          "eventId": "event-id"
+        },
+        {
+          "logStreamName": "<log-stream-name:1>",
+          "timestamp": "timestamp",
+          "message": "START RequestId: <request-id> Version: $LATEST\n",
+          "ingestionTime": "timestamp",
+          "eventId": "event-id"
+        },
+        {
+          "logStreamName": "<log-stream-name:1>",
+          "timestamp": "timestamp",
+          "message": "multi\n",
+          "ingestionTime": "timestamp",
+          "eventId": "event-id"
+        },
+        {
+          "logStreamName": "<log-stream-name:1>",
+          "timestamp": "timestamp",
+          "message": "line\n",
+          "ingestionTime": "timestamp",
+          "eventId": "event-id"
+        },
+        {
+          "logStreamName": "<log-stream-name:1>",
+          "timestamp": "timestamp",
+          "message": "string\n",
+          "ingestionTime": "timestamp",
+          "eventId": "event-id"
+        },
+        {
+          "logStreamName": "<log-stream-name:1>",
+          "timestamp": "timestamp",
+          "message": "another\rline\n",
+          "ingestionTime": "timestamp",
+          "eventId": "event-id"
+        },
+        {
+          "logStreamName": "<log-stream-name:1>",
+          "timestamp": "timestamp",
+          "message": "END RequestId: <request-id>\n",
+          "ingestionTime": "timestamp",
+          "eventId": "event-id"
+        },
+        {
+          "logStreamName": "<log-stream-name:1>",
+          "timestamp": "timestamp",
+          "message": "REPORT RequestId: <request-id>\tDuration: <duration> ms\tBilled Duration: <duration> ms\tMemory Size: 128 MB\tMax Memory Used: <memory> MB\tInit Duration: <duration> ms\t\n",
+          "ingestionTime": "timestamp",
+          "eventId": "event-id"
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_runtimes.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_runtimes.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestCloudwatchLogs::test_multi_line_prints": {
+    "last_validated_date": "2025-04-02T12:35:33+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestGoProvidedRuntimes::test_manual_endpoint_injection[provided.al2023]": {
     "last_validated_date": "2024-11-26T09:46:59+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With #10294 we had to revert increased performance for lambda cloudwatch logs, reduced requests necessary for every log storage from 3 to (on average) 1.

The root cause for this revert was the `.splitlines()` method used to split the logs, as it also splits on several other characters, like a carriage return, unlike the old log method.

Since the runtime interface clients patch the loggers (e.g. here: https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/2ea9a34b5c1b15621df132eb2d377ac54b330c8f/src/LogPatch.js#L82-L88), we need to leave carriage returns as is for now.

In the long term, to further increase logging parity, we need to:
1. Properly log the `INIT_START` message (this should allow for proper snapshotting of logs as well then, as the count should align)
2. Use the file descriptor based logging mechanism (counterpart to this: https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/2ea9a34b5c1b15621df132eb2d377ac54b330c8f/src/LogPatch.js#L102-L120). This should allow proper log line delimiters for logging as well, and avoid the replacement of newlines by carriage returns in some RIC patches.

The test added mostly assures normal carriage returns are not split into multiple messages - the main cause for the failing ext test.
In the future, with the improvements above, we need to add more tests for parity for different logging mechanisms.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Reduced load on LocalStack for every invocation, due to less requests.
* Log events now have (correctly) trailing newlines, instead of stripping them out.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
