### PR TITLE
Support IAM transitive session tagging

### DIFF
--- a/localstack-core/localstack/services/sts/models.py
+++ b/localstack-core/localstack/services/sts/models.py
@@ -1,9 +1,16 @@
+from typing import TypedDict
+
 from localstack.services.stores import AccountRegionBundle, BaseStore, CrossRegionAttribute
+
+
+class SessionTaggingConfig(TypedDict):
+    tags: dict[str, str]
+    transitive_tags: list[str]
 
 
 class STSStore(BaseStore):
     # maps access key ids to tags for the session they belong to
-    session_tags: dict[str, dict[str, str]] = CrossRegionAttribute(default=dict)
+    session_tags: dict[str, SessionTaggingConfig] = CrossRegionAttribute(default=dict)
 
 
 sts_stores = AccountRegionBundle("sts", STSStore)

--- a/localstack-core/localstack/services/sts/models.py
+++ b/localstack-core/localstack/services/sts/models.py
@@ -1,15 +1,18 @@
 from typing import TypedDict
 
+from localstack.aws.api.sts import Tag
 from localstack.services.stores import AccountRegionBundle, BaseStore, CrossRegionAttribute
 
 
 class SessionTaggingConfig(TypedDict):
-    tags: dict[str, str]
+    # <lower-case-tag-key> => {"Key": <case-preserved-tag-key>, "Value": <tag-value>}
+    tags: dict[str, Tag]
+    # list of lowercase transitive tag keys
     transitive_tags: list[str]
 
 
 class STSStore(BaseStore):
-    # maps access key ids to tags for the session they belong to
+    # maps access key ids to tagging config for the session they belong to
     session_tags: dict[str, SessionTaggingConfig] = CrossRegionAttribute(default=dict)
 
 

--- a/localstack-core/localstack/services/sts/provider.py
+++ b/localstack-core/localstack/services/sts/provider.py
@@ -85,7 +85,7 @@ class StsProvider(StsApi, ServiceLifecycleHook):
 
         transitive_tag_keys = transitive_tag_keys or []
         tags = tags or []
-        transformed_tags = {tag["Key"].lower(): tag["Value"].lower() for tag in tags}
+        transformed_tags = {tag["Key"].lower(): tag["Value"] for tag in tags}
         # propagate transitive tags
         if existing_tagging_config:
             for tag in existing_tagging_config["transitive_tags"]:

--- a/tests/aws/services/sts/test_sts.py
+++ b/tests/aws/services/sts/test_sts.py
@@ -3,6 +3,7 @@ from base64 import b64encode
 
 import pytest
 import requests
+from botocore.exceptions import ClientError
 
 from localstack import config
 from localstack.constants import APPLICATION_JSON
@@ -321,3 +322,119 @@ class TestSTSIntegrations:
         response = sts_role_client_2.get_caller_identity()
         assert fake_account_id == response["Account"]
         assert assume_role_response_other_account["AssumedRoleUser"]["Arn"] == response["Arn"]
