### PR TITLE
Manually update ASF APIs and all dependencies

### DIFF
--- a/localstack-core/localstack/aws/api/ec2/__init__.py
+++ b/localstack-core/localstack/aws/api/ec2/__init__.py
@@ -3171,6 +3171,7 @@ class ServiceConnectivityType(StrEnum):
 class ServiceManaged(StrEnum):
     alb = "alb"
     nlb = "nlb"
+    rnat = "rnat"
 
 
 class ServiceState(StrEnum):
@@ -6104,6 +6105,14 @@ class ClientLoginBannerResponseOptions(TypedDict, total=False):
     BannerText: Optional[String]
 
 
+class ClientRouteEnforcementOptions(TypedDict, total=False):
+    Enforced: Optional[Boolean]
+
+
+class ClientRouteEnforcementResponseOptions(TypedDict, total=False):
+    Enforced: Optional[Boolean]
+
+
 class FederatedAuthentication(TypedDict, total=False):
     SamlProviderArn: Optional[String]
     SelfServiceSamlProviderArn: Optional[String]
@@ -6202,6 +6211,7 @@ class ClientVpnEndpoint(TypedDict, total=False):
     ClientConnectOptions: Optional[ClientConnectResponseOptions]
     SessionTimeoutHours: Optional[Integer]
     ClientLoginBannerOptions: Optional[ClientLoginBannerResponseOptions]
+    ClientRouteEnforcementOptions: Optional[ClientRouteEnforcementResponseOptions]
     DisconnectOnSessionTimeout: Optional[Boolean]
 
 
@@ -6551,6 +6561,7 @@ class CreateClientVpnEndpointRequest(ServiceRequest):
     ClientConnectOptions: Optional[ClientConnectOptions]
     SessionTimeoutHours: Optional[Integer]
     ClientLoginBannerOptions: Optional[ClientLoginBannerOptions]
+    ClientRouteEnforcementOptions: Optional[ClientRouteEnforcementOptions]
     DisconnectOnSessionTimeout: Optional[Boolean]
 
 
@@ -18054,6 +18065,7 @@ class ModifyClientVpnEndpointRequest(ServiceRequest):
     ClientConnectOptions: Optional[ClientConnectOptions]
     SessionTimeoutHours: Optional[Integer]
     ClientLoginBannerOptions: Optional[ClientLoginBannerOptions]
+    ClientRouteEnforcementOptions: Optional[ClientRouteEnforcementOptions]
     DisconnectOnSessionTimeout: Optional[Boolean]
 
 
@@ -20993,6 +21005,7 @@ class Ec2Api:
         client_connect_options: ClientConnectOptions = None,
         session_timeout_hours: Integer = None,
         client_login_banner_options: ClientLoginBannerOptions = None,
+        client_route_enforcement_options: ClientRouteEnforcementOptions = None,
         disconnect_on_session_timeout: Boolean = None,
         **kwargs,
     ) -> CreateClientVpnEndpointResult:
@@ -26572,6 +26585,7 @@ class Ec2Api:
         client_connect_options: ClientConnectOptions = None,
         session_timeout_hours: Integer = None,
         client_login_banner_options: ClientLoginBannerOptions = None,
+        client_route_enforcement_options: ClientRouteEnforcementOptions = None,
         disconnect_on_session_timeout: Boolean = None,
         **kwargs,
     ) -> ModifyClientVpnEndpointResult:

--- a/localstack-core/localstack/aws/api/events/__init__.py
+++ b/localstack-core/localstack/aws/api/events/__init__.py
@@ -548,6 +548,7 @@ class CreateConnectionRequest(ServiceRequest):
     AuthorizationType: ConnectionAuthorizationType
     AuthParameters: CreateConnectionAuthRequestParameters
     InvocationConnectivityParameters: Optional[ConnectivityResourceParameters]
+    KmsKeyIdentifier: Optional[KmsKeyIdentifier]
 
 
 class CreateConnectionResponse(TypedDict, total=False):
@@ -757,6 +758,7 @@ class DescribeConnectionResponse(TypedDict, total=False):
     StateReason: Optional[ConnectionStateReason]
     AuthorizationType: Optional[ConnectionAuthorizationType]
     SecretArn: Optional[SecretsManagerSecretArn]
+    KmsKeyIdentifier: Optional[KmsKeyIdentifier]
     AuthParameters: Optional[ConnectionAuthResponseParameters]
     CreationTime: Optional[Timestamp]
     LastModifiedTime: Optional[Timestamp]
@@ -1504,6 +1506,7 @@ class UpdateConnectionRequest(ServiceRequest):
     AuthorizationType: Optional[ConnectionAuthorizationType]
     AuthParameters: Optional[UpdateConnectionAuthRequestParameters]
     InvocationConnectivityParameters: Optional[ConnectivityResourceParameters]
