### PR TITLE
Step Functions: validate invalid state transitions on state machine creation, update and validation

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/accessible_states_static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/accessible_states_static_analyser.py
@@ -5,21 +5,31 @@ from localstack.services.stepfunctions.asl.antlr.runtime.ASLParser import ASLPar
 from localstack.services.stepfunctions.asl.static_analyser.static_analyser import StaticAnalyser
 
 
+@dataclass(frozen=True)
+class TargetState:
+    target_state: str
+    source_tree_path: str
+
+
 @dataclass
 class StateNamesScope:
     found_state_names: Set[str] = field(default_factory=set)
-    target_states: Set[tuple[str, str]] = field(default_factory=set)  # FIXME use type
+    target_states: Set[TargetState] = field(default_factory=set)
 
 
 class AccessibleStatesStaticAnalyser(StaticAnalyser):
     _state_names_scope: List[StateNamesScope]
     _error_messages: List[str]
+    _tree_path: List[str | int]
+
     _ERROR_MSG_PREFIX: str = "Invalid State Machine Definition: "
+    _TREE_PATH_SEP: str = "/"
 
     def __init__(self):
         super().__init__()
         self._state_names_scope = []
         self._error_messages = []
+        self._tree_path = []
 
     def analyse(self, definition: str) -> None:
         super().analyse(definition=definition)
@@ -33,37 +43,78 @@ class AccessibleStatesStaticAnalyser(StaticAnalyser):
         self._assert_all_states_targetted(scope)
 
     def _assert_all_targets_found(self, scope: StateNamesScope) -> None:
-        for target_state_name, target_type in scope.target_states:
-            if target_state_name not in scope.found_state_names:
+        for state in scope.target_states:
+            if state.target_state not in scope.found_state_names:
+                target_type = self._path_leaf(state.source_tree_path)
                 self._error_messages.append(
-                    f"MISSING_TRANSITION_TARGET: Missing {target_type} target: {target_state_name} at FIXME"
+                    f"MISSING_TRANSITION_TARGET: Missing '{target_type}' target: {state.target_state} at {state.source_tree_path}"
                 )
 
     def _assert_all_states_targetted(self, scope: StateNamesScope) -> None:
-        target_state_names = {state for (state, _) in scope.target_states}
+        target_state_names = {state.target_state for state in scope.target_states}
         for state_name in scope.found_state_names - target_state_names:
             self._error_messages.append(
-                f"MISSING_TRANSITION_TARGET: State {state_name} is not reachable. at FIXME"
+                f'MISSING_TRANSITION_TARGET: State "{state_name}" is not reachable. at FIXME'
             )
 
     def _current_scope(self) -> StateNamesScope:
         return self._state_names_scope[-1]
 
+    def _current_tree_path(self) -> str:
+        path = ""
+        for node in self._tree_path:
+            match node:
+                case str():
+                    path += self._TREE_PATH_SEP + node
+                case int():
+                    path += f"[{node}]"
+        return path
+
+    def _path_leaf(self, source_tree_path: str) -> str:
+        return source_tree_path.split(self._TREE_PATH_SEP)[-1]
+
+    def _path_move_to_sibling(self):
+        if len(self._tree_path) > 0 and type(self._tree_path[-1]) is int:
+            self._tree_path[-1] += 1
+
     def visitNext_decl(self, ctx: ASLParser.Next_declContext):
-        next_state_name: str = ctx.string_literal().getText()[1:-1]
-        self._current_scope().target_states.add((next_state_name, "Next"))
+        target_state_name: str = ctx.string_literal().getText()[1:-1]
+        self._tree_path.append("Next")
+        self._current_scope().target_states.add(
+            TargetState(target_state_name, self._current_tree_path())
+        )
+        self._tree_path.pop()
 
     def visitStartat_decl(self, ctx: ASLParser.Startat_declContext):
-        start_state_name: str = ctx.string_literal().getText()[1:-1]
-        self._current_scope().target_states.add((start_state_name, "StartAt"))
+        target_state_name: str = ctx.string_literal().getText()[1:-1]
+        self._tree_path.append("StartAt")
+        self._current_scope().target_states.add(
+            TargetState(target_state_name, self._current_tree_path())
+        )
+        self._tree_path.pop()
 
     def visitState_decl(self, ctx: ASLParser.State_declContext):
         state_name: str = ctx.string_literal().getText()[1:-1]
+        self._tree_path.append(state_name)
         self._current_scope().found_state_names.add(state_name)
         super().visitState_decl(ctx=ctx)
+        self._tree_path.pop()
 
     def visitProgram_decl(self, ctx: ASLParser.Program_declContext):
         self._state_names_scope.append(StateNamesScope())
         super().visitProgram_decl(ctx=ctx)
         scope = self._state_names_scope.pop()
+        self._path_move_to_sibling()
         self._assert_missing_transitions(scope)
