### PR TITLE
unpin pytest-httpserver, fix patches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,7 @@ test = [
     "pluggy>=1.3.0",
     "pytest>=7.4.2",
     "pytest-split>=0.8.0",
-    # TODO fix issues with pytest-httpserver==1.1.2, remove upper boundary
-    "pytest-httpserver>=1.0.1,<1.1.2",
+    "pytest-httpserver>=1.1.2",
     "pytest-rerunfailures>=12.0",
     "pytest-tinybird>=0.2.0",
     "aws-cdk-lib>=2.88.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -355,7 +355,7 @@ pytest==8.3.5
     #   pytest-rerunfailures
     #   pytest-split
     #   pytest-tinybird
-pytest-httpserver==1.1.1
+pytest-httpserver==1.1.2
     # via localstack-core
 pytest-rerunfailures==15.0
     # via localstack-core

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -323,7 +323,7 @@ pytest==8.3.5
     #   pytest-rerunfailures
     #   pytest-split
     #   pytest-tinybird
-pytest-httpserver==1.1.1
+pytest-httpserver==1.1.2
     # via localstack-core (pyproject.toml)
 pytest-rerunfailures==15.0
     # via localstack-core (pyproject.toml)

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -565,7 +565,7 @@ pytest==8.3.5
     #   pytest-rerunfailures
     #   pytest-split
     #   pytest-tinybird
-pytest-httpserver==1.1.1
+pytest-httpserver==1.1.2
     # via localstack-core
 pytest-rerunfailures==15.0
     # via localstack-core

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -163,7 +163,7 @@ class TestEventsTargetApiDestination:
         clean_up(rule_name=rule_name, target_ids=target_id)
 
         to_recv = 2 if auth["type"] == "OAUTH_CLIENT_CREDENTIALS" else 1
-        poll_condition(lambda: len(httpserver.log) >= to_recv, timeout=5)
+        assert poll_condition(lambda: len(httpserver.log) >= to_recv, timeout=5)
 
         event_request, _ = httpserver.log[-1]
         event = event_request.get_json(force=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,23 +20,31 @@ pytest_plugins = [
 ]
 
 
-# FIXME: remove this, quick hack to prevent the HTTPServer fixture to spawn non-daemon threads
+# FIXME: remove this once https://github.com/csernazs/pytest-httpserver/pull/411 is merged
 def pytest_sessionstart(session):
     import threading
 
     try:
         from pytest_httpserver import HTTPServer, HTTPServerError
+        from werkzeug import Request
         from werkzeug.serving import make_server
 
         from localstack.utils.patch import Patch
 
-        def start_non_daemon_thread(self):
+        def start_non_daemon_thread(self) -> None:
             if self.is_running():
                 raise HTTPServerError("Server is already running")
 
+            app = Request.application(self.application)
+
             self.server = make_server(
-                self.host, self.port, self.application, ssl_context=self.ssl_context
+                self.host,
+                self.port,
+                app,
+                ssl_context=self.ssl_context,
+                threaded=self.threaded,
             )
+
             self.port = self.server.port  # Update port (needed if `port` was set to 0)
             self.server_thread = threading.Thread(target=self.thread_target, daemon=True)
             self.server_thread.start()


### PR DESCRIPTION
## Motivation
In the past we were facing issues with our integration tests timing out due to shutdowns being blocked. It turns out that some of the `pytest-httpserver` threads were not properly shut down. @bentsku fixed this by patching the `HTTPServer` class to spawn a deamon thread to make sure that it cannot block the shutdown of the interpreter with https://github.com/localstack/localstack/pull/10052.
This patch broke with the latest release, as the `start` method was modified (which is why we did not upgrade to the latest version 1.1.2, but introduced an upper limit with https://github.com/localstack/localstack/pull/12303/commits/01a97ba1fa8619da6266815f88c542f7ea952011).

This PR updates the patch and updates the dependency declaration for `pytest-httpserver`. I also filed https://github.com/csernazs/pytest-httpserver/pull/411 which would allow us to remove the patch completely if it gets merged upstream.

## Changes
- Unpins `pytest-httpserver` in the `pyproject.toml` and in the `requirement*.txt` lock files.
- Updates a patch introduced by @bentsku with https://github.com/localstack/localstack/pull/10052 for `pytest-httpserver==1.1.2`.