### PR TITLE
Step Functions: Fix Mock Test for Multi-Region

### DIFF
--- a/tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.py
+++ b/tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.py
@@ -2,6 +2,7 @@ import json
 
 from localstack_snapshot.snapshots.transformer import JsonpathTransformer, RegexTransformer
 
+import localstack.testing.config
 from localstack import config
 from localstack.aws.api.lambda_ import Runtime
 from localstack.aws.api.stepfunctions import HistoryEventType
@@ -76,8 +77,11 @@ class TestBaseScenarios:
             }
             mock_config_file_path = mock_config_file(mock_config)
             monkeypatch.setattr(config, "SFN_MOCK_CONFIG", mock_config_file_path)
+            # Insert the test environment's region name into this mock ARN
+            # to maintain snapshot compatibility across multi-region tests.
+            test_region_name = localstack.testing.config.TEST_AWS_REGION_NAME
             template["States"]["step1"]["Resource"] = (
-                f"arn:aws:lambda:us-east-1:111111111111:function:{function_name}"
+                f"arn:aws:lambda:{test_region_name}:111111111111:function:{function_name}"
             )
             definition = json.dumps(template)
             create_and_record_mocked_execution(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The mocked integration test at `aws.services.stepfunctions.v2.mocking.test_base_scenarios.TestBaseScenarios.test_lambda_invoke` introduced in e8b8794e37a025948b42f3b3f8aadd4958b7c97b is not compatible with multi-region test runs; these changes resolve this incompatibility.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Insert the test environment's region name into this mock ARN to maintain snapshot compatibility across multi-region tests

## Testing
- multi-region job: https://app.circleci.com/pipelines/github/localstack/localstack/32466/workflows/6925f6bc-dc15-48fa-b047-8767394e3f13


<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
