### PR TITLE
CFn: Add Lambda Function LoggingConfig

### DIFF
--- a/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_function.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_function.py
@@ -99,6 +99,13 @@ class Code(TypedDict):
     ZipFile: Optional[str]
 
 
+class LoggingConfig(TypedDict):
+    ApplicationLogLevel: Optional[str]
+    LogFormat: Optional[str]
+    LogGroup: Optional[str]
+    SystemLogLevel: Optional[str]
+
+
 class Environment(TypedDict):
     Variables: Optional[dict]
 
@@ -333,11 +340,22 @@ class LambdaFunctionProvider(ResourceProvider[LambdaFunctionProperties]):
           - ec2:DescribeSecurityGroups
           - ec2:DescribeSubnets
           - ec2:DescribeVpcs
+          - elasticfilesystem:DescribeMountTargets
+          - kms:CreateGrant
           - kms:Decrypt
+          - kms:Encrypt
+          - kms:GenerateDataKey
           - lambda:GetCodeSigningConfig
           - lambda:GetFunctionCodeSigningConfig
+          - lambda:GetLayerVersion
           - lambda:GetRuntimeManagementConfig
           - lambda:PutRuntimeManagementConfig
+          - lambda:TagResource
+          - lambda:GetPolicy
+          - lambda:AddPermission
+          - lambda:RemovePermission
+          - lambda:GetResourcePolicy
+          - lambda:PutResourcePolicy
 
         """
         model = request.desired_state
@@ -368,6 +386,7 @@ class LambdaFunctionProvider(ResourceProvider[LambdaFunctionProperties]):
                     "Timeout",
                     "TracingConfig",
                     "VpcConfig",
+                    "LoggingConfig",
                 ],
             )
             if "Timeout" in kwargs:
@@ -481,13 +500,22 @@ class LambdaFunctionProvider(ResourceProvider[LambdaFunctionProperties]):
           - ec2:DescribeSecurityGroups
           - ec2:DescribeSubnets
           - ec2:DescribeVpcs
+          - elasticfilesystem:DescribeMountTargets
+          - kms:CreateGrant
           - kms:Decrypt
+          - kms:GenerateDataKey
+          - lambda:GetRuntimeManagementConfig
+          - lambda:PutRuntimeManagementConfig
           - lambda:PutFunctionCodeSigningConfig
           - lambda:DeleteFunctionCodeSigningConfig
           - lambda:GetCodeSigningConfig
           - lambda:GetFunctionCodeSigningConfig
-          - lambda:GetRuntimeManagementConfig
-          - lambda:PutRuntimeManagementConfig
+          - lambda:GetPolicy
+          - lambda:AddPermission
+          - lambda:RemovePermission
+          - lambda:GetResourcePolicy
+          - lambda:PutResourcePolicy
+          - lambda:DeleteResourcePolicy
         """
         client = request.aws_client_factory.lambda_
 
@@ -512,6 +540,7 @@ class LambdaFunctionProvider(ResourceProvider[LambdaFunctionProperties]):
             "Timeout",
             "TracingConfig",
             "VpcConfig",
+            "LoggingConfig",
         ]
         update_config_props = util.select_attributes(request.desired_state, config_keys)
         function_name = request.previous_state["FunctionName"]

--- a/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_function.schema.json
+++ b/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_function.schema.json
@@ -1,4 +1,11 @@
 {
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "tagProperty": "/properties/Tags",
+    "cloudFormationSystemTags": true
+  },
   "handlers": {
     "read": {
       "permissions": [
@@ -17,11 +24,22 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeVpcs",
+        "elasticfilesystem:DescribeMountTargets",
+        "kms:CreateGrant",
         "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
         "lambda:GetCodeSigningConfig",
         "lambda:GetFunctionCodeSigningConfig",
+        "lambda:GetLayerVersion",
         "lambda:GetRuntimeManagementConfig",
-        "lambda:PutRuntimeManagementConfig"
+        "lambda:PutRuntimeManagementConfig",
+        "lambda:TagResource",
+        "lambda:GetPolicy",
+        "lambda:AddPermission",
+        "lambda:RemovePermission",
+        "lambda:GetResourcePolicy",
+        "lambda:PutResourcePolicy"
       ]
     },
     "update": {
@@ -40,13 +58,22 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeVpcs",
+        "elasticfilesystem:DescribeMountTargets",
+        "kms:CreateGrant",
         "kms:Decrypt",
+        "kms:GenerateDataKey",
+        "lambda:GetRuntimeManagementConfig",
+        "lambda:PutRuntimeManagementConfig",
         "lambda:PutFunctionCodeSigningConfig",
         "lambda:DeleteFunctionCodeSigningConfig",
         "lambda:GetCodeSigningConfig",
         "lambda:GetFunctionCodeSigningConfig",
-        "lambda:GetRuntimeManagementConfig",
-        "lambda:PutRuntimeManagementConfig"
+        "lambda:GetPolicy",
+        "lambda:AddPermission",
+        "lambda:RemovePermission",
+        "lambda:GetResourcePolicy",
+        "lambda:PutResourcePolicy",
+        "lambda:DeleteResourcePolicy"
       ]
     },
     "list": {
@@ -63,13 +90,15 @@
   },
   "typeName": "AWS::Lambda::Function",
   "readOnlyProperties": [
-    "/properties/Arn",
     "/properties/SnapStartResponse",
     "/properties/SnapStartResponse/ApplyOn",
-    "/properties/SnapStartResponse/OptimizationStatus"
+    "/properties/SnapStartResponse/OptimizationStatus",
+    "/properties/Arn"
   ],
