### PR TITLE
[ESM] Re-initialize shards when NextShardIterator value is empty

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/dynamodb_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/dynamodb_poller.py
@@ -61,6 +61,8 @@ class DynamoDBPoller(StreamPoller):
                 **kwargs,
             )
             shards[shard_id] = get_shard_iterator_response["ShardIterator"]
+
+        LOG.debug("Event source %s has %d shards.", self.source_arn, len(self.shards))
         return shards
 
     def stream_arn_param(self) -> dict:

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/kinesis_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/kinesis_poller.py
@@ -84,6 +84,8 @@ class KinesisPoller(StreamPoller):
                 **kwargs,
             )
             shards[shard_id] = get_shard_iterator_response["ShardIterator"]
+
+        LOG.debug("Event source %s has %d shards.", self.source_arn, len(self.shards))
         return shards
 
     def stream_arn_param(self) -> dict:

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -154,7 +154,6 @@ class StreamPoller(Poller):
             LOG.debug("No shards found for %s.", self.source_arn)
             raise EmptyPollResultsException(service=self.event_source(), source_arn=self.source_arn)
         else:
-            LOG.debug("Event source %s has %d shards.", self.source_arn, len(self.shards))
             # Remove all shard batchers without corresponding shards
             for shard_id in self.shard_batcher.keys() - self.shards.keys():
                 self.shard_batcher.pop(shard_id, None)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We do not currently cater for the case of a next shard iterator value not being present in a `GetRecords` response. According to the [AWS doc](https://docs.aws.amazon.com/streams/latest/dev/troubleshooting-consumers.html#getrecords-returns-empty):

> In a production scenario, the only time the continuous loop should be exited is when the NextShardIterator value is `NULL`. When NextShardIterator is `NULL`, it means that the current shard has been closed and the ShardIteratorvalue would otherwise point past the last record.

In addition, DynamoDB Local can occasionally not return a `NextShardIterator` in its response. This seems to occur when trying to read from a closed shard or when using an expired iterator. Hence, an exception is raised since the StreamPoller always expects this field in a `GetRecords` response -- raising the below `KeyError` exception:

```
2025-03-20T16:02:18.318 ERROR --- [functhread17] l.s.l.e.esm_worker         : Error while polling messages for event source arn:aws:dynamodb:us-east-1:000000000000:table/test_table/stream/2025-03-19T22:20:57.833: 'NextShardIterator'
Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/lambda_/event_source_mapping/esm_worker.py", line 155, in poller_loop
    self.poller.poll_events()
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py", line 155, in poll_events
    self.poll_events_from_shard(*current_shard_tuple)
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py", line 166, in poll_events_from_shard
    self.shards[shard_id] = get_records_response["NextShardIterator"]
```

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Re-initialize shards when a `NextShardIterator` is not returned or is `None` in a `GetRecords` response.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
