### PR TITLE
removed create appsync fixtures

### DIFF
--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -2180,29 +2180,6 @@ def create_rest_apigw_openapi(aws_client_factory):
 
 
 @pytest.fixture
-def appsync_create_api(aws_client):
-    graphql_apis = []
-
-    def factory(**kwargs):
-        if "name" not in kwargs:
-            kwargs["name"] = f"graphql-api-testing-name-{short_uid()}"
-        if not kwargs.get("authenticationType"):
-            kwargs["authenticationType"] = "API_KEY"
-
-        result = aws_client.appsync.create_graphql_api(**kwargs)["graphqlApi"]
-        graphql_apis.append(result["apiId"])
-        return result
-
-    yield factory
-
-    for api in graphql_apis:
-        try:
-            aws_client.appsync.delete_graphql_api(apiId=api)
-        except Exception as e:
-            LOG.debug("Error cleaning up AppSync API: %s, %s", api, e)
-
-
-@pytest.fixture
 def assert_host_customisation(monkeypatch):
     localstack_host = "foo.bar"
     monkeypatch.setattr(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This fixture was moved upstream as the underlying resources can't be deployed in the community version of LocalStack

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Delete `appsync_create_api` fixture

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
