### PR TITLE
[ESM] Support discarding events exceeding MaxRecordAgeInSeconds

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_event_processor.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_event_processor.py
@@ -159,6 +159,8 @@ class EsmEventProcessor(EventProcessor):
         if not error_payload:
             return {}
         # TODO: Should 'requestContext' and 'responseContext' be defined as models?
+        # TODO: Allow for generating failure context where there is no responseContext i.e
+        # if a RecordAgeExceeded condition is triggered.
         context = {
             "requestContext": {
                 "requestId": error_payload.get("requestId"),

--- a/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
+++ b/localstack-core/localstack/services/lambda_/event_source_mapping/esm_worker_factory.py
@@ -172,6 +172,7 @@ class EsmWorkerFactory:
                         "MaximumBatchingWindowInSeconds"
                     ],
                     MaximumRetryAttempts=self.esm_config["MaximumRetryAttempts"],
+                    MaximumRecordAgeInSeconds=self.esm_config["MaximumRecordAgeInSeconds"],
                     **optional_params,
                 ),
             )
@@ -203,6 +204,7 @@ class EsmWorkerFactory:
                         "MaximumBatchingWindowInSeconds"
                     ],
                     MaximumRetryAttempts=self.esm_config["MaximumRetryAttempts"],
+                    MaximumRecordAgeInSeconds=self.esm_config["MaximumRecordAgeInSeconds"],
                     **optional_params,
                 ),
             )

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1988,6 +1988,8 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
 
     def validate_event_source_mapping(self, context, request):
         # TODO: test whether stream ARNs are valid sources for Pipes or ESM or whether only DynamoDB table ARNs work
+        # TODO: Validate MaxRecordAgeInSeconds (i.e cannot subceed 60s but can be -1) and MaxRetryAttempts parameters.
+        # See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-maximumrecordageinseconds
         is_create_esm_request = context.operation.name == self.create_event_source_mapping.operation
 
         if destination_config := request.get("DestinationConfig"):

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py
@@ -26,6 +26,7 @@ from tests.aws.services.lambda_.event_source_mapping.utils import (
 )
 from tests.aws.services.lambda_.functions import FUNCTIONS_PATH, lambda_integration
 from tests.aws.services.lambda_.test_lambda import (
+    TEST_LAMBDA_EVENT_SOURCE_MAPPING_SEND_MESSAGE,
     TEST_LAMBDA_PYTHON,
     TEST_LAMBDA_PYTHON_ECHO,
 )
@@ -35,6 +36,7 @@ TEST_LAMBDA_KINESIS_LOG = FUNCTIONS_PATH / "kinesis_log.py"
 TEST_LAMBDA_KINESIS_BATCH_ITEM_FAILURE = (
     FUNCTIONS_PATH / "lambda_report_batch_item_failures_kinesis.py"
 )
+TEST_LAMBDA_ECHO_FAILURE = FUNCTIONS_PATH / "lambda_echofail.py"
 TEST_LAMBDA_PROVIDED_BOOTSTRAP_EMPTY = FUNCTIONS_PATH / "provided_bootstrap_empty"
 
 