+
+    def visitStates_decl(self, ctx: ASLParser.States_declContext):
+        self._tree_path.append("States")
+        super().visitStates_decl(ctx=ctx)
+        self._tree_path.pop()
+
+    def visitBranches_decl(self, ctx: ASLParser.Branches_declContext):
+        self._tree_path.append("Branches")
+        self._tree_path.append(0)
+        super().visitBranches_decl(ctx=ctx)
+        self._tree_path.pop()
+        self._tree_path.pop()

--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/accessible_states_static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/accessible_states_static_analyser.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass, field
+from typing import List, Set
+
+from localstack.services.stepfunctions.asl.antlr.runtime.ASLParser import ASLParser
+from localstack.services.stepfunctions.asl.static_analyser.static_analyser import StaticAnalyser
+
+
+@dataclass
+class StateNamesScope:
+    found_state_names: Set[str] = field(default_factory=set)
+    target_states: Set[tuple[str, str]] = field(default_factory=set)  # FIXME use type
+
+
+class AccessibleStatesStaticAnalyser(StaticAnalyser):
+    _state_names_scope: List[StateNamesScope]
+    _error_messages: List[str]
+    _ERROR_MSG_PREFIX: str = "Invalid State Machine Definition: "
+
+    def __init__(self):
+        super().__init__()
+        self._state_names_scope = []
+        self._error_messages = []
+
+    def analyse(self, definition: str) -> None:
+        super().analyse(definition=definition)
+
+        if len(self._error_messages) > 0:
+            error_msg = ", ".join(self._error_messages)
+            raise ValueError(self._ERROR_MSG_PREFIX + error_msg)
+
+    def _assert_missing_transitions(self, scope: StateNamesScope) -> None:
+        self._assert_all_targets_found(scope)
+        self._assert_all_states_targetted(scope)
+
+    def _assert_all_targets_found(self, scope: StateNamesScope) -> None:
+        for target_state_name, target_type in scope.target_states:
+            if target_state_name not in scope.found_state_names:
+                self._error_messages.append(
+                    f"MISSING_TRANSITION_TARGET: Missing {target_type} target: {target_state_name} at FIXME"
+                )
+
+    def _assert_all_states_targetted(self, scope: StateNamesScope) -> None:
+        target_state_names = {state for (state, _) in scope.target_states}
+        for state_name in scope.found_state_names - target_state_names:
+            self._error_messages.append(
+                f"MISSING_TRANSITION_TARGET: State {state_name} is not reachable. at FIXME"
+            )
+
+    def _current_scope(self) -> StateNamesScope:
+        return self._state_names_scope[-1]
+
+    def visitNext_decl(self, ctx: ASLParser.Next_declContext):
+        next_state_name: str = ctx.string_literal().getText()[1:-1]
+        self._current_scope().target_states.add((next_state_name, "Next"))
+
+    def visitStartat_decl(self, ctx: ASLParser.Startat_declContext):
+        start_state_name: str = ctx.string_literal().getText()[1:-1]
+        self._current_scope().target_states.add((start_state_name, "StartAt"))
+
+    def visitState_decl(self, ctx: ASLParser.State_declContext):
+        state_name: str = ctx.string_literal().getText()[1:-1]
+        self._current_scope().found_state_names.add(state_name)
+        super().visitState_decl(ctx=ctx)
+
+    def visitProgram_decl(self, ctx: ASLParser.Program_declContext):
+        self._state_names_scope.append(StateNamesScope())
+        super().visitProgram_decl(ctx=ctx)
+        scope = self._state_names_scope.pop()
+        self._assert_missing_transitions(scope)

--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/static_analyser.py
@@ -1,72 +1,10 @@
 import abc
-from dataclasses import dataclass, field
-from typing import List, Set
 
-from localstack.services.stepfunctions.asl.antlr.runtime.ASLParser import ASLParser
 from localstack.services.stepfunctions.asl.antlr.runtime.ASLParserVisitor import ASLParserVisitor
 from localstack.services.stepfunctions.asl.parse.asl_parser import AmazonStateLanguageParser
 
 
-@dataclass
-class StateNamesScope:
-    found_state_names: Set[str] = field(default_factory=set)
-    target_states: Set[tuple[str, str]] = field(default_factory=set)  # FIXME use type
-
-
 class StaticAnalyser(ASLParserVisitor, abc.ABC):
-    _state_names_scope: List[StateNamesScope]
-    _error_messages: List[str]
-    _ERROR_MSG_PREFIX: str = "Invalid State Machine Definition: "
-
-    def __init__(self):
-        super().__init__()
-        self._state_names_scope = []
-        self._error_messages = []
-
     def analyse(self, definition: str) -> None:
         _, parser_rule_context = AmazonStateLanguageParser.parse(definition)
         self.visit(parser_rule_context)
