### PR TITLE
feat: add current region and account as input to _proxy_capture_input_event

### DIFF
--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -1849,7 +1849,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
 
         trace_header = context.trace_context["aws_trace_header"]
 
-        self._proxy_capture_input_event(event_formatted, trace_header)
+        self._proxy_capture_input_event(event_formatted, trace_header, region, account_id)
 
         # Always add the successful EventId entry, even if target processing might fail
         processed_entries.append({"EventId": event_formatted["id"]})
@@ -1867,8 +1867,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                 )
             )
 
-    def _proxy_capture_input_event(self, event: FormattedEvent, trace_header: TraceHeader) -> None:
-        # only required for eventstudio to capture input event if no rule is configured
+    def _proxy_capture_input_event(
+        self, event: FormattedEvent, trace_header: TraceHeader, region: str, account_id: str
+    ) -> None:
+        # only required for EventStudio to capture input event if no rule is configured
         pass
 
     def _process_rules(

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -187,6 +187,7 @@ def format_event(
     event: PutEventsRequestEntry, region: str, account_id: str, event_bus_name: EventBusName
 ) -> FormattedEvent:
     # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-events.html
+    # region_name and account_id of original event is preserved fro cross-region event bus communication
     trace_header = event.get("TraceHeader")
     message = {}
     if trace_header:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
To capture the internal step that transforms the event in EventStudio we utilize a proxy `_proxy_capture_input_event`. In EventStudio we extract the region and account_id from the actual transformed event, but for cross region / cross account event bus to event bus communication, the region and account id in the transformed event is preserved from the region and account of the original "sender" event bus.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
 - adding account_id and region as additional input to `_proxy_capture_input_event`
 