### PR TITLE
Add dry_run support to GenerateDataKeyPair/GenerateDataKeyPairWithoutPlaintext.

### DIFF
--- a/localstack-core/localstack/services/kms/exceptions.py
+++ b/localstack-core/localstack/services/kms/exceptions.py
@@ -15,6 +15,7 @@ class TagException(CommonServiceException):
     def __init__(self, message=None):
         super().__init__("TagException", status_code=400, message=message)
 
+
 class DryRunOperationException(CommonServiceException):
     def __init__(self, message="The request would have succeeded, but the DryRun option is set."):
         super().__init__("DryRunOperationException", status_code=400, message=message)

--- a/localstack-core/localstack/services/kms/exceptions.py
+++ b/localstack-core/localstack/services/kms/exceptions.py
@@ -14,8 +14,3 @@ class AccessDeniedException(CommonServiceException):
 class TagException(CommonServiceException):
     def __init__(self, message=None):
         super().__init__("TagException", status_code=400, message=message)
-
-
-class DryRunOperationException(CommonServiceException):
-    def __init__(self, message="The request would have succeeded, but the DryRun option is set."):
-        super().__init__("DryRunOperationException", status_code=400, message=message)

--- a/localstack-core/localstack/services/kms/exceptions.py
+++ b/localstack-core/localstack/services/kms/exceptions.py
@@ -14,3 +14,7 @@ class AccessDeniedException(CommonServiceException):
 class TagException(CommonServiceException):
     def __init__(self, message=None):
         super().__init__("TagException", status_code=400, message=message)
+
+class DryRunOperationException(CommonServiceException):
+    def __init__(self, message="The request would succeed if DryRun wasn’t specified."):
+        super().__init__("DryRunOperationException", status_code=400, message=message)

--- a/localstack-core/localstack/services/kms/exceptions.py
+++ b/localstack-core/localstack/services/kms/exceptions.py
@@ -16,5 +16,5 @@ class TagException(CommonServiceException):
         super().__init__("TagException", status_code=400, message=message)
 
 class DryRunOperationException(CommonServiceException):
-    def __init__(self, message="The request would succeed if DryRun wasn’t specified."):
+    def __init__(self, message="The request would have succeeded, but the DryRun option is set."):
         super().__init__("DryRunOperationException", status_code=400, message=message)

--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -197,7 +197,8 @@ class KmsCryptoKey:
             raise ValidationException(
                 f"1 validation error detected: Value '{key_spec}' at 'keySpec' "
                 f"failed to satisfy constraint: Member must satisfy enum value set: "
-                f"{valid_specs}"
+                f"[RSA_2048, ECC_NIST_P384, ECC_NIST_P256, ECC_NIST_P521, HMAC_384, RSA_3072, "
+                f"ECC_SECG_P256K1, RSA_4096, SYMMETRIC_DEFAULT, HMAC_256, HMAC_224, HMAC_512]"
             )
 
     def __init__(self, key_spec: str, key_material: Optional[bytes] = None):

--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -47,7 +47,6 @@ from localstack.aws.api.kms import (
     ReplicateKeyRequest,
     SigningAlgorithmSpec,
     TagList,
-    UnsupportedOperationException,
 )
 from localstack.constants import TAG_KEY_CUSTOM_ID
 from localstack.services.kms.exceptions import TagException, ValidationException
@@ -215,7 +214,7 @@ class KmsCryptoKey:
 
         if key_spec == "SYMMETRIC_DEFAULT":
             return
-       
+
         if key_spec.startswith("RSA"):
             key_size = RSA_CRYPTO_KEY_LENGTHS.get(key_spec)
             key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)

--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -178,6 +178,32 @@ class KmsCryptoKey:
     key_material: bytes
     key_spec: str
 
+    @staticmethod
+    def assert_valid(key_spec: str):
+        """
+        Validates that the given key_spec is supported in the current context.
+
+        LocalStack supports additional key specs beyond what AWS officially allows.
+        For example, AWS's GenerateDataKeyPair operation supports only the following:
+            - RSA_2048, RSA_3072, RSA_4096
+            - ECC_NIST_P256, ECC_NIST_P384, ECC_NIST_P521, ECC_SECG_P256K1, SM2
+
+        Raises:
+            ValidationException: If key_spec is not in the supported list.
+        """
+        valid_specs = (
+            list(RSA_CRYPTO_KEY_LENGTHS.keys()) +
+            list(ECC_CURVES.keys()) +
+            list(HMAC_RANGE_KEY_LENGTHS.keys())
+        )
+
+        if key_spec not in valid_specs:
+            raise ValidationException(
+                f"1 validation error detected: Value '{key_spec}' at 'keySpec' "
+                f"failed to satisfy constraint: Member must satisfy enum value set: "
+                f"{valid_specs}"
+            )
+
     def __init__(self, key_spec: str, key_material: Optional[bytes] = None):
         self.private_key = None
         self.public_key = None