-
-        if len(self._error_messages) > 0:
-            error_msg = ", ".join(self._error_messages)
-            raise ValueError(self._ERROR_MSG_PREFIX + error_msg)
-
-    def _assert_missing_transitions(self, scope: StateNamesScope) -> None:
-        self._assert_all_targets_found(scope)
-        self._assert_all_states_targetted(scope)
-
-    def _assert_all_targets_found(self, scope: StateNamesScope) -> None:
-        for target_state_name, target_type in scope.target_states:
-            if target_state_name not in scope.found_state_names:
-                self._error_messages.append(
-                    f"MISSING_TRANSITION_TARGET: Missing {target_type} target: {target_state_name} at FIXME"
-                )
-
-    def _assert_all_states_targetted(self, scope: StateNamesScope) -> None:
-        target_state_names = {state for (state, _) in scope.target_states}
-        for state_name in scope.found_state_names - target_state_names:
-            self._error_messages.append(
-                f"MISSING_TRANSITION_TARGET: State {state_name} is not reachable. at FIXME"
-            )
-
-    def _current_scope(self) -> StateNamesScope:
-        return self._state_names_scope[-1]
-
-    def visitNext_decl(self, ctx: ASLParser.Next_declContext):
-        next_state_name: str = ctx.string_literal().getText()[1:-1]
-        self._current_scope().target_states.add((next_state_name, "Next"))
-
-    def visitStartat_decl(self, ctx: ASLParser.Startat_declContext):
-        start_state_name: str = ctx.string_literal().getText()[1:-1]
-        self._current_scope().target_states.add((start_state_name, "StartAt"))
-
-    def visitState_decl(self, ctx: ASLParser.State_declContext):
-        state_name: str = ctx.string_literal().getText()[1:-1]
-        self._current_scope().found_state_names.add(state_name)
-        super().visitState_decl(ctx=ctx)
-
-    def visitProgram_decl(self, ctx: ASLParser.Program_declContext):
-        self._state_names_scope.append(StateNamesScope())
-        super().visitProgram_decl(ctx=ctx)
-        scope = self._state_names_scope.pop()
-        self._assert_missing_transitions(scope)

--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/static_analyser.py
@@ -1,15 +1,17 @@
 import abc
-from typing import List, Set
 from dataclasses import dataclass, field
+from typing import List, Set
 
+from localstack.services.stepfunctions.asl.antlr.runtime.ASLParser import ASLParser
 from localstack.services.stepfunctions.asl.antlr.runtime.ASLParserVisitor import ASLParserVisitor
 from localstack.services.stepfunctions.asl.parse.asl_parser import AmazonStateLanguageParser
-from localstack.services.stepfunctions.asl.antlr.runtime.ASLParser import ASLParser
+
 
 @dataclass
 class StateNamesScope:
     found_state_names: Set[str] = field(default_factory=set)
-    target_states: Set[tuple[str, str]] = field(default_factory=set) # FIXME use type
+    target_states: Set[tuple[str, str]] = field(default_factory=set)  # FIXME use type
+
 
 class StaticAnalyser(ASLParserVisitor, abc.ABC):
     _state_names_scope: List[StateNamesScope]
@@ -19,7 +21,7 @@ class StaticAnalyser(ASLParserVisitor, abc.ABC):
     def __init__(self):
         super().__init__()
         self._state_names_scope = []
-        self._error_messages = [] 
+        self._error_messages = []
 
     def analyse(self, definition: str) -> None:
         _, parser_rule_context = AmazonStateLanguageParser.parse(definition)
@@ -36,32 +38,35 @@ class StaticAnalyser(ASLParserVisitor, abc.ABC):
     def _assert_all_targets_found(self, scope: StateNamesScope) -> None:
         for target_state_name, target_type in scope.target_states:
             if target_state_name not in scope.found_state_names:
-                self._error_messages.append(f"MISSING_TRANSITION_TARGET: Missing {target_type} target: {target_state_name} at FIXME")
+                self._error_messages.append(
+                    f"MISSING_TRANSITION_TARGET: Missing {target_type} target: {target_state_name} at FIXME"
+                )
 
     def _assert_all_states_targetted(self, scope: StateNamesScope) -> None:
-        target_state_names = { state for (state, _) in scope.target_states }
-        for state_name in ( scope.found_state_names - target_state_names ):
-            self._error_messages.append(f"MISSING_TRANSITION_TARGET: State {state_name} is not reachable. at FIXME")
+        target_state_names = {state for (state, _) in scope.target_states}
+        for state_name in scope.found_state_names - target_state_names:
+            self._error_messages.append(
+                f"MISSING_TRANSITION_TARGET: State {state_name} is not reachable. at FIXME"
+            )
 
     def _current_scope(self) -> StateNamesScope:
         return self._state_names_scope[-1]
 
