### PR TITLE
Clarify coverage error messages to distinguish license and emulation limits

### DIFF
--- a/localstack-core/localstack/utils/coverage_docs.py
+++ b/localstack-core/localstack/utils/coverage_docs.py
@@ -1,8 +1,4 @@
-COVERAGE_LINK_BASE = "https://docs.localstack.cloud/references/coverage/"
-MESSAGE_TEMPLATE = (
-    f"API %sfor service '%s' not yet implemented or pro feature"
-    f" - please check {COVERAGE_LINK_BASE}%s for further information"
-)
+_COVERAGE_LINK_BASE = "https://docs.localstack.cloud/references/coverage/"
 
 
 def get_coverage_link_for_service(service_name: str, action_name: str) -> str:
@@ -11,11 +7,14 @@ def get_coverage_link_for_service(service_name: str, action_name: str) -> str:
     available_services = SERVICE_PLUGINS.list_available()
 
     if service_name not in available_services:
-        return MESSAGE_TEMPLATE % ("", service_name, "")
-
+        return (
+            f"The API for service '{service_name}' is either not included in your current license plan "
+            "or has not yet been emulated by LocalStack. "
+            f"Please refer to {_COVERAGE_LINK_BASE} for more details."
+        )
     else:
-        return MESSAGE_TEMPLATE % (
-            f"action '{action_name}' ",
-            service_name,
-            f"coverage_{service_name}/",
+        return (
+            f"The API action '{action_name}' for service '{service_name}' is either not available in "
+            "your current license plan or has not yet been emulated by LocalStack. "
+            f"Please refer to {_COVERAGE_LINK_BASE} for more information."
         )

--- a/localstack-core/localstack/utils/coverage_docs.py
+++ b/localstack-core/localstack/utils/coverage_docs.py
@@ -1,4 +1,4 @@
-_COVERAGE_LINK_BASE = "https://docs.localstack.cloud/references/coverage/"
+_COVERAGE_LINK_BASE = "https://docs.localstack.cloud/references/coverage"
 
 
 def get_coverage_link_for_service(service_name: str, action_name: str) -> str:
@@ -16,5 +16,5 @@ def get_coverage_link_for_service(service_name: str, action_name: str) -> str:
         return (
             f"The API action '{action_name}' for service '{service_name}' is either not available in "
             "your current license plan or has not yet been emulated by LocalStack. "
-            f"Please refer to {_COVERAGE_LINK_BASE} for more information."
+            f"Please refer to {_COVERAGE_LINK_BASE}/coverage_{service_name} for more information."
         )

--- a/tests/unit/aws/test_skeleton.py
+++ b/tests/unit/aws/test_skeleton.py
@@ -200,8 +200,11 @@ def test_skeleton_e2e_sqs_send_message():
     [
         (
             TestSqsApiNotImplemented(),
-            "API action 'SendMessage' for service 'sqs' not yet implemented or pro feature"
-            " - please check https://docs.localstack.cloud/references/coverage/coverage_sqs/ for further information",
+            (
+                "The API action 'SendMessage' for service 'sqs' is either not available "
+                "in your current license plan or has not yet been emulated by LocalStack. "
+                "Please refer to https://docs.localstack.cloud/references/coverage/coverage_sqs for more information."
+            ),
         ),
         (
             TestSqsApiNotImplementedWithMessage(),
@@ -312,8 +315,11 @@ def test_dispatch_missing_method_returns_internal_failure():
     assert "Error" in parsed_response
     assert parsed_response["Error"] == {
         "Code": "InternalFailure",
-        "Message": "API action 'DeleteQueue' for service 'sqs' not yet implemented or pro feature - please check "
-        "https://docs.localstack.cloud/references/coverage/coverage_sqs/ for further information",
+        "Message": (
+            "The API action 'DeleteQueue' for service 'sqs' is either not available in your "
+            "current license plan or has not yet been emulated by LocalStack. "
+            "Please refer to https://docs.localstack.cloud/references/coverage/coverage_sqs for more information."
+        ),
     }
 
 

--- a/tests/unit/utils/test_coverage_docs.py
+++ b/tests/unit/utils/test_coverage_docs.py
@@ -6,7 +6,7 @@ def test_coverage_link_for_existing_service():
     assert coverage_link == (
         "The API action 'random_action' for service 's3' is either not available in your current "
         "license plan or has not yet been emulated by LocalStack. "
-        "Please refer to https://docs.localstack.cloud/references/coverage/ for more information."
+        "Please refer to https://docs.localstack.cloud/references/coverage/coverage_s3 for more information."
     )
 
 
@@ -15,5 +15,5 @@ def test_coverage_link_for_non_existing_service():
     assert coverage_link == (
         "The API for service 'dummy_service' is either not included in your current license plan or "
         "has not yet been emulated by LocalStack. "
-        "Please refer to https://docs.localstack.cloud/references/coverage/ for more details."
+        "Please refer to https://docs.localstack.cloud/references/coverage for more details."
     )

--- a/tests/unit/utils/test_coverage_docs.py
+++ b/tests/unit/utils/test_coverage_docs.py
@@ -3,15 +3,17 @@ from localstack.utils.coverage_docs import get_coverage_link_for_service
 
 def test_coverage_link_for_existing_service():
     coverage_link = get_coverage_link_for_service("s3", "random_action")
-    assert (
-        coverage_link
-        == "API action 'random_action' for service 's3' not yet implemented or pro feature - please check https://docs.localstack.cloud/references/coverage/coverage_s3/ for further information"
+    assert coverage_link == (
+        "The API action 'random_action' for service 's3' is either not available in your current "
+        "license plan or has not yet been emulated by LocalStack. "
+        "Please refer to https://docs.localstack.cloud/references/coverage/ for more information."
     )
 
 
 def test_coverage_link_for_non_existing_service():
     coverage_link = get_coverage_link_for_service("dummy_service", "random_action")
-    assert (
-        coverage_link
-        == "API for service 'dummy_service' not yet implemented or pro feature - please check https://docs.localstack.cloud/references/coverage/ for further information"
+    assert coverage_link == (
+        "The API for service 'dummy_service' is either not included in your current license plan or "
+        "has not yet been emulated by LocalStack. "
+        "Please refer to https://docs.localstack.cloud/references/coverage/ for more details."
     )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
By refining our coverage error messages to explicitly distinguish between license-plan restrictions and missing LocalStack emulation, developers immediately know whether they need to upgrade or await feature support. This is especially valuable for integrated services like Step Functions, where missing or unlicensed services defined in the state machines can result in evaluation failure.



<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Error for service action limitations rewritten from 
```API action <action-name> for service <service-name> not yet implemented or pro feature - please check https://docs.localstack.cloud/references/coverage/coverage_s3/ for further information```
to
```The API action <action-name> for service <service-name> is either not available in your current license plan or has not yet been emulated by LocalStack. Please refer to https://docs.localstack.cloud/references/coverage/coverage_<service-name> for more information.```

- Error for service limitations rewritten from
```API for service <service-name> not yet implemented or pro feature - please check https://docs.localstack.cloud/references/coverage/ for further information```
to
```The API for service <service-name> is either not included in your current license plan or has not yet been emulated by LocalStack. Please refer to https://docs.localstack.cloud/references/coverage for more details.```

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->

## Future Work

Extend these error messages to suggest the specific license tier required to enable a given service or API action, or to clearly indicate when the requested service isn’t supported by LocalStack
