### PR TITLE
[ESM] Fix flaky discarding record age test

### DIFF
--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.validation.json
@@ -42,7 +42,7 @@
     "last_validated_date": "2025-04-13T16:39:43+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_maximum_record_age_exceeded_discard_records": {
-    "last_validated_date": "2025-04-13T17:05:13+00:00"
+    "last_validated_date": "2025-04-23T21:42:09+00:00"
   },
   "tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_report_batch_item_failure_scenarios[empty_string_item_identifier_failure]": {
     "last_validated_date": "2024-12-13T14:23:18+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Fixes a flaky test that was caused by sleeping for 60s, which is instead being replaced by a reactive approach.

As per LS testing docs:
https://github.com/localstack/localstack/blob/49dcd934a8983e85f6870a254439884a17434923/docs/testing/README.md?plain=1#L162-L173

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Continually polls a Kinesis stream until a record has expired.


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
