### PR TITLE
 [Kinesis] add Scala kinesis-mock build behind feature flag 

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -896,6 +896,20 @@ KINESIS_MOCK_LOG_LEVEL = os.environ.get("KINESIS_MOCK_LOG_LEVEL", "").strip()
 # randomly inject faults to Kinesis
 KINESIS_ERROR_PROBABILITY = float(os.environ.get("KINESIS_ERROR_PROBABILITY", "").strip() or 0.0)
 
+# SEMI-PUBLIC: "node" (default); not actively communicated
+# Select whether to use the node or scala build when running Kinesis Mock
+KINESIS_MOCK_PROVIDER_ENGINE = os.environ.get("KINESIS_MOCK_PROVIDER_ENGINE", "").strip() or "node"
+
+# set the maximum Java heap size corresponding to the '-Xmx<size>' flag
+KINESIS_MOCK_MAXIMUM_HEAP_SIZE = (
+    os.environ.get("KINESIS_MOCK_MAXIMUM_HEAP_SIZE", "").strip() or "512m"
+)
+
+# set the initial Java heap size corresponding to the '-Xms<size>' flag
+KINESIS_MOCK_INITIAL_HEAP_SIZE = (
+    os.environ.get("KINESIS_MOCK_INITIAL_HEAP_SIZE", "").strip() or "256m"
+)
+
 # randomly inject faults to DynamoDB
 DYNAMODB_ERROR_PROBABILITY = float(os.environ.get("DYNAMODB_ERROR_PROBABILITY", "").strip() or 0.0)
 DYNAMODB_READ_ERROR_PROBABILITY = float(

--- a/localstack-core/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack-core/localstack/services/kinesis/kinesis_mock_server.py
@@ -2,29 +2,20 @@ import logging
 import os
 import threading
 from abc import abstractmethod
-from enum import StrEnum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from localstack import config
-from localstack.services.kinesis.packages import kinesismock_node_package, kinesismock_scala_package
+from localstack.services.kinesis.packages import (
+    KinesisMockEngine,
+    kinesismock_package,
+    kinesismock_scala_package,
+)
 from localstack.utils.common import TMP_THREADS, ShellCommandThread, get_free_tcp_port, mkdir
 from localstack.utils.run import FuncThread
 from localstack.utils.serving import Server
 
 LOG = logging.getLogger(__name__)
-
-
-class KinesisMockEngine(StrEnum):
-    NODE = "node"
-    SCALA = "scala"
-
-    @classmethod
-    def _missing_(cls, value: str | Any) -> str:
-        # default to 'node' if invalid enum
-        if not isinstance(value, str):
-            return cls(cls.NODE)
-        return cls.__members__.get(value.upper(), cls.NODE)
 
 
 class KinesisMockServer(Server):
@@ -229,8 +220,8 @@ class KinesisServerManager:
             )
 
         # Otherwise, install the NodeJS version (default)
