### PR TITLE
Switch to using `kclpy-ext`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.7
+    rev: v0.11.8
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,8 @@ runtime = [
     # pinned / updated by ASF update action
     "awscli>=1.37.0",
     "airspeed-ext>=0.6.3",
-    "amazon_kclpy>=3.0.0",
+    # version that has a built wheel
+    "kclpy-ext>=3.0.0",
     # antlr4-python3-runtime: exact pin because antlr4 runtime is tightly coupled to the generated parser code
     "antlr4-python3-runtime==4.13.2",
     "apispec>=5.1.1",

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -9,7 +9,7 @@ attrs==25.3.0
     #   jsonschema
     #   localstack-twisted
     #   referencing
-awscrt==0.27.0
+awscrt==0.26.1
     # via localstack-core (pyproject.toml)
 boto3==1.38.0
     # via localstack-core (pyproject.toml)
@@ -28,7 +28,7 @@ certifi==2025.4.26
     # via requests
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 click==8.1.8
     # via localstack-core (pyproject.toml)

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -12,7 +12,7 @@ certifi==2025.4.26
     # via requests
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 click==8.1.8
     # via localstack-core (pyproject.toml)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,8 +6,6 @@
 #
 airspeed-ext==0.6.7
     # via localstack-core
-amazon-kclpy==3.0.3
-    # via localstack-core
 annotated-types==0.7.0
     # via pydantic
 antlr4-python3-runtime==4.13.2
@@ -19,7 +17,7 @@ anyio==4.9.0
 apispec==6.8.1
     # via localstack-core
 argparse==1.4.0
-    # via amazon-kclpy
+    # via kclpy-ext
 attrs==25.3.0
     # via
     #   cattrs
@@ -27,13 +25,13 @@ attrs==25.3.0
     #   jsonschema
     #   localstack-twisted
     #   referencing
-aws-cdk-asset-awscli-v1==2.2.233
+aws-cdk-asset-awscli-v1==2.2.234
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
 aws-cdk-cloud-assembly-schema==41.2.0
     # via aws-cdk-lib
-aws-cdk-lib==2.192.0
+aws-cdk-lib==2.194.0
     # via localstack-core
 aws-sam-translator==1.97.0
     # via
@@ -43,12 +41,12 @@ aws-xray-sdk==2.14.0
     # via moto-ext
 awscli==1.39.0
     # via localstack-core
-awscrt==0.27.0
+awscrt==0.26.1
     # via localstack-core
 boto3==1.38.0
     # via
-    #   amazon-kclpy
     #   aws-sam-translator
+    #   kclpy-ext
     #   localstack-core
     #   moto-ext
 botocore==1.38.0
@@ -84,7 +82,7 @@ cfgv==3.4.0
     # via pre-commit
 cfn-lint==1.34.2
     # via moto-ext
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 click==8.1.8
     # via
@@ -234,6 +232,8 @@ jsonschema-specifications==2025.4.1
     # via
     #   jsonschema
     #   openapi-schema-validator
+kclpy-ext==3.0.3
+    # via localstack-core
 lazy-object-proxy==1.11.0
     # via openapi-spec-validator
 localstack-snapshot==0.2.0
@@ -335,13 +335,13 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.22
     # via cffi
-pydantic==2.11.3
+pydantic==2.11.4
     # via aws-sam-translator
-pydantic-core==2.33.1
+pydantic-core==2.33.2
     # via pydantic
 pygments==2.19.1
     # via rich
-pymongo==4.12.0
+pymongo==4.12.1
     # via localstack-core
 pyopenssl==25.0.0
     # via
@@ -429,7 +429,7 @@ rsa==4.7.2
     # via awscli
 rstr==3.2.2
     # via localstack-core (pyproject.toml)
-ruff==0.11.7
+ruff==0.11.8
     # via localstack-core (pyproject.toml)
 s3transfer==0.12.0
     # via

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -6,8 +6,6 @@
 #
 airspeed-ext==0.6.7
     # via localstack-core (pyproject.toml)
-amazon-kclpy==3.0.3
-    # via localstack-core (pyproject.toml)
 annotated-types==0.7.0
     # via pydantic
 antlr4-python3-runtime==4.13.2
@@ -17,7 +15,7 @@ antlr4-python3-runtime==4.13.2
 apispec==6.8.1
     # via localstack-core (pyproject.toml)
 argparse==1.4.0
-    # via amazon-kclpy
+    # via kclpy-ext
 attrs==25.3.0
     # via
     #   jsonschema
@@ -31,12 +29,12 @@ aws-xray-sdk==2.14.0
     # via moto-ext
 awscli==1.39.0
     # via localstack-core (pyproject.toml)
-awscrt==0.27.0
+awscrt==0.26.1
     # via localstack-core
 boto3==1.38.0
     # via
-    #   amazon-kclpy
     #   aws-sam-translator
+    #   kclpy-ext
     #   localstack-core
     #   moto-ext
 botocore==1.38.0
@@ -66,7 +64,7 @@ cffi==1.17.1
     # via cryptography
 cfn-lint==1.34.2
     # via moto-ext
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 click==8.1.8
     # via
@@ -174,6 +172,8 @@ jsonschema-specifications==2025.4.1
     # via
     #   jsonschema
     #   openapi-schema-validator
+kclpy-ext==3.0.3
+    # via localstack-core (pyproject.toml)
 lazy-object-proxy==1.11.0
     # via openapi-spec-validator
 localstack-twisted==24.3.0
@@ -239,13 +239,13 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.22
     # via cffi
-pydantic==2.11.3
+pydantic==2.11.4
     # via aws-sam-translator
-pydantic-core==2.33.1
+pydantic-core==2.33.2
     # via pydantic
 pygments==2.19.1
     # via rich
-pymongo==4.12.0
+pymongo==4.12.1
     # via localstack-core (pyproject.toml)
 pyopenssl==25.0.0
     # via

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,8 +6,6 @@
 #
 airspeed-ext==0.6.7
     # via localstack-core
-amazon-kclpy==3.0.3
-    # via localstack-core
 annotated-types==0.7.0
     # via pydantic
 antlr4-python3-runtime==4.13.2
@@ -19,7 +17,7 @@ anyio==4.9.0
 apispec==6.8.1
     # via localstack-core
 argparse==1.4.0
-    # via amazon-kclpy
+    # via kclpy-ext
 attrs==25.3.0
     # via
     #   cattrs
@@ -27,13 +25,13 @@ attrs==25.3.0
     #   jsonschema
     #   localstack-twisted
     #   referencing
-aws-cdk-asset-awscli-v1==2.2.233
+aws-cdk-asset-awscli-v1==2.2.234
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
 aws-cdk-cloud-assembly-schema==41.2.0
     # via aws-cdk-lib
-aws-cdk-lib==2.192.0
+aws-cdk-lib==2.194.0
     # via localstack-core (pyproject.toml)
 aws-sam-translator==1.97.0
     # via
@@ -43,12 +41,12 @@ aws-xray-sdk==2.14.0
     # via moto-ext
 awscli==1.39.0
     # via localstack-core
-awscrt==0.27.0
+awscrt==0.26.1
     # via localstack-core
 boto3==1.38.0
     # via
-    #   amazon-kclpy
     #   aws-sam-translator
+    #   kclpy-ext
     #   localstack-core
     #   moto-ext
 botocore==1.38.0
@@ -82,7 +80,7 @@ cffi==1.17.1
     # via cryptography
 cfn-lint==1.34.2
     # via moto-ext
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 click==8.1.8
     # via
@@ -218,6 +216,8 @@ jsonschema-specifications==2025.4.1
     # via
     #   jsonschema
     #   openapi-schema-validator
+kclpy-ext==3.0.3
+    # via localstack-core
 lazy-object-proxy==1.11.0
     # via openapi-spec-validator
 localstack-snapshot==0.2.0
@@ -301,13 +301,13 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.22
     # via cffi
-pydantic==2.11.3
+pydantic==2.11.4
     # via aws-sam-translator
-pydantic-core==2.33.1
+pydantic-core==2.33.2
     # via pydantic
 pygments==2.19.1
     # via rich
-pymongo==4.12.0
+pymongo==4.12.1
     # via localstack-core
 pyopenssl==25.0.0
     # via

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -6,8 +6,6 @@
 #
 airspeed-ext==0.6.7
     # via localstack-core
-amazon-kclpy==3.0.3
-    # via localstack-core
 annotated-types==0.7.0
     # via pydantic
 antlr4-python3-runtime==4.13.2
@@ -19,7 +17,7 @@ anyio==4.9.0
 apispec==6.8.1
     # via localstack-core
 argparse==1.4.0
-    # via amazon-kclpy
+    # via kclpy-ext
 attrs==25.3.0
     # via
     #   cattrs
@@ -27,13 +25,13 @@ attrs==25.3.0
     #   jsonschema
     #   localstack-twisted
     #   referencing
-aws-cdk-asset-awscli-v1==2.2.233
+aws-cdk-asset-awscli-v1==2.2.234
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
 aws-cdk-cloud-assembly-schema==41.2.0
     # via aws-cdk-lib
-aws-cdk-lib==2.192.0
+aws-cdk-lib==2.194.0
     # via localstack-core
 aws-sam-translator==1.97.0
     # via
@@ -43,15 +41,15 @@ aws-xray-sdk==2.14.0
     # via moto-ext
 awscli==1.39.0
     # via localstack-core
-awscrt==0.27.0
+awscrt==0.26.1
     # via localstack-core
 boto3==1.38.0
     # via
-    #   amazon-kclpy
     #   aws-sam-translator
+    #   kclpy-ext
     #   localstack-core
     #   moto-ext
-boto3-stubs==1.38.4
+boto3-stubs==1.38.7
     # via localstack-core (pyproject.toml)
 botocore==1.38.0
     # via
@@ -61,7 +59,7 @@ botocore==1.38.0
     #   localstack-core
     #   moto-ext
     #   s3transfer
-botocore-stubs==1.38.4
+botocore-stubs==1.38.7
     # via boto3-stubs
 build==1.2.2.post1
     # via
@@ -88,7 +86,7 @@ cfgv==3.4.0
     # via pre-commit
 cfn-lint==1.34.2
     # via moto-ext
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 click==8.1.8
     # via
@@ -238,6 +236,8 @@ jsonschema-specifications==2025.4.1
     # via
     #   jsonschema
     #   openapi-schema-validator
+kclpy-ext==3.0.3
+    # via localstack-core
 lazy-object-proxy==1.11.0
     # via openapi-spec-validator
 localstack-snapshot==0.2.0
@@ -272,7 +272,7 @@ mypy-boto3-apigateway==1.38.0
     # via boto3-stubs
 mypy-boto3-apigatewayv2==1.38.0
     # via boto3-stubs
-mypy-boto3-appconfig==1.38.0
+mypy-boto3-appconfig==1.38.7
     # via boto3-stubs
 mypy-boto3-appconfigdata==1.38.0
     # via boto3-stubs
@@ -324,9 +324,9 @@ mypy-boto3-dynamodb==1.38.4
     # via boto3-stubs
 mypy-boto3-dynamodbstreams==1.38.0
     # via boto3-stubs
-mypy-boto3-ec2==1.38.0
+mypy-boto3-ec2==1.38.6
     # via boto3-stubs
-mypy-boto3-ecr==1.38.0
+mypy-boto3-ecr==1.38.6
     # via boto3-stubs
 mypy-boto3-ecs==1.38.3
     # via boto3-stubs
@@ -370,7 +370,7 @@ mypy-boto3-iotwireless==1.38.0
     # via boto3-stubs
 mypy-boto3-kafka==1.38.0
     # via boto3-stubs
-mypy-boto3-kinesis==1.38.0
+mypy-boto3-kinesis==1.38.5
     # via boto3-stubs
 mypy-boto3-kinesisanalytics==1.38.0
     # via boto3-stubs
@@ -382,7 +382,7 @@ mypy-boto3-lakeformation==1.38.0
     # via boto3-stubs
 mypy-boto3-lambda==1.38.0
     # via boto3-stubs
-mypy-boto3-logs==1.38.0
+mypy-boto3-logs==1.38.6
     # via boto3-stubs
 mypy-boto3-managedblockchain==1.38.0
     # via boto3-stubs
@@ -430,7 +430,7 @@ mypy-boto3-s3==1.38.0
     # via boto3-stubs
 mypy-boto3-s3control==1.38.0
     # via boto3-stubs
-mypy-boto3-sagemaker==1.38.0
+mypy-boto3-sagemaker==1.38.7
     # via boto3-stubs
 mypy-boto3-sagemaker-runtime==1.38.0
     # via boto3-stubs
@@ -448,7 +448,7 @@ mypy-boto3-sns==1.38.0
     # via boto3-stubs
 mypy-boto3-sqs==1.38.0
     # via boto3-stubs
-mypy-boto3-ssm==1.38.0
+mypy-boto3-ssm==1.38.5
     # via boto3-stubs
 mypy-boto3-sso-admin==1.38.0
     # via boto3-stubs
@@ -462,7 +462,7 @@ mypy-boto3-timestream-write==1.38.0
     # via boto3-stubs
 mypy-boto3-transcribe==1.38.0
     # via boto3-stubs
-mypy-boto3-verifiedpermissions==1.38.0
+mypy-boto3-verifiedpermissions==1.38.7
     # via boto3-stubs
 mypy-boto3-wafv2==1.38.0
     # via boto3-stubs
@@ -545,13 +545,13 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.22
     # via cffi
-pydantic==2.11.3
+pydantic==2.11.4
     # via aws-sam-translator
-pydantic-core==2.33.1
+pydantic-core==2.33.2
     # via pydantic
 pygments==2.19.1
     # via rich
-pymongo==4.12.0
+pymongo==4.12.1
     # via localstack-core
 pyopenssl==25.0.0
     # via
@@ -639,7 +639,7 @@ rsa==4.7.2
     # via awscli
 rstr==3.2.2
     # via localstack-core
-ruff==0.11.7
+ruff==0.11.8
     # via localstack-core
 s3transfer==0.12.0
     # via


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We repeatedly run into issues of kclpy wheels not being able to build inside of our pipelines (in the Docker build). This is because kclpy needs to download JARs from maven and there is no built wheel including those JARs available in PyPI. 

However, we can just create and publish that wheel once ourselves and then use our own published package/wheel instead - therefore not relying on maven anymore.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Switch from `amazon-kclpy` to `kclpy-ext`, which we build and publish in the https://github.com/localstack/amazon-kinesis-client-python repo. 

## Testing

The existing kinesis test suite should handle this sufficiently. After all, this should be the exact same package, just with a pre-built wheel available

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] Are we ok with using the same JARs throughout the lifecycle of one version? Currently, we theoretically could receive updates to the JARs on every build.
