### PR TITLE
APIGW: fix selection pattern for AWS Lambda integration

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
@@ -69,7 +69,7 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
         # we first need to find the right IntegrationResponse based on their selection template, linked to the status
         # code of the Response
         if integration_type == IntegrationType.AWS and "lambda:path/" in integration["uri"]:
-            selection_value = self.parse_error_message_from_lambda(body) or str(status_code)
+            selection_value = self.parse_error_message_from_lambda(body)
         else:
             selection_value = str(status_code)
 

--- a/tests/aws/services/apigateway/test_apigateway_lambda.py
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.py
@@ -832,6 +832,7 @@ def test_lambda_selection_patterns(
         resourceId=resource_id,
         httpMethod="GET",
         statusCode="200",
+        selectionPattern="",
     )
     # 4xx
     aws_client.apigateway.put_integration_response(
@@ -839,15 +840,27 @@ def test_lambda_selection_patterns(
         resourceId=resource_id,
         httpMethod="GET",
         statusCode="405",
-        selectionPattern=".*400.*",
+        selectionPattern=".*four hundred.*",
     )
+
     # 5xx
     aws_client.apigateway.put_integration_response(
         restApiId=api_id,
         resourceId=resource_id,
         httpMethod="GET",
         statusCode="502",
-        selectionPattern=".*5\\d\\d.*",
+        selectionPattern=".+",
+    )
+
+    # assert that this does not get matched even though it's the status code returned by the Lambda, showing that
+    # AWS does match on the status code for this specific integration
+    # https://docs.aws.amazon.com/apigateway/latest/api/API_IntegrationResponse.html
+    aws_client.apigateway.put_integration_response(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="GET",
+        statusCode="504",
+        selectionPattern="200",
     )
 
     aws_client.apigateway.create_deployment(restApiId=api_id, stageName="dev")

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1473,23 +1473,23 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_selection_patterns": {
-    "recorded-date": "05-09-2023, 21:54:21",
+    "recorded-date": "05-05-2025, 14:10:11",
     "recorded-content": {
       "lambda-selection-pattern-200": "Pass",
       "lambda-selection-pattern-400": {
-        "errorMessage": "Error: Raising 400 from within the Lambda function",
+        "errorMessage": "Error: Raising four hundred from within the Lambda function",
         "errorType": "Exception",
         "requestId": "<uuid:1>",
         "stackTrace": [
-          "  File \"/var/task/lambda_select_pattern.py\", line 7, in handler\n    raise Exception(\"Error: Raising 400 from within the Lambda function\")\n"
+          "  File \"/var/task/lambda_select_pattern.py\", line 7, in handler\n    raise Exception(\"Error: Raising four hundred from within the Lambda function\")\n"
         ]
       },
       "lambda-selection-pattern-500": {
-        "errorMessage": "Error: Raising 500 from within the Lambda function",
+        "errorMessage": "Error: Raising five hundred from within the Lambda function",
         "errorType": "Exception",
         "requestId": "<uuid:2>",
         "stackTrace": [
-          "  File \"/var/task/lambda_select_pattern.py\", line 9, in handler\n    raise Exception(\"Error: Raising 500 from within the Lambda function\")\n"
+          "  File \"/var/task/lambda_select_pattern.py\", line 9, in handler\n    raise Exception(\"Error: Raising five hundred from within the Lambda function\")\n"
         ]
       }
     }

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -30,7 +30,7 @@
     "last_validated_date": "2024-05-31T19:17:51+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_selection_patterns": {
-    "last_validated_date": "2023-09-05T19:54:21+00:00"
+    "last_validated_date": "2025-05-05T14:10:11+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_put_integration_aws_proxy_uri": {
     "last_validated_date": "2025-03-03T12:58:39+00:00"

--- a/tests/aws/services/lambda_/functions/lambda_select_pattern.py
+++ b/tests/aws/services/lambda_/functions/lambda_select_pattern.py
@@ -4,8 +4,8 @@ def handler(event, context):
         case "200":
             return "Pass"
         case "400":
-            raise Exception("Error: Raising 400 from within the Lambda function")
+            raise Exception("Error: Raising four hundred from within the Lambda function")
         case "500":
-            raise Exception("Error: Raising 500 from within the Lambda function")
+            raise Exception("Error: Raising five hundred from within the Lambda function")
         case _:
             return "Error Value in the json request should either be 400 or 500 to demonstrate"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #12574, we had an issue when using the `selectionPattern` with AWS Lambda integration. AWS has very specific behavior for this specific integration, and we used the status code of the lambda invocation as a fallback for the selection pattern. This was wrong and should have been an empty string instead. 

See https://docs.aws.amazon.com/apigateway/latest/api/API_IntegrationResponse.html
> Specifies the regular expression (regex) pattern used to choose an integration response based on the response from the back end. For example, if the success response returns nothing and the error response returns some string, you could use the .+ regex to match error response. However, make sure that the error response does not contain any newline (\n) character in such cases. If the back end is an AWS Lambda function, the AWS Lambda function error header is matched. For all other HTTP and AWS back ends, the HTTP status code is matched.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update the selection pattern test for the AWS Lambda integration to verify behavior
- remove the status code fallback for the lambda error message selection matching

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
