### PR TITLE
KMS: add ability to decrypt data with all rotated keys

### DIFF
--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -705,7 +705,7 @@ class KmsKey:
             return request_key_usage or "ENCRYPT_DECRYPT"
 
     def rotate_key_on_demand(self):
-        if len(self.previous_keys) == ON_DEMAND_ROTATION_LIMIT:
+        if len(self.previous_keys) >= ON_DEMAND_ROTATION_LIMIT:
             raise LimitExceededException(
                 f"The on-demand rotations limit has been reached for the given keyId. "
                 f"No more on-demand rotations can be performed for this key: {self.metadata['Arn']}"

--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
-from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
+from cryptography.exceptions import InvalidSignature, InvalidTag, UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.primitives import serialization as crypto_serialization
@@ -29,6 +29,7 @@ from localstack.aws.api.kms import (
     CreateGrantRequest,
     CreateKeyRequest,
     EncryptionContextType,
+    InvalidCiphertextException,
     InvalidKeyUsageException,
     KeyMetadata,
     KeySpec,
@@ -36,6 +37,7 @@ from localstack.aws.api.kms import (
     KeyUsageType,
     KMSInvalidMacException,
     KMSInvalidSignatureException,
+    LimitExceededException,
     MacAlgorithmSpec,
     MessageType,
     MultiRegionConfiguration,
@@ -84,6 +86,7 @@ HMAC_RANGE_KEY_LENGTHS = {
     "HMAC_512": (64, 128),
 }
 
+ON_DEMAND_ROTATION_LIMIT = 10
 KEY_ID_LEN = 36
 # Moto uses IV_LEN of 12, as it is fine for GCM encryption mode, but we use CBC, so have to set it to 16.
 IV_LEN = 16
@@ -249,6 +252,7 @@ class KmsKey:
     is_key_rotation_enabled: bool
     rotation_period_in_days: int
     next_rotation_date: datetime.datetime
+    previous_keys = [str]
 
     def __init__(
         self,
@@ -257,6 +261,7 @@ class KmsKey:
         region: str = None,
     ):
         create_key_request = create_key_request or CreateKeyRequest()
+        self.previous_keys = []
 
         # Please keep in mind that tags of a key could be present in the request, they are not a part of metadata. At
         # least in the sense of DescribeKey not returning them with the rest of the metadata. Instead, tags are more
@@ -319,9 +324,15 @@ class KmsKey:
         self, ciphertext: Ciphertext, encryption_context: EncryptionContextType = None
     ) -> bytes:
         aad = _serialize_encryption_context(encryption_context=encryption_context)
-        return decrypt(
-            self.crypto_key.key_material, ciphertext.ciphertext, ciphertext.iv, ciphertext.tag, aad
-        )
+        keys_to_try = [self.crypto_key.key_material] + self.previous_keys
+
+        for key in keys_to_try:
+            try:
+                return decrypt(key, ciphertext.ciphertext, ciphertext.iv, ciphertext.tag, aad)
+            except (InvalidTag, InvalidSignature):
+                continue
+
+        raise InvalidCiphertextException()
 
     def decrypt_rsa(self, encrypted: bytes) -> bytes:
         private_key = crypto_serialization.load_der_private_key(
@@ -694,6 +705,12 @@ class KmsKey:
             return request_key_usage or "ENCRYPT_DECRYPT"
 
     def rotate_key_on_demand(self):
+        if len(self.previous_keys) == ON_DEMAND_ROTATION_LIMIT:
+            raise LimitExceededException(
+                f"The on-demand rotations limit has been reached for the given keyId. "
+                f"No more on-demand rotations can be performed for this key: {self.metadata['Arn']}"
+            )
+        self.previous_keys.append(self.crypto_key.key_material)
         self.crypto_key = KmsCryptoKey(KeySpec.SYMMETRIC_DEFAULT)
 
 

--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -1341,7 +1341,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         return ListResourceTagsResponse(Tags=page, **kwargs)
 
     @handler("RotateKeyOnDemand", expand=False)
-    # TODO: keep trak of key rotations as AWS does and return them in the ListKeyRotations operation
+    # TODO: return the key rotations in the ListKeyRotations operation
     def rotate_key_on_demand(
         self, context: RequestContext, request: RotateKeyOnDemandRequest
     ) -> RotateKeyOnDemandResponse:

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -2184,5 +2184,27 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_verify_salt_length[ECC_SECG_P256K1-ECDSA_SHA_256]": {
     "recorded-date": "02-04-2025, 06:07:08",
     "recorded-content": {}
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_key_rotations_encryption_decryption": {
+    "recorded-date": "03-04-2025, 09:34:48",
+    "recorded-content": {
+      "bad-ciphertext": "An error occurred (InvalidCiphertextException) when calling the Decrypt operation: "
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_key_rotations_limits": {
+    "recorded-date": "03-04-2025, 11:10:33",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "LimitExceededException",
+          "Message": "The on-demand rotations limit has been reached for the given keyId. No more on-demand rotations can be performed for this key: <key-arn>"
+        },
+        "message": "The on-demand rotations limit has been reached for the given keyId. No more on-demand rotations can be performed for this key: <key-arn>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -176,6 +176,12 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_key_rotation_status": {
     "last_validated_date": "2024-04-11T15:53:48+00:00"
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_key_rotations_encryption_decryption": {
+    "last_validated_date": "2025-04-03T09:34:47+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_key_rotations_limits": {
+    "last_validated_date": "2025-04-03T11:10:33+00:00"
+  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_key_with_long_tag_value_raises_error": {
     "last_validated_date": "2025-01-21T17:18:18+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Add ability to decrypt data that was encrypted before the rotation event by preserving the history of the key material on `RotateKeyOnDemand`. 

Closes: https://github.com/localstack/localstack/issues/10723
<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Store all the previous crypto keys with a maximum of 10 times per KMS key (checkout the [AWS Documentation](https://docs.aws.amazon.com/kms/latest/APIReference/API_RotateKeyOnDemand.html)) to ensure the decryption of the data that was encrypted before the rotation of the key.

Validate the implementation using AWS validated snapshot tests. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