+
+    @markers.aws.validated
+    def test_iam_role_chaining_override_transitive_tags(
+        self,
+        aws_client,
+        aws_client_factory,
+        create_role,
+        snapshot,
+        region_name,
+        account_id,
+        wait_and_assume_role,
+    ):
+        snapshot.add_transformer(snapshot.transform.iam_api())
+        role_name_1 = f"role-1-{short_uid()}"
+        role_name_2 = f"role-2-{short_uid()}"
+        assume_role_policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": ["sts:AssumeRole", "sts:TagSession"],
+                    "Principal": {"AWS": account_id},
+                }
+            ],
+        }
+
+        role_1 = create_role(
+            RoleName=role_name_1, AssumeRolePolicyDocument=json.dumps(assume_role_policy_document)
+        )
+        snapshot.match("role-1", role_1)
+        role_2 = create_role(
+            RoleName=role_name_2,
+            AssumeRolePolicyDocument=json.dumps(assume_role_policy_document),
+        )
+        snapshot.match("role-2", role_2)
+        aws_client.iam.put_role_policy(
+            RoleName=role_name_1,
+            PolicyName=f"policy-{short_uid()}",
+            PolicyDocument=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": ["sts:AssumeRole", "sts:TagSession"],
+                            "Resource": [role_2["Role"]["Arn"]],
+                        }
+                    ],
+                }
+            ),
+        )
+
+        # assume role 1 with transitive tags
+        keys = wait_and_assume_role(
+            role_arn=role_1["Role"]["Arn"],
+            session_name="Session1",
+            Tags=[{"Key": "SessionTag1", "Value": "SessionValue1"}],
+            TransitiveTagKeys=["SessionTag1"],
+        )
+        role_1_clients = aws_client_factory(
+            aws_access_key_id=keys["AccessKeyId"],
+            aws_secret_access_key=keys["SecretAccessKey"],
+            aws_session_token=keys["SessionToken"],
+        )
+
+        # try to assume role 2 by overriding transitive session tags
+        with pytest.raises(ClientError) as e:
+            role_1_clients.sts.assume_role(
+                RoleArn=role_2["Role"]["Arn"],
+                RoleSessionName="Session2SessionTagOverride",
+                Tags=[{"Key": "SessionTag1", "Value": "SessionValue2"}],
+            )
+        snapshot.match("override-transitive-tag-error", e.value.response)
+
+    @markers.aws.validated
+    def test_assume_role_invalid_tags(
+        self,
+        aws_client,
+        aws_client_factory,
+        create_role,
+        snapshot,
+        region_name,
+        account_id,
+        wait_and_assume_role,
+    ):
+        snapshot.add_transformer(snapshot.transform.iam_api())
+        role_name_1 = f"role-1-{short_uid()}"
+        assume_role_policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": ["sts:AssumeRole", "sts:TagSession"],
+                    "Principal": {"AWS": account_id},
+                }
+            ],
+        }
+
+        role_1 = create_role(
+            RoleName=role_name_1, AssumeRolePolicyDocument=json.dumps(assume_role_policy_document)
+        )
+        snapshot.match("role-1", role_1)
+
+        # wait until role 1 is ready to be assumed
+        wait_and_assume_role(
+            role_arn=role_1["Role"]["Arn"],
+            session_name="Session1",
+        )
+        with pytest.raises(ClientError) as e:
+            aws_client.sts.assume_role(
+                RoleArn=role_1["Role"]["Arn"],
+                RoleSessionName="SessionInvalidTransitiveKeys",
+                Tags=[{"Key": "SessionTag1", "Value": "SessionValue1"}],
+                TransitiveTagKeys=["InvalidKey"],
+            )
+        snapshot.match("invalid-transitive-tag-keys", e.value.response)

--- a/tests/aws/services/sts/test_sts.snapshot.json
+++ b/tests/aws/services/sts/test_sts.snapshot.json
@@ -70,8 +70,63 @@
       }
     }
   },