+    KmsKeyIdentifier: Optional[KmsKeyIdentifier]
 
 
 class UpdateConnectionResponse(TypedDict, total=False):
@@ -1603,6 +1606,7 @@ class EventsApi:
         auth_parameters: CreateConnectionAuthRequestParameters,
         description: ConnectionDescription = None,
         invocation_connectivity_parameters: ConnectivityResourceParameters = None,
+        kms_key_identifier: KmsKeyIdentifier = None,
         **kwargs,
     ) -> CreateConnectionResponse:
         raise NotImplementedError
@@ -2072,6 +2076,7 @@ class EventsApi:
         authorization_type: ConnectionAuthorizationType = None,
         auth_parameters: UpdateConnectionAuthRequestParameters = None,
         invocation_connectivity_parameters: ConnectivityResourceParameters = None,
+        kms_key_identifier: KmsKeyIdentifier = None,
         **kwargs,
     ) -> UpdateConnectionResponse:
         raise NotImplementedError

--- a/localstack-core/localstack/aws/api/resource_groups/__init__.py
+++ b/localstack-core/localstack/aws/api/resource_groups/__init__.py
@@ -287,6 +287,7 @@ class GetTagSyncTaskOutput(TypedDict, total=False):
     TaskArn: Optional[TagSyncTaskArn]
     TagKey: Optional[TagKey]
     TagValue: Optional[TagValue]
+    ResourceQuery: Optional[ResourceQuery]
     RoleArn: Optional[RoleArn]
     Status: Optional[TagSyncTaskStatus]
     ErrorMessage: Optional[ErrorMessage]
@@ -463,6 +464,7 @@ class TagSyncTaskItem(TypedDict, total=False):
     TaskArn: Optional[TagSyncTaskArn]
     TagKey: Optional[TagKey]
     TagValue: Optional[TagValue]
+    ResourceQuery: Optional[ResourceQuery]
     RoleArn: Optional[RoleArn]
     Status: Optional[TagSyncTaskStatus]
     ErrorMessage: Optional[ErrorMessage]
@@ -500,8 +502,9 @@ class SearchResourcesOutput(TypedDict, total=False):
 
 class StartTagSyncTaskInput(ServiceRequest):
     Group: GroupStringV2
-    TagKey: TagKey
-    TagValue: TagValue
+    TagKey: Optional[TagKey]
+    TagValue: Optional[TagValue]
+    ResourceQuery: Optional[ResourceQuery]
     RoleArn: RoleArn
 
 
@@ -511,6 +514,7 @@ class StartTagSyncTaskOutput(TypedDict, total=False):
     TaskArn: Optional[TagSyncTaskArn]
     TagKey: Optional[TagKey]
     TagValue: Optional[TagValue]
+    ResourceQuery: Optional[ResourceQuery]
     RoleArn: Optional[RoleArn]
 
 
@@ -738,9 +742,10 @@ class ResourceGroupsApi:
         self,
         context: RequestContext,
         group: GroupStringV2,
-        tag_key: TagKey,
-        tag_value: TagValue,
         role_arn: RoleArn,
+        tag_key: TagKey = None,
+        tag_value: TagValue = None,
+        resource_query: ResourceQuery = None,
         **kwargs,
     ) -> StartTagSyncTaskOutput:
         raise NotImplementedError

--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -396,8 +396,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         auth_parameters: CreateConnectionAuthRequestParameters,
         description: ConnectionDescription = None,
         invocation_connectivity_parameters: ConnectivityResourceParameters = None,
+        kms_key_identifier: KmsKeyIdentifier = None,
         **kwargs,
     ) -> CreateConnectionResponse:
+        # TODO add support for kms_key_identifier
         region = context.region
         account_id = context.account_id
         store = self.get_store(region, account_id)
@@ -490,8 +492,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         authorization_type: ConnectionAuthorizationType = None,
         auth_parameters: UpdateConnectionAuthRequestParameters = None,
         invocation_connectivity_parameters: ConnectivityResourceParameters = None,
+        kms_key_identifier: KmsKeyIdentifier = None,
         **kwargs,
     ) -> UpdateConnectionResponse:
+        # TODO add support for kms_key_identifier
         region = context.region
         account_id = context.account_id
         store = self.get_store(region, account_id)

--- a/localstack-core/localstack/services/events/v1/provider.py
+++ b/localstack-core/localstack/services/events/v1/provider.py
@@ -25,6 +25,7 @@ from localstack.aws.api.events import (
     EventBusNameOrArn,
     EventPattern,
     EventsApi,
+    KmsKeyIdentifier,
     PutRuleResponse,
     PutTargetsResponse,
     RoleArn,
@@ -296,8 +297,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         auth_parameters: CreateConnectionAuthRequestParameters,
         description: ConnectionDescription = None,
         invocation_connectivity_parameters: ConnectivityResourceParameters = None,
+        kms_key_identifier: KmsKeyIdentifier = None,
         **kwargs,
     ) -> CreateConnectionResponse:
+        # TODO add support for kms_key_identifier
         errors = []
 
         if not CONNECTION_NAME_PATTERN.match(name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,9 @@ Issues = "https://github.com/localstack/localstack/issues"
 # minimal required to actually run localstack on the host for services natively implemented in python
 base-runtime = [
     # pinned / updated by ASF update action
-    "boto3==1.37.28",
+    "boto3==1.38.0",
     # pinned / updated by ASF update action
-    "botocore==1.37.28",
+    "botocore==1.38.0",
     "awscrt>=0.13.14",
     "cbor2>=5.5.0",
     "dnspython>=1.16.0",
@@ -78,7 +78,7 @@ base-runtime = [
 runtime = [
     "localstack-core[base-runtime]",
     # pinned / updated by ASF update action
-    "awscli>=1.32.117",
+    "awscli>=1.37.0",
     "airspeed-ext>=0.6.3",
     "amazon_kclpy>=3.0.0",
     # antlr4-python3-runtime: exact pin because antlr4 runtime is tightly coupled to the generated parser code

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -11,9 +11,9 @@ attrs==25.3.0
     #   referencing
 awscrt==0.26.1
     # via localstack-core (pyproject.toml)
-boto3==1.37.28
+boto3==1.38.0
     # via localstack-core (pyproject.toml)
-botocore==1.37.28
+botocore==1.38.0
     # via
     #   boto3
     #   localstack-core (pyproject.toml)
@@ -102,7 +102,7 @@ markupsafe==3.0.2
     # via werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.6.0
+more-itertools==10.7.0
     # via openapi-core
 openapi-core==0.19.4
     # via localstack-core (pyproject.toml)
@@ -170,7 +170,7 @@ rpds-py==0.24.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.11.5
+s3transfer==0.12.0
     # via boto3
 semver==3.0.4
     # via localstack-core (pyproject.toml)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,7 +33,7 @@ aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
 aws-cdk-cloud-assembly-schema==41.2.0
     # via aws-cdk-lib
-aws-cdk-lib==2.190.0
+aws-cdk-lib==2.191.0
     # via localstack-core
 aws-sam-translator==1.97.0
     # via
@@ -41,17 +41,17 @@ aws-sam-translator==1.97.0
     #   localstack-core
 aws-xray-sdk==2.14.0
     # via moto-ext
-awscli==1.38.28
+awscli==1.39.0
     # via localstack-core
 awscrt==0.26.1
     # via localstack-core
-boto3==1.37.28
+boto3==1.38.0
     # via
     #   amazon-kclpy
     #   aws-sam-translator
     #   localstack-core
     #   moto-ext
-botocore==1.37.28
+botocore==1.38.0
     # via
     #   aws-xray-sdk
     #   awscli
@@ -140,7 +140,7 @@ docker==7.1.0
     #   moto-ext
 docopt==0.6.2
     # via coveralls
-docutils==0.16
+docutils==0.19
     # via awscli
 events==0.5
     # via opensearch-py
@@ -248,7 +248,7 @@ markupsafe==3.0.2
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.6.0
+more-itertools==10.7.0
     # via openapi-core
 moto-ext==5.1.3.post1
     # via localstack-core
@@ -258,7 +258,7 @@ multipart==1.2.1
     # via moto-ext
 mypy==1.15.0
     # via localstack-core (pyproject.toml)
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via mypy
 networkx==3.4.2
     # via
@@ -431,7 +431,7 @@ rstr==3.2.2
     # via localstack-core (pyproject.toml)
 ruff==0.11.6
     # via localstack-core (pyproject.toml)
-s3transfer==0.11.5
+s3transfer==0.12.0
     # via
     #   awscli
     #   boto3

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -29,17 +29,17 @@ aws-sam-translator==1.97.0
     #   localstack-core (pyproject.toml)
 aws-xray-sdk==2.14.0
     # via moto-ext
-awscli==1.38.28
+awscli==1.39.0
     # via localstack-core (pyproject.toml)
 awscrt==0.26.1
     # via localstack-core
-boto3==1.37.28
+boto3==1.38.0
     # via
     #   amazon-kclpy
     #   aws-sam-translator
     #   localstack-core
     #   moto-ext
-botocore==1.37.28
+botocore==1.38.0
     # via
     #   aws-xray-sdk
     #   awscli
@@ -104,7 +104,7 @@ docker==7.1.0
     # via
     #   localstack-core
     #   moto-ext
-docutils==0.16
+docutils==0.19
     # via awscli
 events==0.5
     # via opensearch-py
@@ -186,7 +186,7 @@ markupsafe==3.0.2
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.6.0
+more-itertools==10.7.0
     # via openapi-core
 moto-ext==5.1.3.post1
     # via localstack-core (pyproject.toml)
@@ -312,7 +312,7 @@ rpds-py==0.24.0
     #   referencing
 rsa==4.7.2
     # via awscli
-s3transfer==0.11.5
+s3transfer==0.12.0
     # via
     #   awscli
     #   boto3

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -33,7 +33,7 @@ aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
 aws-cdk-cloud-assembly-schema==41.2.0
     # via aws-cdk-lib
-aws-cdk-lib==2.190.0
+aws-cdk-lib==2.191.0
     # via localstack-core (pyproject.toml)
 aws-sam-translator==1.97.0
     # via
@@ -41,17 +41,17 @@ aws-sam-translator==1.97.0
     #   localstack-core
 aws-xray-sdk==2.14.0
     # via moto-ext
-awscli==1.38.28
+awscli==1.39.0
     # via localstack-core
 awscrt==0.26.1
     # via localstack-core
-boto3==1.37.28
+boto3==1.38.0
     # via
     #   amazon-kclpy
     #   aws-sam-translator
     #   localstack-core
     #   moto-ext
-botocore==1.37.28
+botocore==1.38.0
     # via
     #   aws-xray-sdk
     #   awscli
@@ -128,7 +128,7 @@ docker==7.1.0
     # via
     #   localstack-core
     #   moto-ext
-docutils==0.16
+docutils==0.19
     # via awscli
 events==0.5
     # via opensearch-py
@@ -232,7 +232,7 @@ markupsafe==3.0.2
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.6.0
+more-itertools==10.7.0
     # via openapi-core
 moto-ext==5.1.3.post1
     # via localstack-core
@@ -389,7 +389,7 @@ rpds-py==0.24.0
     #   referencing
 rsa==4.7.2
     # via awscli
-s3transfer==0.11.5
+s3transfer==0.12.0
     # via
     #   awscli
     #   boto3

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -33,7 +33,7 @@ aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
 aws-cdk-cloud-assembly-schema==41.2.0
     # via aws-cdk-lib
-aws-cdk-lib==2.190.0
+aws-cdk-lib==2.191.0
     # via localstack-core
 aws-sam-translator==1.97.0
     # via
@@ -41,19 +41,19 @@ aws-sam-translator==1.97.0
     #   localstack-core
 aws-xray-sdk==2.14.0
     # via moto-ext
-awscli==1.38.28
+awscli==1.39.0
     # via localstack-core
 awscrt==0.26.1
     # via localstack-core
-boto3==1.37.28
+boto3==1.38.0
     # via
     #   amazon-kclpy
     #   aws-sam-translator
     #   localstack-core
     #   moto-ext
-boto3-stubs==1.37.38
+boto3-stubs==1.38.0
     # via localstack-core (pyproject.toml)
-botocore==1.37.28
+botocore==1.38.0
     # via
     #   aws-xray-sdk
     #   awscli
@@ -61,7 +61,7 @@ botocore==1.37.28
     #   localstack-core
     #   moto-ext
     #   s3transfer
-botocore-stubs==1.37.38
+botocore-stubs==1.38.0
     # via boto3-stubs
 build==1.2.2.post1
     # via
@@ -144,7 +144,7 @@ docker==7.1.0
     #   moto-ext
 docopt==0.6.2
     # via coveralls
-docutils==0.16
+docutils==0.19
     # via awscli
 events==0.5
     # via opensearch-py
@@ -252,7 +252,7 @@ markupsafe==3.0.2
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.6.0
+more-itertools==10.7.0
     # via openapi-core
 moto-ext==5.1.3.post1
     # via localstack-core
@@ -262,213 +262,213 @@ multipart==1.2.1
     # via moto-ext
 mypy==1.15.0
     # via localstack-core
-mypy-boto3-acm==1.37.0
+mypy-boto3-acm==1.38.0
     # via boto3-stubs
-mypy-boto3-acm-pca==1.37.12
+mypy-boto3-acm-pca==1.38.0
     # via boto3-stubs
-mypy-boto3-amplify==1.37.17
+mypy-boto3-amplify==1.38.0
     # via boto3-stubs
-mypy-boto3-apigateway==1.37.23
+mypy-boto3-apigateway==1.38.0
     # via boto3-stubs
-mypy-boto3-apigatewayv2==1.37.23
+mypy-boto3-apigatewayv2==1.38.0
     # via boto3-stubs
-mypy-boto3-appconfig==1.37.0
+mypy-boto3-appconfig==1.38.0
     # via boto3-stubs
-mypy-boto3-appconfigdata==1.37.0
+mypy-boto3-appconfigdata==1.38.0
     # via boto3-stubs
-mypy-boto3-application-autoscaling==1.37.32
+mypy-boto3-application-autoscaling==1.38.0
     # via boto3-stubs
-mypy-boto3-appsync==1.37.15
+mypy-boto3-appsync==1.38.0
     # via boto3-stubs
-mypy-boto3-athena==1.37.0
+mypy-boto3-athena==1.38.0
     # via boto3-stubs
-mypy-boto3-autoscaling==1.37.36
+mypy-boto3-autoscaling==1.38.0
     # via boto3-stubs
-mypy-boto3-backup==1.37.0
+mypy-boto3-backup==1.38.0
     # via boto3-stubs
-mypy-boto3-batch==1.37.22
+mypy-boto3-batch==1.38.0
     # via boto3-stubs
-mypy-boto3-ce==1.37.30
+mypy-boto3-ce==1.38.0
     # via boto3-stubs
-mypy-boto3-cloudcontrol==1.37.0
+mypy-boto3-cloudcontrol==1.38.0
     # via boto3-stubs
-mypy-boto3-cloudformation==1.37.22
+mypy-boto3-cloudformation==1.38.0
     # via boto3-stubs
-mypy-boto3-cloudfront==1.37.9
+mypy-boto3-cloudfront==1.38.0
     # via boto3-stubs
-mypy-boto3-cloudtrail==1.37.8
+mypy-boto3-cloudtrail==1.38.0
     # via boto3-stubs
-mypy-boto3-cloudwatch==1.37.0
+mypy-boto3-cloudwatch==1.38.0
     # via boto3-stubs
-mypy-boto3-codebuild==1.37.29
+mypy-boto3-codebuild==1.38.0
     # via boto3-stubs
-mypy-boto3-codecommit==1.37.0
+mypy-boto3-codecommit==1.38.0
     # via boto3-stubs
-mypy-boto3-codeconnections==1.37.0
+mypy-boto3-codeconnections==1.38.0
     # via boto3-stubs
-mypy-boto3-codedeploy==1.37.0
+mypy-boto3-codedeploy==1.38.0
     # via boto3-stubs
-mypy-boto3-codepipeline==1.37.0
+mypy-boto3-codepipeline==1.38.0
     # via boto3-stubs
-mypy-boto3-codestar-connections==1.37.0
+mypy-boto3-codestar-connections==1.38.0
     # via boto3-stubs
-mypy-boto3-cognito-identity==1.37.13
+mypy-boto3-cognito-identity==1.38.0
     # via boto3-stubs
-mypy-boto3-cognito-idp==1.37.13.post1
+mypy-boto3-cognito-idp==1.38.0
     # via boto3-stubs
-mypy-boto3-dms==1.37.4
+mypy-boto3-dms==1.38.0
     # via boto3-stubs
-mypy-boto3-docdb==1.37.0
+mypy-boto3-docdb==1.38.0
     # via boto3-stubs
-mypy-boto3-dynamodb==1.37.33
+mypy-boto3-dynamodb==1.38.0
     # via boto3-stubs
-mypy-boto3-dynamodbstreams==1.37.0
+mypy-boto3-dynamodbstreams==1.38.0
     # via boto3-stubs
-mypy-boto3-ec2==1.37.28
+mypy-boto3-ec2==1.38.0
     # via boto3-stubs
-mypy-boto3-ecr==1.37.26
+mypy-boto3-ecr==1.38.0
     # via boto3-stubs
-mypy-boto3-ecs==1.37.36
+mypy-boto3-ecs==1.38.0
     # via boto3-stubs
-mypy-boto3-efs==1.37.0
+mypy-boto3-efs==1.38.0
     # via boto3-stubs
-mypy-boto3-eks==1.37.35
+mypy-boto3-eks==1.38.0
     # via boto3-stubs
-mypy-boto3-elasticache==1.37.32
+mypy-boto3-elasticache==1.38.0
     # via boto3-stubs
-mypy-boto3-elasticbeanstalk==1.37.0
+mypy-boto3-elasticbeanstalk==1.38.0
     # via boto3-stubs
-mypy-boto3-elbv2==1.37.9
+mypy-boto3-elbv2==1.38.0
     # via boto3-stubs
-mypy-boto3-emr==1.37.3
+mypy-boto3-emr==1.38.0
     # via boto3-stubs
-mypy-boto3-emr-serverless==1.37.0
+mypy-boto3-emr-serverless==1.38.0
     # via boto3-stubs
-mypy-boto3-es==1.37.0
+mypy-boto3-es==1.38.0
     # via boto3-stubs
-mypy-boto3-events==1.37.35
+mypy-boto3-events==1.38.0
     # via boto3-stubs
-mypy-boto3-firehose==1.37.38
+mypy-boto3-firehose==1.38.0
     # via boto3-stubs
-mypy-boto3-fis==1.37.0
+mypy-boto3-fis==1.38.0
     # via boto3-stubs
-mypy-boto3-glacier==1.37.0
+mypy-boto3-glacier==1.38.0
     # via boto3-stubs
-mypy-boto3-glue==1.37.31
+mypy-boto3-glue==1.38.0
     # via boto3-stubs
-mypy-boto3-iam==1.37.22
+mypy-boto3-iam==1.38.0
     # via boto3-stubs
-mypy-boto3-identitystore==1.37.0
+mypy-boto3-identitystore==1.38.0
     # via boto3-stubs
-mypy-boto3-iot==1.37.1
+mypy-boto3-iot==1.38.0
     # via boto3-stubs
-mypy-boto3-iot-data==1.37.0
+mypy-boto3-iot-data==1.38.0
     # via boto3-stubs
-mypy-boto3-iotanalytics==1.37.0
+mypy-boto3-iotanalytics==1.38.0
     # via boto3-stubs
-mypy-boto3-iotwireless==1.37.19
+mypy-boto3-iotwireless==1.38.0
     # via boto3-stubs
-mypy-boto3-kafka==1.37.0
+mypy-boto3-kafka==1.38.0
     # via boto3-stubs
-mypy-boto3-kinesis==1.37.0
+mypy-boto3-kinesis==1.38.0
     # via boto3-stubs
-mypy-boto3-kinesisanalytics==1.37.0
+mypy-boto3-kinesisanalytics==1.38.0
     # via boto3-stubs
-mypy-boto3-kinesisanalyticsv2==1.37.0
+mypy-boto3-kinesisanalyticsv2==1.38.0
     # via boto3-stubs
-mypy-boto3-kms==1.37.0
+mypy-boto3-kms==1.38.0
     # via boto3-stubs
-mypy-boto3-lakeformation==1.37.13
+mypy-boto3-lakeformation==1.38.0
     # via boto3-stubs
-mypy-boto3-lambda==1.37.16
+mypy-boto3-lambda==1.38.0
     # via boto3-stubs
-mypy-boto3-logs==1.37.12
+mypy-boto3-logs==1.38.0
     # via boto3-stubs
-mypy-boto3-managedblockchain==1.37.0
+mypy-boto3-managedblockchain==1.38.0
     # via boto3-stubs
-mypy-boto3-mediaconvert==1.37.21
+mypy-boto3-mediaconvert==1.38.0
     # via boto3-stubs
-mypy-boto3-mediastore==1.37.0
+mypy-boto3-mediastore==1.38.0
     # via boto3-stubs
-mypy-boto3-mq==1.37.0
+mypy-boto3-mq==1.38.0
     # via boto3-stubs
-mypy-boto3-mwaa==1.37.0
+mypy-boto3-mwaa==1.38.0
     # via boto3-stubs
-mypy-boto3-neptune==1.37.0
+mypy-boto3-neptune==1.38.0
     # via boto3-stubs
-mypy-boto3-opensearch==1.37.27
+mypy-boto3-opensearch==1.38.0
     # via boto3-stubs
-mypy-boto3-organizations==1.37.0
+mypy-boto3-organizations==1.38.0
     # via boto3-stubs
-mypy-boto3-pi==1.37.0
+mypy-boto3-pi==1.38.0
     # via boto3-stubs
-mypy-boto3-pinpoint==1.37.0
+mypy-boto3-pinpoint==1.38.0
     # via boto3-stubs
-mypy-boto3-pipes==1.37.0
+mypy-boto3-pipes==1.38.0
     # via boto3-stubs
-mypy-boto3-qldb==1.37.0
+mypy-boto3-qldb==1.38.0
     # via boto3-stubs
-mypy-boto3-qldb-session==1.37.0
+mypy-boto3-qldb-session==1.38.0
     # via boto3-stubs
-mypy-boto3-rds==1.37.21
+mypy-boto3-rds==1.38.0
     # via boto3-stubs
-mypy-boto3-rds-data==1.37.0
+mypy-boto3-rds-data==1.38.0
     # via boto3-stubs
-mypy-boto3-redshift==1.37.0
+mypy-boto3-redshift==1.38.0
     # via boto3-stubs
-mypy-boto3-redshift-data==1.37.8
+mypy-boto3-redshift-data==1.38.0
     # via boto3-stubs
-mypy-boto3-resource-groups==1.37.35
+mypy-boto3-resource-groups==1.38.0
     # via boto3-stubs
-mypy-boto3-resourcegroupstaggingapi==1.37.0
+mypy-boto3-resourcegroupstaggingapi==1.38.0
     # via boto3-stubs
-mypy-boto3-route53==1.37.27
+mypy-boto3-route53==1.38.0
     # via boto3-stubs
-mypy-boto3-route53resolver==1.37.0
+mypy-boto3-route53resolver==1.38.0
     # via boto3-stubs
-mypy-boto3-s3==1.37.24
+mypy-boto3-s3==1.38.0
     # via boto3-stubs
-mypy-boto3-s3control==1.37.28
+mypy-boto3-s3control==1.38.0
     # via boto3-stubs
-mypy-boto3-sagemaker==1.37.37
+mypy-boto3-sagemaker==1.38.0
     # via boto3-stubs
-mypy-boto3-sagemaker-runtime==1.37.0
+mypy-boto3-sagemaker-runtime==1.38.0
     # via boto3-stubs
-mypy-boto3-secretsmanager==1.37.0
+mypy-boto3-secretsmanager==1.38.0
     # via boto3-stubs
-mypy-boto3-serverlessrepo==1.37.0
+mypy-boto3-serverlessrepo==1.38.0
     # via boto3-stubs
-mypy-boto3-servicediscovery==1.37.0
+mypy-boto3-servicediscovery==1.38.0
     # via boto3-stubs
-mypy-boto3-ses==1.37.0
+mypy-boto3-ses==1.38.0
     # via boto3-stubs
-mypy-boto3-sesv2==1.37.27
+mypy-boto3-sesv2==1.38.0
     # via boto3-stubs
-mypy-boto3-sns==1.37.0
+mypy-boto3-sns==1.38.0
     # via boto3-stubs
-mypy-boto3-sqs==1.37.0
+mypy-boto3-sqs==1.38.0
     # via boto3-stubs
-mypy-boto3-ssm==1.37.19
+mypy-boto3-ssm==1.38.0
     # via boto3-stubs
-mypy-boto3-sso-admin==1.37.0
+mypy-boto3-sso-admin==1.38.0
     # via boto3-stubs
-mypy-boto3-stepfunctions==1.37.0
+mypy-boto3-stepfunctions==1.38.0
     # via boto3-stubs
-mypy-boto3-sts==1.37.0
+mypy-boto3-sts==1.38.0
     # via boto3-stubs
-mypy-boto3-timestream-query==1.37.0
+mypy-boto3-timestream-query==1.38.0
     # via boto3-stubs
-mypy-boto3-timestream-write==1.37.0
+mypy-boto3-timestream-write==1.38.0
     # via boto3-stubs
-mypy-boto3-transcribe==1.37.27
+mypy-boto3-transcribe==1.38.0
     # via boto3-stubs
-mypy-boto3-verifiedpermissions==1.37.33
+mypy-boto3-verifiedpermissions==1.38.0
     # via boto3-stubs
-mypy-boto3-wafv2==1.37.21
+mypy-boto3-wafv2==1.38.0
     # via boto3-stubs
-mypy-boto3-xray==1.37.0
+mypy-boto3-xray==1.38.0
     # via boto3-stubs
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via mypy
 networkx==3.4.2
     # via
@@ -641,7 +641,7 @@ rstr==3.2.2
     # via localstack-core
 ruff==0.11.6
     # via localstack-core
-s3transfer==0.11.5
+s3transfer==0.12.0
     # via
     #   awscli
     #   boto3
@@ -673,16 +673,120 @@ typeguard==2.13.3
     #   jsii
 types-awscrt==0.26.1
     # via botocore-stubs
-types-s3transfer==0.11.5
+types-s3transfer==0.12.0
     # via boto3-stubs
 typing-extensions==4.13.2
     # via
     #   anyio
     #   aws-sam-translator
+    #   boto3-stubs
     #   cfn-lint
     #   jsii
     #   localstack-twisted
     #   mypy
+    #   mypy-boto3-acm
+    #   mypy-boto3-acm-pca
+    #   mypy-boto3-amplify
+    #   mypy-boto3-apigateway
+    #   mypy-boto3-apigatewayv2
+    #   mypy-boto3-appconfig
+    #   mypy-boto3-appconfigdata
+    #   mypy-boto3-application-autoscaling
+    #   mypy-boto3-appsync
+    #   mypy-boto3-athena
+    #   mypy-boto3-autoscaling
+    #   mypy-boto3-backup
+    #   mypy-boto3-batch
+    #   mypy-boto3-ce
+    #   mypy-boto3-cloudcontrol
+    #   mypy-boto3-cloudformation
+    #   mypy-boto3-cloudfront
+    #   mypy-boto3-cloudtrail
+    #   mypy-boto3-cloudwatch
+    #   mypy-boto3-codebuild
+    #   mypy-boto3-codecommit
+    #   mypy-boto3-codeconnections
+    #   mypy-boto3-codedeploy
+    #   mypy-boto3-codepipeline
+    #   mypy-boto3-codestar-connections
+    #   mypy-boto3-cognito-identity
+    #   mypy-boto3-cognito-idp
+    #   mypy-boto3-dms
+    #   mypy-boto3-docdb
+    #   mypy-boto3-dynamodb
+    #   mypy-boto3-dynamodbstreams
+    #   mypy-boto3-ec2
+    #   mypy-boto3-ecr
+    #   mypy-boto3-ecs
+    #   mypy-boto3-efs
+    #   mypy-boto3-eks
+    #   mypy-boto3-elasticache
+    #   mypy-boto3-elasticbeanstalk
+    #   mypy-boto3-elbv2
+    #   mypy-boto3-emr
+    #   mypy-boto3-emr-serverless
+    #   mypy-boto3-es
+    #   mypy-boto3-events
+    #   mypy-boto3-firehose
+    #   mypy-boto3-fis
+    #   mypy-boto3-glacier
+    #   mypy-boto3-glue
+    #   mypy-boto3-iam
+    #   mypy-boto3-identitystore
+    #   mypy-boto3-iot
+    #   mypy-boto3-iot-data
+    #   mypy-boto3-iotanalytics
+    #   mypy-boto3-iotwireless
+    #   mypy-boto3-kafka
+    #   mypy-boto3-kinesis
+    #   mypy-boto3-kinesisanalytics
+    #   mypy-boto3-kinesisanalyticsv2
+    #   mypy-boto3-kms
+    #   mypy-boto3-lakeformation
+    #   mypy-boto3-lambda
+    #   mypy-boto3-logs
+    #   mypy-boto3-managedblockchain
+    #   mypy-boto3-mediaconvert
+    #   mypy-boto3-mediastore
+    #   mypy-boto3-mq
+    #   mypy-boto3-mwaa
+    #   mypy-boto3-neptune
+    #   mypy-boto3-opensearch
+    #   mypy-boto3-organizations
+    #   mypy-boto3-pi
+    #   mypy-boto3-pinpoint
+    #   mypy-boto3-pipes
+    #   mypy-boto3-qldb
+    #   mypy-boto3-qldb-session
+    #   mypy-boto3-rds
+    #   mypy-boto3-rds-data
+    #   mypy-boto3-redshift
+    #   mypy-boto3-redshift-data
+    #   mypy-boto3-resource-groups
+    #   mypy-boto3-resourcegroupstaggingapi
+    #   mypy-boto3-route53
+    #   mypy-boto3-route53resolver
+    #   mypy-boto3-s3
+    #   mypy-boto3-s3control
+    #   mypy-boto3-sagemaker
+    #   mypy-boto3-sagemaker-runtime
+    #   mypy-boto3-secretsmanager
+    #   mypy-boto3-serverlessrepo
+    #   mypy-boto3-servicediscovery
+    #   mypy-boto3-ses
+    #   mypy-boto3-sesv2
+    #   mypy-boto3-sns
+    #   mypy-boto3-sqs
+    #   mypy-boto3-ssm
+    #   mypy-boto3-sso-admin
+    #   mypy-boto3-stepfunctions
+    #   mypy-boto3-sts
+    #   mypy-boto3-timestream-query
+    #   mypy-boto3-timestream-write
+    #   mypy-boto3-transcribe
+    #   mypy-boto3-verifiedpermissions
+    #   mypy-boto3-wafv2
+    #   mypy-boto3-xray
     #   pydantic
     #   pydantic-core
     #   pyopenssl


### PR DESCRIPTION
## Motivation
With the latest release of `awscli==1.39.0` / `botocore==1.38.0` / `boto3==1.38.0` the [ASF update action started to fail with dependency resolution issues](https://github.com/localstack/localstack/actions/runs/14612933999):
```
ERROR: Cannot install boto3==1.38.0, botocore==1.38.0, localstack-core (pyproject.toml), moto-ext and moto-ext[all]==5.1.3.post1 because these package versions have conflicting dependencies.
```
It turns out that this is due to the fact that there was an update of a transitive dependency of `awscli`: `docutils` was upgraded to version `0.19.0`. This does not work with the way how we currently update the package as it does not consider transitive dependencies of `awscli`:
https://github.com/localstack/localstack/blob/77f30dcd2ed68017e4972d81d5f69a86bcab2b5f/.github/workflows/asf-updates.yml#L86

This was now manually fixed by removing the existing `requirements-*.txt` files and regenerating them.

## Changes
- Upgrade `boto3` / `botocore` to `1.39.0`.
- Regenerate all `requirements-*.txt` files.
- Generate the updated ASF APIs - the following services were updated:
  - `ec2` 
  - `events`
  - `resource_groups`
- Updates the `events` provider signature after the ASF specs were updated (added `kms_key_identifier`). /cc @maxhoheiser @bentsku 