### PR TITLE
Add new volume dir mount option, rename VolumeBind to BindMount

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/docker_runtime_executor.py
+++ b/localstack-core/localstack/services/lambda_/invocation/docker_runtime_executor.py
@@ -32,13 +32,13 @@ from localstack.services.lambda_.packages import get_runtime_client_path
 from localstack.services.lambda_.runtimes import IMAGE_MAPPING
 from localstack.utils.container_networking import get_main_container_name
 from localstack.utils.container_utils.container_client import (
+    BindMount,
     ContainerConfiguration,
     DockerNotAvailable,
     DockerPlatform,
     NoSuchContainer,
     NoSuchImage,
     PortMappings,
-    VolumeBind,
     VolumeMappings,
 )
 from localstack.utils.docker_utils import DOCKER_CLIENT as CONTAINER_CLIENT
@@ -331,7 +331,7 @@ class DockerRuntimeExecutor(RuntimeExecutor):
                 if container_config.volumes is None:
                     container_config.volumes = VolumeMappings()
                 container_config.volumes.add(
-                    VolumeBind(
+                    BindMount(
                         str(self.function_version.config.code.get_unzipped_code_location()),
                         "/var/task",
                         read_only=True,

--- a/localstack-core/localstack/utils/analytics/metadata.py
+++ b/localstack-core/localstack/utils/analytics/metadata.py
@@ -237,11 +237,11 @@ def prepare_host_machine_id():
 
 @hooks.configure_localstack_container()
 def _mount_machine_file(container: Container):
-    from localstack.utils.container_utils.container_client import VolumeBind
+    from localstack.utils.container_utils.container_client import BindMount
 
     # mount tha machine file from the host's CLI cache directory into the appropriate location in the
     # container
     machine_file = os.path.join(config.dirs.cache, "machine.json")
     if os.path.isfile(machine_file):
         target = os.path.join(config.dirs.for_container().cache, "machine.json")
-        container.config.volumes.add(VolumeBind(machine_file, target, read_only=True))
+        container.config.volumes.add(BindMount(machine_file, target, read_only=True))

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -24,6 +24,7 @@ from localstack.constants import VERSION
 from localstack.runtime import hooks
 from localstack.utils.container_networking import get_main_container_name
 from localstack.utils.container_utils.container_client import (
+    BindMount,
     CancellableStream,
     ContainerClient,
     ContainerConfiguration,
@@ -33,7 +34,7 @@ from localstack.utils.container_utils.container_client import (
     NoSuchImage,
     NoSuchNetwork,
     PortMappings,
-    VolumeBind,
+    VolumeDirMount,
     VolumeMappings,
 )
 from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
@@ -491,7 +492,7 @@ class ContainerConfigurators:
         target = "/var/run/docker.sock"
         if cfg.volumes.find_target_mapping(target):
             return
-        cfg.volumes.add(VolumeBind(source, target))
+        cfg.volumes.add(BindMount(source, target))
         cfg.env_vars["DOCKER_HOST"] = f"unix://{target}"
 
     @staticmethod
@@ -501,7 +502,7 @@ class ContainerConfigurators:
         def _cfg(cfg: ContainerConfiguration):
             if cfg.volumes.find_target_mapping(constants.DEFAULT_VOLUME_DIR):
                 return
-            cfg.volumes.add(VolumeBind(str(host_path), constants.DEFAULT_VOLUME_DIR))
+            cfg.volumes.add(BindMount(str(host_path), constants.DEFAULT_VOLUME_DIR))
 
         return _cfg
 
@@ -679,7 +680,7 @@ class ContainerConfigurators:
         return _cfg
 
     @staticmethod
-    def volume(volume: VolumeBind):
+    def volume(volume: BindMount | VolumeDirMount):
         def _cfg(cfg: ContainerConfiguration):
             cfg.volumes.add(volume)
 
@@ -807,7 +808,7 @@ class ContainerConfigurators:
 
         def _cfg(cfg: ContainerConfiguration):
             for param in params:
-                cfg.volumes.append(VolumeBind.parse(param))
+                cfg.volumes.append(BindMount.parse(param))
 
         return _cfg
 

--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -371,7 +371,7 @@ SimpleVolumeBind = Tuple[str, str]
 
 
 @dataclasses.dataclass
-class VolumeBind:
+class BindMount:
     """Represents a --volume argument run/create command. When using VolumeBind to bind-mount a file or directory
     that does not yet exist on the Docker host, -v creates the endpoint for you. It is always created as a directory.
     """
@@ -403,7 +403,7 @@ class VolumeBind:
         }
 
     @classmethod
-    def parse(cls, param: str) -> "VolumeBind":
+    def parse(cls, param: str) -> "BindMount":
         parts = param.split(":")
         if 1 > len(parts) > 3:
             raise ValueError(f"Cannot parse volume bind {param}")
@@ -456,19 +456,19 @@ class VolumeDirMount:
 
 
 class VolumeMappings:
-    mappings: List[Union[SimpleVolumeBind, VolumeBind]]
+    mappings: List[Union[SimpleVolumeBind, BindMount]]
 
-    def __init__(self, mappings: List[Union[SimpleVolumeBind, VolumeBind, VolumeDirMount]] = None):
+    def __init__(self, mappings: List[Union[SimpleVolumeBind, BindMount, VolumeDirMount]] = None):
         self.mappings = mappings if mappings is not None else []
 
-    def add(self, mapping: Union[SimpleVolumeBind, VolumeBind, VolumeDirMount]):
+    def add(self, mapping: Union[SimpleVolumeBind, BindMount, VolumeDirMount]):
         self.append(mapping)
 
     def append(
         self,
         mapping: Union[
             SimpleVolumeBind,
-            VolumeBind,
+            BindMount,
             VolumeDirMount,
         ],
     ):
@@ -476,7 +476,7 @@ class VolumeMappings:
 
     def find_target_mapping(
         self, container_dir: str
-    ) -> Optional[Union[SimpleVolumeBind, VolumeBind, VolumeDirMount]]:
+    ) -> Optional[Union[SimpleVolumeBind, BindMount, VolumeDirMount]]:
         """
         Looks through the volumes and returns the one where the container dir matches ``container_dir``.
         Returns None if there is no volume mapping to the given container directory.
@@ -1495,8 +1495,8 @@ class Util:
     ) -> Dict[str, Dict[str, str]]:
         """Converts a List of (host_path, container_path) tuples to a Dict suitable as volume argument for docker sdk"""
 
-        def _map_to_dict(paths: SimpleVolumeBind | VolumeBind | VolumeDirMount):
-            if isinstance(paths, (VolumeBind, VolumeDirMount)):
+        def _map_to_dict(paths: SimpleVolumeBind | BindMount | VolumeDirMount):
+            if isinstance(paths, (BindMount, VolumeDirMount)):
                 return paths.to_dict()
             else:
                 return str(paths[0]), {"bind": paths[1], "mode": "rw"}

--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -396,7 +396,7 @@ class BindMount:
 
         return ":".join(args)
 
-    def to_dict(self):
+    def to_docker_sdk_parameters(self) -> tuple[str, dict[str, str]]:
         return str(self.host_dir), {
             "bind": self.container_dir,
             "mode": "ro" if self.read_only else "rw",
@@ -442,7 +442,7 @@ class VolumeDirMount:
         if not self.container_path:
             raise ValueError("no container dir specified")
 
-    def to_dict(self) -> tuple[str, dict]:
+    def to_docker_sdk_parameters(self) -> tuple[str, dict[str, str]]:
         self._validate()
         from localstack.utils.docker_utils import get_host_path_for_path_in_docker
 
@@ -1495,7 +1495,7 @@ class Util:
 
         def _map_to_dict(paths: SimpleVolumeBind | BindMount | VolumeDirMount):
             if isinstance(paths, (BindMount, VolumeDirMount)):
-                return paths.to_dict()
+                return paths.to_docker_sdk_parameters()
             else:
                 return str(paths[0]), {"bind": paths[1], "mode": "rw"}
 

--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -448,6 +448,12 @@ class VolumeMappings:
     def __repr__(self):
         return self.mappings.__repr__()
 
+    def __len__(self):
+        return len(self.mappings)
+
+    def __getitem__(self, item: int):
+        return self.mappings[item]
+
 
 VolumeType = Literal["bind", "volume"]
 

--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -437,21 +437,19 @@ class VolumeDirMount:
     def _validate(self):
         if not self.volume_path:
             raise ValueError("no volume dir specified")
-        if not self.volume_path.startswith(DEFAULT_VOLUME_DIR):
+        if config.is_in_docker and not self.volume_path.startswith(DEFAULT_VOLUME_DIR):
             raise ValueError(f"volume dir not starting with {DEFAULT_VOLUME_DIR}")
         if not self.container_path:
             raise ValueError("no container dir specified")
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> tuple[str, dict]:
         self._validate()
         from localstack.utils.docker_utils import get_host_path_for_path_in_docker
 
         host_dir = get_host_path_for_path_in_docker(self.volume_path)
-        return {
-            host_dir: {
-                "bind": self.container_path,
-                "mode": "ro" if self.read_only else "rw",
-            }
+        return host_dir, {
+            "bind": self.container_path,
+            "mode": "ro" if self.read_only else "rw",
         }
 
 

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -30,6 +30,7 @@ from localstack.utils.container_utils.container_client import (
     Ulimit,
     Util,
     VolumeBind,
+    VolumeDirMount,
 )
 from localstack.utils.run import run
 from localstack.utils.strings import first_char_to_upper, to_str
@@ -878,7 +879,7 @@ class CmdDockerClient(ContainerClient):
         return cmd, env_file
 
     @staticmethod
-    def _map_to_volume_param(volume: Union[SimpleVolumeBind, VolumeBind]) -> str:
+    def _map_to_volume_param(volume: Union[SimpleVolumeBind, VolumeBind, VolumeDirMount]) -> str:
         """
         Maps the mount volume, to a parameter for the -v docker cli argument.
 
@@ -889,7 +890,7 @@ class CmdDockerClient(ContainerClient):
         :param volume: Either a SimpleVolumeBind, in essence a tuple (host_dir, container_dir), or a VolumeBind object
         :return: String which is passable as parameter to the docker cli -v option
         """
-        if isinstance(volume, VolumeBind):
+        if isinstance(volume, (VolumeBind, VolumeDirMount)):
             return volume.to_str()
         else:
             return f"{volume[0]}:{volume[1]}"

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -12,6 +12,7 @@ from localstack import config
 from localstack.utils.collections import ensure_list
 from localstack.utils.container_utils.container_client import (
     AccessDenied,
+    BindMount,
     CancellableStream,
     ContainerClient,
     ContainerException,
@@ -29,7 +30,6 @@ from localstack.utils.container_utils.container_client import (
     SimpleVolumeBind,
     Ulimit,
     Util,
-    VolumeBind,
     VolumeDirMount,
 )
 from localstack.utils.run import run
@@ -879,7 +879,7 @@ class CmdDockerClient(ContainerClient):
         return cmd, env_file
 
     @staticmethod
-    def _map_to_volume_param(volume: Union[SimpleVolumeBind, VolumeBind, VolumeDirMount]) -> str:
+    def _map_to_volume_param(volume: Union[SimpleVolumeBind, BindMount, VolumeDirMount]) -> str:
         """
         Maps the mount volume, to a parameter for the -v docker cli argument.
 
@@ -890,7 +890,7 @@ class CmdDockerClient(ContainerClient):
         :param volume: Either a SimpleVolumeBind, in essence a tuple (host_dir, container_dir), or a VolumeBind object
         :return: String which is passable as parameter to the docker cli -v option
         """
-        if isinstance(volume, (VolumeBind, VolumeDirMount)):
+        if isinstance(volume, (BindMount, VolumeDirMount)):
             return volume.to_str()
         else:
             return f"{volume[0]}:{volume[1]}"

--- a/tests/bootstrap/test_container_configurators.py
+++ b/tests/bootstrap/test_container_configurators.py
@@ -9,7 +9,7 @@ from localstack.utils.bootstrap import (
     get_gateway_url,
 )
 from localstack.utils.common import external_service_ports
-from localstack.utils.container_utils.container_client import VolumeBind
+from localstack.utils.container_utils.container_client import BindMount
 
 
 def test_common_container_fixture_configurators(
@@ -96,7 +96,7 @@ def test_custom_command_configurator(container_factory, tmp_path, stream_contain
             ContainerConfigurators.custom_command(
                 ["/tmp/pytest-tmp-path/my-command.sh", "hello", "world"]
             ),
-            ContainerConfigurators.volume(VolumeBind(str(tmp_path), "/tmp/pytest-tmp-path")),
+            ContainerConfigurators.volume(BindMount(str(tmp_path), "/tmp/pytest-tmp-path")),
         ],
         remove=False,
     )

--- a/tests/bootstrap/test_init.py
+++ b/tests/bootstrap/test_init.py
@@ -6,7 +6,7 @@ import requests
 from localstack.config import in_docker
 from localstack.testing.pytest.container import ContainerFactory
 from localstack.utils.bootstrap import ContainerConfigurators
-from localstack.utils.container_utils.container_client import VolumeBind
+from localstack.utils.container_utils.container_client import BindMount
 
 pytestmarks = pytest.mark.skipif(
     condition=in_docker(), reason="cannot run bootstrap tests in docker"
@@ -43,7 +43,7 @@ class TestInitHooks:
                 ContainerConfigurators.default_gateway_port,
                 ContainerConfigurators.mount_localstack_volume(volume),
                 ContainerConfigurators.volume(
-                    VolumeBind(str(shutdown_hooks), "/etc/localstack/init/shutdown.d")
+                    BindMount(str(shutdown_hooks), "/etc/localstack/init/shutdown.d")
                 ),
             ]
         )

--- a/tests/unit/test_docker_utils.py
+++ b/tests/unit/test_docker_utils.py
@@ -94,9 +94,10 @@ class TestDockerUtils:
             )
             result = volume_dir_mount.to_dict()
             get_volume.assert_called_once()
-            assert result == {
-                "/home/some-user/.cache/localstack/volume/some/test/file": {
+            assert result == (
+                "/home/some-user/.cache/localstack/volume/some/test/file",
+                {
                     "bind": "/target/file",
                     "mode": "rw",
-                }
-            }
+                },
+            )

--- a/tests/unit/test_docker_utils.py
+++ b/tests/unit/test_docker_utils.py
@@ -92,7 +92,7 @@ class TestDockerUtils:
             volume_dir_mount = VolumeDirMount(
                 "/var/lib/localstack/some/test/file", "/target/file", read_only=False
             )
-            result = volume_dir_mount.to_dict()
+            result = volume_dir_mount.to_docker_sdk_parameters()
             get_volume.assert_called_once()
             assert result == (
                 "/home/some-user/.cache/localstack/volume/some/test/file",
@@ -101,3 +101,5 @@ class TestDockerUtils:
                     "mode": "rw",
                 },
             )
+            result = volume_dir_mount.to_str()
+            assert result == "/home/some-user/.cache/localstack/volume/some/test/file:/target/file"

--- a/tests/unit/utils/test_bootstrap.py
+++ b/tests/unit/utils/test_bootstrap.py
@@ -12,7 +12,7 @@ from localstack.utils.bootstrap import (
     get_gateway_port,
     get_preloaded_services,
 )
-from localstack.utils.container_utils.container_client import ContainerConfiguration, VolumeBind
+from localstack.utils.container_utils.container_client import BindMount, ContainerConfiguration
 
 
 @contextmanager
@@ -246,5 +246,5 @@ class TestContainerConfigurators:
             "53/udp": 53,
             "6000/tcp": 5000,
         }
-        assert VolumeBind(host_dir="foo", container_dir="/tmp/foo", read_only=False) in c.volumes
-        assert VolumeBind(host_dir="/bar", container_dir="/tmp/bar", read_only=True) in c.volumes
+        assert BindMount(host_dir="foo", container_dir="/tmp/foo", read_only=False) in c.volumes
+        assert BindMount(host_dir="/bar", container_dir="/tmp/bar", read_only=True) in c.volumes


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR refactors the usage of `get_host_path_for_path_in_docker`. 
This utility is very specific, assuming:

1. The volume dir is mounted as bind mount
2. We are using docker (or something API compatible, like podman) for spawning containers

To overcome these restrictions in the long term, I added a new type of mount for our container clients, the `VolumeDirMount`.

This mount should convey the intent to make the contents of a subpath of `/var/lib/localstack` (as path inside the LS container) available to the target container - however this happens.

This shifts the responsibility for this from the services to the docker client - which can then decide how it is achieved.
Currently this will continue to be `get_host_path_for_path_in_docker`, but in the future support for named volumes and kubernetes is thinkable as well.

From here on out, we should not use `get_host_path_for_path_in_docker` outside tests, and very specific, to be considered, usecases.

Also, `VolumeBind` is renamed to `BindMount`, which is a clearer name in my opinion. I did a usage search for this class within or organization, and could find any usages outside of localstack and our ext repository.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* No user facing changes
* Introduce new VolumeDirMount to mount subpaths of /var/lib/localstack into other containers
* Rename VolumeBind to BindMount


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
