### PR TITLE
Improve stream poller exception logging

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -322,6 +322,7 @@ class StreamPoller(Poller):
                     attempts,
                     self.partner_resource_arn or self.source_arn,
                     events,
+                    exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
             finally:
                 # Retry polling until the record expires at the source

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -312,13 +312,21 @@ class StreamPoller(Poller):
 
                 # Discard all successful events and re-process from sequence number of failed event
                 _, events = self.bisect_events(lowest_sequence_id, events)
-            except (BatchFailureError, Exception) as ex:
-                if isinstance(ex, BatchFailureError):
-                    error_payload = ex.error
+            except BatchFailureError as ex:
+                error_payload = ex.error
 
                 # FIXME partner_resource_arn is not defined in ESM
                 LOG.debug(
                     "Attempt %d failed while processing %s with events: %s",
+                    attempts,
+                    self.partner_resource_arn or self.source_arn,
+                    events,
+                    exc_info=LOG.isEnabledFor(logging.DEBUG),
+                )
+            except Exception:
+                # FIXME partner_resource_arn is not defined in ESM
+                LOG.warning(
+                    "Attempt %d failed with unexpected error while processing %s with events: %s",
                     attempts,
                     self.partner_resource_arn or self.source_arn,
                     events,

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py
@@ -325,7 +325,7 @@ class StreamPoller(Poller):
                 )
             except Exception:
                 # FIXME partner_resource_arn is not defined in ESM
-                LOG.warning(
+                LOG.error(
                     "Attempt %d failed with unexpected error while processing %s with events: %s",
                     attempts,
                     self.partner_resource_arn or self.source_arn,

--- a/localstack-core/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack-core/localstack/services/lambda_/invocation/version_manager.py
@@ -109,7 +109,7 @@ class LambdaVersionManager:
                 self.function_arn,
                 self.function_version.config.internal_revision,
                 e,
-                exc_info=True,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
         return self.state
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We currently do not log any details about unhandled exceptions or BatchFailureError in the stream poller, which makes debugging hard.

Context: the exception details might be logged as error further down the invocation chain, for example in `localstack.services.lambda_.event_source_mapping.esm_event_processor.EsmEventProcessor.process_events_batch` starting with `Unhandled exception while processing Lambda event source mapping ...`
One of the challenges is that ESM and Pipes share infrastructure and require different metadata logging, but the poller is at the top level in the invocation chain. We would need to raise a decorated error to provide sufficient context for meaningful top-level error logging without such duplication.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Add `exc_info` for debug logs
* Bump log level to error for unexpected error and include stack trace for better context info

## Testing

1. Add `raise Exception('sample exception')` in `self.processor.process_events_batch(events)`
2. Run the test `aws.services.lambda_.event_source_mapping.test_lambda_integration_kinesis.TestKinesisSource.test_create_kinesis_event_source_mapping`

### Before

Single ERROR (ESM) with stack trace and single DEBUG (Poller) without stack trace:

* ➖ requires implicit matching with ESM uuid and events content to figure out the root cause

```
2025-04-16T15:10:24.112 ERROR --- [event-source-mapping-poller-ea34ad75-374f-4d5b-ad10-fda44874b691-functhread5] localstack.services.lambda_.event_source_mapping.esm_event_processor : Unhandled exception while processing Lambda event source mapping (ESM) events [<LONG-LIST-OF-EVENTS>] for ESM with execution id ed870bf7-5e34-484c-a1ed-e24f5dc614a9
Traceback (most recent call last):
  File "/Users/joe/Projects/LocalStack/localstack/localstack-core/localstack/services/lambda_/event_source_mapping/esm_event_processor.py", line 56, in process_events_batch
    raise Exception('sample exception')
Exception: sample exception
2025-04-16T15:10:24.115 DEBUG --- [event-source-mapping-poller-ea34ad75-374f-4d5b-ad10-fda44874b691-functhread5] localstack.services.lambda_.event_source_mapping.pollers.stream_poller : Attempt 0 failed while processing arn:aws:kinesis:us-east-1:000000000000:stream/test-foobar-aa27b335 with events: [<LONG-LIST-OF-EVENTS>]
```

### After

Double ERROR (ESM & Poller) with stack trace:

* ➖  double stack trace for the same error

```
2025-04-16T15:05:28.075 ERROR --- [event-source-mapping-poller-18fc1f24-f94f-4643-bedd-df65462c8e90-functhread5] localstack.services.lambda_.event_source_mapping.esm_event_processor : Unhandled exception while processing Lambda event source mapping (ESM) events [<LONG-LIST-OF-EVENTS>] for ESM with execution id 940d7550-9495-4076-8ed8-03d61291fc91
Traceback (most recent call last):
  File "/Users/joe/Projects/LocalStack/localstack/localstack-core/localstack/services/lambda_/event_source_mapping/esm_event_processor.py", line 56, in process_events_batch
    raise Exception('sample exception')
Exception: sample exception
2025-04-16T15:05:28.076 ERROR --- [event-source-mapping-poller-18fc1f24-f94f-4643-bedd-df65462c8e90-functhread5] localstack.services.lambda_.event_source_mapping.pollers.stream_poller : Attempt 7 failed with unexpected error while processing arn:aws:kinesis:us-east-1:000000000000:stream/test-foobar-f51282db with events: [<LONG-LIST-OF-EVENTS>]
Traceback (most recent call last):
  File "/Users/joe/Projects/LocalStack/localstack/localstack-core/localstack/services/lambda_/event_source_mapping/pollers/stream_poller.py", line 270, in forward_events_to_target
    self.processor.process_events_batch(events)
  File "/Users/joe/Projects/LocalStack/localstack/localstack-core/localstack/services/lambda_/event_source_mapping/esm_event_processor.py", line 99, in process_events_batch
    raise e
  File "/Users/joe/Projects/LocalStack/localstack/localstack-core/localstack/services/lambda_/event_source_mapping/esm_event_processor.py", line 56, in process_events_batch
    raise Exception('sample exception')
Exception: sample exception
```

## Discussion

What's the most user-friendly way to log such unexpected errors?