### PR TITLE
APIGW: migrate TestInvokeMethod to NextGen

### DIFF
--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -3,7 +3,6 @@ import copy
 import hashlib
 import json
 import logging
-from datetime import datetime
 from typing import List, Optional, TypedDict, Union
 from urllib import parse as urlparse
 
@@ -60,7 +59,6 @@ INVOKE_TEST_LOG_TEMPLATE = """Execution log for request {request_id}
         {formatted_date} : Successfully completed execution
         {formatted_date} : Method completed with status: {status_code}
         """
-
 
 EMPTY_MODEL = "Empty"
 ERROR_MODEL = "Error"
@@ -982,35 +980,6 @@ def is_greedy_path(path_part: str) -> bool:
 
 def is_variable_path(path_part: str) -> bool:
     return path_part.startswith("{") and path_part.endswith("}")
-
-
-def log_template(
-    request_id: str,
-    date: datetime,
-    http_method: str,
-    resource_path: str,
-    request_path: str,
-    query_string: str,
-    request_headers: str,
-    request_body: str,
-    response_body: str,
-    response_headers: str,
-    status_code: str,
-):
-    formatted_date = date.strftime("%a %b %d %H:%M:%S %Z %Y")
-    return INVOKE_TEST_LOG_TEMPLATE.format(
-        request_id=request_id,
-        formatted_date=formatted_date,
-        http_method=http_method,
-        resource_path=resource_path,
-        request_path=request_path,
-        query_string=query_string,
-        request_headers=request_headers,
-        request_body=request_body,
-        response_body=response_body,
-        response_headers=response_headers,
-        status_code=status_code,
-    )
 
 
 def get_domain_name_hash(domain_name: str) -> str:

