### PR TITLE
fix IAM.SimulatePrincipalPolicy

### DIFF
--- a/tests/aws/services/iam/test_iam.snapshot.json
+++ b/tests/aws/services/iam/test_iam.snapshot.json
@@ -6241,5 +6241,239 @@
         }
       }
     }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_simulate_principle_policy[role]": {
+    "recorded-date": "21-04-2025, 20:07:35",
+    "recorded-content": {
+      "response": {
+        "EvaluationResults": [
+          {
+            "EvalActionName": "s3:PutObject",
+            "EvalDecision": "allowed",
+            "EvalDecisionDetails": {},
+            "EvalResourceName": "arn:<partition>:s3:::bucket",
+            "MatchedStatements": [
+              {
+                "EndPosition": {
+                  "Column": 113,
+                  "Line": 1
+                },
+                "SourcePolicyId": "<source-policy-id:1>",
+                "SourcePolicyType": "IAM Policy",
+                "StartPosition": {
+                  "Column": 41,
+                  "Line": 1
+                }
+              }
+            ],
+            "MissingContextValues": [],
+            "OrganizationsDecisionDetail": {
+              "AllowedByOrganizations": true
+            },
+            "ResourceSpecificResults": [
+              {
+                "EvalResourceDecision": "allowed",
+                "EvalResourceName": "arn:<partition>:s3:::bucket",
+                "MatchedStatements": [
+                  {
+                    "EndPosition": {
+                      "Column": 113,
+                      "Line": 1
+                    },
+                    "SourcePolicyId": "<source-policy-id:1>",
+                    "SourcePolicyType": "IAM Policy",
+                    "StartPosition": {
+                      "Column": 41,
+                      "Line": 1
+                    }
+                  }
+                ],
+                "MissingContextValues": []
+              }
+            ]
+          },
+          {
+            "EvalActionName": "s3:GetObjectVersion",
+            "EvalDecision": "implicitDeny",
+            "EvalDecisionDetails": {},
+            "EvalResourceName": "arn:<partition>:s3:::bucket",
+            "MatchedStatements": [],
+            "MissingContextValues": [],
+            "OrganizationsDecisionDetail": {
+              "AllowedByOrganizations": true
+            },
+            "ResourceSpecificResults": [
+              {
+                "EvalResourceDecision": "implicitDeny",
+                "EvalResourceName": "arn:<partition>:s3:::bucket",
+                "MatchedStatements": [],
+                "MissingContextValues": []
+              }
+            ]
+          }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_simulate_principle_policy[group]": {
+    "recorded-date": "21-04-2025, 20:07:37",
+    "recorded-content": {
+      "response": {
+        "EvaluationResults": [
+          {
+            "EvalActionName": "s3:PutObject",
+            "EvalDecision": "allowed",
+            "EvalDecisionDetails": {},
+            "EvalResourceName": "arn:<partition>:s3:::bucket",
+            "MatchedStatements": [
+              {
+                "EndPosition": {
+                  "Column": 113,
+                  "Line": 1
+                },
+                "SourcePolicyId": "<source-policy-id:1>",
+                "SourcePolicyType": "IAM Policy",
+                "StartPosition": {
+                  "Column": 41,
+                  "Line": 1
+                }
+              }
+            ],
+            "MissingContextValues": [],
+            "OrganizationsDecisionDetail": {
+              "AllowedByOrganizations": true
+            },
+            "ResourceSpecificResults": [
+              {
+                "EvalResourceDecision": "allowed",
+                "EvalResourceName": "arn:<partition>:s3:::bucket",
+                "MatchedStatements": [
+                  {
+                    "EndPosition": {
+                      "Column": 113,
+                      "Line": 1
+                    },
+                    "SourcePolicyId": "<source-policy-id:1>",
+                    "SourcePolicyType": "IAM Policy",
+                    "StartPosition": {
+                      "Column": 41,
+                      "Line": 1
+                    }
+                  }
+                ],
+                "MissingContextValues": []
+              }
+            ]
+          },
+          {
+            "EvalActionName": "s3:GetObjectVersion",
+            "EvalDecision": "implicitDeny",
+            "EvalDecisionDetails": {},
+            "EvalResourceName": "arn:<partition>:s3:::bucket",
+            "MatchedStatements": [],
+            "MissingContextValues": [],
+            "OrganizationsDecisionDetail": {
+              "AllowedByOrganizations": true
+            },
+            "ResourceSpecificResults": [
+              {
+                "EvalResourceDecision": "implicitDeny",
+                "EvalResourceName": "arn:<partition>:s3:::bucket",
+                "MatchedStatements": [],
+                "MissingContextValues": []
+              }
+            ]
+          }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_simulate_principle_policy[user]": {
+    "recorded-date": "21-04-2025, 20:07:38",
+    "recorded-content": {
+      "response": {
+        "EvaluationResults": [
+          {
+            "EvalActionName": "s3:PutObject",
+            "EvalDecision": "allowed",
+            "EvalDecisionDetails": {},
+            "EvalResourceName": "arn:<partition>:s3:::bucket",
+            "MatchedStatements": [
+              {
+                "EndPosition": {
+                  "Column": 113,
+                  "Line": 1
+                },
+                "SourcePolicyId": "<source-policy-id:1>",
+                "SourcePolicyType": "IAM Policy",
+                "StartPosition": {
+                  "Column": 41,
+                  "Line": 1
+                }
+              }
+            ],
+            "MissingContextValues": [],
+            "OrganizationsDecisionDetail": {
+              "AllowedByOrganizations": true
+            },
+            "ResourceSpecificResults": [
+              {
+                "EvalResourceDecision": "allowed",
+                "EvalResourceName": "arn:<partition>:s3:::bucket",
+                "MatchedStatements": [
+                  {
+                    "EndPosition": {
+                      "Column": 113,
+                      "Line": 1
+                    },
+                    "SourcePolicyId": "<source-policy-id:1>",
+                    "SourcePolicyType": "IAM Policy",
+                    "StartPosition": {
+                      "Column": 41,
+                      "Line": 1
+                    }
+                  }
+                ],
+                "MissingContextValues": []
+              }
+            ]
+          },
+          {
+            "EvalActionName": "s3:GetObjectVersion",
+            "EvalDecision": "implicitDeny",
+            "EvalDecisionDetails": {},
+            "EvalResourceName": "arn:<partition>:s3:::bucket",
+            "MatchedStatements": [],
+            "MissingContextValues": [],
+            "OrganizationsDecisionDetail": {
+              "AllowedByOrganizations": true
+            },
+            "ResourceSpecificResults": [
+              {
+                "EvalResourceDecision": "implicitDeny",
+                "EvalResourceName": "arn:<partition>:s3:::bucket",
+                "MatchedStatements": [],
+                "MissingContextValues": []
+              }
+            ]
+          }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/iam/test_iam.validation.json
+++ b/tests/aws/services/iam/test_iam.validation.json
@@ -47,6 +47,15 @@
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_role_attach_policy": {
     "last_validated_date": "2025-03-06T12:25:03+00:00"
   },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_simulate_principle_policy[group]": {
+    "last_validated_date": "2025-04-21T20:07:37+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_simulate_principle_policy[role]": {
+    "last_validated_date": "2025-04-21T20:07:35+00:00"
+  },
+  "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_simulate_principle_policy[user]": {
+    "last_validated_date": "2025-04-21T20:07:38+00:00"
+  },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_update_assume_role_policy": {
     "last_validated_date": "2025-03-06T12:24:58+00:00"
   },


### PR DESCRIPTION
## Motivation
This PR fixes an issue described in #12427. Where the service operation wrongly assumes that the parameter Arn is for from a Policy.  This PR allows the operation to accept an User, Role or Group ARN, and obtain its policies. 

## Changes
- Fix behavior of operation

## Testing
- Fixed previous test