--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -192,9 +192,9 @@ class KmsCryptoKey:
             ValidationException: If key_spec is not in the supported list.
         """
         valid_specs = (
-            list(RSA_CRYPTO_KEY_LENGTHS.keys()) +
-            list(ECC_CURVES.keys()) +
-            list(HMAC_RANGE_KEY_LENGTHS.keys())
+            list(RSA_CRYPTO_KEY_LENGTHS.keys())
+            + list(ECC_CURVES.keys())
+            + list(HMAC_RANGE_KEY_LENGTHS.keys())
         )
 
         if key_spec not in valid_specs:

--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -190,16 +190,11 @@ class KmsCryptoKey:
         """
 
         def raise_validation():
-            all_valid_specs = (
-                list(RSA_CRYPTO_KEY_LENGTHS.keys())
-                + list(ECC_CURVES.keys())
-                + list(HMAC_RANGE_KEY_LENGTHS.keys())
-                + ["SYMMETRIC_DEFAULT"]
-            )
             raise ValidationException(
                 f"1 validation error detected: Value '{key_spec}' at 'keySpec' "
                 f"failed to satisfy constraint: Member must satisfy enum value set: "
-                f"{all_valid_specs}"
+                f"[RSA_2048, ECC_NIST_P384, ECC_NIST_P256, ECC_NIST_P521, HMAC_384, RSA_3072, "
+                f"ECC_SECG_P256K1, RSA_4096, SYMMETRIC_DEFAULT, HMAC_256, HMAC_224, HMAC_512]"
             )
 
         if key_spec == "SYMMETRIC_DEFAULT":

--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -188,14 +188,14 @@ class KmsCryptoKey:
         :raises ValidationException: If ``key_spec`` is not a known valid spec.
         :raises UnsupportedOperationException: If ``key_spec`` is entirely unsupported.
         """
-        all_valid_specs = (
-            list(RSA_CRYPTO_KEY_LENGTHS.keys())
-            + list(ECC_CURVES.keys())
-            + list(HMAC_RANGE_KEY_LENGTHS.keys())
-            + ["SYMMETRIC_DEFAULT"]
-        )
 
         def raise_validation():
+            all_valid_specs = (
+                list(RSA_CRYPTO_KEY_LENGTHS.keys())
+                + list(ECC_CURVES.keys())
+                + list(HMAC_RANGE_KEY_LENGTHS.keys())
+                + ["SYMMETRIC_DEFAULT"]
+            )
             raise ValidationException(
                 f"1 validation error detected: Value '{key_spec}' at 'keySpec' "
                 f"failed to satisfy constraint: Member must satisfy enum value set: "

--- a/localstack-core/localstack/services/kms/models.py
+++ b/localstack-core/localstack/services/kms/models.py
@@ -181,15 +181,11 @@ class KmsCryptoKey:
     @staticmethod
     def assert_valid(key_spec: str):
         """
-        Validates that the given key_spec is supported in the current context.
+        Validates that the given ``key_spec`` is supported in the current context.
 