--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -98,6 +98,7 @@ from localstack.services.apigateway.exporter import OpenApiExporter
 from localstack.services.apigateway.helpers import (
     EMPTY_MODEL,
     ERROR_MODEL,
+    INVOKE_TEST_LOG_TEMPLATE,
     OpenAPIExt,
     apply_json_patch_safe,
     get_apigateway_store,
@@ -108,7 +109,6 @@ from localstack.services.apigateway.helpers import (
     import_api_from_openapi_spec,
     is_greedy_path,
     is_variable_path,
-    log_template,
     resolve_references,
 )
 from localstack.services.apigateway.legacy.helpers import multi_value_dict_for_list
@@ -217,9 +217,10 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
         # TODO: add the missing fields to the log. Next iteration will add helpers to extract the missing fields
         # from the apicontext
-        log = log_template(
+        formatted_date = req_start_time.strftime("%a %b %d %H:%M:%S %Z %Y")
+        log = INVOKE_TEST_LOG_TEMPLATE.format(
             request_id=invocation_context.context["requestId"],
-            date=req_start_time,
+            formatted_date=formatted_date,
             http_method=invocation_context.method,
             resource_path=invocation_context.invocation_path,
             request_path="",
@@ -230,6 +231,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             response_headers=result.headers,
             status_code=result.status_code,
         )
+
         return TestInvokeMethodResponse(
             status=result.status_code,
             headers=dict(result.headers),

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
@@ -164,12 +164,6 @@ def create_test_invocation_context(
     return invocation_context
 
 
-def _fix_headers(headers: Headers) -> Headers:
-    headers.remove("Content-Length")
-
-    return headers
-
-
 def run_test_invocation(
     test_request: TestInvokeMethodRequest, deployment: RestApiDeployment
 ) -> TestInvokeMethodResponse:
@@ -193,7 +187,10 @@ def run_test_invocation(
     test_chain.handle(context=invocation_context, response=test_response)
     end_time = datetime.datetime.now()
 
-    response_headers = _fix_headers(test_response.headers.copy())
+    response_headers = test_response.headers.copy()
+    # AWS does not return the Content-Length for TestInvokeMethod
+    response_headers.remove("Content-Length")
+
     log = log_template(invocation_context, response_headers)
 
     headers = dict(response_headers)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
@@ -1,0 +1,203 @@
+import datetime
+import json
+from urllib.parse import parse_qs
+
+from rolo import Request
+from rolo.gateway.chain import HandlerChain
+from werkzeug.datastructures import Headers
+
+from localstack.aws.api.apigateway import TestInvokeMethodRequest, TestInvokeMethodResponse
+from localstack.constants import APPLICATION_JSON
+from localstack.http import Response
+from localstack.utils.strings import to_bytes, to_str
+
+from ...models import RestApiDeployment
+from . import handlers
+from .context import InvocationRequest, RestApiInvocationContext
+from .handlers.resource_router import RestAPIResourceRouter
+from .header_utils import build_multi_value_headers
+from .template_mapping import dict_to_string
+
+# Sun Feb 04 18:48:23 UTC 2024
+# TODO: we probably need to write and populate those logs as part of the handler chain itself
+#  and store it in the InvocationContext. That way, we could also retrieve in when calling TestInvoke
+# endpoint_request_headers -> truncated at 998 chars [TRUNCATED]
+
+
+TEST_INVOKE_TEMPLATE = """Execution log for request {request_id}
+{formatted_date} : Starting execution for request: {request_id}
+{formatted_date} : HTTP Method: GET, Resource Path: {resource_path}
+{formatted_date} : Method request path: {method_request_path_parameters}
+{formatted_date} : Method request query string: {method_request_query_string}
+{formatted_date} : Method request headers: {method_request_headers}
+{formatted_date} : Method request body before transformations: {method_request_body}
+{formatted_date} : Endpoint request URI: {endpoint_uri}
+{formatted_date} : Endpoint request headers: {endpoint_request_headers}
+{formatted_date} : Endpoint request body after transformations: {endpoint_request_body}
+{formatted_date} : Sending request to {endpoint_uri}
+{formatted_date} : Received response. Status: {endpoint_response_status_code}, Integration latency: {endpoint_response_latency} ms
+{formatted_date} : Endpoint response headers: {endpoint_response_headers}
+{formatted_date} : Endpoint response body before transformations: {endpoint_response_body}
+{formatted_date} : Method response body after transformations: {method_response_body}
+{formatted_date} : Method response headers: {method_response_headers}
+{formatted_date} : Successfully completed execution
+{formatted_date} : Method completed with status: {method_response_status}
+"""
+
+
+def _dump_headers(headers: Headers) -> str:
+    if not headers:
+        return "{}"
+    multi_headers = {key: ",".join(headers.getlist(key)) for key in headers.keys()}
+    string_headers = dict_to_string(multi_headers)
+    if len(string_headers) > 998:
+        return f"{string_headers[:998]} [TRUNCATED]"
+
+    return string_headers
+
+
+def log_template(invocation_context: RestApiInvocationContext) -> str:
+    # formatted_date = date.strftime("%a %b %d %H:%M:%S %Z %Y")
+    request = invocation_context.invocation_request
+    context_var = invocation_context.context_variables
+    integration_req = invocation_context.integration_request
+    endpoint_resp = invocation_context.endpoint_response
+    method_resp = invocation_context.invocation_response
+    # TODO: if endpoint_uri is an ARN, it means it's an AWS_PROXY integration
+    #  this should be transformed to the true URL of a lambda invoke call
+    endpoint_uri = integration_req.get("uri", "")
+    # TODO: funny enough, in AWS for the `endpoint_response_headers` in AWS_PROXY, they log the response headers from
+    #  lambda HTTP Invoke call even though we use the headers from the lambda response itself
+
+    return TEST_INVOKE_TEMPLATE.format(
+        formatted_date="",
+        request_id=context_var["requestId"],
+        resource_path="",
+        method_request_path_parameters=json.dumps(request["path_parameters"]),
+        method_request_query_string="",
+        method_request_headers=_dump_headers(request.get("headers")),
+        method_request_body=to_str(request.get("body", "")),
+        endpoint_uri=endpoint_uri,
+        endpoint_request_headers=_dump_headers(integration_req.get("headers")),
+        endpoint_request_body=to_str(integration_req.get("body", "")),
+        endpoint_response_latency="",
+        endpoint_response_status_code=endpoint_resp.get("status"),
+        endpoint_response_body=to_str(endpoint_resp.get("body", "")),
+        endpoint_response_headers=_dump_headers(endpoint_resp.get("headers")),
+        method_response_status=method_resp.get("status"),
+        method_response_body=to_str(method_resp.get("body", "")),
+        method_response_headers=_dump_headers(method_resp.get("headers")),
+    )
+
+
+def create_test_chain() -> HandlerChain[RestApiInvocationContext]:
+    return HandlerChain(
+        request_handlers=[
+            handlers.method_request_handler,
+            handlers.integration_request_handler,
+            handlers.integration_handler,
+            handlers.integration_response_handler,
+            handlers.method_response_handler,
+        ],
+        exception_handlers=[
+            handlers.gateway_exception_handler,
+        ],
+    )
+
+
+def create_test_invocation_context(
+    test_request: TestInvokeMethodRequest,
+    deployment: RestApiDeployment,
+) -> RestApiInvocationContext:
+    #     restApiId: String
+    #     resourceId: String
+    #     httpMethod: String
+    #     pathWithQueryString: Optional[String]
+    #     body: Optional[String]
+    #     headers: Optional[MapOfStringToString]
+    #     multiValueHeaders: Optional[MapOfStringToList]
+    #     clientCertificateId: Optional[String]
+    #     stageVariables: Optional[MapOfStringToString]
+
+    # we do not need a true HTTP request for the context, as we are skipping all the parsing steps
+    #
+    parse_handler = handlers.parse_request
+    http_method = test_request["httpMethod"]
+
+    invocation_context = RestApiInvocationContext(
+        request=Request(method=http_method),
+    )
+    path_query = test_request.get("pathWithQueryString", "/").split("?")
+    path = path_query[0]
+    multi_query_args: dict[str, list[str]] = {}
+
+    if len(path_query) > 1:
+        multi_query_args = parse_qs(path_query[1])
+
+    # for the single value parameters, AWS only keeps the last value of the list
+    single_query_args = {k: v[-1] for k, v in multi_query_args.items()}
+
+    invocation_request = InvocationRequest(
+        http_method=http_method,
+        path=path,
+        raw_path=path,
+        query_string_parameters=single_query_args,
+        multi_value_query_string_parameters=multi_query_args,
+        headers=Headers(test_request.get("headers")),
+        # TODO: handle multiValueHeaders
+        body=to_bytes(test_request.get("body") or ""),
+    )
+    invocation_context.invocation_request = invocation_request
+
+    _, path_parameters = RestAPIResourceRouter(deployment).match(invocation_context)
+    invocation_request["path_parameters"] = path_parameters
+
+    invocation_context.deployment = deployment
+    invocation_context.api_id = test_request["restApiId"]
+    invocation_context.stage = None
+    invocation_context.deployment_id = ""
+    invocation_context.account_id = deployment.account_id
+    invocation_context.region = deployment.region
+    invocation_context.stage_variables = test_request.get("stageVariables", {})
+    invocation_context.context_variables = parse_handler.create_context_variables(
+        invocation_context
+    )
+    invocation_context.trace_id = parse_handler.populate_trace_id({})
+
+    resource = deployment.rest_api.resources[test_request["resourceId"]]
+    resource_method = resource["resourceMethods"][http_method]
+    invocation_context.resource = resource
+    invocation_context.resource_method = resource_method
+    invocation_context.integration = resource_method["methodIntegration"]
+
+    return invocation_context
+
+
+def run_test_invocation(
+    test_request: TestInvokeMethodRequest, deployment: RestApiDeployment
+) -> TestInvokeMethodResponse:
+    # validate resource exists in deployment
+    invocation_context = create_test_invocation_context(test_request, deployment)
+
+    test_chain = create_test_chain()
+    test_response = Response(headers={"Content-Type": APPLICATION_JSON})
+    start_time = datetime.datetime.now()
+    test_chain.handle(context=invocation_context, response=test_response)
+    end_time = datetime.datetime.now()
+
+    log = log_template(invocation_context)
+    headers = dict(test_response.headers)
+    multi_value_headers = build_multi_value_headers(test_response.headers)
+    # we manually add the trace-id, as it is normally added by handlers.response_enricher which adds to much data for
+    # the TestInvoke
+    headers["X-Amzn-Trace-Id"] = invocation_context.trace_id
+    multi_value_headers["X-Amzn-Trace-Id"] = [invocation_context.trace_id]
+
+    return TestInvokeMethodResponse(
+        log=log,
+        status=test_response.status_code,
+        body=test_response.get_data(as_text=True),
+        headers=headers,
+        multiValueHeaders=multi_value_headers,
+        latency=int((end_time - start_time).total_seconds()),
+    )

--- a/tests/aws/services/apigateway/apigateway_fixtures.py
+++ b/tests/aws/services/apigateway/apigateway_fixtures.py
@@ -26,6 +26,15 @@ def assert_response_is_201(response: Dict) -> bool:
     return True
 
 
+def import_rest_api(apigateway_client, **kwargs):
+    response = apigateway_client.import_rest_api(**kwargs)
+    assert_response_is_201(response)
+    resources = apigateway_client.get_resources(restApiId=response.get("id"))
+    root_id = next(item for item in resources["items"] if item["path"] == "/")["id"]
+
+    return response, root_id
+
+
 def create_rest_resource(apigateway_client, **kwargs):
     response = apigateway_client.create_resource(**kwargs)
     assert_response_is_201(response)

--- a/tests/aws/services/apigateway/apigateway_fixtures.py
+++ b/tests/aws/services/apigateway/apigateway_fixtures.py
@@ -26,47 +26,10 @@ def assert_response_is_201(response: Dict) -> bool:
     return True
 
 
-def import_rest_api(apigateway_client, **kwargs):
-    response = apigateway_client.import_rest_api(**kwargs)
-    assert_response_is_201(response)
-    resources = apigateway_client.get_resources(restApiId=response.get("id"))
-    root_id = next(item for item in resources["items"] if item["path"] == "/")["id"]
-
-    return response, root_id
-
-
-def get_rest_api(apigateway_client, **kwargs):
-    response = apigateway_client.get_rest_api(**kwargs)
-    assert_response_is_200(response)
-    return response.get("id"), response.get("name")
-
-
-def put_rest_api(apigateway_client, **kwargs):
-    response = apigateway_client.put_rest_api(**kwargs)
-    assert_response_is_200(response)
-    return response.get("id"), response.get("name")
-
-
-def get_rest_apis(apigateway_client, **kwargs):
-    response = apigateway_client.get_rest_apis(**kwargs)
-    assert_response_is_200(response)
-    return response.get("items")
-
-
-def delete_rest_api(apigateway_client, **kwargs):
-    response = apigateway_client.delete_rest_api(**kwargs)
-    assert_response_status(response, 202)
-
-
 def create_rest_resource(apigateway_client, **kwargs):
     response = apigateway_client.create_resource(**kwargs)
     assert_response_is_201(response)
     return response.get("id"), response.get("parentId")
-
-
-def delete_rest_resource(apigateway_client, **kwargs):
-    response = apigateway_client.delete_resource(**kwargs)
-    assert_response_is_200(response)
 
 
 def create_rest_resource_method(apigateway_client, **kwargs):
@@ -75,32 +38,10 @@ def create_rest_resource_method(apigateway_client, **kwargs):
     return response.get("httpMethod"), response.get("authorizerId")
 
 
-def create_rest_authorizer(apigateway_client, **kwargs):
-    response = apigateway_client.create_authorizer(**kwargs)
-    assert_response_is_201(response)
-    return response.get("id"), response.get("type")
-
-
 def create_rest_api_integration(apigateway_client, **kwargs):
     response = apigateway_client.put_integration(**kwargs)
     assert_response_is_201(response)
     return response.get("uri"), response.get("type")
-
-
-def get_rest_api_resources(apigateway_client, **kwargs):
-    response = apigateway_client.get_resources(**kwargs)
-    assert_response_is_200(response)
-    return response.get("items")
-
-
-def delete_rest_api_integration(apigateway_client, **kwargs):
-    response = apigateway_client.delete_integration(**kwargs)
-    assert_response_is_200(response)
-
-
-def get_rest_api_integration(apigateway_client, **kwargs):
-    response = apigateway_client.get_integration(**kwargs)
-    assert_response_is_200(response)
 
 
 def create_rest_api_method_response(apigateway_client, **kwargs):
@@ -113,17 +54,6 @@ def create_rest_api_integration_response(apigateway_client, **kwargs):
     response = apigateway_client.put_integration_response(**kwargs)
     assert_response_is_201(response)
     return response.get("statusCode")
-
-
-def create_domain_name(apigateway_client, **kwargs):
-    response = apigateway_client.create_domain_name(**kwargs)
-    assert_response_is_201(response)
-
-
-def create_base_path_mapping(apigateway_client, **kwargs):
-    response = apigateway_client.create_base_path_mapping(**kwargs)
-    assert_response_is_201(response)
-    return response.get("basePath"), response.get("stage")
 
 
 def create_rest_api_deployment(apigateway_client, **kwargs):
@@ -148,47 +78,6 @@ def update_rest_api_stage(apigateway_client, **kwargs):
     response = apigateway_client.update_stage(**kwargs)
     assert_response_is_200(response)
     return response.get("stageName")
-
-
-def create_cognito_user_pool(cognito_idp, **kwargs):
-    response = cognito_idp.create_user_pool(**kwargs)
-    assert_response_is_200(response)
-    return response.get("UserPool").get("Id"), response.get("UserPool").get("Arn")
-
-
-def delete_cognito_user_pool(cognito_idp, **kwargs):
-    response = cognito_idp.delete_user_pool(**kwargs)
-    assert_response_is_200(response)
-
-
-def create_cognito_user_pool_client(cognito_idp, **kwargs):
-    response = cognito_idp.create_user_pool_client(**kwargs)
-    assert_response_is_200(response)
-    return (
-        response.get("UserPoolClient").get("ClientId"),
-        response.get("UserPoolClient").get("ClientName"),
-    )
-
-
-def create_cognito_user(cognito_idp, **kwargs):
-    response = cognito_idp.sign_up(**kwargs)
-    assert_response_is_200(response)
-
-
-def create_cognito_sign_up_confirmation(cognito_idp, **kwargs):
-    response = cognito_idp.admin_confirm_sign_up(**kwargs)
-    assert_response_is_200(response)
-
-
-def create_initiate_auth(cognito_idp, **kwargs):
-    response = cognito_idp.initiate_auth(**kwargs)
-    assert_response_is_200(response)
-    return response.get("AuthenticationResult").get("IdToken")
-
-
-def delete_cognito_user_pool_client(cognito_idp, **kwargs):
-    response = cognito_idp.delete_user_pool_client(**kwargs)
-    assert_response_is_200(response)
 
 
 #

--- a/tests/aws/services/apigateway/conftest.py
+++ b/tests/aws/services/apigateway/conftest.py
@@ -13,6 +13,7 @@ from tests.aws.services.apigateway.apigateway_fixtures import (
     create_rest_api_stage,
     create_rest_resource,
     create_rest_resource_method,
+    import_rest_api,
 )
 from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON_ECHO_STATUS_CODE
 
@@ -223,7 +224,7 @@ def import_apigw(aws_client, aws_client_factory):
         apigateway_client = aws_client.apigateway
 
     def _import_apigateway_function(*args, **kwargs):
-        response, root_id = apigateway_client.import_rest_api(**kwargs)
+        response, root_id = import_rest_api(apigateway_client, **kwargs)
         rest_api_ids.append(response.get("id"))
         return response, root_id
 

--- a/tests/aws/services/apigateway/conftest.py
+++ b/tests/aws/services/apigateway/conftest.py
@@ -13,8 +13,6 @@ from tests.aws.services.apigateway.apigateway_fixtures import (
     create_rest_api_stage,
     create_rest_resource,
     create_rest_resource_method,
-    delete_rest_api,
-    import_rest_api,
 )
 from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON_ECHO_STATUS_CODE
 
@@ -225,14 +223,14 @@ def import_apigw(aws_client, aws_client_factory):
         apigateway_client = aws_client.apigateway
 
     def _import_apigateway_function(*args, **kwargs):
-        response, root_id = import_rest_api(apigateway_client, **kwargs)
+        response, root_id = apigateway_client.import_rest_api(**kwargs)
         rest_api_ids.append(response.get("id"))
         return response, root_id
 
     yield _import_apigateway_function
 
     for rest_api_id in rest_api_ids:
-        delete_rest_api(apigateway_client, restApiId=rest_api_id)
+        apigateway_client.delete_rest_api(restApiId=rest_api_id)
 
 
 @pytest.fixture

--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -2320,6 +2320,7 @@ class TestApigatewayTestInvoke:
                 lambda k, v: str(v) if k == "latency" else None, "latency", replace_reference=False
             )
         )
+        # TODO: maybe transformer `log` better
         snapshot.add_transformer(
             snapshot.transform.key_value("log", "log", reference_replacement=False)
         )

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -1254,15 +1254,22 @@ class TestAPIGateway:
                 ),
                 snapshot.transform.regex(
                     r"Date=[a-zA-Z]{3},\s\d{2}\s[a-zA-Z]{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\sGMT",
-                    r"Date=Day, dd MMM yyyy hh:mm:ss GMT",
+                    "Date=Day, dd MMM yyyy hh:mm:ss GMT",
                 ),
                 snapshot.transform.regex(
-                    r"x-amzn-RequestId=[a-f0-9-]{36}", r"x-amzn-RequestId=<request-id-lambda>"
+                    r"x-amzn-RequestId=[a-f0-9-]{36}", "x-amzn-RequestId=<request-id-lambda>"
                 ),
                 snapshot.transform.regex(
                     r"[a-zA-Z]{3}\s[a-zA-Z]{3}\s\d{2}\s\d{2}:\d{2}:\d{2}\sUTC\s\d{4} :",
-                    r"DDD MMM dd hh:mm:ss UTC yyyy :",
+                    "DDD MMM dd hh:mm:ss UTC yyyy :",
                 ),
+                snapshot.transform.regex(
+                    r"Authorization=.*?,", "Authorization=<authorization-header>,"
+                ),
+                snapshot.transform.regex(
+                    r"X-Amz-Security-Token=.*?\s\[", "X-Amz-Security-Token=<token> ["
+                ),
+                snapshot.transform.regex(r"\d{8}T\d{6}Z", "<date>"),
             ]
         )
 
