### PR TITLE
Step Functions: Increase Retry Attempts on Service Integrations for Resilience Against Transient Network Errors

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/utils/boto_client.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/utils/boto_client.py
@@ -10,6 +10,9 @@ from localstack.utils.aws.client_types import ServicePrincipal
 
 _BOTO_CLIENT_CONFIG = config = Config(
     parameter_validation=False,
+    # Temporary workaround—should be reverted once underlying potential Lambda limitation is resolved.
+    # Increased total boto client retry attempts from 1 to 5 to mitigate transient service issues.
+    # This helps reduce unnecessary state machine retries on non-service-level errors.
     retries={"total_max_attempts": 5},
     connect_timeout=TimeoutSeconds.DEFAULT_TIMEOUT_SECONDS,
     read_timeout=TimeoutSeconds.DEFAULT_TIMEOUT_SECONDS,

--- a/localstack-core/localstack/services/stepfunctions/asl/utils/boto_client.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/utils/boto_client.py
@@ -10,7 +10,7 @@ from localstack.utils.aws.client_types import ServicePrincipal
 
 _BOTO_CLIENT_CONFIG = config = Config(
     parameter_validation=False,
-    retries={"total_max_attempts": 1},
+    retries={"total_max_attempts": 5},
     connect_timeout=TimeoutSeconds.DEFAULT_TIMEOUT_SECONDS,
     read_timeout=TimeoutSeconds.DEFAULT_TIMEOUT_SECONDS,
     tcp_keepalive=True,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
To temporarily reduce the impact of transient network instability in concurrent Lambda executions, this PR increases the total number of retry attempts for the boto client from 1 to 5. Due to occasional “connection refused” errors, the previous setting would immediately trigger retry workflows in the state machine. This could significantly increase the runtime of the program if large backoff rates or wait settings were used in case of failures https://github.com/localstack/localstack/issues/12399. This change does not affect the semantics of evaluation. Catch and Retry blocks still function as intended, but it makes the state machine slightly more resilient against non-service errors such as transient connection failures.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- increase the total_max_attempts of service integrations

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
