### PR TITLE
add AVP to list of CFN composite quirks

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/quirks.py
+++ b/localstack-core/localstack/services/cloudformation/engine/quirks.py
@@ -30,6 +30,9 @@ PHYSICAL_RESOURCE_ID_SPECIAL_CASES = {
     "AWS::Logs::SubscriptionFilter": "/properties/LogGroupName",
     "AWS::RDS::DBProxyTargetGroup": "/properties/TargetGroupName",
     "AWS::Glue::SchemaVersionMetadata": "</properties/SchemaVersionId>|</properties/Key>|</properties/Value>",  # composite
+    "AWS::VerifiedPermissions::IdentitySource": "</properties/IdentitySourceId>|</properties/PolicyStoreId>",  # composite
+    "AWS::VerifiedPermissions::Policy": "</properties/PolicyId>|</properties/PolicyStoreId>",  # composite
+    "AWS::VerifiedPermissions::PolicyTemplate": "</properties/PolicyStoreId>|</properties/PolicyTemplateId>",  # composite
     "AWS::WAFv2::WebACL": "</properties/Name>|</properties/Id>|</properties/Scope>",
     "AWS::WAFv2::WebACLAssociation": "</properties/ResourceArn>|</properties/WebACLArn>",
     "AWS::WAFv2::IPSet": "</properties/Name>|</properties/Id>|</properties/Scope>",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While implement AVP resource providers, it appeared that we needed to add custom composites refs for some of its resources.

The values are... quite random. Both `Policy` and `IdentitySource` follow the "own resource id"|"policyStoreId" but `PolicyTemplate` is reversed, and has "PolicyStoreId"|"own resource id" order 🤷 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add `AWS::VerifiedPermissions::IdentitySource`, `AWS::VerifiedPermissions::Policy`, `AWS::VerifiedPermissions::PolicyTemplate` to the list of quirks

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