-  "description": "Resource Type definition for AWS::Lambda::Function",
+  "description": "Resource Type definition for AWS::Lambda::Function in region",
   "writeOnlyProperties": [
+    "/properties/SnapStart",
+    "/properties/SnapStart/ApplyOn",
     "/properties/Code",
     "/properties/Code/ImageUri",
     "/properties/Code/S3Bucket",
@@ -133,6 +162,10 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
+        "Ipv6AllowedForDualStack": {
+          "description": "A boolean indicating whether IPv6 protocols will be allowed for dual stack subnets",
+          "type": "boolean"
+        },
         "SecurityGroupIds": {
           "maxItems": 5,
           "uniqueItems": false,
@@ -258,6 +291,49 @@
         "ImageUri": {
           "description": "ImageUri.",
           "type": "string"
+        }
+      }
+    },
+    "LoggingConfig": {
+      "description": "The function's logging configuration.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "LogFormat": {
+          "description": "Log delivery format for the lambda function",
+          "type": "string",
+          "enum": [
+            "Text",
+            "JSON"
+          ]
+        },
+        "ApplicationLogLevel": {
+          "description": "Application log granularity level, can only be used when LogFormat is set to JSON",
+          "type": "string",
+          "enum": [
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "FATAL"
+          ]
+        },
+        "LogGroup": {
+          "minLength": 1,
+          "pattern": "[\\.\\-_/#A-Za-z0-9]+",
+          "description": "The log group name.",
+          "type": "string",
+          "maxLength": 512
+        },
+        "SystemLogLevel": {
+          "description": "System log granularity level, can only be used when LogFormat is set to JSON",
+          "type": "string",
+          "enum": [
+            "DEBUG",
+            "INFO",
+            "WARN"
+          ]
         }
       }
     },
@@ -456,6 +532,10 @@
       "pattern": "^arn:(aws[a-zA-Z-]*)?:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+$",
       "description": "The Amazon Resource Name (ARN) of the function's execution role.",
       "type": "string"