-    def visitNext_decl(self, ctx:ASLParser.Next_declContext):
+    def visitNext_decl(self, ctx: ASLParser.Next_declContext):
         next_state_name: str = ctx.string_literal().getText()[1:-1]
         self._current_scope().target_states.add((next_state_name, "Next"))
 
-    def visitStartat_decl(self, ctx:ASLParser.Startat_declContext):
+    def visitStartat_decl(self, ctx: ASLParser.Startat_declContext):
         start_state_name: str = ctx.string_literal().getText()[1:-1]
         self._current_scope().target_states.add((start_state_name, "StartAt"))
 
-    def visitState_decl(self, ctx:ASLParser.State_declContext):
+    def visitState_decl(self, ctx: ASLParser.State_declContext):
         state_name: str = ctx.string_literal().getText()[1:-1]
         self._current_scope().found_state_names.add(state_name)
         super().visitState_decl(ctx=ctx)
 
-    def visitProgram_decl(self, ctx:ASLParser.Program_declContext):
+    def visitProgram_decl(self, ctx: ASLParser.Program_declContext):
         self._state_names_scope.append(StateNamesScope())
         super().visitProgram_decl(ctx=ctx)
         scope = self._state_names_scope.pop()
         self._assert_missing_transitions(scope)
-

--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/static_analyser.py
@@ -1,10 +1,73 @@
 import abc
+from typing import List, Set
 
 from localstack.services.stepfunctions.asl.antlr.runtime.ASLParserVisitor import ASLParserVisitor
 from localstack.services.stepfunctions.asl.parse.asl_parser import AmazonStateLanguageParser
-
+from localstack.services.stepfunctions.asl.antlr.runtime.ASLParser import ASLParser
 
 class StaticAnalyser(ASLParserVisitor, abc.ABC):
+    _found_state_names: Set[str]
+    _target_states: Set[tuple[str, str]] # FIXME use type
+    _duplicate_state_names: Set[str]
+    _error_messages: List[str]
+    _ERROR_MSG_PREFIX: str = "Invalid State Machine Definition: "
+
+    def __init__(self):
+        super().__init__()
+        self._found_state_names = set()
+        self._target_states = set()
+        self._duplicate_state_names = set()
+        self._error_messages = [] 
+
     def analyse(self, definition: str) -> None:
         _, parser_rule_context = AmazonStateLanguageParser.parse(definition)
         self.visit(parser_rule_context)
+        self._assert()
+
+    def _assert(self) -> None:
+        self._assert_all_targets_found()
+        self._assert_all_states_targetted()
+        self._assert_no_duplicate_states()
+
+        if len(self._error_messages) > 0:
+            error_msg = ", ".join(self._error_messages)
+            raise ValueError(self._ERROR_MSG_PREFIX + error_msg)
+
+    def _assert_all_targets_found(self) -> None:
+        for target_state_name, target_type in self._target_states:
+            if target_state_name not in self._found_state_names:
+                self._error_messages.append(f"MISSING_TRANSITION_TARGET: Missing {target_type} target: {target_state_name} at FIXME")
+
+    def _assert_all_states_targetted(self) -> None:
+        target_state_names = { state for (state, _) in self._target_states }
+        for state_name in ( self._found_state_names - target_state_names ):
+            self._error_messages.append(f"MISSING_TRANSITION_TARGET: State {state_name} is not reachable. at FIXME")
+
+    def _assert_no_duplicate_states(self) -> None:
+        for state_name in self._duplicate_state_names:
+            self._error_messages.append(f"DUPLICATE_STATE_NAME:  Duplicate State name {state_name}  at FIXME")
+
+    def visitNext_decl(self, ctx:ASLParser.Next_declContext):
+        """
+        extract the next string from ctx and store in member var
+        """
+        next_state_name: str = ctx.string_literal().getText()[1:-1]
+        self._target_states.add((next_state_name, "Next"))
+
+    def visitStartat_decl(self, ctx:ASLParser.Startat_declContext):
+        """"
+        extract the start at string from ctx and check in the member var store if it exists in this scope
+        """
+        start_state_name: str = ctx.string_literal().getText()[1:-1]
+        self._target_states.add((start_state_name, "StartAt"))
+
+    def visitState_decl(self, ctx:ASLParser.State_declContext):
+        """
+        sample the state name string and store it in a member var for the current scope
+        """
+        state_name: str = ctx.string_literal().getText()[1:-1]
+        if state_name in self._found_state_names:
+            self._duplicate_state_names.add(state_name)
+        self._found_state_names.add(state_name)
+        super().visitState_decl(ctx=ctx)
+

--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/static_analyser.py
@@ -25,15 +25,13 @@ class StaticAnalyser(ASLParserVisitor, abc.ABC):
         _, parser_rule_context = AmazonStateLanguageParser.parse(definition)
         self.visit(parser_rule_context)
 
