### PR TITLE
Bump moto-ext to 5.1.3.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.1.1.post2",
+    "moto-ext[all]==5.1.3.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -250,7 +250,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.1.1.post2
+moto-ext==5.1.3.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.1.1.post2
+moto-ext==5.1.3.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -234,7 +234,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.1.1.post2
+moto-ext==5.1.3.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -254,7 +254,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.1.1.post2
+moto-ext==5.1.3.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/tests/aws/services/cloudformation/resources/test_ec2.py
+++ b/tests/aws/services/cloudformation/resources/test_ec2.py
@@ -155,6 +155,8 @@ def test_dhcp_options(aws_client, deploy_cfn_template, snapshot):
         "$..Tags",
         "$..Options.AssociationDefaultRouteTableId",
         "$..Options.PropagationDefaultRouteTableId",
+        "$..Options.TransitGatewayCidrBlocks",  # an empty list returned by Moto but not by AWS
+        "$..Options.SecurityGroupReferencingSupport",  # not supported by Moto
     ]
 )
 def test_transit_gateway_attachment(deploy_cfn_template, aws_client, snapshot):

--- a/tests/aws/services/cloudformation/resources/test_ec2.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.snapshot.json
@@ -91,7 +91,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_transit_gateway_attachment": {
-    "recorded-date": "28-03-2024, 06:48:11",
+    "recorded-date": "08-04-2025, 10:51:02",
     "recorded-content": {
       "attachment": {
         "Association": {
@@ -125,6 +125,7 @@
           "DnsSupport": "enable",
           "MulticastSupport": "disable",
           "PropagationDefaultRouteTableId": "<transit-gateway-route-table-id:1>",
+          "SecurityGroupReferencingSupport": "disable",
           "VpnEcmpSupport": "enable"
         },
         "OwnerId": "111111111111",

--- a/tests/aws/services/cloudformation/resources/test_ec2.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.validation.json
@@ -24,7 +24,7 @@
     "last_validated_date": "2024-07-01T20:10:52+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_transit_gateway_attachment": {
-    "last_validated_date": "2024-03-28T06:48:11+00:00"
+    "last_validated_date": "2025-04-08T10:51:02+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_vpc_creates_default_sg": {
     "last_validated_date": "2024-04-01T11:21:54+00:00"


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.1.3.post1.

> [!NOTE]
> The last few moto-ext bumps were heavily cherry picked to omit certain incompatible changes. The affected components have been fixed, so this release brings everything up-to-date with Moto upstream.

## To do

- [x] Ext compatibility (Ext integration tests) Ext Integration Tests # 4218 (relevant fixes in the companion branch. failures don't seem to be related and are observed in other pipelines)
```
FAILED tests/aws/services/cloudformation/resources/test_customresources.py::test_customresource_lambda_backed - AssertionError: assert 'custom-data' == 'unknown'
FAILED tests/aws/services/cloudformation/resources/test_customresources.py::test_customresource_sns_backed - AssertionError: assert 'custom-data' == 'unknown'
FAILED tests/aws/services/cloudformation/resources/test_customresources.py::test_update_custom_resource - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
- [x] Multi-account/region compatibility ([Randomised credentials test run](https://app.circleci.com/pipelines/github/localstack/localstack/32341/workflows/3e44457b-51de-4c4b-824c-81ff89321928))