### PR TITLE
Add `start snowflake` cli command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,9 @@ gen/
 
 # setuptools_scm version.py
 */*/version.py
+
+# mypy cache
+*.mypy_cache
+
+# ruff cache
+*.ruff_cache

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -807,6 +807,8 @@ class ContainerConfigurators:
         """
 
         def _cfg(cfg: ContainerConfiguration):
+            if not params:
+                return
             for param in params:
                 cfg.volumes.append(BindMount.parse(param))
 


### PR DESCRIPTION
## Motivation

- Provide a direct approach to start LocalStack for Snowflake by running `localstack start snowflake` instead of passing the `IMAGE_NAME` environment variable.
- The same env variable can still be passed to override the image version, though in the future we can introduce a cli option that can be passed to specify versions explicitly, i.e. `localstack start snowflake --v 0.3.0`. We can even drop the environment variable completely at that point, considering this can be scaled for other platforms as well! Happy to discuss and get more opinions on this!

## Changes

- Switched `start` to a cli group in order to contain other sub-commands while making it available to be run as a standalone command too
- Added `snowflake` sub-command to support starting LocalStack for Snowflake