-        self._assert_missing_transitions()
         if len(self._error_messages) > 0:
             error_msg = ", ".join(self._error_messages)
             raise ValueError(self._ERROR_MSG_PREFIX + error_msg)
 
-    def _assert_missing_transitions(self) -> None:
-        for scope in self._state_names_scope:
-            self._assert_all_targets_found(scope)
-            self._assert_all_states_targetted(scope)
+    def _assert_missing_transitions(self, scope: StateNamesScope) -> None:
+        self._assert_all_targets_found(scope)
+        self._assert_all_states_targetted(scope)
 
     def _assert_all_targets_found(self, scope: StateNamesScope) -> None:
         for target_state_name, target_type in scope.target_states:
@@ -64,4 +62,6 @@ class StaticAnalyser(ASLParserVisitor, abc.ABC):
     def visitProgram_decl(self, ctx:ASLParser.Program_declContext):
         self._state_names_scope.append(StateNamesScope())
         super().visitProgram_decl(ctx=ctx)
+        scope = self._state_names_scope.pop()
+        self._assert_missing_transitions(scope)
 

--- a/localstack-core/localstack/services/stepfunctions/asl/static_analyser/static_analyser.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/static_analyser/static_analyser.py
@@ -1,73 +1,67 @@
 import abc
 from typing import List, Set
+from dataclasses import dataclass, field
 
 from localstack.services.stepfunctions.asl.antlr.runtime.ASLParserVisitor import ASLParserVisitor
 from localstack.services.stepfunctions.asl.parse.asl_parser import AmazonStateLanguageParser
 from localstack.services.stepfunctions.asl.antlr.runtime.ASLParser import ASLParser
 
+@dataclass
+class StateNamesScope:
+    found_state_names: Set[str] = field(default_factory=set)
+    target_states: Set[tuple[str, str]] = field(default_factory=set) # FIXME use type
+
 class StaticAnalyser(ASLParserVisitor, abc.ABC):
-    _found_state_names: Set[str]
-    _target_states: Set[tuple[str, str]] # FIXME use type
-    _duplicate_state_names: Set[str]
+    _state_names_scope: List[StateNamesScope]
     _error_messages: List[str]
     _ERROR_MSG_PREFIX: str = "Invalid State Machine Definition: "
 
     def __init__(self):
         super().__init__()
-        self._found_state_names = set()
-        self._target_states = set()
-        self._duplicate_state_names = set()
+        self._state_names_scope = []
         self._error_messages = [] 
 
     def analyse(self, definition: str) -> None:
         _, parser_rule_context = AmazonStateLanguageParser.parse(definition)
         self.visit(parser_rule_context)
-        self._assert()
 
-    def _assert(self) -> None:
-        self._assert_all_targets_found()
-        self._assert_all_states_targetted()
-        self._assert_no_duplicate_states()
-
+        self._assert_missing_transitions()
         if len(self._error_messages) > 0:
             error_msg = ", ".join(self._error_messages)
             raise ValueError(self._ERROR_MSG_PREFIX + error_msg)
 
-    def _assert_all_targets_found(self) -> None:
-        for target_state_name, target_type in self._target_states:
-            if target_state_name not in self._found_state_names:
+    def _assert_missing_transitions(self) -> None:
+        for scope in self._state_names_scope:
+            self._assert_all_targets_found(scope)
+            self._assert_all_states_targetted(scope)
+
+    def _assert_all_targets_found(self, scope: StateNamesScope) -> None:
+        for target_state_name, target_type in scope.target_states:
+            if target_state_name not in scope.found_state_names:
                 self._error_messages.append(f"MISSING_TRANSITION_TARGET: Missing {target_type} target: {target_state_name} at FIXME")
 
-    def _assert_all_states_targetted(self) -> None:
-        target_state_names = { state for (state, _) in self._target_states }
-        for state_name in ( self._found_state_names - target_state_names ):
+    def _assert_all_states_targetted(self, scope: StateNamesScope) -> None:
+        target_state_names = { state for (state, _) in scope.target_states }
+        for state_name in ( scope.found_state_names - target_state_names ):
             self._error_messages.append(f"MISSING_TRANSITION_TARGET: State {state_name} is not reachable. at FIXME")
 
-    def _assert_no_duplicate_states(self) -> None:
-        for state_name in self._duplicate_state_names:
-            self._error_messages.append(f"DUPLICATE_STATE_NAME:  Duplicate State name {state_name}  at FIXME")
+    def _current_scope(self) -> StateNamesScope:
+        return self._state_names_scope[-1]
 
     def visitNext_decl(self, ctx:ASLParser.Next_declContext):
-        """
-        extract the next string from ctx and store in member var
-        """
         next_state_name: str = ctx.string_literal().getText()[1:-1]