-        kinesismock_node_package.install()
-        kinesis_mock_path = Path(kinesismock_node_package.get_installer().get_executable_path())
+        kinesismock_package.install()
+        kinesis_mock_path = Path(kinesismock_package.get_installer().get_executable_path())
 
         return KinesisMockNodeServer(
             port=port,

--- a/localstack-core/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack-core/localstack/services/kinesis/kinesis_mock_server.py
@@ -1,11 +1,12 @@
 import logging
 import os
 import threading
+from abc import abstractmethod
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from localstack import config
-from localstack.services.kinesis.packages import kinesismock_package
+from localstack.services.kinesis.packages import KinesisMockEngine, kinesismock_package
 from localstack.utils.common import TMP_THREADS, ShellCommandThread, get_free_tcp_port, mkdir
 from localstack.utils.run import FuncThread
 from localstack.utils.serving import Server
@@ -21,7 +22,7 @@ class KinesisMockServer(Server):
     def __init__(
         self,
         port: int,
-        js_path: Path,
+        exe_path: Path,
         latency: str,
         account_id: str,
         host: str = "localhost",
@@ -32,7 +33,7 @@ class KinesisMockServer(Server):
         self._latency = latency
         self._data_dir = data_dir
         self._data_filename = f"{self._account_id}.json"
-        self._js_path = js_path
+        self._exe_path = exe_path
         self._log_level = log_level
         super().__init__(port, host)
 
@@ -51,15 +52,9 @@ class KinesisMockServer(Server):
         t.start()
         return t
 
-    def _create_shell_command(self) -> Tuple[List, Dict]:
-        """
-        Helper method for creating kinesis mock invocation command
-        :return: returns a tuple containing the command list and a dictionary with the environment variables
-        """
-
+    @property
+    def _environment_variables(self) -> Dict:
         env_vars = {
-            # Use the `server.json` packaged next to the main.js
-            "KINESIS_MOCK_CERT_PATH": str((self._js_path.parent / "server.json").absolute()),
             "KINESIS_MOCK_PLAIN_PORT": self.port,
             # Each kinesis-mock instance listens to two ports - secure and insecure.
             # LocalStack uses only one - the insecure one. Block the secure port to avoid conflicts.
@@ -91,11 +86,62 @@ class KinesisMockServer(Server):
             env_vars["PERSIST_INTERVAL"] = config.KINESIS_MOCK_PERSIST_INTERVAL
 
         env_vars["LOG_LEVEL"] = self._log_level
-        cmd = ["node", self._js_path]
-        return cmd, env_vars
+
+        return env_vars
+
+    @abstractmethod
+    def _create_shell_command(self) -> Tuple[List, Dict]:
+        """
+        Helper method for creating kinesis mock invocation command
+        :return: returns a tuple containing the command list and a dictionary with the environment variables
+        """
+        pass
 
     def _log_listener(self, line, **_kwargs):
         LOG.info(line.rstrip())
+
+
+class KinesisMockScalaServer(KinesisMockServer):
+    def _create_shell_command(self) -> Tuple[List, Dict]:
+        cmd = ["java", "-jar", *self._get_java_vm_options(), str(self._exe_path)]
+        return cmd, self._environment_variables
+
+    @property
+    def _environment_variables(self) -> Dict:
+        default_env_vars = super()._environment_variables
+        kinesis_mock_installer = kinesismock_package.get_installer()
+        return {
+            **default_env_vars,
+            **kinesis_mock_installer.get_java_env_vars(),
+        }
+
+    def _get_java_vm_options(self) -> list[str]:
+        return [
+            f"-Xms{config.KINESIS_MOCK_INITIAL_HEAP_SIZE}",
+            f"-Xmx{config.KINESIS_MOCK_MAXIMUM_HEAP_SIZE}",
+            "-XX:+UseG1GC",
+            "-XX:MaxGCPauseMillis=500",
+            "-XX:+UseGCOverheadLimit",
+            "-XX:+ExplicitGCInvokesConcurrent",
+            "-XX:+HeapDumpOnOutOfMemoryError",
+            "-XX:+ExitOnOutOfMemoryError",
+        ]
+
+
+class KinesisMockNodeServer(KinesisMockServer):
+    @property
+    def _environment_variables(self) -> Dict:
+        node_env_vars = {
+            # Use the `server.json` packaged next to the main.js
+            "KINESIS_MOCK_CERT_PATH": str((self._exe_path.parent / "server.json").absolute()),
+        }
+
+        default_env_vars = super()._environment_variables
+        return {**node_env_vars, **default_env_vars}
+
+    def _create_shell_command(self) -> Tuple[List, Dict]:
+        cmd = ["node", self._exe_path]
+        return cmd, self._environment_variables
 
 
 class KinesisServerManager:
@@ -137,7 +183,7 @@ class KinesisServerManager:
         """
         port = get_free_tcp_port()
         kinesismock_package.install()
-        kinesis_mock_js_path = Path(kinesismock_package.get_installer().get_executable_path())
+        kinesis_mock_path = Path(kinesismock_package.get_installer().get_executable_path())
 
         # kinesis-mock stores state in json files <account_id>.json, so we can dump everything into `kinesis/`
         persist_path = os.path.join(config.dirs.data, "kinesis")
@@ -159,12 +205,21 @@ class KinesisServerManager:
             log_level = "INFO"
         latency = config.KINESIS_LATENCY + "ms"
 
-        server = KinesisMockServer(
+        if kinesismock_package.engine == KinesisMockEngine.SCALA:
+            return KinesisMockScalaServer(
+                port=port,
+                exe_path=kinesis_mock_path,
+                log_level=log_level,
+                latency=latency,
+                data_dir=persist_path,
+                account_id=account_id,
+            )
+
+        return KinesisMockNodeServer(
             port=port,
-            js_path=kinesis_mock_js_path,
+            exe_path=kinesis_mock_path,
             log_level=log_level,
             latency=latency,
             data_dir=persist_path,
             account_id=account_id,
         )
-        return server

--- a/localstack-core/localstack/services/kinesis/packages.py
+++ b/localstack-core/localstack/services/kinesis/packages.py
@@ -1,28 +1,77 @@
 import os
-from functools import lru_cache
-from typing import List
+from enum import StrEnum
+from functools import cached_property, lru_cache
+from typing import Any, List
 
-from localstack.packages import Package
-from localstack.packages.core import NodePackageInstaller
+from localstack import config
+from localstack.packages import InstallTarget, Package
+from localstack.packages.core import GitHubReleaseInstaller, NodePackageInstaller
+from localstack.packages.java import JavaInstallerMixin, java_package
 
-_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.9"
+_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.12"
 
 
-class KinesisMockPackage(Package[NodePackageInstaller]):
-    def __init__(self, default_version: str = _KINESIS_MOCK_VERSION):
+class KinesisMockEngine(StrEnum):
+    NODE = "node"
+    SCALA = "scala"
+
+    @classmethod
+    def _missing_(cls, value: str | Any) -> str:
+        # default to 'node' if invalid enum
+        if not isinstance(value, str):
+            return cls(cls.NODE)
+        return cls.__members__.get(value.upper(), cls.NODE)
+
+
+class KinesisMockNodePackageInstaller(NodePackageInstaller):
+    def __init__(self, version: str):
+        super().__init__(package_name="kinesis-local", version=version)
+
+
+class KinesisMockScalaPackageInstaller(JavaInstallerMixin, GitHubReleaseInstaller):
+    def __init__(self, version: str = _KINESIS_MOCK_VERSION):
+        super().__init__(
+            name="kinesis-local", tag=f"v{version}", github_slug="etspaceman/kinesis-mock"
+        )
+
+        # Kinesis Mock requires JRE 21+
+        self.java_version = "21"
+
+    def _get_github_asset_name(self) -> str:
+        return "kinesis-mock.jar"
+
+    def _prepare_installation(self, target: InstallTarget) -> None:
+        java_package.get_installer(self.java_version).install(target)
+
+    def get_java_home(self) -> str | None:
+        """Override to use the specific Java version"""
+        return java_package.get_installer(self.java_version).get_java_home()
+
+
+class KinesisMockPackage(
+    Package[KinesisMockNodePackageInstaller | KinesisMockScalaPackageInstaller]
+):
+    def __init__(
+        self,
+        default_version: str = _KINESIS_MOCK_VERSION,
+    ):
         super().__init__(name="Kinesis Mock", default_version=default_version)
 
+    @cached_property
+    def engine(self) -> KinesisMockEngine:
+        return KinesisMockEngine(config.KINESIS_MOCK_PROVIDER_ENGINE)
+
     @lru_cache
-    def _get_installer(self, version: str) -> NodePackageInstaller:
-        return KinesisMockPackageInstaller(version)
+    def _get_installer(
+        self, version: str
+    ) -> KinesisMockNodePackageInstaller | KinesisMockScalaPackageInstaller:
+        if self.engine == KinesisMockEngine.SCALA:
+            return KinesisMockScalaPackageInstaller(version)
+
+        return KinesisMockNodePackageInstaller(version)
 
     def get_versions(self) -> List[str]:
         return [_KINESIS_MOCK_VERSION]
-
-
-class KinesisMockPackageInstaller(NodePackageInstaller):
-    def __init__(self, version: str):
-        super().__init__(package_name="kinesis-local", version=version)
 
 
 kinesismock_package = KinesisMockPackage()

--- a/localstack-core/localstack/services/kinesis/packages.py
+++ b/localstack-core/localstack/services/kinesis/packages.py
@@ -1,12 +1,25 @@
 import os
+from enum import StrEnum
 from functools import lru_cache
-from typing import List
+from typing import Any, List
 
 from localstack.packages import InstallTarget, Package
 from localstack.packages.core import GitHubReleaseInstaller, NodePackageInstaller
 from localstack.packages.java import JavaInstallerMixin, java_package
 
 _KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.12"
+
+
+class KinesisMockEngine(StrEnum):
+    NODE = "node"
+    SCALA = "scala"
+
+    @classmethod
+    def _missing_(cls, value: str | Any) -> str:
+        # default to 'node' if invalid enum
+        if not isinstance(value, str):
+            return cls(cls.NODE)
+        return cls.__members__.get(value.upper(), cls.NODE)
 
 
 class KinesisMockNodePackageInstaller(NodePackageInstaller):
@@ -64,5 +77,6 @@ class KinesisMockNodePackage(Package[KinesisMockNodePackageInstaller]):
         return [_KINESIS_MOCK_VERSION]
 
 
-kinesismock_node_package = KinesisMockNodePackage()
+# leave as 'kinesismock_package' for backwards compatability
+kinesismock_package = KinesisMockNodePackage()
 kinesismock_scala_package = KinesisMockScalaPackage()

--- a/localstack-core/localstack/services/kinesis/plugins.py
+++ b/localstack-core/localstack/services/kinesis/plugins.py
@@ -1,8 +1,16 @@
+import localstack.config as config
 from localstack.packages import Package, package
 
 
 @package(name="kinesis-mock")
 def kinesismock_package() -> Package:
-    from localstack.services.kinesis.packages import kinesismock_package
+    from localstack.services.kinesis.packages import (
+        KinesisMockEngine,
+        kinesismock_package,
+        kinesismock_scala_package,
+    )
+
+    if KinesisMockEngine(config.KINESIS_MOCK_PROVIDER_ENGINE) == KinesisMockEngine.SCALA:
+        return kinesismock_scala_package
 
     return kinesismock_package

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -758,6 +758,25 @@ class TestKinesisJavaSDK:
         assert response_content == "ok"
 
 
+@pytest.mark.skipif(
+    condition=is_aws_cloud(),
+    reason="Duplicate of all tests in TestKinesis. Since we cannot unmark test cases, only run against LocalStack.",
+)
+class TestKinesisMockScala(TestKinesis):
+    @pytest.fixture(autouse=True)
+    def set_kinesis_mock_scala_engine(self, monkeypatch):
+        monkeypatch.setattr(config, "KINESIS_MOCK_PROVIDER_ENGINE", "scala")
+
+    @pytest.fixture(autouse=True, scope="function")
+    def override_snapshot_session(self, _snapshot_session):
+        # Replace the scope_key of the snapshot session to reference parent class' recorded snapshots
+        _snapshot_session.scope_key = _snapshot_session.scope_key.replace(
+            "TestKinesisMockScala", "TestKinesis"
+        )
+        # Ensure we load in the previously recorded state now that the scope key has been updated
+        _snapshot_session.recorded_state = _snapshot_session._load_state()
+
+
 class TestKinesisPythonClient:
     @markers.skip_offline
     @markers.aws.only_localstack

--- a/tests/unit/cli/test_lpm.py
+++ b/tests/unit/cli/test_lpm.py
@@ -102,3 +102,15 @@ def test_install_with_package(runner):
     result = runner.invoke(cli, ["install", "kinesis-mock"])
     assert result.exit_code == 0
     assert os.path.exists(kinesismock_package.get_installed_dir())
+
+
+@markers.skip_offline
+def test_install_with_package_override(runner, monkeypatch):
+    from localstack import config
+    from localstack.services.kinesis.packages import kinesismock_scala_package
+
+    monkeypatch.setattr(config, "KINESIS_MOCK_PROVIDER_ENGINE", "scala")
+
+    result = runner.invoke(cli, ["install", "kinesis-mock"])
+    assert result.exit_code == 0
+    assert os.path.exists(kinesismock_scala_package.get_installed_dir())


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've observed the `NodeJS` build of kinesis mock to encounter performance issues at higher volumes of requests -- namely with larger payload sizes.

This PR adds the original Scala build as an alternative engine for our Kinesis server behind the `KINESIS_MOCK_PROVIDER_ENGINE` flag.

### Notes
- Relevant upstream issue: https://github.com/etspaceman/kinesis-mock/issues/1082
- Ext run with flag enabled: https://github.com/localstack/localstack-ext/actions/runs/14646658785

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

### Functionality
- Splits up the `KinesisMockServer` to include a `KinesisMockScalaServer` and `KinesisMockNodeServer`
- `KinesisMockPackage` can now either use the `KinesisMockScalaPackageInstaller` (downloads from GitHub) or `KinesisMockNodePackageInstaller` (downloads from NPM)

### Config
- Adds a `KINESIS_MOCK_PROVIDER_ENGINE` flag for switching to Scala build of Kinesis Mock. Valid values are `node` or `scala` -- where empty or invalid values will always default to `node`.
- `KINESIS_MOCK_MAXIMUM_HEAP_SIZE` sets the maximum Java heap size corresponding to the '-Xmx<size>' flag
- `KINESIS_MOCK_INITIAL_HEAP_SIZE` sets the initial Java heap size corresponding to the '-Xms<size>' flag

## Testing
- Creates a `TestKinesisMockScala(TestKinesis)` subclass that runs all tests in `tests/aws/services/kinesis/test_kinesis.py::TestKinesis` but with the configuration value `monkeypatched` to use the Scala build of Kinesis mock instead of NodeJS.


<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