@@ -1283,6 +1290,7 @@ class TestAPIGateway:
 
         # create REST API and test resource
         rest_api_id, _, root = create_rest_apigw(name=f"test-{short_uid()}")
+        snapshot.add_transformer(snapshot.transform.regex(rest_api_id, "<rest-api-id>"))
         resource = aws_client.apigateway.create_resource(
             restApiId=rest_api_id, parentId=root, pathPart="foo"
         )

--- a/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
@@ -1,62 +1,7 @@
 {
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigw_test_invoke_method_api": {
-    "recorded-date": "04-02-2024, 18:48:24",
-    "recorded-content": {
-      "test_invoke_method_response": {
-        "body": {
-          "statusCode": 200,
-          "body": "\"response from localstack lambda: {}\"",
-          "isBase64Encoded": false,
-          "headers": {}
-        },
-        "headers": {
-          "Content-Type": "application/json",
-          "X-Amzn-Trace-Id": "Root=1-65bfdbf7-1b5920a5a0a57e32194306b3;Parent=5c9925637b7d89fa;Sampled=0;lineage=59cc7ee1:0"
-        },
-        "latency": 394,
-        "log": "Execution log for request d09d726b-32a3-42fc-87c7-42ac58bca845\nSun Feb 04 18:48:23 UTC 2024 : Starting execution for request: d09d726b-32a3-42fc-87c7-42ac58bca845\nSun Feb 04 18:48:23 UTC 2024 : HTTP Method: GET, Resource Path: /foo\nSun Feb 04 18:48:23 UTC 2024 : Method request path: {}\nSun Feb 04 18:48:23 UTC 2024 : Method request query string: {}\nSun Feb 04 18:48:23 UTC 2024 : Method request headers: {}\nSun Feb 04 18:48:23 UTC 2024 : Method request body before transformations: \nSun Feb 04 18:48:23 UTC 2024 : Endpoint request URI: https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:test-de2a8789/invocations\nSun Feb 04 18:48:23 UTC 2024 : Endpoint request headers: {x-amzn-lambda-integration-tag=d09d726b-32a3-42fc-87c7-42ac58bca845, Authorization=*********************************************************************************************************************************************************************************************************************************************************************fd20ad, X-Amz-Date=20240204T184823Z, x-amzn-apigateway-api-id=96m844vit9, Accept=application/json, User-Agent=AmazonAPIGateway_96m844vit9, X-Amz-Security-Token=IQoJb3JpZ2luX2VjEMv//////////wEaCXVzLWVhc3QtMSJHMEUCIQDH/nm1y4gMfoEBmxGW3/Tvqy4n6O3lzViNg021ao2NOQIgXFf6aGDn2L5egYErKkRsBaOKEvTn/jpaZgmTjAGO1BEq7gIIlP//////////ARACGgw2NTk2NzY4MjExMTgiDGZzbbOVj3R7zPeswyrCAtEzQYGuVCS1ylMX93oVtpfyXNQx3ZLeknme7FtyuuFFuzM2lU+a3C4ykL4j8qQmT8nFXdfX7ZzLCLmRjr1EhTgPrh7SE5XSxfBQdxTQxkoaGImnDRbceKLPxSMALrub+owhkfeZT29laOyBzPdttLM7iG7Q/bws/ywC0I8HMJA4Dl5KHMhiKDBncYXjdYhlHCSPb+qN/5cZ1Wm+jUV/znw6RG8Hhz+mKzFDckbVItiRD+CdbP5V3IjVZgtzSvwXqN8EXN9R0tRXE+b0FD7AUMctWoDbCqkIHf [TRUNCATED]\nSun Feb 04 18:48:23 UTC 2024 : Endpoint request body after transformations: \nSun Feb 04 18:48:23 UTC 2024 : Sending request to https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:test-de2a8789/invocations\nSun Feb 04 18:48:24 UTC 2024 : Received response. Status: 200, Integration latency: 356 ms\nSun Feb 04 18:48:24 UTC 2024 : Endpoint response headers: {Date=Sun, 04 Feb 2024 18:48:24 GMT, Content-Type=application/json, Content-Length=104, Connection=keep-alive, x-amzn-RequestId=20a0cc6d-ade0-417f-853d-04c72dbe23d6, x-amzn-Remapped-Content-Length=0, X-Amz-Executed-Version=$LATEST, X-Amzn-Trace-Id=root=1-65bfdbf7-1b5920a5a0a57e32194306b3;parent=5c9925637b7d89fa;sampled=0;lineage=59cc7ee1:0}\nSun Feb 04 18:48:24 UTC 2024 : Endpoint response body before transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}\nSun Feb 04 18:48:24 UTC 2024 : Method response body after transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}\nSun Feb 04 18:48:24 UTC 2024 : Method response headers: {X-Amzn-Trace-Id=Root=1-65bfdbf7-1b5920a5a0a57e32194306b3;Parent=5c9925637b7d89fa;Sampled=0;lineage=59cc7ee1:0, Content-Type=application/json}\nSun Feb 04 18:48:24 UTC 2024 : Successfully completed execution\nSun Feb 04 18:48:24 UTC 2024 : Method completed with status: 200\n",
-        "multiValueHeaders": {
-          "Content-Type": [
-            "application/json"
-          ],
-          "X-Amzn-Trace-Id": [
-            "Root=1-65bfdbf7-1b5920a5a0a57e32194306b3;Parent=5c9925637b7d89fa;Sampled=0;lineage=59cc7ee1:0"
-          ]
-        },
-        "status": 200,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "test_invoke_method_response_with_body": {
-        "body": {
-          "statusCode": 200,
-          "body": "\"response from localstack lambda: {\\\"test\\\":\\\"val123\\\"}\"",
-          "isBase64Encoded": false,
-          "headers": {}
-        },
-        "headers": {
-          "Content-Type": "application/json",
-          "X-Amzn-Trace-Id": "Root=1-65bfdbf8-caa70673935f456b40debcda;Parent=0f5819866f6639ce;Sampled=0;lineage=59cc7ee1:0"
-        },
-        "latency": 62,
-        "log": "Execution log for request 63ecf43a-1b6e-40ef-80b7-98c5b7484ec9\nSun Feb 04 18:48:24 UTC 2024 : Starting execution for request: 63ecf43a-1b6e-40ef-80b7-98c5b7484ec9\nSun Feb 04 18:48:24 UTC 2024 : HTTP Method: GET, Resource Path: /foo\nSun Feb 04 18:48:24 UTC 2024 : Method request path: {}\nSun Feb 04 18:48:24 UTC 2024 : Method request query string: {}\nSun Feb 04 18:48:24 UTC 2024 : Method request headers: {content-type=application/json}\nSun Feb 04 18:48:24 UTC 2024 : Method request body before transformations: {\"test\": \"val123\"}\nSun Feb 04 18:48:24 UTC 2024 : Endpoint request URI: https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:test-de2a8789/invocations\nSun Feb 04 18:48:24 UTC 2024 : Endpoint request headers: {x-amzn-lambda-integration-tag=63ecf43a-1b6e-40ef-80b7-98c5b7484ec9, Authorization=*******************************************************************************************************************************************************************************************************************************************************************************************************4b5ad4, X-Amz-Date=20240204T184824Z, x-amzn-apigateway-api-id=96m844vit9, Accept=application/json, User-Agent=AmazonAPIGateway_96m844vit9, X-Amz-Security-Token=IQoJb3JpZ2luX2VjEMv//////////wEaCXVzLWVhc3QtMSJIMEYCIQCX8aMq+Q5P6zw4SzP7nSzzMTzd2D0tbCwx9jyQnWiiSgIhAKevG8f4Qo1O/lr+A17AujqFg9AqJCIB5zNu+g8RZFl+Ku4CCJT//////////wEQAhoMNjU5Njc2ODIxMTE4IgxyHR1NVV6IvXrBrD8qwgJNyGLqGkyhoWFD36VE4ENpEW9PzKtbnKkQq/tqZdBBSwvzTmANSNEE7dIpiTolgXGMN4llNaV9CNYF+Ro/zXmsY4u/y8HgSFnTst/iOam+hEGQEr9BEflhu1Sqy7xqBt5pfIVscdpPNVsdX0OLKDT98v3pTRUnilsMDK/6F4wzl4SJ8mQ4vYqCN5mh6n+96Ze2Q0ldYEDjbBmMItgyDk2so2OxMiVPtrhJ81u7NYsEYdmgQ5dve3rQYT7+oVnA [TRUNCATED]\nSun Feb 04 18:48:24 UTC 2024 : Endpoint request body after transformations: {\"test\": \"val123\"}\nSun Feb 04 18:48:24 UTC 2024 : Sending request to https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:test-de2a8789/invocations\nSun Feb 04 18:48:24 UTC 2024 : Received response. Status: 200, Integration latency: 25 ms\nSun Feb 04 18:48:24 UTC 2024 : Endpoint response headers: {Date=Sun, 04 Feb 2024 18:48:24 GMT, Content-Type=application/json, Content-Length=131, Connection=keep-alive, x-amzn-RequestId=57dc53e3-bc2e-449b-83ef-fd7d97479909, x-amzn-Remapped-Content-Length=0, X-Amz-Executed-Version=$LATEST, X-Amzn-Trace-Id=root=1-65bfdbf8-caa70673935f456b40debcda;parent=0f5819866f6639ce;sampled=0;lineage=59cc7ee1:0}\nSun Feb 04 18:48:24 UTC 2024 : Endpoint response body before transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {\\\\\\\"test\\\\\\\":\\\\\\\"val123\\\\\\\"}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}\nSun Feb 04 18:48:24 UTC 2024 : Method response body after transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {\\\\\\\"test\\\\\\\":\\\\\\\"val123\\\\\\\"}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}\nSun Feb 04 18:48:24 UTC 2024 : Method response headers: {X-Amzn-Trace-Id=Root=1-65bfdbf8-caa70673935f456b40debcda;Parent=0f5819866f6639ce;Sampled=0;lineage=59cc7ee1:0, Content-Type=application/json}\nSun Feb 04 18:48:24 UTC 2024 : Successfully completed execution\nSun Feb 04 18:48:24 UTC 2024 : Method completed with status: 200\n",
-        "multiValueHeaders": {
-          "Content-Type": [
-            "application/json"
-          ],
-          "X-Amzn-Trace-Id": [
-            "Root=1-65bfdbf8-caa70673935f456b40debcda;Parent=0f5819866f6639ce;Sampled=0;lineage=59cc7ee1:0"
-          ]
-        },
-        "status": 200,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
+    "recorded-date": "09-04-2025, 18:24:25",
+    "recorded-content": {}
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_update_rest_api_deployment": {
     "recorded-date": "12-04-2024, 21:24:49",

--- a/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
@@ -1,7 +1,102 @@
 {
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigw_test_invoke_method_api": {
-    "recorded-date": "09-04-2025, 18:24:25",
-    "recorded-content": {}
+    "recorded-date": "10-04-2025, 19:40:04",
+    "recorded-content": {
+      "test_invoke_method_response": {
+        "body": {
+          "statusCode": 200,
+          "body": "\"response from localstack lambda: {}\"",
+          "isBase64Encoded": false,
+          "headers": {}
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "X-Amzn-Trace-Id": "<x-amz-trace-id:1>"
+        },
+        "latency": "<latency>",
+        "log": {
+          "line00": "Execution log for request <request-id-1>",
+          "line01": "DDD MMM dd hh:mm:ss UTC yyyy : Starting execution for request: <request-id-1>",
+          "line02": "DDD MMM dd hh:mm:ss UTC yyyy : HTTP Method: GET, Resource Path: /foo",
+          "line03": "DDD MMM dd hh:mm:ss UTC yyyy : Method request path: {}",
+          "line04": "DDD MMM dd hh:mm:ss UTC yyyy : Method request query string: {}",
+          "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {}",
+          "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: ",
+          "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request URI: https://<endpoint_url>/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<function-name>/invocations",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request headers: {x-amzn-lambda-integration-tag=<request-id-1>, Authorization=*********************************************************************************************************************************************************************************************************************************************************************ca7606, X-Amz-Date=20250410T194004Z, x-amzn-apigateway-api-id=9tmlb8b101, Accept=application/json, User-Agent=AmazonAPIGateway_9tmlb8b101, X-Amz-Security-Token=IQoJb3JpZ2luX2VjEDQaCWV1LXdlc3QtMyJHMEUCIGhArE0d1b6khTa1VNnEYLGSGEdKirUtUpk4EcFQA2RWAiEA5rSnLQg1Dj7sEEeJt4j8skkzKqh2IU43diqRS/ZE0fgq7gIIrf//////////ARAAGgw2NzExMDc2Nzg0MTIiDKkWYgsnQ8xn9BzveSrCArA9qunrwSdEylofk8s22UEVNPdgJ+YcnRYDJ0/242R6Bu6CjLORoDmrGmYYlYhkH96ekamZw4jwZb1MaQTgVW+KIqkE+UiG5byM4Geq2uQWSmA+vAWAhJADh0lvzTlhYw7yQbBUq/obsbs8Jmp064RIY5IZYEHVinWfRkwyjL06i5r1DpYj7SCiaZCE18/JSLn02Rt1pnN6VhJwzadx/USf7B81kNNNntYE8akM+b+oxLFTYtG4jPEG3FmobaCrnJcC+eMNR4hkkFqaDd27lTzjhNV9/nPf0dr3Earg85OYOF [TRUNCATED]",
+          "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request body after transformations: ",
+          "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Sending request to https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<function-name>/invocations",
+          "line11": "DDD MMM dd hh:mm:ss UTC yyyy : Received response. Status: 200, Integration latency: <latency> ms",
+          "line12": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint response headers: {Date=Day, dd MMM yyyy hh:mm:ss GMT, Content-Type=application/json, Content-Length=104, Connection=keep-alive, x-amzn-RequestId=<request-id-lambda>, x-amzn-Remapped-Content-Length=0, X-Amz-Executed-Version=$LATEST, X-Amzn-Trace-Id=<x-amz-trace-id:1>}",
+          "line13": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint response body before transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}",
+          "line14": "DDD MMM dd hh:mm:ss UTC yyyy : Method response body after transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}",
+          "line15": "DDD MMM dd hh:mm:ss UTC yyyy : Method response headers: {X-Amzn-Trace-Id=<x-amz-trace-id:1>, Content-Type=application/json}",
+          "line16": "DDD MMM dd hh:mm:ss UTC yyyy : Successfully completed execution",
+          "line17": "DDD MMM dd hh:mm:ss UTC yyyy : Method completed with status: 200",
+          "line18": ""
+        },
+        "multiValueHeaders": {
+          "Content-Type": [
+            "application/json"
+          ],
+          "X-Amzn-Trace-Id": [
+            "<x-amz-trace-id:1>"
+          ]
+        },
+        "status": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "test_invoke_method_response_with_body": {
+        "body": {
+          "statusCode": 200,
+          "body": "\"response from localstack lambda: {\\\"test\\\":\\\"val123\\\"}\"",
+          "isBase64Encoded": false,
+          "headers": {}
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "X-Amzn-Trace-Id": "<x-amz-trace-id:2>"
+        },
+        "latency": "<latency>",
+        "log": {
+          "line00": "Execution log for request <request-id-2>",
+          "line01": "DDD MMM dd hh:mm:ss UTC yyyy : Starting execution for request: <request-id-2>",
+          "line02": "DDD MMM dd hh:mm:ss UTC yyyy : HTTP Method: GET, Resource Path: /foo",
+          "line03": "DDD MMM dd hh:mm:ss UTC yyyy : Method request path: {}",
+          "line04": "DDD MMM dd hh:mm:ss UTC yyyy : Method request query string: {queryTest=value}",
+          "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {content-type=application/json}",
+          "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: {\"test\": \"val123\"}",
+          "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request URI: https://<endpoint_url>/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<function-name>/invocations",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request headers: {x-amzn-lambda-integration-tag=<request-id-2>, Authorization=*******************************************************************************************************************************************************************************************************************************************************************************************************28eddc, X-Amz-Date=20250410T194004Z, x-amzn-apigateway-api-id=9tmlb8b101, Accept=application/json, User-Agent=AmazonAPIGateway_9tmlb8b101, X-Amz-Security-Token=IQoJb3JpZ2luX2VjEDQaCWV1LXdlc3QtMyJGMEQCIGUEndRBbvLl3Ueps7zoq7WeMd7Pi7papod7KAbC58tlAiAwacGZkYpzdiAx2FxQlGTyM3+6X68ew/HHVyvITaYyqyruAgit//////////8BEAAaDDY3MTEwNzY3ODQxMiIM6rAlcNDNqulZTyYaKsIC5Y3tA6xr/2uiYNj/DDQdZ3VrN12G1YU1jQWaOlbcrAFV5KrX42A+1kxHcrerVSvmm0SY5ZwCyb/QeExP1QV4d33sWO3R+IHtehpiqGyULAH4fWen48DxUkggjBIW+ehRY8E5aeyzSjShaZwDAikRF/gzhYoEfq+Oowpmp2Xq3vwTLCiLtMWqEqXsZAgDUslUce8c3LzpRhBFbU0LfEBeFRTiIH9l1Ul15HpnR/p1pSfo/IrejU2Bme0yTwgzUN8YxhsUX3vXCCX/ [TRUNCATED]",
+          "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request body after transformations: {\"test\": \"val123\"}",
+          "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Sending request to https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<function-name>/invocations",
+          "line11": "DDD MMM dd hh:mm:ss UTC yyyy : Received response. Status: 200, Integration latency: <latency> ms",
+          "line12": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint response headers: {Date=Day, dd MMM yyyy hh:mm:ss GMT, Content-Type=application/json, Content-Length=131, Connection=keep-alive, x-amzn-RequestId=<request-id-lambda>, x-amzn-Remapped-Content-Length=0, X-Amz-Executed-Version=$LATEST, X-Amzn-Trace-Id=<x-amz-trace-id:2>}",
+          "line13": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint response body before transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {\\\\\\\"test\\\\\\\":\\\\\\\"val123\\\\\\\"}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}",
+          "line14": "DDD MMM dd hh:mm:ss UTC yyyy : Method response body after transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {\\\\\\\"test\\\\\\\":\\\\\\\"val123\\\\\\\"}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}",
+          "line15": "DDD MMM dd hh:mm:ss UTC yyyy : Method response headers: {X-Amzn-Trace-Id=<x-amz-trace-id:2>, Content-Type=application/json}",
+          "line16": "DDD MMM dd hh:mm:ss UTC yyyy : Successfully completed execution",
+          "line17": "DDD MMM dd hh:mm:ss UTC yyyy : Method completed with status: 200",
+          "line18": ""
+        },
+        "multiValueHeaders": {
+          "Content-Type": [
+            "application/json"
+          ],
+          "X-Amzn-Trace-Id": [
+            "<x-amz-trace-id:2>"
+          ]
+        },
+        "status": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_update_rest_api_deployment": {
     "recorded-date": "12-04-2024, 21:24:49",

--- a/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigw_test_invoke_method_api": {
-    "recorded-date": "10-04-2025, 19:40:04",
+    "recorded-date": "11-04-2025, 18:02:16",
     "recorded-content": {
       "test_invoke_method_response": {
         "body": {
@@ -23,7 +23,7 @@
           "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {}",
           "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: ",
           "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request URI: https://<endpoint_url>/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<function-name>/invocations",
-          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request headers: {x-amzn-lambda-integration-tag=<request-id-1>, Authorization=*********************************************************************************************************************************************************************************************************************************************************************ca7606, X-Amz-Date=20250410T194004Z, x-amzn-apigateway-api-id=9tmlb8b101, Accept=application/json, User-Agent=AmazonAPIGateway_9tmlb8b101, X-Amz-Security-Token=IQoJb3JpZ2luX2VjEDQaCWV1LXdlc3QtMyJHMEUCIGhArE0d1b6khTa1VNnEYLGSGEdKirUtUpk4EcFQA2RWAiEA5rSnLQg1Dj7sEEeJt4j8skkzKqh2IU43diqRS/ZE0fgq7gIIrf//////////ARAAGgw2NzExMDc2Nzg0MTIiDKkWYgsnQ8xn9BzveSrCArA9qunrwSdEylofk8s22UEVNPdgJ+YcnRYDJ0/242R6Bu6CjLORoDmrGmYYlYhkH96ekamZw4jwZb1MaQTgVW+KIqkE+UiG5byM4Geq2uQWSmA+vAWAhJADh0lvzTlhYw7yQbBUq/obsbs8Jmp064RIY5IZYEHVinWfRkwyjL06i5r1DpYj7SCiaZCE18/JSLn02Rt1pnN6VhJwzadx/USf7B81kNNNntYE8akM+b+oxLFTYtG4jPEG3FmobaCrnJcC+eMNR4hkkFqaDd27lTzjhNV9/nPf0dr3Earg85OYOF [TRUNCATED]",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request headers: {x-amzn-lambda-integration-tag=<request-id-1>, Authorization=<authorization-header>, X-Amz-Date=<date>, x-amzn-apigateway-api-id=<rest-api-id>, Accept=application/json, User-Agent=AmazonAPIGateway_<rest-api-id>, X-Amz-Security-Token=<token> [TRUNCATED]",
           "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request body after transformations: ",
           "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Sending request to https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<function-name>/invocations",
           "line11": "DDD MMM dd hh:mm:ss UTC yyyy : Received response. Status: 200, Integration latency: <latency> ms",
@@ -70,7 +70,7 @@
           "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {content-type=application/json}",
           "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: {\"test\": \"val123\"}",
           "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request URI: https://<endpoint_url>/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<function-name>/invocations",
-          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request headers: {x-amzn-lambda-integration-tag=<request-id-2>, Authorization=*******************************************************************************************************************************************************************************************************************************************************************************************************28eddc, X-Amz-Date=20250410T194004Z, x-amzn-apigateway-api-id=9tmlb8b101, Accept=application/json, User-Agent=AmazonAPIGateway_9tmlb8b101, X-Amz-Security-Token=IQoJb3JpZ2luX2VjEDQaCWV1LXdlc3QtMyJGMEQCIGUEndRBbvLl3Ueps7zoq7WeMd7Pi7papod7KAbC58tlAiAwacGZkYpzdiAx2FxQlGTyM3+6X68ew/HHVyvITaYyqyruAgit//////////8BEAAaDDY3MTEwNzY3ODQxMiIM6rAlcNDNqulZTyYaKsIC5Y3tA6xr/2uiYNj/DDQdZ3VrN12G1YU1jQWaOlbcrAFV5KrX42A+1kxHcrerVSvmm0SY5ZwCyb/QeExP1QV4d33sWO3R+IHtehpiqGyULAH4fWen48DxUkggjBIW+ehRY8E5aeyzSjShaZwDAikRF/gzhYoEfq+Oowpmp2Xq3vwTLCiLtMWqEqXsZAgDUslUce8c3LzpRhBFbU0LfEBeFRTiIH9l1Ul15HpnR/p1pSfo/IrejU2Bme0yTwgzUN8YxhsUX3vXCCX/ [TRUNCATED]",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request headers: {x-amzn-lambda-integration-tag=<request-id-2>, Authorization=<authorization-header>, X-Amz-Date=<date>, x-amzn-apigateway-api-id=<rest-api-id>, Accept=application/json, User-Agent=AmazonAPIGateway_<rest-api-id>, X-Amz-Security-Token=<token> [TRUNCATED]",
           "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request body after transformations: {\"test\": \"val123\"}",
           "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Sending request to https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<function-name>/invocations",
           "line11": "DDD MMM dd hh:mm:ss UTC yyyy : Received response. Status: 200, Integration latency: <latency> ms",

--- a/tests/aws/services/apigateway/test_apigateway_basic.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.validation.json
@@ -15,7 +15,7 @@
     "last_validated_date": "2024-07-12T20:04:15+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigw_test_invoke_method_api": {
-    "last_validated_date": "2025-04-09T18:24:25+00:00"
+    "last_validated_date": "2025-04-10T19:40:04+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_update_rest_api_deployment": {
     "last_validated_date": "2024-04-12T21:24:49+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_basic.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.validation.json
@@ -15,7 +15,7 @@
     "last_validated_date": "2024-07-12T20:04:15+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigw_test_invoke_method_api": {
-    "last_validated_date": "2025-04-10T19:40:04+00:00"
+    "last_validated_date": "2025-04-11T18:03:13+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_update_rest_api_deployment": {
     "last_validated_date": "2024-04-12T21:24:49+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_basic.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.validation.json
@@ -15,7 +15,7 @@
     "last_validated_date": "2024-07-12T20:04:15+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigw_test_invoke_method_api": {
-    "last_validated_date": "2024-02-04T18:48:24+00:00"
+    "last_validated_date": "2025-04-09T18:24:25+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_update_rest_api_deployment": {
     "last_validated_date": "2024-04-12T21:24:49+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The `TestInvokeMethod` operation was still relying on the legacy invocation logic of API Gateway. This PR migrates it to not rely on old code anymore and use the new handler chain, create one and invoke it. 

I've also improved the test, it is now fully transformed and can run against AWS with snapshot validation enabled. 

Also took the opportunity to remove some old "fixtures" doing nothing. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implement new TestInvokeOperation for the NextGen provider
- create new file keeping all of this together (might be better organized to be honest... but it's also not very important at the moment? should it have better encapsulation?)
- adapt the existing test to allow better parity
- clean up some old APIGW "fixtures"

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
