### PR TITLE
Added new codeowners for CircleCI and GithubActions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,8 +17,8 @@
 /Dockerfile @alexrashed
 
 # Git, Pipelines, GitHub config
-/.circleci @alexrashed @dfangl @dominikschubert
-/.github @alexrashed @dfangl @dominikschubert
+/.circleci @alexrashed @dfangl @dominikschubert @silv-io @k-a-il
+/.github @alexrashed @dfangl @dominikschubert @silv-io @k-a-il
 /.test_durations @alexrashed
 /.git-blame-ignore-revs @alexrashed @thrau
 /bin/release-dev.sh @thrau @alexrashed


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR adds myself and @silv-io to Codeowners of `.circleci` and `.github`. This change will help us to ensure that we do not miss any changes in CI/CD pipelines during migration from CircleCI. Once the migration from CircleCI is complete, we'll determine whether our role as code owners is still necessary.

Also discussed here: https://github.com/localstack/localstack/pull/12556#issuecomment-2829601201

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Added myself and @silv-io to Codeowners of `.circleci` and `.github`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