-        self._target_states.add((next_state_name, "Next"))
+        self._current_scope().target_states.add((next_state_name, "Next"))
 
     def visitStartat_decl(self, ctx:ASLParser.Startat_declContext):
-        """"
-        extract the start at string from ctx and check in the member var store if it exists in this scope
-        """
         start_state_name: str = ctx.string_literal().getText()[1:-1]
-        self._target_states.add((start_state_name, "StartAt"))
+        self._current_scope().target_states.add((start_state_name, "StartAt"))
 
     def visitState_decl(self, ctx:ASLParser.State_declContext):
-        """
-        sample the state name string and store it in a member var for the current scope
-        """
         state_name: str = ctx.string_literal().getText()[1:-1]
-        if state_name in self._found_state_names:
-            self._duplicate_state_names.add(state_name)
-        self._found_state_names.add(state_name)
+        self._current_scope().found_state_names.add(state_name)
         super().visitState_decl(ctx=ctx)
+
+    def visitProgram_decl(self, ctx:ASLParser.Program_declContext):
+        self._state_names_scope.append(StateNamesScope())
+        super().visitProgram_decl(ctx=ctx)
 

--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -125,6 +125,9 @@ from localstack.services.stepfunctions.asl.eval.event.logging import (
 from localstack.services.stepfunctions.asl.parse.asl_parser import (
     ASLParserException,
 )
+from localstack.services.stepfunctions.asl.static_analyser.accessible_states_static_analyser import (
+    AccessibleStatesStaticAnalyser,
+)
 from localstack.services.stepfunctions.asl.static_analyser.express_static_analyser import (
     ExpressStaticAnalyser,
 )
@@ -491,7 +494,8 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
             )
         else:
             StepFunctionsProvider._validate_definition(
-                definition=state_machine_definition, static_analysers=[StaticAnalyser()]
+                definition=state_machine_definition,
+                static_analysers=[AccessibleStatesStaticAnalyser()],
             )
 
         # Create the state machine and add it to the store.
@@ -1246,7 +1250,9 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
             )
 
         if definition is not None:
-            self._validate_definition(definition=definition, static_analysers=[StaticAnalyser()])
+            self._validate_definition(
+                definition=definition, static_analysers=[AccessibleStatesStaticAnalyser()]
+            )
 
         if logging_configuration is not None:
             self._sanitise_logging_configuration(logging_configuration=logging_configuration)
@@ -1586,7 +1592,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
 
         static_analysers = list()
         if state_machine_type == StateMachineType.STANDARD:
-            static_analysers.append(StaticAnalyser())
+            static_analysers.append(AccessibleStatesStaticAnalyser())
         else:
             static_analysers.append(ExpressStaticAnalyser())
 