@@ -1053,6 +1055,226 @@ class TestKinesisSource:
 
         invocation_events = retry(_verify_messages_received, retries=30, sleep=5)
         snapshot.match("kinesis_events", invocation_events)
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            # FIXME: Generate and send a requestContext in StreamPoller for RecordAgeExceeded
+            # which contains no responseContext object.
+            "$..Messages..Body.requestContext",
+            "$..Messages..MessageId",  # Skip while no requestContext generated in StreamPoller due to transformation issues
+        ]
+    )
+    @pytest.mark.parametrize(
+        "processing_delay_seconds, max_retries",
+        [
+            # The record expired while retrying
+            pytest.param(0, -1, id="expire-while-retrying"),
+            # The record expired prior to arriving (no retries expected)
+            pytest.param(60, 0, id="expire-before-ingestion"),
+        ],
+    )
+    def test_kinesis_maximum_record_age_exceeded(
+        self,
+        create_lambda_function,
+        kinesis_create_stream,
+        sqs_get_queue_arn,
+        create_event_source_mapping,
+        lambda_su_role,
+        wait_for_stream_ready,
+        snapshot,
+        aws_client,
+        sqs_create_queue,
+        # Parametrized arguments
+        processing_delay_seconds,
+        max_retries,
+    ):
+        # snapshot setup
+        snapshot.add_transformer(snapshot.transform.key_value("MD5OfBody"))
+        snapshot.add_transformer(snapshot.transform.key_value("ReceiptHandle"))
+        snapshot.add_transformer(snapshot.transform.key_value("startSequenceNumber"))
+
+        function_name = f"lambda_func-{short_uid()}"
+        stream_name = f"test-kinesis-{short_uid()}"
+
+        kinesis_create_stream(StreamName=stream_name, ShardCount=1)
+        wait_for_stream_ready(stream_name=stream_name)
+        stream_summary = aws_client.kinesis.describe_stream_summary(StreamName=stream_name)
+        assert stream_summary["StreamDescriptionSummary"]["OpenShardCount"] == 1
+        stream_arn = aws_client.kinesis.describe_stream(StreamName=stream_name)[
+            "StreamDescription"
+        ]["StreamARN"]
+
+        aws_client.kinesis.put_record(
+            Data="stream-data",
+            PartitionKey="test",
+            StreamName=stream_name,
+        )
+
+        if processing_delay_seconds > 0:
+            # Optionally delay the ESM creation, allowing a record to expire prior to being ingested.
+            time.sleep(processing_delay_seconds)
+
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_ECHO_FAILURE,
+            func_name=function_name,
+            runtime=Runtime.python3_12,
+            role=lambda_su_role,
+        )
+
+        # Use OnFailure config with a DLQ to minimise flakiness instead of relying on Cloudwatch logs
+        queue_event_source_mapping = sqs_create_queue()
+        destination_queue = sqs_get_queue_arn(queue_event_source_mapping)
+        destination_config = {"OnFailure": {"Destination": destination_queue}}
+
+        create_event_source_mapping_response = create_event_source_mapping(
+            FunctionName=function_name,
+            BatchSize=1,
+            StartingPosition="TRIM_HORIZON",
+            EventSourceArn=stream_arn,
+            MaximumBatchingWindowInSeconds=1,
+            MaximumRetryAttempts=max_retries,
+            MaximumRecordAgeInSeconds=60,
+            DestinationConfig=destination_config,
+        )
+        snapshot.match("create_event_source_mapping_response", create_event_source_mapping_response)
+        event_source_mapping_uuid = create_event_source_mapping_response["UUID"]
+        _await_event_source_mapping_enabled(aws_client.lambda_, event_source_mapping_uuid)
+
+        def _verify_failure_received():
+            result = aws_client.sqs.receive_message(QueueUrl=queue_event_source_mapping)
+            assert result.get("Messages")
+            return result
+
+        sleep = 15 if is_aws_cloud() else 5
+        record_age_exceeded_payload = retry(
+            _verify_failure_received, retries=15, sleep=sleep, sleep_before=5
+        )
+        snapshot.match("record_age_exceeded_payload", record_age_exceeded_payload)
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            # FIXME: Generate and send a requestContext in StreamPoller for RecordAgeExceeded
+            # which contains no responseContext object.
+            "$..Messages..Body.requestContext",
+            "$..Messages..MessageId",  # Skip while no requestContext generated in StreamPoller due to transformation issues
+        ]
+    )
+    def test_kinesis_maximum_record_age_exceeded_discard_records(
+        self,
+        create_lambda_function,
+        kinesis_create_stream,
+        sqs_get_queue_arn,
+        create_event_source_mapping,
+        lambda_su_role,
+        wait_for_stream_ready,
+        snapshot,
+        aws_client,
+        sqs_create_queue,
+    ):
+        # snapshot setup
+        snapshot.add_transformer(snapshot.transform.key_value("MD5OfBody"))
+        snapshot.add_transformer(snapshot.transform.key_value("ReceiptHandle"))
+        snapshot.add_transformer(snapshot.transform.key_value("startSequenceNumber"))
+
+        function_name = f"lambda_func-{short_uid()}"
+        stream_name = f"test-kinesis-{short_uid()}"
+
+        kinesis_create_stream(StreamName=stream_name, ShardCount=1)
+        wait_for_stream_ready(stream_name=stream_name)
+        stream_summary = aws_client.kinesis.describe_stream_summary(StreamName=stream_name)
+        assert stream_summary["StreamDescriptionSummary"]["OpenShardCount"] == 1
+        stream_arn = aws_client.kinesis.describe_stream(StreamName=stream_name)[
+            "StreamDescription"
+        ]["StreamARN"]
+
+        aws_client.kinesis.put_record(
+            Data="stream-data",
+            PartitionKey="test",
+            StreamName=stream_name,
+        )
+
+        # Ensure that the first record has expired
+        time.sleep(60)
+
+        # The first record in the batch has expired with the remaining batch not exceeding any age-limits.
+        for i in range(5):
+            aws_client.kinesis.put_record(
+                Data=f"stream-data-{i + 1}",
+                PartitionKey="test",
+                StreamName=stream_name,
+            )
+
+        destination_queue_url = sqs_create_queue()
+        create_lambda_function(
+            func_name=function_name,
+            handler_file=TEST_LAMBDA_EVENT_SOURCE_MAPPING_SEND_MESSAGE,
+            runtime=Runtime.python3_12,
+            envvars={"SQS_QUEUE_URL": destination_queue_url},
+            role=lambda_su_role,
+        )
+
+        # Use OnFailure config with a DLQ to minimise flakiness instead of relying on Cloudwatch logs
+        dead_letter_queue = sqs_create_queue()
+        dead_letter_queue_arn = sqs_get_queue_arn(dead_letter_queue)
+        destination_config = {"OnFailure": {"Destination": dead_letter_queue_arn}}
+
+        create_event_source_mapping_response = create_event_source_mapping(
+            FunctionName=function_name,
+            BatchSize=10,
+            StartingPosition="TRIM_HORIZON",
+            EventSourceArn=stream_arn,
+            MaximumBatchingWindowInSeconds=1,
+            MaximumRetryAttempts=0,
+            MaximumRecordAgeInSeconds=60,
+            DestinationConfig=destination_config,
+        )
+        snapshot.match("create_event_source_mapping_response", create_event_source_mapping_response)
+        event_source_mapping_uuid = create_event_source_mapping_response["UUID"]
+        _await_event_source_mapping_enabled(aws_client.lambda_, event_source_mapping_uuid)
+
+        def _verify_failure_received():
+            result = aws_client.sqs.receive_message(QueueUrl=dead_letter_queue)
+            assert result.get("Messages")
+            return result
+
+        batches = []
+
+        def _verify_events_received(expected: int):
+            messages_to_delete = []
+            receive_message_response = aws_client.sqs.receive_message(
+                QueueUrl=destination_queue_url,
+                MaxNumberOfMessages=10,
+                VisibilityTimeout=120,
+                WaitTimeSeconds=5 if is_aws_cloud() else 1,
+            )
+            messages = receive_message_response.get("Messages", [])
+            for message in messages:
+                received_batch = json.loads(message["Body"])
+                batches.append(received_batch)
+                messages_to_delete.append(
+                    {"Id": message["MessageId"], "ReceiptHandle": message["ReceiptHandle"]}
+                )
+            if messages_to_delete:
+                aws_client.sqs.delete_message_batch(
+                    QueueUrl=destination_queue_url, Entries=messages_to_delete
+                )
+            assert sum([len(batch) for batch in batches]) == expected
+            return [message for batch in batches for message in batch]
+
+        sleep = 15 if is_aws_cloud() else 5
+        record_age_exceeded_payload = retry(
+            _verify_failure_received, retries=15, sleep=sleep, sleep_before=5
+        )
+        snapshot.match("record_age_exceeded_payload", record_age_exceeded_payload)
+
+        # While 6 records were sent, we expect 5 records since the first
+        # record should have expired and been discarded.
+        kinesis_events = retry(
+            _verify_events_received, retries=15, sleep=sleep, sleep_before=5, expected=5
+        )
+        snapshot.match("Records", kinesis_events)
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.snapshot.json
@@ -3173,5 +3173,282 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_maximum_record_age_exceeded[expire-while-retrying]": {
+    "recorded-date": "13-04-2025, 15:00:55",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 1,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {
+            "Destination": "arn:<partition>:sqs:<region>:111111111111:<resource:1>"
+          }
+        },
+        "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumRecordAgeInSeconds": 60,
+        "MaximumRetryAttempts": -1,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "record_age_exceeded_payload": {
+        "Messages": [
+          {
+            "Body": {
+              "requestContext": {
+                "requestId": "<uuid:2>",
+                "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
+                "condition": "RecordAgeExceeded",
+                "approximateInvokeCount": 1
+              },
+              "version": "1.0",
+              "timestamp": "<timestamp:2022-07-13T13:48:01.000Z>",
+              "KinesisBatchInfo": {
+                "shardId": "shardId-000000000000",
+                "startSequenceNumber": "<start-sequence-number:1>",
+                "endSequenceNumber": "<start-sequence-number:1>",
+                "approximateArrivalOfFirstRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
+                "approximateArrivalOfLastRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
+                "batchSize": 1,
+                "streamArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
+              }
+            },
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "MessageId": "<uuid:3>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_maximum_record_age_exceeded[expire-before-ingestion]": {
+    "recorded-date": "13-04-2025, 16:29:29",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 1,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {
+            "Destination": "arn:<partition>:sqs:<region>:111111111111:<resource:1>"
+          }
+        },
+        "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumRecordAgeInSeconds": 60,
+        "MaximumRetryAttempts": 0,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "record_age_exceeded_payload": {
+        "Messages": [
+          {
+            "Body": {
+              "requestContext": {
+                "requestId": "<uuid:2>",
+                "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
+                "condition": "RecordAgeExceeded",
+                "approximateInvokeCount": 1
+              },
+              "version": "1.0",
+              "timestamp": "<timestamp:2022-07-13T13:48:01.000Z>",
+              "KinesisBatchInfo": {
+                "shardId": "shardId-000000000000",
+                "startSequenceNumber": "<start-sequence-number:1>",
+                "endSequenceNumber": "<start-sequence-number:1>",
+                "approximateArrivalOfFirstRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
+                "approximateArrivalOfLastRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
+                "batchSize": 1,
+                "streamArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
+              }
+            },
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "MessageId": "<uuid:3>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_maximum_record_age_exceeded_discard_records": {
+    "recorded-date": "13-04-2025, 17:05:16",
+    "recorded-content": {
+      "create_event_source_mapping_response": {
+        "BatchSize": 10,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {
+            "Destination": "arn:<partition>:sqs:<region>:111111111111:<resource:1>"
+          }
+        },
+        "EventSourceArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>",
+        "EventSourceMappingArn": "arn:<partition>:lambda:<region>:111111111111:event-source-mapping:<uuid:1>",
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
+        "FunctionResponseTypes": [],
+        "LastModified": "<datetime>",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumRecordAgeInSeconds": 60,
+        "MaximumRetryAttempts": 0,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "record_age_exceeded_payload": {
+        "Messages": [
+          {
+            "Body": {
+              "requestContext": {
+                "requestId": "<uuid:2>",
+                "functionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>",
+                "condition": "RecordAgeExceeded",
+                "approximateInvokeCount": 1
+              },
+              "version": "1.0",
+              "timestamp": "<timestamp:2022-07-13T13:48:01.000Z>",
+              "KinesisBatchInfo": {
+                "shardId": "shardId-000000000000",
+                "startSequenceNumber": "<start-sequence-number:1>",
+                "endSequenceNumber": "<start-sequence-number:1>",
+                "approximateArrivalOfFirstRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
+                "approximateArrivalOfLastRecord": "<timestamp:2022-07-13T13:48:01.000Z>",
+                "batchSize": 1,
+                "streamArn": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
+              }
+            },
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "MessageId": "<uuid:3>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "Records": [
+        {
+          "kinesis": {
+            "kinesisSchemaVersion": "1.0",
+            "partitionKey": "test",
+            "sequenceNumber": "<sequence-number:1>",
+            "data": "c3RyZWFtLWRhdGEtMQ==",
+            "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+          },
+          "eventSource": "aws:kinesis",
+          "eventVersion": "1.0",
+          "eventID": "shardId-000000000000:<sequence-number:1>",
+          "eventName": "aws:kinesis:record",
+          "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:4>",
+          "awsRegion": "<region>",
+          "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
+        },
+        {
+          "kinesis": {
+            "kinesisSchemaVersion": "1.0",
+            "partitionKey": "test",
+            "sequenceNumber": "<sequence-number:2>",
+            "data": "c3RyZWFtLWRhdGEtMg==",
+            "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+          },
+          "eventSource": "aws:kinesis",
+          "eventVersion": "1.0",
+          "eventID": "shardId-000000000000:<sequence-number:2>",
+          "eventName": "aws:kinesis:record",
+          "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:4>",
+          "awsRegion": "<region>",
+          "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
+        },
+        {
+          "kinesis": {
+            "kinesisSchemaVersion": "1.0",
+            "partitionKey": "test",
+            "sequenceNumber": "<sequence-number:3>",
+            "data": "c3RyZWFtLWRhdGEtMw==",
+            "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+          },
+          "eventSource": "aws:kinesis",
+          "eventVersion": "1.0",
+          "eventID": "shardId-000000000000:<sequence-number:3>",
+          "eventName": "aws:kinesis:record",
+          "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:4>",
+          "awsRegion": "<region>",
+          "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
+        },
+        {
+          "kinesis": {
+            "kinesisSchemaVersion": "1.0",
+            "partitionKey": "test",
+            "sequenceNumber": "<sequence-number:4>",
+            "data": "c3RyZWFtLWRhdGEtNA==",
+            "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+          },
+          "eventSource": "aws:kinesis",
+          "eventVersion": "1.0",
+          "eventID": "shardId-000000000000:<sequence-number:4>",
+          "eventName": "aws:kinesis:record",
+          "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:4>",
+          "awsRegion": "<region>",
+          "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
+        },
+        {
+          "kinesis": {
+            "kinesisSchemaVersion": "1.0",
+            "partitionKey": "test",
+            "sequenceNumber": "<sequence-number:5>",
+            "data": "c3RyZWFtLWRhdGEtNQ==",
+            "approximateArrivalTimestamp": "<approximate-arrival-timestamp>"
+          },
+          "eventSource": "aws:kinesis",
+          "eventVersion": "1.0",
+          "eventID": "shardId-000000000000:<sequence-number:5>",
+          "eventName": "aws:kinesis:record",
+          "invokeIdentityArn": "arn:<partition>:iam::111111111111:role/<resource:4>",
+          "awsRegion": "<region>",
+          "eventSourceARN": "arn:<partition>:kinesis:<region>:111111111111:stream/<resource:2>"
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -32,6 +32,18 @@
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_trim_horizon": {
     "last_validated_date": "2024-12-13T14:06:49+00:00"
   },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_maximum_record_age_exceeded": {
+    "last_validated_date": "2025-04-13T15:57:25+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_maximum_record_age_exceeded[expire-before-ingestion]": {
+    "last_validated_date": "2025-04-13T16:29:25+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_maximum_record_age_exceeded[expire-with-mixed-arrival-batch]": {
+    "last_validated_date": "2025-04-13T16:39:43+00:00"
+  },
+  "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_maximum_record_age_exceeded_discard_records": {
+    "last_validated_date": "2025-04-13T17:05:13+00:00"
+  },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[empty_string_item_identifier_failure]": {
     "last_validated_date": "2024-12-13T14:23:18+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
To further improve ESM parity, this PR adds support for expiring/discarding events based on their age.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Refactor `StreamPoller` processing loop to account for discarding records based on event age.
- Add `bisect_events_by_record_age` function to bisect retrieved records in a stream based on their age.

## Testing
- `test_kinesis_maximum_record_age_exceeded` -- tests an expired event being ingested prior to invocation as well as an event expiring while retrying.
- `test_kinesis_maximum_record_age_exceeded_discard_records` -- tests discarding an expired record within a batch of valid records.


## TODO

What's left to do:

- [ ] Add changes in pipes.
- [ ] Potentially add validations in a sibling PR.
- [ ] Re-evaluate [ESM behaviour docs](https://docs.localstack.cloud/user-guide/aws/lambda/#behaviour-coverage) since we were (incorrectly) saying this behaviour was supported when in actuality it wasn't.

