### PR TITLE
SES: add ARN utility for SES identity

### DIFF
--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -1974,6 +1974,30 @@ def ses_verify_identity(aws_client):
 
 
 @pytest.fixture
+def setup_sender_email_address(ses_verify_identity):
+    """
+    If the test is running against AWS then assume the email address passed is already
+    verified, and passes the given email address through. Otherwise, it generates one random
+    email address and verify them.
+    """
+
+    def inner(sender_email_address: Optional[str] = None) -> str:
+        if is_aws_cloud():
+            if sender_email_address is None:
+                raise ValueError(
+                    "sender_email_address must be specified to run this test against AWS"
+                )
+        else:
+            # overwrite the given parameters with localstack specific ones
+            sender_email_address = f"sender-{short_uid()}@example.com"
+            ses_verify_identity(sender_email_address)
+
+        return sender_email_address
+
+    return inner
+
+
+@pytest.fixture
 def ec2_create_security_group(aws_client):
     ec2_sgs = []
 

--- a/localstack-core/localstack/utils/aws/arns.py
+++ b/localstack-core/localstack/utils/aws/arns.py
@@ -525,6 +525,16 @@ def route53_resolver_query_log_config_arn(id: str, account_id: str, region_name:
 
 
 #
+# SES
+#
+
+
+def ses_identity_arn(email: str, account_id: str, region_name: str) -> str:
+    pattern = "arn:%s:ses:%s:%s:identity/%s"
+    return _resource_arn(email, pattern, account_id=account_id, region_name=region_name)
+
+
+#
 # Other ARN related helpers
 #
 

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -117,30 +117,6 @@ def setup_email_addresses(ses_verify_identity):
 
 
 @pytest.fixture
-def setup_sender_email_address(ses_verify_identity):
-    """
-    If the test is running against AWS then assume the email address passed is already
-    verified, and passes the given email address through. Otherwise, it generates one random
-    email address and verify them.
-    """
-
-    def inner(sender_email_address: Optional[str] = None) -> str:
-        if is_aws_cloud():
-            if sender_email_address is None:
-                raise ValueError(
-                    "sender_email_address must be specified to run this test against AWS"
-                )
-        else:
-            # overwrite the given parameters with localstack specific ones
-            sender_email_address = f"sender-{short_uid()}@example.com"
-            ses_verify_identity(sender_email_address)
-
-        return sender_email_address
-
-    return inner
-
-
-@pytest.fixture
 def add_snapshot_transformer_for_sns_event(snapshot):
     def _inner(sender_email, recipient_email, config_set_name):
         snapshot.add_transformers_list(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Companion PR for https://github.com/localstack/localstack-ext/pull/4318. Simply adds an arn utility method and moves a fixture.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Implementing `ses_identity_arn`;
- Moving the `setup_sender_email_address` fixture.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
