### PR TITLE
apply fix for podman container labels dict

### DIFF
--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -909,7 +909,7 @@ class CmdDockerClient(ContainerClient):
         if any(msg.lower() in process_stdout_lower for msg in error_messages):
             raise NoSuchContainer(container_name_or_id, stdout=error.stdout, stderr=error.stderr)
 
-    def _transform_container_labels(self, labels: str | Dict[str,str]) -> Dict[str, str]:
+    def _transform_container_labels(self, labels: str | Dict[str, str]) -> Dict[str, str]:
         """
         Transforms the container labels returned by the docker command from the key-value pair format to a dict
         :param labels: Input string, comma separated key value pairs. Example: key1=value1,key2=value2

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -909,7 +909,7 @@ class CmdDockerClient(ContainerClient):
         if any(msg.lower() in process_stdout_lower for msg in error_messages):
             raise NoSuchContainer(container_name_or_id, stdout=error.stdout, stderr=error.stderr)
 
-    def _transform_container_labels(self, labels: str | Dict[str, str]) -> Dict[str, str]:
+    def _transform_container_labels(self, labels: Union[str, Dict[str, str]]) -> Dict[str, str]:
         """
         Transforms the container labels returned by the docker command from the key-value pair format to a dict
         :param labels: Input string, comma separated key value pairs. Example: key1=value1,key2=value2

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -909,12 +909,15 @@ class CmdDockerClient(ContainerClient):
         if any(msg.lower() in process_stdout_lower for msg in error_messages):
             raise NoSuchContainer(container_name_or_id, stdout=error.stdout, stderr=error.stderr)
 
-    def _transform_container_labels(self, labels: str) -> Dict[str, str]:
+    def _transform_container_labels(self, labels: str | Dict[str,str]) -> Dict[str, str]:
         """
         Transforms the container labels returned by the docker command from the key-value pair format to a dict
         :param labels: Input string, comma separated key value pairs. Example: key1=value1,key2=value2
         :return: Dict representation of the passed values, example: {"key1": "value1", "key2": "value2"}
         """
+        if isinstance(labels, Dict):
+            return labels
+
         labels = labels.split(",")
         labels = [label.partition("=") for label in labels]
         return {label[0]: label[2] for label in labels}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The [existing PR](https://github.com/localstack/localstack/pull/12236) seems to be waiting on a small change, so to speed up the process I made the change here.

[Related Bug report](https://github.com/localstack/localstack/issues/12084)

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
When invoking _transform_container_labels, I added a check to veryify is the supplied parameter is already a Dict, which is the default in Podman. if so return the Dict, otherwise split the string and transform it into a Dict as usual.

semver: patch
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
