### PR TITLE
CloudFormation Engine V2: Improve delta computation of properties, conditional resolution, and physical resources ref

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
@@ -769,7 +769,10 @@ class ChangeSetModel:
             before_properties=before_properties,
             after_properties=after_properties,
         )
-        change_type = change_type.for_child(properties.change_type)
+        if properties.properties:
+            # Properties were defined in the before or after template, thus must play a role
+            # in affecting the change type of this resource.
+            change_type = change_type.for_child(properties.change_type)
         node_resource = NodeResource(
             scope=scope,
             change_type=change_type,

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
@@ -82,10 +82,6 @@ class ChangeSetModelDescriber(ChangeSetModelPreproc):
         before_properties: Optional[PreprocProperties],
         after_properties: Optional[PreprocProperties],
     ) -> None:
-        # unchanged: nothing to do.
-        if before_properties == after_properties:
-            return
-
         action = cfn_api.ChangeAction.Modify
         if before_properties is None:
             action = cfn_api.ChangeAction.Add
@@ -111,6 +107,9 @@ class ChangeSetModelDescriber(ChangeSetModelPreproc):
     def _describe_resource_change(
         self, name: str, before: Optional[PreprocResource], after: Optional[PreprocResource]
     ) -> None:
+        if before == after:
+            # unchanged: nothing to do.
+            return
         if before is not None and after is not None:
             # Case: change on same type.
             if before.resource_type == after.resource_type:

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -1526,10 +1526,6 @@ class TestCaptureUpdateProcess:
         capture_update_process(snapshot, t1, t1, p1={"TopicName": "key1"}, p2={"TopicName": "key2"})
 
     @markers.aws.validated
