### PR TITLE
APIGW: validate REST API custom id tag

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -201,13 +201,20 @@ class TestApiGatewayApiRestApi:
         snapshot.match("get-rest-apis-w-tags", response)
 
     @markers.aws.only_localstack
-    def test_create_rest_api_with_custom_id_tag(self, apigw_create_rest_api):
+    def test_create_rest_api_with_custom_id_tag(self, apigw_create_rest_api, aws_client):
         custom_id_tag = "testid123"
         response = apigw_create_rest_api(
             name="my_api", description="this is my api", tags={TAG_KEY_CUSTOM_ID: custom_id_tag}
         )
         api_id = response["id"]
         assert api_id == custom_id_tag
+
+        with pytest.raises(aws_client.apigateway.exceptions.BadRequestException):
+            apigw_create_rest_api(
+                name="my_api",
+                description="bad custom id",
+                tags={TAG_KEY_CUSTOM_ID: "bad-custom-id-hyphen"},
+            )
 
     @markers.aws.validated
     def test_update_rest_api_operation_add_remove(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When setting a custom id for a REST API and using the `_custom_id_` tag, using an hyphen will make the API fail because the routing won't work, as the regex explicitly doesn't match hyphens: `<regex('[^-]+'):api_id>`, to avoid matching on the `-vpce` part. 
It would fail silently, because it wouldn't be able to find the API. 

We now validate the custom id to not allow `-` character in it. 

Note: maybe another solution would be to adapt the regex to allow hyphens, but didn't want to take the risk to change it, and this has been the behavior since this has been introduced. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add validation and adapt existing test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