+    },
+    "LoggingConfig": {
+      "description": "The logging configuration of your function",
+      "$ref": "#/definitions/LoggingConfig"
     },
     "Environment": {
       "description": "Environment variables that are accessible from function code during execution.",

--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -254,19 +254,17 @@ def test_lambda_alias(deploy_cfn_template, snapshot, aws_client):
 
 
 @markers.aws.validated
-@markers.snapshot.skip_snapshot_verify(
-    paths=[
-        "$..StackResources..PhysicalResourceId",  # TODO: compatibility between AWS URL and localstack URL
-    ]
-)
 def test_lambda_logging_config(deploy_cfn_template, snapshot, aws_client):
-    snapshot.add_transformer(snapshot.transform.cloudformation_api())
-    snapshot.add_transformer(snapshot.transform.lambda_api())
-    snapshot.add_transformer(
-        SortingTransformer("StackResources", lambda x: x["LogicalResourceId"]), priority=-1
-    )
-
     function_name = f"function{short_uid()}"
+
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+    snapshot.add_transformer(SortingTransformer("StackResources", lambda x: x["LogicalResourceId"]))
+    snapshot.add_transformer(
+        snapshot.transform.key_value("LogicalResourceId", reference_replacement=False)
+    )
+    snapshot.add_transformer(
+        snapshot.transform.key_value("PhysicalResourceId", reference_replacement=False)
+    )
     snapshot.add_transformer(snapshot.transform.regex(function_name, "<function-name>"))
 
     deployment = deploy_cfn_template(

--- a/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
@@ -1608,7 +1608,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_logging_config": {
-    "recorded-date": "03-04-2025, 17:34:50",
+    "recorded-date": "08-04-2025, 12:10:56",
     "recorded-content": {
       "stack_resource_descriptions": {
         "StackResources": [
@@ -1616,8 +1616,8 @@
             "DriftInformation": {
               "StackResourceDriftStatus": "NOT_CHECKED"
             },
-            "LogicalResourceId": "LambdaFunction",
-            "PhysicalResourceId": "<function-name>",
+            "LogicalResourceId": "logical-resource-id",
+            "PhysicalResourceId": "physical-resource-id",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::Lambda::Function",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
@@ -1628,8 +1628,8 @@
             "DriftInformation": {
               "StackResourceDriftStatus": "NOT_CHECKED"
             },
-            "LogicalResourceId": "MyFnServiceRole",
-            "PhysicalResourceId": "<stack-name:1>-MyFnServiceRole-IVwvF4i3Fcqy",
+            "LogicalResourceId": "logical-resource-id",
+            "PhysicalResourceId": "physical-resource-id",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::IAM::Role",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
@@ -1640,8 +1640,8 @@
             "DriftInformation": {
               "StackResourceDriftStatus": "NOT_CHECKED"
             },
-            "LogicalResourceId": "Version",
-            "PhysicalResourceId": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+            "LogicalResourceId": "logical-resource-id",
+            "PhysicalResourceId": "physical-resource-id",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::Lambda::Version",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",

--- a/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
@@ -1606,5 +1606,60 @@
         "LayerVersionRef": "arn:<partition>:lambda:<region>:111111111111:layer:<layer-name:1>:1"
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_logging_config": {
+    "recorded-date": "03-04-2025, 17:34:50",
+    "recorded-content": {
+      "stack_resource_descriptions": {
+        "StackResources": [
+          {
+            "DriftInformation": {
+              "StackResourceDriftStatus": "NOT_CHECKED"
+            },
+            "LogicalResourceId": "LambdaFunction",
+            "PhysicalResourceId": "<function-name>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::Lambda::Function",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "DriftInformation": {
+              "StackResourceDriftStatus": "NOT_CHECKED"
+            },
+            "LogicalResourceId": "MyFnServiceRole",
+            "PhysicalResourceId": "<stack-name:1>-MyFnServiceRole-IVwvF4i3Fcqy",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::IAM::Role",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "DriftInformation": {
+              "StackResourceDriftStatus": "NOT_CHECKED"
+            },
+            "LogicalResourceId": "Version",
+            "PhysicalResourceId": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::Lambda::Version",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "logging_config": {
+        "ApplicationLogLevel": "INFO",
+        "LogFormat": "JSON",
+        "LogGroup": "/aws/lambda/<function-name>",
+        "SystemLogLevel": "INFO"
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -41,6 +41,9 @@
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_layer_crud": {
     "last_validated_date": "2024-12-20T18:23:31+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_logging_config": {
+    "last_validated_date": "2025-04-03T17:34:50+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_version": {
     "last_validated_date": "2024-04-09T07:21:37+00:00"
   },

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -42,7 +42,7 @@
     "last_validated_date": "2024-12-20T18:23:31+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_logging_config": {
-    "last_validated_date": "2025-04-03T17:34:50+00:00"
+    "last_validated_date": "2025-04-08T12:12:01+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_version": {
     "last_validated_date": "2024-04-09T07:21:37+00:00"

--- a/tests/aws/templates/cfn_lambda_logging_config.yaml
+++ b/tests/aws/templates/cfn_lambda_logging_config.yaml
@@ -1,0 +1,53 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  FunctionName:
+    Type: String
+
+Resources:
+  MyFnServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  LambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Ref FunctionName
+      Code:
+        ZipFile: |
+          exports.handler = function(event) {
+            return {
+              statusCode: 200,
+              body: "Hello, World!" 
+            };
+          };
+      Role:
+        Fn::GetAtt:
+          - MyFnServiceRole
+          - Arn
+      Handler: index.handler
+      Runtime: nodejs18.x
+      LoggingConfig:
+        LogFormat: JSON
+    DependsOn:
+      - MyFnServiceRole
+
+  Version:
+    Type: AWS::Lambda::Version
+    Properties:
+      FunctionName: !Ref LambdaFunction
+      Description: v1
+

--- a/tests/aws/templates/cfn_lambda_logging_config.yaml
+++ b/tests/aws/templates/cfn_lambda_logging_config.yaml
@@ -28,18 +28,17 @@ Resources:
       FunctionName: !Ref FunctionName
       Code:
         ZipFile: |
-          exports.handler = function(event) {
+          def handler(event, context):
             return {
               statusCode: 200,
               body: "Hello, World!" 
-            };
-          };
+            }
       Role:
         Fn::GetAtt:
           - MyFnServiceRole
           - Arn
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: python3.12
       LoggingConfig:
         LogFormat: JSON
     DependsOn:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Customer reported in https://github.com/localstack/localstack/issues/12424 that `LoggingConfig` is not set properly via Cloudformation.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added `LoggingConfig` param in `LambdaFunctionProvider` _kwargs_ used to  create and update lambda in: `lambda_/resource_providers/aws_lambda_function.schema.json`
- Updated schema specification (& manually tackled custom logic) via [scaffolding](https://www.notion.so/localstack/Writing-a-Resource-Provider-d83bbd2d17ec4bff90d193f232a4e945): `python -m localstack.services.cloudformation.scaffolding generate --resource-type "AWS::Lambda::Function" ...`
- Added aws validated test `test_lambda_logging_config`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
