### PR TITLE
CFn: remove get_resource_type

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -35,7 +35,7 @@ from localstack.services.cloudformation.resource_provider import (
     ProgressEvent,
     ResourceProviderExecutor,
     ResourceProviderPayload,
-    get_resource_type,
+    standardise_resource_type,
 )
 from localstack.services.cloudformation.service_models import (
     DependencyNotYetSatisfied,
@@ -364,7 +364,7 @@ def _resolve_refs_recursively(
             )
             resource = resources.get(resource_logical_id)
 
-            resource_type = get_resource_type(resource)
+            resource_type = standardise_resource_type(resource["Type"])
             resolved_getatt = get_attr_from_model_instance(
                 resource,
                 attribute_name,
@@ -812,7 +812,7 @@ def resolve_placeholders_in_string(
             resolved = get_attr_from_model_instance(
                 resources[logical_resource_id],
                 attr_name,
-                get_resource_type(resources[logical_resource_id]),
+                standardise_resource_type(resources[logical_resource_id]["Type"]),
                 logical_resource_id,
             )
             if resolved is None:
@@ -1295,7 +1295,9 @@ class TemplateDeployer:
             action, logical_resource_id=resource_id
         )
 
-        resource_provider = executor.try_load_resource_provider(get_resource_type(resource))
+        resource_provider = executor.try_load_resource_provider(
+            standardise_resource_type(resource["Type"])
+        )
         if resource_provider is not None:
             # add in-progress event
             resource_status = f"{get_action_name_for_resource_change(action)}_IN_PROGRESS"
@@ -1407,7 +1409,7 @@ class TemplateDeployer:
             resource["Properties"] = resource.get(
                 "Properties", clone_safe(resource)
             )  # TODO: why is there a fallback?
-            resource["ResourceType"] = get_resource_type(resource)
+            resource["ResourceType"] = standardise_resource_type(resource["Type"])
 
         ordered_resource_ids = list(
             order_resources(
@@ -1438,7 +1440,9 @@ class TemplateDeployer:
                     len(resources),
                     resource["ResourceType"],
                 )
-                resource_provider = executor.try_load_resource_provider(get_resource_type(resource))
+                resource_provider = executor.try_load_resource_provider(
+                    standardise_resource_type(resource["Type"])
+                )
                 if resource_provider is not None:
                     event = executor.deploy_loop(
                         resource_provider, resource, resource_provider_payload

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -222,25 +222,6 @@ class ResourceProvider(Generic[Properties]):
         raise NotImplementedError
 
 
-# legacy helpers
-def get_resource_type(resource: dict) -> str:
-    """this is currently overwritten in PRO to add support for custom resources"""
-    if isinstance(resource, str):
-        raise ValueError(f"Invalid argument: {resource}")
-    try:
-        resource_type: str = resource["Type"]
-
-        if resource_type.startswith("Custom::"):
-            return "AWS::CloudFormation::CustomResource"
-        return resource_type
-    except Exception:
-        LOG.warning(
-            "Failed to retrieve resource type %s",
-            resource.get("Type"),
-            exc_info=LOG.isEnabledFor(logging.DEBUG),
-        )
-
-
 def standardise_resource_type(resource_type: str) -> str:
     """
     Custom resources can either start with Custom:: or AWS::CloudFormation::CustomResource.

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -453,7 +453,7 @@ class ResourceProviderExecutor:
         max_iterations = max(ceil(max_timeout / sleep_time), 2)
 
         for current_iteration in range(max_iterations):
-            resource_type = get_resource_type({"Type": raw_payload["resourceType"]})
+            resource_type = standardise_resource_type(raw_payload["resourceType"])
             resource["SpecifiedProperties"] = raw_payload["requestData"]["resourceProperties"]
 
             try:

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -241,6 +241,15 @@ def get_resource_type(resource: dict) -> str:
         )
 
 
+def standardise_resource_type(resource_type: str) -> str:
+    """
+    Custom resources can either start with Custom:: or AWS::CloudFormation::CustomResource.
+    """
+    if resource_type.startswith("Custom::"):
+        return "AWS::CloudFormation::CustomResource"
+    return resource_type
+
+
 def invoke_function(
     account_id: str,
     region_name: str,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In a [previous PR](https://github.com/localstack/localstack/pull/12511) I incorrectly removed the `get_resource_type` function from CloudFormation. This broke CI for our private repository so the function was replaced in [#12534](https://github.com/localstack/localstack/pull/12534).

This function _is_ suitable for removal since it's not used in the private codebase, and it's API is a little strange.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Swap `get_resource_type` for `standardise_resource_type` which takes the resource type, and _if_ it is a custom resource, standardise the name. Otherwise return the name unaffected.

## Testing

* Community testing should be enough as it's a core component of the CloudFormation engine
* I will perform a manual run of our private CI to ensure we don't break that code base

<!-- Optional section: How to test these changes? -->
<!--

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