--- a/tests/unit/services/stepfunctions/test_accessible_states_static_analyser.py
+++ b/tests/unit/services/stepfunctions/test_accessible_states_static_analyser.py
@@ -1,0 +1,135 @@
+import json
+
+import pytest
+
+from localstack.services.stepfunctions.asl.static_analyser.accessible_states_static_analyser import (
+    AccessibleStatesStaticAnalyser,
+)
+
+NO_MISSING_TARGET_SINGLE_SCOPE = json.dumps(
+    {
+        "StartAt": "pass1",
+        "States": {
+            "pass1": {"Type": "Pass", "Next": "pass2"},
+            "pass2": {"Type": "Pass", "End": True},
+        },
+    }
+)
+
+NO_MISSING_TARGET_PARALLEL_SCOPE = json.dumps(
+    {
+        "StartAt": "pass1",
+        "States": {
+            "pass1": {"Type": "Pass", "Next": "pass2"},
+            "pass2": {"Type": "Pass", "Next": "parallel"},
+            "parallel": {
+                "Type": "Parallel",
+                "Branches": [
+                    {"StartAt": "pass1p", "States": {"pass1p": {"Type": "Pass", "End": True}}},
+                    {"StartAt": "pass2p", "States": {"pass2p": {"Type": "Pass", "End": True}}},
+                ],
+                "Next": "pass3",
+            },
+            "pass3": {"Type": "Pass", "End": True},
+        },
+    }
+)
+
+MISSING_TARGET_SINGLE_SCOPE = json.dumps(
+    {
+        "StartAt": "pass1",
+        "States": {
+            "pass1": {"Type": "Pass", "Next": "pass3"},
+            "pass2": {"Type": "Pass", "End": True},
+        },
+    }
+)
+
+MISSING_TARGET_ROOT_SCOPE_UNREACHABLE_FROM_PARALLEL = json.dumps(
+    {
+        "StartAt": "pass1",
+        "States": {
+            "pass1": {"Type": "Pass", "Next": "pass2"},
+            "pass2": {"Type": "Pass", "Next": "parallel"},
+            "parallel": {
+                "Type": "Parallel",
+                "Branches": [
+                    {"StartAt": "pass1p", "States": {"pass1p": {"Type": "Pass", "Next": "pass2"}}},
+                    {"StartAt": "pass2p", "States": {"pass2p": {"Type": "Pass", "End": True}}},
+                ],
+                "End": True,
+            },
+        },
+    }
+)
+
+MISSING_TARGET_OTHER_BRANCH_SCOPE_UNREACHABLE_FROM_PARALLEL = json.dumps(
+    {
+        "StartAt": "pass1",
+        "States": {
+            "pass1": {"Type": "Pass", "Next": "pass2"},
+            "pass2": {"Type": "Pass", "Next": "parallel"},
+            "parallel": {
+                "Type": "Parallel",
+                "Branches": [
+                    {"StartAt": "pass1p", "States": {"pass1p": {"Type": "Pass", "Next": "pass2p"}}},
+                    {"StartAt": "pass2p", "States": {"pass2p": {"Type": "Pass", "End": True}}},
+                ],
+                "End": True,
+            },
+        },
+    }
+)
+
+
+class TestAccessibleStatesStaticAnalyser:
+    @pytest.mark.parametrize(
+        "definition",
+        [
+            NO_MISSING_TARGET_SINGLE_SCOPE,
+            NO_MISSING_TARGET_PARALLEL_SCOPE,
+        ],
+        ids=[
+            "NO_MISSING_TARGET_SINGLE_SCOPE",
+            "NO_MISSING_TARGET_PARALLEL_SCOPE",
+        ],
+    )
+    def test_no_missing_target(self, definition):
+        AccessibleStatesStaticAnalyser().analyse(definition=definition)
+
+    @pytest.mark.parametrize(
+        "definition,expected_messages",
+        [
+            (
+                MISSING_TARGET_SINGLE_SCOPE,
+                [
+                    "MISSING_TRANSITION_TARGET: Missing Next target: pass3 at FIXME",
+                    "MISSING_TRANSITION_TARGET: State pass2 is not reachable. at FIXME",
+                ],
+            ),
+            (
+                MISSING_TARGET_ROOT_SCOPE_UNREACHABLE_FROM_PARALLEL,
+                ["MISSING_TRANSITION_TARGET: Missing Next target: pass2 at FIXME"],
+            ),
+            (
+                MISSING_TARGET_OTHER_BRANCH_SCOPE_UNREACHABLE_FROM_PARALLEL,
+                ["MISSING_TRANSITION_TARGET: Missing Next target: pass2p at FIXME"],
+            ),
+        ],
+        ids=[
+            "MISSING_TARGET_SINGLE_SCOPE",
+            "MISSING_TARGET_ROOT_SCOPE_UNREACHABLE_FROM_PARALLEL",
+            "MISSING_TARGET_OTHER_BRANCH_SCOPE_UNREACHABLE_FROM_PARALLEL",
+        ],
+    )
+    def test_missing_target(self, definition, expected_messages):
+        with pytest.raises(ValueError) as analysis_err:
+            AccessibleStatesStaticAnalyser().analyse(definition=definition)
+        error_msg = str(analysis_err.value)
+        TestAccessibleStatesStaticAnalyser._assert_error_msg_prefix(error_msg)
+        for expected_message in expected_messages:
+            assert expected_message in error_msg
+
+    @staticmethod
+    def _assert_error_msg_prefix(msg):
+        assert msg.startswith("Invalid State Machine Definition: ")

--- a/tests/unit/services/stepfunctions/test_accessible_states_static_analyser.py
+++ b/tests/unit/services/stepfunctions/test_accessible_states_static_analyser.py
@@ -16,6 +16,17 @@ NO_MISSING_TARGET_SINGLE_SCOPE = json.dumps(
     }
 )
 
