### PR TITLE
refactor Counter usage in APIGW

### DIFF
--- a/localstack-core/localstack/services/apigateway/analytics.py
+++ b/localstack-core/localstack/services/apigateway/analytics.py
@@ -1,0 +1,5 @@
+from localstack.utils.analytics.metrics import Counter
+
+invocation_counter = Counter(
+    namespace="apigateway", name="rest_api_execute", labels=["invocation_type"]
+)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/__init__.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/__init__.py
@@ -1,5 +1,7 @@
 from rolo.gateway import CompositeHandler
 
+from localstack.services.apigateway.analytics import invocation_counter
+
 from .analytics import IntegrationUsageCounter
 from .api_key_validation import ApiKeyValidationHandler
 from .gateway_exception import GatewayExceptionHandler
@@ -24,4 +26,4 @@ method_response_handler = MethodResponseHandler()
 gateway_exception_handler = GatewayExceptionHandler()
 api_key_validation_handler = ApiKeyValidationHandler()
 response_enricher = InvocationResponseEnricher()
-usage_counter = IntegrationUsageCounter()
+usage_counter = IntegrationUsageCounter(counter=invocation_counter)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/analytics.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/analytics.py
@@ -1,7 +1,7 @@
 import logging
 
 from localstack.http import Response
-from localstack.utils.analytics.metrics import Counter, LabeledCounterMetric
+from localstack.utils.analytics.metrics import LabeledCounterMetric
 
 from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import RestApiInvocationContext
@@ -12,10 +12,8 @@ LOG = logging.getLogger(__name__)
 class IntegrationUsageCounter(RestApiGatewayHandler):
     counter: LabeledCounterMetric
 
-    def __init__(self, counter: LabeledCounterMetric = None):
-        self.counter = counter or Counter(
-            namespace="apigateway", name="rest_api_execute", labels=["invocation_type"]
-        )
+    def __init__(self, counter: LabeledCounterMetric):
+        self.counter = counter
 
     def __call__(
         self,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When migrating to GH Actions, we've seen this strange issue pop up in API Gateway:
```python
2025-04-29T18:02:37.1793745Z 2025-04-29T18:02:37.177 ERROR --- [PoolThread-twisted.internet.reactor-2] plux.runtime.manager       : error loading plugin PluginSpec(localstack.aws.provider.apigateway:default = <function apigateway at 0xff2981162e80>)
2025-04-29T18:02:37.1794844Z Traceback (most recent call last):
2025-04-29T18:02:37.1805344Z   File "/opt/code/localstack/.venv/lib/python3.11/site-packages/plux/runtime/manager.py", line 348, in _load_plugin
2025-04-29T18:02:37.1806131Z     result = plugin.load(*args, **kwargs)
2025-04-29T18:02:37.1806453Z              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-29T18:02:37.1807069Z   File "/opt/code/localstack/localstack-core/localstack/services/plugins.py", line 347, in load
2025-04-29T18:02:37.1807571Z     self.service = self.create_service()
2025-04-29T18:02:37.1807939Z                    ^^^^^^^^^^^^^^^^^^^^^
2025-04-29T18:02:37.1808494Z   File "/opt/code/localstack/localstack-core/localstack/services/plugins.py", line 369, in create_service
2025-04-29T18:02:37.1809043Z     return self._create_service()
2025-04-29T18:02:37.1809378Z            ^^^^^^^^^^^^^^^^^^^^^^
2025-04-29T18:02:37.1810096Z   File "/opt/code/localstack/localstack-core/localstack/services/providers.py", line 19, in apigateway
2025-04-29T18:02:37.1810838Z     from localstack.services.apigateway.next_gen.provider import ApigatewayNextGenProvider
2025-04-29T18:02:37.1811614Z   File "/opt/code/localstack/localstack-core/localstack/services/apigateway/next_gen/provider.py", line 26, in <module>
2025-04-29T18:02:37.1812721Z     from localstack.services.apigateway.legacy.provider import ApigatewayProvider
2025-04-29T18:02:37.1813606Z   File "/opt/code/localstack/localstack-core/localstack/services/apigateway/legacy/provider.py", line 118, in <module>
2025-04-29T18:02:37.1814288Z     from localstack.services.apigateway.next_gen.execute_api.router import (
2025-04-29T18:02:37.1815102Z   File "/opt/code/localstack/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py", line 16, in <module>
2025-04-29T18:02:37.1815779Z     from .gateway import RestApiGateway
2025-04-29T18:02:37.1816394Z   File "/opt/code/localstack/localstack-core/localstack/services/apigateway/next_gen/execute_api/gateway.py", line 4, in <module>
2025-04-29T18:02:37.1817056Z     from . import handlers
2025-04-29T18:02:37.1817681Z   File "/opt/code/localstack/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/__init__.py", line 27, in <module>
2025-04-29T18:02:37.1818436Z     usage_counter = IntegrationUsageCounter()
2025-04-29T18:02:37.1818741Z                     ^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-29T18:02:37.1819380Z   File "/opt/code/localstack/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/analytics.py", line 16, in __init__
2025-04-29T18:02:37.1823656Z     self.counter = counter or Counter(
2025-04-29T18:02:37.1823959Z                               ^^^^^^^^
2025-04-29T18:02:37.1824677Z   File "/opt/code/localstack/localstack-core/localstack/utils/analytics/metrics.py", line 284, in __new__
2025-04-29T18:02:37.1825326Z     return LabeledCounterMetric(namespace=namespace, name=name, labels=labels)
2025-04-29T18:02:37.1825819Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-29T18:02:37.1826403Z   File "/opt/code/localstack/localstack-core/localstack/utils/analytics/metrics.py", line 204, in __init__
2025-04-29T18:02:37.1826901Z     MetricRegistry().register(self)
2025-04-29T18:02:37.1827509Z   File "/opt/code/localstack/localstack-core/localstack/utils/analytics/metrics.py", line 58, in register
2025-04-29T18:02:37.1829421Z     raise ValueError(f"Metric '{metric.name}' already exists.")
2025-04-29T18:02:37.1830076Z ValueError: Metric 'rest_api_execute' already exists.
```

This is pretty weird, because we're only supposed to create the `IntegrationUsageCounter` once, when importing the `handlers.__init__.py` file. This might be caused by a race condition, or us trying to load the plugin twice. 

But the logic itself is a bit flawed, because if you were to not pass a `Counter` when using the class, it would fail in the same way. This PR makes the `counter` argument mandatory and explicit. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- make the `IntegrationUsageCounter` parameter mandatory, and do not fall back to a default value
- migrate the `Counter` instantiation in its own file at the root of the APIGW module 


\cc @k-a-il 

<!-- Optional section: How to test these changes? -->

## Testing

This PR has been tested in the full-run GH Action pipeline and it did fix the issue

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