-        LocalStack supports additional key specs beyond what AWS officially allows.
-        For example, AWS's GenerateDataKeyPair operation supports only the following:
-            - RSA_2048, RSA_3072, RSA_4096
-            - ECC_NIST_P256, ECC_NIST_P384, ECC_NIST_P521, ECC_SECG_P256K1, SM2
-
-        Raises:
-            ValidationException: If key_spec is not in the supported list.
+        :param key_spec: The key specification to validate.
+        :type key_spec: str
+        :raises ValidationException: If ``key_spec`` is not in the supported list.
         """
         valid_specs = (
             list(RSA_CRYPTO_KEY_LENGTHS.keys())

--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -737,6 +737,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         account_id, region_name, key_id = self._parse_key_id(key_id, context)
         key = self._get_kms_key(account_id, region_name, key_id)
         self._validate_key_for_encryption_decryption(context, key)
+        KmsCryptoKey.assert_valid(key_pair_spec)
         return execute_dry_run_capable(self._build_data_key_pair_response, dry_run, key, key_pair_spec, encryption_context)
 
     def _build_data_key_pair_response(
@@ -768,7 +769,6 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         **kwargs,
     ) -> GenerateDataKeyPairResponse:
         # TODO add support for "dry_run"
-        print(f"[handler] dry_run = {dry_run}")
         result = self._generate_data_key_pair(context, key_id, key_pair_spec, encryption_context, dry_run)
         return GenerateDataKeyPairResponse(**result)
 
@@ -806,7 +806,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         **kwargs,
     ) -> GenerateDataKeyPairWithoutPlaintextResponse:
         # TODO add support for "dry_run"
-        result = self._generate_data_key_pair(context, key_id, key_pair_spec, encryption_context)
+        result = self._generate_data_key_pair(context, key_id, key_pair_spec, encryption_context, dry_run)
         result.pop("PrivateKeyPlaintext")
         return GenerateDataKeyPairResponse(**result)
 

--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -123,7 +123,12 @@ from localstack.services.kms.models import (
     deserialize_ciphertext_blob,
     kms_stores,
 )
-from localstack.services.kms.utils import execute_dry_run_capable, is_valid_key_arn, parse_key_arn, validate_alias_name
+from localstack.services.kms.utils import (
+    execute_dry_run_capable,
+    is_valid_key_arn,
+    parse_key_arn,
+    validate_alias_name,
+)
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.aws.arns import get_partition, kms_alias_arn, parse_arn
 from localstack.utils.collections import PaginatedList
@@ -732,19 +737,18 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         key_id: str,
         key_pair_spec: str,
         encryption_context: EncryptionContextType = None,
-        dry_run: NullableBooleanType = None
+        dry_run: NullableBooleanType = None,
     ):
         account_id, region_name, key_id = self._parse_key_id(key_id, context)
         key = self._get_kms_key(account_id, region_name, key_id)
         self._validate_key_for_encryption_decryption(context, key)
         KmsCryptoKey.assert_valid(key_pair_spec)
-        return execute_dry_run_capable(self._build_data_key_pair_response, dry_run, key, key_pair_spec, encryption_context)
+        return execute_dry_run_capable(
+            self._build_data_key_pair_response, dry_run, key, key_pair_spec, encryption_context
+        )
 
     def _build_data_key_pair_response(
-        self,
-        key: KmsKey,
-        key_pair_spec: str,
-        encryption_context: EncryptionContextType = None
+        self, key: KmsKey, key_pair_spec: str, encryption_context: EncryptionContextType = None
     ):
         crypto_key = KmsCryptoKey(key_pair_spec)
 
@@ -769,7 +773,9 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         **kwargs,
     ) -> GenerateDataKeyPairResponse:
         # TODO add support for "dry_run"
-        result = self._generate_data_key_pair(context, key_id, key_pair_spec, encryption_context, dry_run)
+        result = self._generate_data_key_pair(
+            context, key_id, key_pair_spec, encryption_context, dry_run
+        )
         return GenerateDataKeyPairResponse(**result)
 
     @handler("GenerateRandom", expand=False)
@@ -806,7 +812,9 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         **kwargs,
     ) -> GenerateDataKeyPairWithoutPlaintextResponse:
         # TODO add support for "dry_run"
-        result = self._generate_data_key_pair(context, key_id, key_pair_spec, encryption_context, dry_run)
+        result = self._generate_data_key_pair(
+            context, key_id, key_pair_spec, encryption_context, dry_run
+        )
         result.pop("PrivateKeyPlaintext")
         return GenerateDataKeyPairResponse(**result)
 

--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -772,7 +772,6 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         dry_run: NullableBooleanType = None,
         **kwargs,
     ) -> GenerateDataKeyPairResponse:
-        # TODO add support for "dry_run"
         result = self._generate_data_key_pair(
             context, key_id, key_pair_spec, encryption_context, dry_run
         )
@@ -811,7 +810,6 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         dry_run: NullableBooleanType = None,
         **kwargs,
     ) -> GenerateDataKeyPairWithoutPlaintextResponse:
-        # TODO add support for "dry_run"
         result = self._generate_data_key_pair(
             context, key_id, key_pair_spec, encryption_context, dry_run
         )

--- a/localstack-core/localstack/services/kms/utils.py
+++ b/localstack-core/localstack/services/kms/utils.py
@@ -81,5 +81,7 @@ def execute_dry_run_capable(func: Callable[..., T], dry_run: bool, *args, **kwar
     :raises DryRunOperationException: If ``dry_run`` is ``True``.
     """
     if dry_run:
-        raise DryRunOperationException()
+        raise DryRunOperationException(
+            "The request would have succeeded, but the DryRun option is set."
+        )
     return func(*args, **kwargs)

--- a/localstack-core/localstack/services/kms/utils.py
+++ b/localstack-core/localstack/services/kms/utils.py
@@ -1,8 +1,8 @@
 import re
 from typing import Callable, Tuple, TypeVar
 
-from localstack.aws.api.kms import  Tag, TagException
-from localstack.services.kms.exceptions import DryRunOperationException,ValidationException
+from localstack.aws.api.kms import Tag, TagException
+from localstack.services.kms.exceptions import DryRunOperationException, ValidationException
 from localstack.utils.aws.arns import ARN_PARTITION_REGEX
 
 T = TypeVar("T")
@@ -60,6 +60,7 @@ def validate_tag(tag_position: int, tag: Tag) -> None:
 
     if tag_key.lower().startswith("aws:"):
         raise TagException("Tags beginning with aws: are reserved")
+
 
 def execute_dry_run_capable(func: Callable[..., T], dry_run: bool, *args, **kwargs) -> T:
     """

--- a/localstack-core/localstack/services/kms/utils.py
+++ b/localstack-core/localstack/services/kms/utils.py
@@ -66,20 +66,19 @@ def execute_dry_run_capable(func: Callable[..., T], dry_run: bool, *args, **kwar
     """
     Executes a function unless dry run mode is enabled.
 
