### PR TITLE
Events: add classmethod to recreate services

### DIFF
--- a/localstack-core/localstack/services/events/api_destination.py
+++ b/localstack-core/localstack/services/events/api_destination.py
@@ -65,7 +65,7 @@ class APIDestinationService:
         )
 
     @classmethod
-    def from_api_destination_and_connection(
+    def restore_from_api_destination_and_connection(
         cls, api_destination: ApiDestination, connection: Connection
     ):
         api_destination_service = cls(

--- a/localstack-core/localstack/services/events/api_destination.py
+++ b/localstack-core/localstack/services/events/api_destination.py
@@ -64,6 +64,23 @@ class APIDestinationService:
             description,
         )
 
+    @classmethod
+    def from_api_destination_and_connection(
+        cls, api_destination: ApiDestination, connection: Connection
+    ):
+        api_destination_service = cls(
+            name=api_destination.name,
+            region=api_destination.region,
+            account_id=api_destination.account_id,
+            connection_arn=api_destination.connection_arn,
+            connection=connection,
+            invocation_endpoint=api_destination.invocation_endpoint,
+            http_method=api_destination.http_method,
+            invocation_rate_limit_per_second=api_destination.invocation_rate_limit_per_second,
+        )
+        api_destination_service.api_destination = api_destination
+        return api_destination_service
+
     @property
     def arn(self) -> Arn:
         return self.api_destination.arn

--- a/localstack-core/localstack/services/events/connection.py
+++ b/localstack-core/localstack/services/events/connection.py
@@ -64,6 +64,7 @@ class ConnectionService:
             connection.account_id,
             connection.authorization_type,
             connection.auth_parameters,
+            create_secret=False,
         )
         connection_service.connection = connection
         return connection_service

--- a/localstack-core/localstack/services/events/connection.py
+++ b/localstack-core/localstack/services/events/connection.py
@@ -57,7 +57,7 @@ class ConnectionService:
         )
 
     @classmethod
-    def from_connection(cls, connection: Connection):
+    def restore_from_connection(cls, connection: Connection):
         connection_service = cls(
             connection.name,
             connection.region,

--- a/localstack-core/localstack/services/events/connection.py
+++ b/localstack-core/localstack/services/events/connection.py
@@ -32,12 +32,16 @@ class ConnectionService:
         auth_parameters: CreateConnectionAuthRequestParameters,
         description: ConnectionDescription | None = None,
         invocation_connectivity_parameters: ConnectivityResourceParameters | None = None,
+        create_secret: bool = True,
     ):
         self._validate_input(name, authorization_type)
         state = self._get_initial_state(authorization_type)
-        secret_arn = self.create_connection_secret(
-            region, account_id, name, authorization_type, auth_parameters
-        )
+
+        secret_arn = None
+        if create_secret:
+            secret_arn = self.create_connection_secret(
+                region, account_id, name, authorization_type, auth_parameters
+            )
         public_auth_parameters = self._get_public_parameters(authorization_type, auth_parameters)
 
         self.connection = Connection(
@@ -51,6 +55,18 @@ class ConnectionService:
             description,
             invocation_connectivity_parameters,
         )
+
+    @classmethod
+    def from_connection(cls, connection: Connection):
+        connection_service = cls(
+            connection.name,
+            connection.region,
+            connection.account_id,
+            connection.authorization_type,
+            connection.auth_parameters,
+        )
+        connection_service.connection = connection
+        return connection_service
 
     @property
     def arn(self) -> Arn:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following some issues to recreate internal services that hold state as those are re-creating their own ID every time you re-instantiate them, leading to issue in the persistence mechanism. 

These class methods allow to recreate them and override the internal state they set. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add 2 class methods to recreate internal services for Events

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
