### PR TITLE
KMS: enable `_custom_key_material_` for ECC keys

### DIFF
--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -193,7 +193,10 @@ class KmsCryptoKey:
             key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
         elif key_spec.startswith("ECC"):
             curve = ECC_CURVES.get(key_spec)
-            key = ec.generate_private_key(curve)
+            if key_material:
+                key = crypto_serialization.load_der_private_key(key_material, password=None)
+            else:
+                key = ec.generate_private_key(curve)
         elif key_spec.startswith("HMAC"):
             if key_spec not in HMAC_RANGE_KEY_LENGTHS:
                 raise ValidationException(

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -404,16 +404,17 @@ class TestKMS:
 
         # Do a sign/verify cycle
         plaintext = b"test message 123 !%$@ 1234567890"
-        sign_algo = "ECDSA_SHA_256"
 
-        signed_data = aws_client.kms.sign(
-            Message=plaintext, MessageType="RAW", SigningAlgorithm=sign_algo, KeyId=key_id
+        signature = crypto_key.sign(
+            plaintext,
+            ec.ECDSA(hashes.SHA256()),
         )
+
         verify_data = aws_client.kms.verify(
             Message=plaintext,
-            Signature=signed_data["Signature"],
+            Signature=signature,
             MessageType="RAW",
-            SigningAlgorithm=sign_algo,
+            SigningAlgorithm="ECDSA_SHA_256",
             KeyId=key_id,
         )
         assert verify_data["SignatureValid"]

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -372,6 +372,52 @@ class TestKMS:
         )["Plaintext"]
         assert plaintext == message
 
+    @markers.aws.only_localstack
+    def test_create_custom_key_asymmetric(self, kms_create_key, aws_client):
+        crypto_key = ec.generate_private_key(ec.SECP256K1())
+        raw_private_key = crypto_key.private_bytes(
+            serialization.Encoding.DER,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+        raw_public_key = crypto_key.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+
+        custom_key_material = raw_private_key
+
+        custom_key_tag_value = base64.b64encode(custom_key_material).decode("utf-8")
+
+        key_spec = "ECC_SECG_P256K1"
+        key_usage = "SIGN_VERIFY"
+
+        key_id = kms_create_key(
+            Tags=[{"TagKey": "_custom_key_material_", "TagValue": custom_key_tag_value}],
+            KeySpec=key_spec,
+            KeyUsage=key_usage,
+        )["KeyId"]
+
+        public_key = aws_client.kms.get_public_key(KeyId=key_id)["PublicKey"]
+
+        assert public_key == raw_public_key
+
+        # Do a sign/verify cycle
+        plaintext = b"test message 123 !%$@ 1234567890"
+        sign_algo = "ECDSA_SHA_256"
+
+        signed_data = aws_client.kms.sign(
+            Message=plaintext, MessageType="RAW", SigningAlgorithm=sign_algo, KeyId=key_id
+        )
+        verify_data = aws_client.kms.verify(
+            Message=plaintext,
+            Signature=signed_data["Signature"],
+            MessageType="RAW",
+            SigningAlgorithm=sign_algo,
+            KeyId=key_id,
+        )
+        assert verify_data["SignatureValid"]
+
     @markers.aws.validated
     def test_get_key_in_different_region(
         self, kms_client_for_region, kms_create_key, snapshot, region_name, secondary_region_name


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes an issue where custom key material provided via the `_custom_key_material_` tag during kms `create-key` for ECC keys is ignored.
 
Closes https://github.com/localstack/localstack/issues/11678

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Enables `_custom_key_material_` for ECC keys and verifies the implementation using a test with `ECC_SECG_P256K1` key specification. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
