### PR TITLE
Admin: Update License

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
     { name = "LocalStack Contributors", email = "info@localstack.cloud" }
 ]
 description = "The core library and runtime of LocalStack"
+license = "Apache-2.0"
 requires-python = ">=3.9"
 dependencies = [
     "build",
@@ -31,7 +32,6 @@ dynamic = ["version"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
-    "License-Expression :: OSI Approved :: Apache Software License",
     "Topic :: Internet",
     "Topic :: Software Development :: Testing",
     "Topic :: System :: Emulators",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Followup to #12455 

I originally made this same change in Moto, but PyPi actually rejects this `License-Expression` with the following error:
> ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         'License-Expression :: OSI Approved :: Apache Software License' is not 
         a valid classifier. See https://packaging.python.org/specifications/core-metadata for more information.

The reason: even though PEP 639 talks about the _License-Expression_ field, that is actually a Core Metadata field. And a [Core Metadata field](https://packaging.python.org/en/latest/glossary/#term-Core-Metadata-Field) is described as:
> A single key-value pair (or sequence of such with the same name, for multiple-use fields) defined in the [Core Metadata](https://packaging.python.org/en/latest/glossary/#term-Core-Metadata) spec and stored in the [Built Metadata](https://packaging.python.org/en/latest/glossary/#term-Built-Metadata). Notably, distinct from a [Pyproject Metadata Key](https://packaging.python.org/en/latest/glossary/#term-Pyproject-Metadata-Key).

So the Core Metadata is part of the build output - it is not part of the original project metadata.

The [Licensing Examples](https://packaging.python.org/pt-br/latest/guides/licensing-examples-and-user-scenarios/#licensing-examples) make it more clear that licenses should be part of the `project.license` field, instead of setting it as a clarifier.

The Moto release passes [with this change](https://github.com/getmoto/moto/commit/897dfde9bbcdbcbf55ad295575b5a18ef2303ed5).

## Note
The old version (`Apache Software License`) is ambiguous, so I assumed that it should be interpreted as `Apache 2.0`. Snyk has a handy guide to explain Apache 2.0 and the difference with the original 1.0 version:
https://snyk.io/articles/apache-license/