### PR TITLE
Admin: Use cryptography instead of OpenSSL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ base-runtime = [
     "hypercorn>=0.14.4",
     "localstack-twisted>=23.0",
     "openapi-core>=0.19.2",
-    "pyopenssl>=23.0.0",
     "readerwriterlock>=1.0.7",
     "requests-aws4auth>=1.0",
     # explicitly set urllib3 to force its usage / ensure compatibility
@@ -95,7 +94,6 @@ runtime = [
     "moto-ext[all]==5.1.3.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
-    "pyopenssl>=23.0.0",
 ]
 
 # for running tests and coverage analysis

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -131,9 +131,7 @@ pycparser==2.22
 pygments==2.19.1
     # via rich
 pyopenssl==25.0.0
-    # via
-    #   localstack-core (pyproject.toml)
-    #   localstack-twisted
+    # via localstack-twisted
 pyproject-hooks==1.2.0
     # via build
 python-dateutil==2.9.0.post0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -340,9 +340,7 @@ pygments==2.19.1
 pymongo==4.12.0
     # via localstack-core
 pyopenssl==25.0.0
-    # via
-    #   localstack-core
-    #   localstack-twisted
+    # via localstack-twisted
 pypandoc==1.15
     # via localstack-core (pyproject.toml)
 pyparsing==3.2.3

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -248,10 +248,7 @@ pygments==2.19.1
 pymongo==4.12.0
     # via localstack-core (pyproject.toml)
 pyopenssl==25.0.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
-    #   localstack-twisted
+    # via localstack-twisted
 pyparsing==3.2.3
     # via moto-ext
 pyproject-hooks==1.2.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -310,9 +310,7 @@ pygments==2.19.1
 pymongo==4.12.0
     # via localstack-core
 pyopenssl==25.0.0
-    # via
-    #   localstack-core
-    #   localstack-twisted
+    # via localstack-twisted
 pyparsing==3.2.3
     # via moto-ext
 pyproject-hooks==1.2.0


### PR DESCRIPTION
## Motivation
The [PyOpenSSL](https://pypi.org/project/pyOpenSSL/) module explicitly suggests that users should use the standard `cryptography` module instead.

As far as I can tell, all SSL-related functions within LocalStack (Pro) now use `cryptography`, so this both simplifies the implementation, and reduces the mental load for developers.

I was hoping to be able to remove the dependency as well, just to make LocalStack's footprint a little smaller, but unfortunately `twisted` still uses it. :cry: 