-    If `dry_run` is True, the function is not executed and a `DryRunOperationException` is raised.
-    Otherwise, the provided function is called with the given arguments and keyword arguments.
+    If ``dry_run`` is ``True``, the function is not executed and a
+    ``DryRunOperationException`` is raised. Otherwise, the provided
+    function is called with the given positional and keyword arguments.
 
-    Args:
-        func (Callable[..., T]): The function to be executed.
-        dry_run (bool): Flag indicating whether the execution is a dry run.
-        *args: Positional arguments to pass to the function.
-        **kwargs: Keyword arguments to pass to the function.
-
-    Returns:
-        T: The result of the function call if `dry_run` is False.
-
-    Raises:
-        DryRunOperationException: If `dry_run` is True.
+    :param func: The function to be executed.
+    :type func: Callable[..., T]
+    :param dry_run: Flag indicating whether the execution is a dry run.
+    :type dry_run: bool
+    :param args: Positional arguments to pass to the function.
+    :param kwargs: Keyword arguments to pass to the function.
+    :returns: The result of the function call if ``dry_run`` is ``False``.
+    :rtype: T
+    :raises DryRunOperationException: If ``dry_run`` is ``True``.
     """
     if dry_run:
         raise DryRunOperationException()

--- a/localstack-core/localstack/services/kms/utils.py
+++ b/localstack-core/localstack/services/kms/utils.py
@@ -62,6 +62,24 @@ def validate_tag(tag_position: int, tag: Tag) -> None:
         raise TagException("Tags beginning with aws: are reserved")
 
 def execute_dry_run_capable(func: Callable[..., T], dry_run: bool, *args, **kwargs) -> T:
+    """
+    Executes a function unless dry run mode is enabled.
+
+    If `dry_run` is True, the function is not executed and a `DryRunOperationException` is raised.
+    Otherwise, the provided function is called with the given arguments and keyword arguments.
+
+    Args:
+        func (Callable[..., T]): The function to be executed.
+        dry_run (bool): Flag indicating whether the execution is a dry run.
+        *args: Positional arguments to pass to the function.
+        **kwargs: Keyword arguments to pass to the function.
+
+    Returns:
+        T: The result of the function call if `dry_run` is False.
+
+    Raises:
+        DryRunOperationException: If `dry_run` is True.
+    """
     if dry_run:
         raise DryRunOperationException()
     return func(*args, **kwargs)

--- a/localstack-core/localstack/services/kms/utils.py
+++ b/localstack-core/localstack/services/kms/utils.py
@@ -1,8 +1,8 @@
 import re
 from typing import Callable, Tuple, TypeVar
 
-from localstack.aws.api.kms import Tag, TagException
-from localstack.services.kms.exceptions import DryRunOperationException, ValidationException
+from localstack.aws.api.kms import DryRunOperationException, Tag, TagException
+from localstack.services.kms.exceptions import ValidationException
 from localstack.utils.aws.arns import ARN_PARTITION_REGEX
 
 T = TypeVar("T")

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -2053,8 +2053,7 @@ class TestKMSGenerateKeys:
         snapshot.match("decrypt-without-encryption-context", e.value.response)
 
     @markers.aws.validated
-    def test_generate_data_key_pair_dry_run(
-            self, kms_key, aws_client, snapshot):
+    def test_generate_data_key_pair_dry_run(self, kms_key, aws_client, snapshot):
         snapshot.add_transformer(
             snapshot.transform.key_value("PrivateKeyCiphertextBlob", reference_replacement=False)
         )
@@ -2068,11 +2067,7 @@ class TestKMSGenerateKeys:
         key_id = kms_key["KeyId"]
 
         with pytest.raises(ClientError) as exc:
-            aws_client.kms.generate_data_key_pair(
-                KeyId=key_id,
-                KeyPairSpec="RSA_2048",
-                DryRun=True
-            )
+            aws_client.kms.generate_data_key_pair(KeyId=key_id, KeyPairSpec="RSA_2048", DryRun=True)
 
         err = exc.value.response
         assert err["Error"]["Code"] == "DryRunOperationException"
@@ -2090,15 +2085,13 @@ class TestKMSGenerateKeys:
         )
 
         key_id = kms_key["KeyId"]
-        result = aws_client.kms.generate_data_key_pair_without_plaintext(
+        aws_client.kms.generate_data_key_pair_without_plaintext(
             KeyId=key_id, KeyPairSpec="RSA_2048"
         )
 
         with pytest.raises(ClientError) as exc:
             aws_client.kms.generate_data_key_pair_without_plaintext(
-                KeyId=key_id,
-                KeyPairSpec="RSA_2048",
-                DryRun=True
+                KeyId=key_id, KeyPairSpec="RSA_2048", DryRun=True
             )
 
         err = exc.value.response

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -2051,3 +2051,31 @@ class TestKMSGenerateKeys:
         with pytest.raises(ClientError) as e:
             aws_client.kms.decrypt(CiphertextBlob=result["PrivateKeyCiphertextBlob"], KeyId=key_id)
         snapshot.match("decrypt-without-encryption-context", e.value.response)
+
+    @markers.aws.needs_fixing
+    def test_generate_data_key_pair_dry_run(
+            self, kms_key, aws_client, snapshot):
+        snapshot.add_transformer(
+            snapshot.transform.key_value("PrivateKeyCiphertextBlob", reference_replacement=False)
+        )
+        snapshot.add_transformer(
+            snapshot.transform.key_value("PrivateKeyPlaintext", reference_replacement=False)
+        )
+        snapshot.add_transformer(
+            snapshot.transform.key_value("PublicKey", reference_replacement=False)
+        )
+
+        key_id = kms_key["KeyId"]
+
+        with pytest.raises(ClientError) as exc:
+            aws_client.kms.generate_data_key_pair(
+                KeyId=key_id,
+                KeyPairSpec="RSA_2048",
+                DryRun=True
+            )
+
+        err = exc.value.response
+        assert err["Error"]["Code"] == "DryRunOperationException"
+
+        # Optional: match the exception with snapshot
+        snapshot.match("dryrun_exception", err)

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -2070,9 +2070,6 @@ class TestKMSGenerateKeys:
             aws_client.kms.generate_data_key_pair(KeyId=key_id, KeyPairSpec="RSA_2048", DryRun=True)
 
         err = exc.value.response
-        assert err["Error"]["Code"] == "DryRunOperationException"
-
-        # Optional: match the exception with snapshot
         snapshot.match("dryrun_exception", err)
 
     @markers.aws.validated
@@ -2095,7 +2092,4 @@ class TestKMSGenerateKeys:
             )
 
         err = exc.value.response
-        assert err["Error"]["Code"] == "DryRunOperationException"
-
-        # Optional: match the exception with snapshot
         snapshot.match("dryrun_exception", err)

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -2206,5 +2206,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMSGenerateKeys::test_generate_data_key_pair_dry_run": {
+    "recorded-date": "06-04-2025, 11:54:20",
+    "recorded-content": {
+      "dryrun_exception": {
+        "Error": {
+          "Code": "DryRunOperationException",
+          "Message": "The request would have succeeded, but the DryRun option is set."
+        },
+        "message": "The request would have succeeded, but the DryRun option is set.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -2222,5 +2222,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMSGenerateKeys::test_generate_data_key_pair_without_plaintext_dry_run": {
+    "recorded-date": "07-04-2025, 17:12:37",
+    "recorded-content": {
+      "dryrun_exception": {
+        "Error": {
+          "Code": "DryRunOperationException",
+          "Message": "The request would have succeeded, but the DryRun option is set."
+        },
+        "message": "The request would have succeeded, but the DryRun option is set.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -331,5 +331,8 @@
   },
   "tests/aws/services/kms/test_kms.py::TestKMSGenerateKeys::test_generate_data_key_pair_dry_run": {
     "last_validated_date": "2025-04-06T11:54:20+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMSGenerateKeys::test_generate_data_key_pair_without_plaintext_dry_run": {
+    "last_validated_date": "2025-04-13T15:44:57+00:00"
   }
 }

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -328,5 +328,8 @@
   },
   "tests/aws/services/kms/test_kms.py::TestKMSGenerateKeys::test_generate_data_key_without_plaintext": {
     "last_validated_date": "2024-04-11T15:54:31+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMSGenerateKeys::test_generate_data_key_pair_dry_run": {
+    "last_validated_date": "2025-04-06T11:54:20+00:00"
   }
 }

--- a/tests/unit/services/kms/test_kms.py
+++ b/tests/unit/services/kms/test_kms.py
@@ -1,8 +1,8 @@
 import pytest
 
 from localstack.aws.api import RequestContext
-from localstack.aws.api.kms import CreateKeyRequest
-from localstack.services.kms.exceptions import DryRunOperationException, ValidationException
+from localstack.aws.api.kms import CreateKeyRequest, DryRunOperationException
+from localstack.services.kms.exceptions import ValidationException
 from localstack.services.kms.provider import KmsProvider
 from localstack.services.kms.utils import execute_dry_run_capable, validate_alias_name
 

--- a/tests/unit/services/kms/test_kms.py
+++ b/tests/unit/services/kms/test_kms.py
@@ -3,9 +3,8 @@ import pytest
 from localstack.aws.api import RequestContext
 from localstack.aws.api.kms import CreateKeyRequest
 from localstack.services.kms.exceptions import DryRunOperationException, ValidationException
-from localstack.services.kms.models import KmsKey
 from localstack.services.kms.provider import KmsProvider
-from localstack.services.kms.utils import validate_alias_name
+from localstack.services.kms.utils import execute_dry_run_capable, validate_alias_name
 
 
 def test_alias_name_validator():
@@ -17,15 +16,14 @@ def test_alias_name_validator():
 def provider():
     return KmsProvider()
 
+def test_execute_dry_run_capable_runs_when_not_dry():
+    result = execute_dry_run_capable(lambda: 1 + 1, dry_run=False)
+    assert result == 2
 
-@pytest.fixture
-def mock_key():
-    # You can mock this more fully based on what _get_kms_key expects
-    return KmsKey(
-        metadata={
-            "Arn": "arn:aws:kms:us-east-1:000000000000:key/abc123",
-        }
-    )
+
+def test_execute_dry_run_capable_raises_when_dry():
+    with pytest.raises(DryRunOperationException):
+        execute_dry_run_capable(lambda: "should not run", dry_run=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/services/kms/test_kms.py
+++ b/tests/unit/services/kms/test_kms.py
@@ -1,19 +1,17 @@
 import pytest
 
-from localstack.services.kms.exceptions import DryRunOperationException, ValidationException
-from localstack.services.kms.provider import KmsProvider, kms_stores
-from localstack.services.kms.models import KmsKey
-from localstack.aws.api.kms import (
-    CreateKeyRequest
-)
 from localstack.aws.api import RequestContext
-
+from localstack.aws.api.kms import CreateKeyRequest
+from localstack.services.kms.exceptions import DryRunOperationException, ValidationException
+from localstack.services.kms.models import KmsKey
+from localstack.services.kms.provider import KmsProvider
 from localstack.services.kms.utils import validate_alias_name
 
 
 def test_alias_name_validator():
     with pytest.raises(Exception):
         validate_alias_name("test-alias")
+
 
 @pytest.fixture
 def provider():
@@ -29,16 +27,18 @@ def mock_key():
         }
     )
 
-@pytest.mark.parametrize("invalid_spec", [
-    "INVALID_SPEC",
-    "RSA_1024",         # Not supported by AWS
-    "ECC_FAKE",         # Invalid ECC curve
-    "AES_256",          # Symmetric, not key pair
-    ""
-])
-@pytest.mark.parametrize("dry_run", [
-    True, False
-])
+
+@pytest.mark.parametrize(
+    "invalid_spec",
+    [
+        "INVALID_SPEC",
+        "RSA_1024",  # Not supported by AWS
+        "ECC_FAKE",  # Invalid ECC curve
+        "AES_256",  # Symmetric, not key pair
+        "",
+    ],
+)
+@pytest.mark.parametrize("dry_run", [True, False])
 def test_generate_data_key_pair_invalid_spec(provider, invalid_spec, dry_run):
     # Arrange
     context = RequestContext()
@@ -60,6 +60,7 @@ def test_generate_data_key_pair_invalid_spec(provider, invalid_spec, dry_run):
 
     assert "1 validation error detected" in str(exc.value)
     assert invalid_spec in str(exc.value)
+
 
 def test_generate_data_key_pair_real_key(provider):
     # Arrange
@@ -90,6 +91,7 @@ def test_generate_data_key_pair_real_key(provider):
     assert response["KeyId"] == key["KeyMetadata"]["Arn"]
     assert response["KeyPairSpec"] == "RSA_2048"
 
+
 def test_generate_data_key_pair_dry_run(provider):
     # Arrange
     account_id = "000000000000"
@@ -108,13 +110,14 @@ def test_generate_data_key_pair_dry_run(provider):
     key_id = key["KeyMetadata"]["KeyId"]
 
     # Act & Assert
-    with pytest.raises(DryRunOperationException) as exc_info:
+    with pytest.raises(DryRunOperationException):
         provider.generate_data_key_pair(
             context=context,
             key_id=key_id,
             key_pair_spec="RSA_2048",
-            dry_run=True,  # <-- this is the core of the dry-run test
+            dry_run=True,
         )
+
 
 def test_generate_data_key_pair_without_plaintext(provider):
     # Arrange
@@ -145,6 +148,7 @@ def test_generate_data_key_pair_without_plaintext(provider):
     assert response["KeyPairSpec"] == "RSA_2048"
     assert "PrivateKeyPlaintext" not in response  # Confirm plaintext was removed
 
+
 def test_generate_data_key_pair_without_plaintext_dry_run(provider):
     # Arrange
     account_id = "000000000000"
@@ -158,7 +162,7 @@ def test_generate_data_key_pair_without_plaintext_dry_run(provider):
     key_id = key["KeyMetadata"]["KeyId"]
 
     # Act & Assert
-    with pytest.raises(DryRunOperationException) as exc_info:
+    with pytest.raises(DryRunOperationException):
         provider.generate_data_key_pair_without_plaintext(
             context=context,
             key_id=key_id,

--- a/tests/unit/services/kms/test_kms.py
+++ b/tests/unit/services/kms/test_kms.py
@@ -1,6 +1,6 @@
 import pytest
 
-from localstack.services.kms.exceptions import DryRunOperationException
+from localstack.services.kms.exceptions import DryRunOperationException, ValidationException
 from localstack.services.kms.provider import KmsProvider, kms_stores
 from localstack.services.kms.models import KmsKey
 from localstack.aws.api.kms import (
@@ -29,6 +29,37 @@ def mock_key():
         }
     )
 
+@pytest.mark.parametrize("invalid_spec", [
+    "INVALID_SPEC",
+    "RSA_1024",         # Not supported by AWS
+    "ECC_FAKE",         # Invalid ECC curve
+    "AES_256",          # Symmetric, not key pair
+    ""
+])
+@pytest.mark.parametrize("dry_run", [
+    True, False
+])
+def test_generate_data_key_pair_invalid_spec(provider, invalid_spec, dry_run):
+    # Arrange
+    context = RequestContext()
+    context.account_id = "000000000000"
+    context.region = "us-east-1"
+
+    key_request = CreateKeyRequest(Description="Test key")
+    key = provider.create_key(context, key_request)
+    key_id = key["KeyMetadata"]["KeyId"]
+
+    # Act & Assert
+    with pytest.raises(ValidationException) as exc:
+        provider.generate_data_key_pair(
+            context=context,
+            key_id=key_id,
+            key_pair_spec=invalid_spec,
+            dry_run=dry_run,
+        )
+
+    assert "1 validation error detected" in str(exc.value)
+    assert invalid_spec in str(exc.value)
 
 def test_generate_data_key_pair_real_key(provider):
     # Arrange
@@ -83,4 +114,54 @@ def test_generate_data_key_pair_dry_run(provider):
             key_id=key_id,
             key_pair_spec="RSA_2048",
             dry_run=True,  # <-- this is the core of the dry-run test
+        )
+
+def test_generate_data_key_pair_without_plaintext(provider):
+    # Arrange
+    account_id = "000000000000"
+    region_name = "us-east-1"
+    context = RequestContext()
+    context.account_id = account_id
+    context.region = region_name
+
+    # Note: we're using `provider.create_key` to set up the test, which introduces a hidden dependency.
+    # If `create_key` fails or changes its behavior, this test might fail incorrectly even if the logic
+    # under test (`generate_data_key_pair_without_plaintext`) is still correct. Ideally, we would decouple
+    # the store through dependency injection to isolate test concerns.
+    key_request = CreateKeyRequest(Description="Test key")
+    key = provider.create_key(context, key_request)
+    key_id = key["KeyMetadata"]["KeyId"]
+
+    # Act
+    response = provider.generate_data_key_pair_without_plaintext(
+        context=context,
+        key_id=key_id,
+        key_pair_spec="RSA_2048",
+        dry_run=False,
+    )
+
+    # Assert
+    assert response["KeyId"] == key["KeyMetadata"]["Arn"]
+    assert response["KeyPairSpec"] == "RSA_2048"
+    assert "PrivateKeyPlaintext" not in response  # Confirm plaintext was removed
+
+def test_generate_data_key_pair_without_plaintext_dry_run(provider):
+    # Arrange
+    account_id = "000000000000"
+    region_name = "us-east-1"
+    context = RequestContext()
+    context.account_id = account_id
+    context.region = region_name
+
+    key_request = CreateKeyRequest(Description="Test key")
+    key = provider.create_key(context, key_request)
+    key_id = key["KeyMetadata"]["KeyId"]
+
+    # Act & Assert
+    with pytest.raises(DryRunOperationException) as exc_info:
+        provider.generate_data_key_pair_without_plaintext(
+            context=context,
+            key_id=key_id,
+            key_pair_spec="RSA_2048",
+            dry_run=True,
         )

--- a/tests/unit/services/kms/test_kms.py
+++ b/tests/unit/services/kms/test_kms.py
@@ -1,7 +1,7 @@
 import pytest
 
 from localstack.services.kms.exceptions import DryRunOperationException
-from localstack.services.kms.provider import KmsProvider
+from localstack.services.kms.provider import KmsProvider, kms_stores
 from localstack.services.kms.models import KmsKey
 from localstack.aws.api.kms import (
     CreateKeyRequest
@@ -38,10 +38,13 @@ def test_generate_data_key_pair_real_key(provider):
     context.account_id = account_id
     context.region = region_name
 
-    # Create a real KMS key via internal method
+    # Note: we're using `provider.create_key` to set up the test, which introduces a hidden dependency.
+    # If `create_key` fails or changes its behavior, this test might fail incorrectly even if the logic
+    # under test (`generate_data_key_pair`) is still correct. Ideally, we would decouple the store
+    # through dependency injection (e.g., by abstracting the KMS store), so that
+    # we could stub it or inject a pre-populated instance directly in the test setup.
     key_request = CreateKeyRequest(Description="Test key")
     key = provider.create_key(context, key_request)
-    print("[test] Created key:", key)
     key_id = key["KeyMetadata"]["KeyId"]
 
     # # Act
@@ -51,7 +54,6 @@ def test_generate_data_key_pair_real_key(provider):
         key_pair_spec="RSA_2048",
         dry_run=False,
     )
-    print (response)
 
     # # Assert
     assert response["KeyId"] == key["KeyMetadata"]["Arn"]
@@ -65,7 +67,11 @@ def test_generate_data_key_pair_dry_run(provider):
     context.account_id = account_id
     context.region = region_name
 
-    # Create a real KMS key via internal method
+    # Note: we're using `provider.create_key` to set up the test, which introduces a hidden dependency.
+    # If `create_key` fails or changes its behavior, this test might fail incorrectly even if the logic
+    # under test (`generate_data_key_pair`) is still correct. Ideally, we would decouple the store
+    # through dependency injection (e.g., by abstracting the KMS store), so that
+    # we could stub it or inject a pre-populated instance directly in the test setup.
     key_request = CreateKeyRequest(Description="Test key")
     key = provider.create_key(context, key_request)
     key_id = key["KeyMetadata"]["KeyId"]

--- a/tests/unit/services/kms/test_kms.py
+++ b/tests/unit/services/kms/test_kms.py
@@ -16,6 +16,7 @@ def test_alias_name_validator():
 def provider():
     return KmsProvider()
 
+
 def test_execute_dry_run_capable_runs_when_not_dry():
     result = execute_dry_run_capable(lambda: 1 + 1, dry_run=False)
     assert result == 2

--- a/tests/unit/services/kms/test_kms.py
+++ b/tests/unit/services/kms/test_kms.py
@@ -1,8 +1,80 @@
 import pytest
 
+from localstack.services.kms.exceptions import DryRunOperationException
+from localstack.services.kms.provider import KmsProvider
+from localstack.services.kms.models import KmsKey
+from localstack.aws.api.kms import (
+    CreateKeyRequest
+)
+from localstack.aws.api import RequestContext
+
 from localstack.services.kms.utils import validate_alias_name
 
 
 def test_alias_name_validator():
     with pytest.raises(Exception):
         validate_alias_name("test-alias")
+
+@pytest.fixture
+def provider():
+    return KmsProvider()
+
+
+@pytest.fixture
+def mock_key():
+    # You can mock this more fully based on what _get_kms_key expects
+    return KmsKey(
+        metadata={
+            "Arn": "arn:aws:kms:us-east-1:000000000000:key/abc123",
+        }
+    )
+
+
+def test_generate_data_key_pair_real_key(provider):
+    # Arrange
+    account_id = "000000000000"
+    region_name = "us-east-1"
+    context = RequestContext()
+    context.account_id = account_id
+    context.region = region_name
+
+    # Create a real KMS key via internal method
+    key_request = CreateKeyRequest(Description="Test key")
+    key = provider.create_key(context, key_request)
+    print("[test] Created key:", key)
+    key_id = key["KeyMetadata"]["KeyId"]
+
+    # # Act
+    response = provider.generate_data_key_pair(
+        context=context,
+        key_id=key_id,
+        key_pair_spec="RSA_2048",
+        dry_run=False,
+    )
+    print (response)
+
+    # # Assert
+    assert response["KeyId"] == key["KeyMetadata"]["Arn"]
+    assert response["KeyPairSpec"] == "RSA_2048"
+
+def test_generate_data_key_pair_dry_run(provider):
+    # Arrange
+    account_id = "000000000000"
+    region_name = "us-east-1"
+    context = RequestContext()
+    context.account_id = account_id
+    context.region = region_name
+
+    # Create a real KMS key via internal method
+    key_request = CreateKeyRequest(Description="Test key")
+    key = provider.create_key(context, key_request)
+    key_id = key["KeyMetadata"]["KeyId"]
+
+    # Act & Assert
+    with pytest.raises(DryRunOperationException) as exc_info:
+        provider.generate_data_key_pair(
+            context=context,
+            key_id=key_id,
+            key_pair_spec="RSA_2048",
+            dry_run=True,  # <-- this is the core of the dry-run test
+        )


### PR DESCRIPTION
## Motivation
I am adding support for the _dry_run_ parameter to the **GenerateDataKeyPair** and **GenerateDataKeyPairWithoutPlaintext** operations to align with AWS behavior and enhance validation capabilities. 

Reference: [AWS KMS Dry Run Documentation](https://docs.aws.amazon.com/kms/latest/developerguide/testing-permissions.html)

## Changes
Before these changes, the **GenerateDataKeyPair** and **GenerateDataKeyPairWithoutPlaintext** operations in KMS did not take the _dry_run_ parameter into account. This PR updates both operations to properly respect the _dry_run_ flag, aligning their behavior with AWS expectations.

Since IAM permission checks are not yet implemented in KMS, the primary purpose of this functionality is to determine whether a request would succeed (in which case a **DryRunOperationException** is raised when `dry_run=True`) or fail due to validation errors, rather than to enforce or simulate IAM permissions

## Testing
You can verify the behavior by executing the following CLI commands:
```
awslocal kms generate-data-key-pair \
  --key-id <key_id> \
  --key-pair-spec RSA_2048 \
  --dry-run

awslocal kms generate-data-key-pair-without-plaintext \
  --key-id <key_id> \
  --key-pair-spec RSA_2048 \
  --dry-run
```

When the request is valid, these commands should return a **DryRunOperationException**. If the input is invalid, a validation error will be returned instead.