-  "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_iam_role_chaining_override_transitive_tags": {
-    "recorded-date": "09-04-2025, 14:30:13",
+  "tests/aws/services/sts/test_sts.py::TestSTSAssumeRoleTagging::test_assume_role_tag_validation": {
+    "recorded-date": "10-04-2025, 08:53:12",
+    "recorded-content": {
+      "role-1": {
+        "Role": {
+          "Arn": "arn:<partition>:iam::111111111111:role/<role-name:1>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole",
+                  "sts:TagSession"
+                ],
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "111111111111"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "RoleId": "<role-id:1>",
+          "RoleName": "<role-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invalid-transitive-tag-keys": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "The specified transitive tag key must be included in the requested tags.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "duplicate-tag-keys-different-casing": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Duplicate tag keys found. Please note that Tag keys are case insensitive.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSAssumeRoleTagging::test_iam_role_chaining_override_transitive_tags": {
+    "recorded-date": "10-04-2025, 08:53:00",
     "recorded-content": {
       "role-1": {
         "Role": {
@@ -139,44 +194,11 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
         }
-      }
-    }
-  },
-  "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_assume_role_invalid_tags": {
-    "recorded-date": "09-04-2025, 14:30:56",
-    "recorded-content": {
-      "role-1": {
-        "Role": {
-          "Arn": "arn:<partition>:iam::111111111111:role/<role-name:1>",
-          "AssumeRolePolicyDocument": {
-            "Statement": [
-              {
-                "Action": [
-                  "sts:AssumeRole",
-                  "sts:TagSession"
-                ],
-                "Effect": "Allow",
-                "Principal": {
-                  "AWS": "111111111111"
-                }
-              }
-            ],
-            "Version": "2012-10-17"
-          },
-          "CreateDate": "<datetime>",
-          "Path": "/",
-          "RoleId": "<role-id:1>",
-          "RoleName": "<role-name:1>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
       },
-      "invalid-transitive-tag-keys": {
+      "override-transitive-tag-case-ignore-error": {
         "Error": {
           "Code": "InvalidParameterValue",
-          "Message": "The specified transitive tag key must be included in the requested tags.",
+          "Message": "One of the specified transitive tag keys can't be set because it conflicts with a transitive tag key from the calling session.",
           "Type": "Sender"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/sts/test_sts.snapshot.json
+++ b/tests/aws/services/sts/test_sts.snapshot.json
@@ -69,5 +69,121 @@
         }
       }
     }
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_iam_role_chaining_override_transitive_tags": {
+    "recorded-date": "09-04-2025, 14:30:13",
+    "recorded-content": {
+      "role-1": {
+        "Role": {
+          "Arn": "arn:<partition>:iam::111111111111:role/<role-name:1>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole",
+                  "sts:TagSession"
+                ],
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "111111111111"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "RoleId": "<role-id:1>",
+          "RoleName": "<role-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "role-2": {
+        "Role": {
+          "Arn": "arn:<partition>:iam::111111111111:role/<role-name:2>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole",
+                  "sts:TagSession"
+                ],
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "111111111111"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "RoleId": "<role-id:2>",
+          "RoleName": "<role-name:2>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "override-transitive-tag-error": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "One of the specified transitive tag keys can't be set because it conflicts with a transitive tag key from the calling session.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_assume_role_invalid_tags": {
+    "recorded-date": "09-04-2025, 14:30:56",
+    "recorded-content": {
+      "role-1": {
+        "Role": {
+          "Arn": "arn:<partition>:iam::111111111111:role/<role-name:1>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole",
+                  "sts:TagSession"
+                ],
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "111111111111"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "RoleId": "<role-id:1>",
+          "RoleName": "<role-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invalid-transitive-tag-keys": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "The specified transitive tag key must be included in the requested tags.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sts/test_sts.validation.json
+++ b/tests/aws/services/sts/test_sts.validation.json
@@ -2,7 +2,13 @@
   "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_assume_role": {
     "last_validated_date": "2024-06-05T17:23:49+00:00"
   },
+  "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_assume_role_invalid_tags": {
+    "last_validated_date": "2025-04-09T14:30:56+00:00"
+  },
   "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_get_federation_token": {
     "last_validated_date": "2024-06-05T13:39:17+00:00"
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_iam_role_chaining_override_transitive_tags": {
+    "last_validated_date": "2025-04-09T14:30:13+00:00"
   }
 }

--- a/tests/aws/services/sts/test_sts.validation.json
+++ b/tests/aws/services/sts/test_sts.validation.json
@@ -1,14 +1,23 @@
 {
+  "tests/aws/services/sts/test_sts.py::TestSTSAssumeRoleTagging::test_assume_role_tag_validation": {
+    "last_validated_date": "2025-04-10T08:53:12+00:00"
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSAssumeRoleTagging::test_iam_role_chaining_override_transitive_tags": {
+    "last_validated_date": "2025-04-10T08:53:00+00:00"
+  },
   "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_assume_role": {
     "last_validated_date": "2024-06-05T17:23:49+00:00"
   },
   "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_assume_role_invalid_tags": {
     "last_validated_date": "2025-04-09T14:30:56+00:00"
   },
+  "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_assume_role_tag_validation": {
+    "last_validated_date": "2025-04-10T08:31:58+00:00"
+  },
   "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_get_federation_token": {
     "last_validated_date": "2024-06-05T13:39:17+00:00"
   },
   "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_iam_role_chaining_override_transitive_tags": {
-    "last_validated_date": "2025-04-09T14:30:13+00:00"
+    "last_validated_date": "2025-04-10T08:08:37+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds IAM transitive session tagging support for the STS `assume_role` operation.
By now storing both session tags, and transitive session tags in the session store, we can make use of them for IAM enforcement.

The session tag store for a session will now include both new tags and transitive tags from the assuming session.
This leads to proper aggregation of transitive tags over role chaining operations.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Store transitive session tags when creating new sessions
* Introduce some input validation for tags and transitive tags

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
