### PR TITLE
Docker: Improve error messages around port-bound check

### DIFF
--- a/localstack-core/localstack/utils/docker_utils.py
+++ b/localstack-core/localstack/utils/docker_utils.py
@@ -156,14 +156,14 @@ def container_ports_can_be_bound(
     except Exception as e:
         if "port is already allocated" not in str(e) and "address already in use" not in str(e):
             LOG.warning(
-                "Unexpected error when attempting to determine container port status: %s", e
+                "Unexpected error when attempting to determine container port status", exc_info=e
             )
         return False
     # TODO(srw): sometimes the command output from the docker container is "None", particularly when this function is
     #  invoked multiple times consecutively. Work out why.
     if to_str(result[0] or "").strip() != "test123":
         LOG.warning(
-            "Unexpected output when attempting to determine container port status: %s", result[0]
+            "Unexpected output when attempting to determine container port status: %s", result
         )
     return True
 


### PR DESCRIPTION
## Motivation
Minor improvements around the logging when checking if a port is available.

An ealier version of this PR also changed the image to use `bash` instead, but some benchmarks showed that using a smaller image does not improve the performance. This method always takes around `35ms`, regardless of the exact image used.

For reference, this was the original description:

~To check if a certain port is available, we currently start a second LocalStack instance with those ports reserved, and check if it fails. Starting LocalStack is quite resource-intensive - using a smaller image (like `bash`) is much faster. (This is especially important when calling this method multiple times in parallel.)~