### PR TITLE
revert removal of get_resource_type method

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -35,6 +35,7 @@ from localstack.services.cloudformation.resource_provider import (
     ProgressEvent,
     ResourceProviderExecutor,
     ResourceProviderPayload,
+    get_resource_type,
 )
 from localstack.services.cloudformation.service_models import (
     DependencyNotYetSatisfied,
@@ -363,7 +364,7 @@ def _resolve_refs_recursively(
             )
             resource = resources.get(resource_logical_id)
 
-            resource_type = resource["Type"]
+            resource_type = get_resource_type(resource)
             resolved_getatt = get_attr_from_model_instance(
                 resource,
                 attribute_name,
@@ -811,7 +812,7 @@ def resolve_placeholders_in_string(
             resolved = get_attr_from_model_instance(
                 resources[logical_resource_id],
                 attr_name,
-                resources[logical_resource_id]["Type"],
+                get_resource_type(resources[logical_resource_id]),
                 logical_resource_id,
             )
             if resolved is None:
@@ -1294,7 +1295,7 @@ class TemplateDeployer:
             action, logical_resource_id=resource_id
         )
 
-        resource_provider = executor.try_load_resource_provider(resource["Type"])
+        resource_provider = executor.try_load_resource_provider(get_resource_type(resource))
         if resource_provider is not None:
             # add in-progress event
             resource_status = f"{get_action_name_for_resource_change(action)}_IN_PROGRESS"
@@ -1406,7 +1407,7 @@ class TemplateDeployer:
             resource["Properties"] = resource.get(
                 "Properties", clone_safe(resource)
             )  # TODO: why is there a fallback?
-            resource["ResourceType"] = resource["Type"]
+            resource["ResourceType"] = get_resource_type(resource)
 
         ordered_resource_ids = list(
             order_resources(
@@ -1437,7 +1438,7 @@ class TemplateDeployer:
                     len(resources),
                     resource["ResourceType"],
                 )
-                resource_provider = executor.try_load_resource_provider(resource["Type"])
+                resource_provider = executor.try_load_resource_provider(get_resource_type(resource))
                 if resource_provider is not None:
                     event = executor.deploy_loop(
                         resource_provider, resource, resource_provider_payload

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -444,7 +444,7 @@ class ResourceProviderExecutor:
         max_iterations = max(ceil(max_timeout / sleep_time), 2)
 
         for current_iteration in range(max_iterations):
-            resource_type = raw_payload["resourceType"]
+            resource_type = get_resource_type({"Type": raw_payload["resourceType"]})
             resource["SpecifiedProperties"] = raw_payload["requestData"]["resourceProperties"]
 
             try:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Changes from #12511 broke custom resources plugin loading in upstream repo.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Bring back usage of the method

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