+NO_MISSING_TARGET_SINGLE_SCOPE_OUT_OF_ORDER_STATES_AND_START = json.dumps(
+    {
+        "States": {
+            "pass1": {"Type": "Pass", "Next": "pass2"},
+            "pass3": {"Type": "Pass", "End": True},
+            "pass2": {"Type": "Pass", "Next": "pass3"},
+        },
+        "StartAt": "pass1",
+    }
+)
+
 NO_MISSING_TARGET_PARALLEL_SCOPE = json.dumps(
     {
         "StartAt": "pass1",
@@ -25,7 +36,10 @@ NO_MISSING_TARGET_PARALLEL_SCOPE = json.dumps(
             "parallel": {
                 "Type": "Parallel",
                 "Branches": [
-                    {"StartAt": "pass1p", "States": {"pass1p": {"Type": "Pass", "End": True}}},
+                    {
+                        "States": {"pass1p": {"Type": "Pass", "End": True}},
+                        "StartAt": "pass1p",
+                    },
                     {"StartAt": "pass2p", "States": {"pass2p": {"Type": "Pass", "End": True}}},
                 ],
                 "Next": "pass3",
@@ -83,7 +97,13 @@ MISSING_TARGET_OTHER_BRANCH_SCOPE_UNREACHABLE_FROM_PARALLEL = json.dumps(
             "parallel": {
                 "Type": "Parallel",
                 "Branches": [
-                    {"StartAt": "pass1p", "States": {"pass1p": {"Type": "Pass", "Next": "pass2p"}}},
+                    {
+                        "StartAt": "pass1p",
+                        "States": {
+                            "pass1pp": {"Type": "Pass", "Next": "pass2p"},
+                            "pass1p": {"Type": "Pass", "Next": "pass1pp"},
+                        },
+                    },
                     {"StartAt": "pass2p", "States": {"pass2p": {"Type": "Pass", "End": True}}},
                 ],
                 "End": True,
@@ -98,10 +118,12 @@ class TestAccessibleStatesStaticAnalyser:
         "definition",
         [
             NO_MISSING_TARGET_SINGLE_SCOPE,
+            NO_MISSING_TARGET_SINGLE_SCOPE_OUT_OF_ORDER_STATES_AND_START,
             NO_MISSING_TARGET_PARALLEL_SCOPE,
         ],
         ids=[
             "NO_MISSING_TARGET_SINGLE_SCOPE",
+            "NO_MISSING_TARGET_SINGLE_SCOPE_OUT_OF_ORDER_STATES_AND_START",
             "NO_MISSING_TARGET_PARALLEL_SCOPE",
         ],
     )
@@ -134,7 +156,7 @@ class TestAccessibleStatesStaticAnalyser:
             (
                 MISSING_TARGET_OTHER_BRANCH_SCOPE_UNREACHABLE_FROM_PARALLEL,
                 [
-                    "MISSING_TRANSITION_TARGET: Missing 'Next' target: pass2p at /States/parallel/Branches[0]/States/pass1p/Next"
+                    "MISSING_TRANSITION_TARGET: Missing 'Next' target: pass2p at /States/parallel/Branches[0]/States/pass1pp/Next"
                 ],
             ),
         ],

--- a/tests/unit/services/stepfunctions/test_accessible_states_static_analyser.py
+++ b/tests/unit/services/stepfunctions/test_accessible_states_static_analyser.py
@@ -115,14 +115,14 @@ class TestAccessibleStatesStaticAnalyser:
                 MISSING_NEXT_TARGET_SINGLE_SCOPE,
                 [
                     "MISSING_TRANSITION_TARGET: Missing 'Next' target: pass3 at /States/pass1/Next",
-                    'MISSING_TRANSITION_TARGET: State "pass2" is not reachable. at FIXME',
+                    'MISSING_TRANSITION_TARGET: State "pass2" is not reachable. at /States/pass2',
                 ],
             ),
             (
                 MISSING_START_AT_TARGET_SINGLE_SCOPE,
                 [
                     "MISSING_TRANSITION_TARGET: Missing 'StartAt' target: pass3 at /StartAt",
-                    'MISSING_TRANSITION_TARGET: State "pass1" is not reachable. at FIXME',
+                    'MISSING_TRANSITION_TARGET: State "pass1" is not reachable. at /States/pass1',
                 ],
             ),
             (


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

To fix #11978 

Reproduction of #11978 showed the following error:

```bash
AWS='aws --profile ls-sandbox'

$ $AWS stepfunctions create-state-machine --name 11978_illegal --definition file://11978_illegal_state_machine.json ${ROLE_ARG}
An error occurred (InvalidDefinition) when calling the CreateStateMachine operation: Invalid State Machine Definition: 'MISSING_TRANSITION_TARGET: Missing 'Next' target: pass3 at /States/pass1/Next, MISSING_TRANSITION_TARGET: State "pass2" is not reachable. at /States/pass2'
```

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes


This PR modifies the class `StaticAnalyser` used on localstack-core/localstack/services/stepfunctions/provider.py by the functions `create_state_machine`, `update_state_machine` and `validate_state_machine_definition` to validate:

-  all target states exists
- all states are targeted


<!-- Optional section: How to test these changes? -->
## Testing

Added a unit test for the new analyser `AccessibleStatesStaticAnalyser`:

```bash
TEST_PATH="tests/unit/services/stepfunctions/test_accessible_states_static_analyser.py"  make test | tee test.log
```


<!-- Optional section: What's left to do before it can be merged? -->

## TODO

This is a draft PR for discussing the approach

Pending:

- [x] Consider the scope of the target state as discussed on Slack
- [x] Remove duplicate state validation and leaving that for another PR 
- [x] Improve error message formatting with node paths
- [x] Linting and code polishing
- [ ] Unit tests: WIP pending more tests for other nested scopes like `Map`
- [ ] Parity tests

