### PR TITLE
APIGW: fix Host regex to allow hyphen and remove restriction

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -124,7 +124,7 @@ class ApiGatewayRouter:
 
     def register_routes(self) -> None:
         LOG.debug("Registering API Gateway routes.")
-        host_pattern = "<regex('[^-]+'):api_id><regex('(-vpce-[^.]+)?'):vpce_suffix>.execute-api.<regex('.*'):server>"
+        host_pattern = "<regex('.+?'):api_id><regex('(-vpce-[^.]+)?'):vpce_suffix>.execute-api.<regex('.*'):server>"
         deprecated_route_endpoint = deprecated_endpoint(
             endpoint=self.handler,
             previous_path="/restapis/<api_id>/<stage>/_user_request_",

--- a/localstack-core/localstack/services/apigateway/next_gen/provider.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/provider.py
@@ -1,8 +1,6 @@
 from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.apigateway import (
-    BadRequestException,
     CacheClusterSize,
-    CreateRestApiRequest,
     CreateStageRequest,
     Deployment,
     DeploymentCanarySettings,
@@ -14,14 +12,12 @@ from localstack.aws.api.apigateway import (
     NotFoundException,
     NullableBoolean,
     NullableInteger,
-    RestApi,
     Stage,
     StatusCode,
     String,
     TestInvokeMethodRequest,
     TestInvokeMethodResponse,
 )
-from localstack.constants import TAG_KEY_CUSTOM_ID
 from localstack.services.apigateway.helpers import (
     get_apigateway_store,
     get_moto_rest_api,
@@ -59,16 +55,6 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
     def on_after_init(self):
         apply_patches()
         self.router.register_routes()
-
-    @handler("CreateRestApi", expand=False)
-    def create_rest_api(self, context: RequestContext, request: CreateRestApiRequest) -> RestApi:
-        if "-" in request.get("tags", {}).get(TAG_KEY_CUSTOM_ID, ""):
-            raise BadRequestException(
-                f"The '{TAG_KEY_CUSTOM_ID}' tag cannot contain the '-' character."
-            )
-
-        response = super().create_rest_api(context, request)
-        return response
 
     @handler("DeleteRestApi")
     def delete_rest_api(self, context: RequestContext, rest_api_id: String, **kwargs) -> None:

--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -10,7 +10,6 @@ from botocore.exceptions import ClientError
 from localstack_snapshot.snapshots.transformer import KeyValueBasedTransformer, SortingTransformer
 
 from localstack.aws.api.apigateway import PutMode
-from localstack.constants import TAG_KEY_CUSTOM_ID
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.files import load_file
@@ -199,22 +198,6 @@ class TestApiGatewayApiRestApi:
 
         response = aws_client.apigateway.get_rest_apis()
         snapshot.match("get-rest-apis-w-tags", response)
-
-    @markers.aws.only_localstack
-    def test_create_rest_api_with_custom_id_tag(self, apigw_create_rest_api, aws_client):
-        custom_id_tag = "testid123"
-        response = apigw_create_rest_api(
-            name="my_api", description="this is my api", tags={TAG_KEY_CUSTOM_ID: custom_id_tag}
-        )
-        api_id = response["id"]
-        assert api_id == custom_id_tag
-
-        with pytest.raises(aws_client.apigateway.exceptions.BadRequestException):
-            apigw_create_rest_api(
-                name="my_api",
-                description="bad custom id",
-                tags={TAG_KEY_CUSTOM_ID: "bad-custom-id-hyphen"},
-            )
 
     @markers.aws.validated
     def test_update_rest_api_operation_add_remove(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow-up from #12539, sorry for back and forth on this.

A failure on our upstream pipeline put into light the fact that the `-` character would still work when using "path based routing" for the API.
In order to not break existing users' setup, I'm removing the previous restriction, and instead updating the regex to allow for dashes in the REST API id, as this is actually a simple fix (making the quantifier be lazy to not match the next regex group). 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a `only_localstack` test showing that the routing works with hyphen
- remove previous restriction

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