-    @pytest.mark.skip(
-        "Template deployment appears to fail on v2 due to unresolved resource dependencies; "
-        "this should be addressed in the development of the v2 engine executor."
-    )
     def test_conditions(
         self,
         snapshot,
@@ -1695,7 +1691,6 @@ class TestCaptureUpdateProcess:
         capture_update_process(snapshot, t1, t2)
 
     @markers.aws.validated
-    # @pytest.mark.skip("Executor is WIP")
     @pytest.mark.parametrize(
         "template",
         [
@@ -1718,101 +1713,106 @@ class TestCaptureUpdateProcess:
                 },
                 id="change_dynamic",
             ),
-            # pytest.param(
-            #     {
-            #         "Parameters": {
-            #             "ParameterValue": {
-            #                 "Type": "String",
-            #             },
-            #         },
-            #         "Resources": {
-            #             "Parameter1": {
-            #                 "Type": "AWS::SSM::Parameter",
-            #                 "Properties": {
-            #                     "Name": "param-name",
-            #                     "Type": "String",
-            #                     "Value": {"Ref": "ParameterValue"},
-            #                 },
-            #             },
-            #             "Parameter2": {
-            #                 "Type": "AWS::SSM::Parameter",
-            #                 "Properties": {
-            #                     "Type": "String",
-            #                     "Value": {"Fn::GetAtt": ["Parameter1", "Name"]},
-            #                 },
-            #             },
-            #         },
-            #     },
-            #     id="change_unrelated_property",
-            # ),
-            # pytest.param(
-            #     {
-            #         "Parameters": {
-            #             "ParameterValue": {
-            #                 "Type": "String",
-            #             },
-            #         },
-            #         "Resources": {
-            #             "Parameter1": {
-            #                 "Type": "AWS::SSM::Parameter",
-            #                 "Properties": {
-            #                     "Type": "String",
-            #                     "Value": {"Ref": "ParameterValue"},
-            #                 },
-            #             },
-            #             "Parameter2": {
-            #                 "Type": "AWS::SSM::Parameter",
-            #                 "Properties": {
-            #                     "Type": "String",
-            #                     "Value": {"Fn::GetAtt": ["Parameter1", "Type"]},
-            #                 },
-            #             },
-            #         },
-            #     },
-            #     id="change_unrelated_property_not_create_only",
-            # ),
-            # pytest.param(
-            #     {
-            #         "Parameters": {
-            #             "ParameterValue": {
-            #                 "Type": "String",
-            #                 "Default": "value-1",
-            #                 "AllowedValues": ["value-1", "value-2"],
-            #             }
-            #         },
-            #         "Conditions": {
-            #             "ShouldCreateParameter": {
-            #                 "Fn::Equals": [{"Ref": "ParameterValue"}, "value-2"]
-            #             }
-            #         },
-            #         "Resources": {
-            #             "SSMParameter1": {
-            #                 "Type": "AWS::SSM::Parameter",
-            #                 "Properties": {
-            #                     "Type": "String",
-            #                     "Value": "first",
-            #                 },
-            #             },
-            #             "SSMParameter2": {
-            #                 "Type": "AWS::SSM::Parameter",
-            #                 "Condition": "ShouldCreateParameter",
-            #                 "Properties": {
-            #                     "Type": "String",
-            #                     "Value": "first",
-            #                 },
-            #             },
-            #         },
-            #     },
-            #     id="change_parameter_for_condition_create_resource",
-            # ),
+            pytest.param(
+                {
+                    "Parameters": {
+                        "ParameterValue": {
+                            "Type": "String",
+                        },
+                    },
+                    "Resources": {
+                        "Parameter1": {
+                            "Type": "AWS::SSM::Parameter",
+                            "Properties": {
+                                "Name": "param-name",
+                                "Type": "String",
+                                "Value": {"Ref": "ParameterValue"},
+                            },
+                        },
+                        "Parameter2": {
+                            "Type": "AWS::SSM::Parameter",
+                            "Properties": {
+                                "Type": "String",
+                                "Value": {"Fn::GetAtt": ["Parameter1", "Name"]},
+                            },
+                        },
+                    },
+                },
+                id="change_unrelated_property",
+            ),
+            pytest.param(
+                {
+                    "Parameters": {
+                        "ParameterValue": {
+                            "Type": "String",
+                        },
+                    },
+                    "Resources": {
+                        "Parameter1": {
+                            "Type": "AWS::SSM::Parameter",
+                            "Properties": {
+                                "Type": "String",
+                                "Value": {"Ref": "ParameterValue"},
+                            },
+                        },
+                        "Parameter2": {
+                            "Type": "AWS::SSM::Parameter",
+                            "Properties": {
+                                "Type": "String",
+                                "Value": {"Fn::GetAtt": ["Parameter1", "Type"]},
+                            },
+                        },
+                    },
+                },
+                id="change_unrelated_property_not_create_only",
+            ),
+            pytest.param(
+                {
+                    "Parameters": {
+                        "ParameterValue": {
+                            "Type": "String",
+                            "Default": "value-1",
+                            "AllowedValues": ["value-1", "value-2"],
+                        }
+                    },
+                    "Conditions": {
+                        "ShouldCreateParameter": {
+                            "Fn::Equals": [{"Ref": "ParameterValue"}, "value-2"]
+                        }
+                    },
+                    "Resources": {
+                        "SSMParameter1": {
+                            "Type": "AWS::SSM::Parameter",
+                            "Properties": {
+                                "Type": "String",
+                                "Value": "first",
+                            },
+                        },
+                        "SSMParameter2": {
+                            "Type": "AWS::SSM::Parameter",
+                            "Condition": "ShouldCreateParameter",
+                            "Properties": {
+                                "Type": "String",
+                                "Value": "first",
+                            },
+                        },
+                    },
+                },
+                id="change_parameter_for_condition_create_resource",
+            ),
         ],
     )
     def test_base_dynamic_parameter_scenarios(
-        self,
-        snapshot,
-        capture_update_process,
-        template,
+        self, snapshot, capture_update_process, template, request
     ):
+        if request.node.callspec.id in {
+            "change_unrelated_property",
+            "change_unrelated_property_not_create_only",
+        }:
+            pytest.skip(
+                reason="AWS appears to incorrectly mark the dependent resource as needing update when describe "
+                "changeset is invoked without the inclusion of property values."
+            )
         capture_update_process(
             snapshot,
             template,
@@ -1866,7 +1866,6 @@ class TestCaptureUpdateProcess:
         snapshot.match("after-value", after_value)
 
     @markers.aws.validated
-    @pytest.mark.skip("Executor is WIP")
     @pytest.mark.parametrize(
         "template_1, template_2",
         [


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR resolves several issues in the Engine V2 provider related to template delta handling and reference evaluation. Specifically, it addresses:
- Misinterpretation of deltas in templates where property definitions are empty or missing
- Faulty comparison logic in preprocessor delta conditions, where the absence of a condition was incorrectly treated as a match
- Limited handling of reference evaluation when a physical ID changes during updates
- Additional minor issues and inconsistencies

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Fixed misinterpretation of deltas in templates with empty/missing properties
- Corrected logic for comparing preprocessor delta conditions
- Improved handling of Ref evaluation across physical ID changes
- Fixed the lack of describe and execution pruning for unchanged resources
- Addressed various minor issues


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
