### PR TITLE
APIGW: fix binaryMediaTypes when importing/updating REST APIs

### DIFF
--- a/localstack-core/localstack/services/apigateway/exporter.py
+++ b/localstack-core/localstack/services/apigateway/exporter.py
@@ -190,7 +190,15 @@ class _OpenApiSwaggerExporter(_BaseOpenApiExporter):
         self._add_paths(spec, resources, with_extension)
         self._add_models(spec, models["items"], "#/definitions")
 
-        return getattr(spec, self.export_formats.get(export_format))()
+        response = getattr(spec, self.export_formats.get(export_format))()
+        if (
+            with_extension
+            and isinstance(response, dict)
+            and (binary_media_types := rest_api.get("binaryMediaTypes")) is not None
+        ):
+            response[OpenAPIExt.BINARY_MEDIA_TYPES] = binary_media_types
+
+        return response
 
 
 class _OpenApiOAS30Exporter(_BaseOpenApiExporter):
@@ -298,8 +306,16 @@ class _OpenApiOAS30Exporter(_BaseOpenApiExporter):
         self._add_models(spec, models["items"], "#/components/schemas")
 
         response = getattr(spec, self.export_formats.get(export_format))()
-        if isinstance(response, dict) and "components" not in response:
-            response["components"] = {}
+        if isinstance(response, dict):
+            if "components" not in response:
+                response["components"] = {}
+
+            if (
+                with_extension
+                and (binary_media_types := rest_api.get("binaryMediaTypes")) is not None
+            ):
+                response[OpenAPIExt.BINARY_MEDIA_TYPES] = binary_media_types
+
         return response
 
 

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -951,11 +951,11 @@ def import_api_from_openapi_spec(
 
     # binary types
     if mode == "merge":
-        existing_modes = rest_api.binaryMediaTypes or []
+        existing_binary_media_types = rest_api.binaryMediaTypes or []
     else:
-        existing_modes = []
+        existing_binary_media_types = []
 
-    rest_api.binaryMediaTypes = existing_modes + resolved_schema.get(
+    rest_api.binaryMediaTypes = existing_binary_media_types + resolved_schema.get(
         OpenAPIExt.BINARY_MEDIA_TYPES, []
     )
 

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -492,8 +492,10 @@ def import_api_from_openapi_spec(
     region_name = context.region
 
     # TODO:
-    # 1. validate the "mode" property of the spec document, "merge" or "overwrite"
+    # 1. validate the "mode" property of the spec document, "merge" or "overwrite", and properly apply it
+    #    for now, it only considers it for the binaryMediaTypes
     # 2. validate the document type, "swagger" or "openapi"
+    mode = request.get("mode", "merge")
 
     rest_api.version = (
         str(version) if (version := resolved_schema.get("info", {}).get("version")) else None
@@ -948,7 +950,14 @@ def import_api_from_openapi_spec(
         get_or_create_path(base_path + path, base_path=base_path)
 
     # binary types
-    rest_api.binaryMediaTypes = resolved_schema.get(OpenAPIExt.BINARY_MEDIA_TYPES, [])
+    if mode == "merge":
+        existing_modes = rest_api.binaryMediaTypes or []
+    else:
+        existing_modes = []
+
+    rest_api.binaryMediaTypes = existing_modes + resolved_schema.get(
+        OpenAPIExt.BINARY_MEDIA_TYPES, []
+    )
 
     policy = resolved_schema.get(OpenAPIExt.POLICY)
     if policy:

--- a/tests/aws/files/pets.json
+++ b/tests/aws/files/pets.json
@@ -7,6 +7,10 @@
   "schemes": [
     "https"
   ],
+  "x-amazon-apigateway-binary-media-types": [
+    "image/png",
+    "image/jpg"
+  ],
   "paths": {
     "/pets": {
       "get": {

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -78,7 +78,6 @@ TEST_STAGE_NAME = "testing"
 THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
 TEST_SWAGGER_FILE_JSON = os.path.join(THIS_FOLDER, "../../files/swagger.json")
 TEST_SWAGGER_FILE_YAML = os.path.join(THIS_FOLDER, "../../files/swagger.yaml")
-TEST_IMPORT_REST_API_FILE = os.path.join(THIS_FOLDER, "../../files/pets.json")
 TEST_IMPORT_MOCK_INTEGRATION = os.path.join(THIS_FOLDER, "../../files/openapi-mock.json")
 TEST_IMPORT_REST_API_ASYNC_LAMBDA = os.path.join(THIS_FOLDER, "../../files/api_definition.yaml")
 

--- a/tests/aws/services/apigateway/test_apigateway_extended.py
+++ b/tests/aws/services/apigateway/test_apigateway_extended.py
@@ -43,7 +43,13 @@ def apigw_create_api_key(aws_client):
     [TEST_IMPORT_PETSTORE_SWAGGER, TEST_IMPORT_PETS],
     ids=["TEST_IMPORT_PETSTORE_SWAGGER", "TEST_IMPORT_PETS"],
 )
-@markers.snapshot.skip_snapshot_verify(paths=["$..body.host"])
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        "$..body.host",
+        # TODO: not returned by LS
+        "$..endpointConfiguration.ipAddressType",
+    ]
+)
 def test_export_swagger_openapi(aws_client, snapshot, import_apigw, import_file, region_name):
     snapshot.add_transformer(
         [
@@ -82,7 +88,13 @@ def test_export_swagger_openapi(aws_client, snapshot, import_apigw, import_file,
     [TEST_IMPORT_PETSTORE_SWAGGER, TEST_IMPORT_PETS],
     ids=["TEST_IMPORT_PETSTORE_SWAGGER", "TEST_IMPORT_PETS"],
 )
-@markers.snapshot.skip_snapshot_verify(paths=["$..body.servers..url"])
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        "$..body.servers..url",
+        # TODO: not returned by LS
+        "$..endpointConfiguration.ipAddressType",
+    ]
+)
 def test_export_oas30_openapi(aws_client, snapshot, import_apigw, region_name, import_file):
     snapshot.add_transformer(
         [

--- a/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "recorded-date": "15-04-2024, 21:43:25",
+    "recorded-date": "06-05-2025, 18:20:26",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -8,6 +8,7 @@
         "description": "Your first API with Amazon API Gateway. This is a sample API that integrates via HTTP with our demo Pet Store endpoints",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]
@@ -638,13 +639,18 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETS]": {
-    "recorded-date": "15-04-2024, 21:43:56",
+    "recorded-date": "06-05-2025, 18:21:08",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/png",
+          "image/jpg"
+        ],
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]
@@ -727,6 +733,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
                   "responses": {
@@ -734,8 +741,7 @@
                       "statusCode": "200"
                     }
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             },
@@ -755,6 +761,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets/{id}",
                   "responses": {
@@ -765,12 +772,15 @@
                   "requestParameters": {
                     "integration.request.path.id": "method.request.path.petId"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             }
-          }
+          },
+          "x-amazon-apigateway-binary-media-types": [
+            "image/png",
+            "image/jpg"
+          ]
         },
         "contentDisposition": "attachment; filename=\"swagger_1.0.0.json\"",
         "contentType": "application/octet-stream",
@@ -782,7 +792,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "recorded-date": "15-04-2024, 21:45:03",
+    "recorded-date": "06-05-2025, 18:34:11",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -790,6 +800,7 @@
         "description": "Your first API with Amazon API Gateway. This is a sample API that integrates via HTTP with our demo Pet Store endpoints",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]
@@ -1140,6 +1151,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
                   "responses": {
@@ -1154,8 +1166,7 @@
                     "integration.request.querystring.page": "method.request.querystring.page",
                     "integration.request.querystring.type": "method.request.querystring.type"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               },
               "post": {
@@ -1190,6 +1201,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "POST",
                   "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
                   "responses": {
@@ -1200,8 +1212,7 @@
                       }
                     }
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               },
               "options": {
@@ -1235,6 +1246,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "mock",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -1248,8 +1260,7 @@
                   "requestTemplates": {
                     "application/json": "{\"statusCode\": 200}"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "mock"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             },
@@ -1286,6 +1297,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets/{petId}",
                   "responses": {
@@ -1299,8 +1311,7 @@
                   "requestParameters": {
                     "integration.request.path.petId": "method.request.path.petId"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               },
               "options": {
@@ -1344,6 +1355,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "mock",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -1357,8 +1369,7 @@
                   "requestTemplates": {
                     "application/json": "{\"statusCode\": 200}"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "mock"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             },
@@ -1378,6 +1389,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "mock",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -1392,8 +1404,7 @@
                   "requestTemplates": {
                     "application/json": "{\"statusCode\": 200}"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "mock"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             }
@@ -1468,13 +1479,18 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETS]": {
-    "recorded-date": "15-04-2024, 21:45:07",
+    "recorded-date": "06-05-2025, 18:34:49",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/png",
+          "image/jpg"
+        ],
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]
@@ -1620,7 +1636,11 @@
               }
             }
           },
-          "components": {}
+          "components": {},
+          "x-amazon-apigateway-binary-media-types": [
+            "image/png",
+            "image/jpg"
+          ]
         },
         "contentDisposition": "attachment; filename=\"oas30_1.0.0.json\"",
         "contentType": "application/octet-stream",

--- a/tests/aws/services/apigateway/test_apigateway_extended.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.validation.json
@@ -6,15 +6,15 @@
     "last_validated_date": "2024-10-10T18:54:41+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "last_validated_date": "2024-04-15T21:45:02+00:00"
+    "last_validated_date": "2025-05-06T18:34:11+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETS]": {
-    "last_validated_date": "2024-04-15T21:45:04+00:00"
+    "last_validated_date": "2025-05-06T18:34:17+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "last_validated_date": "2024-04-15T21:43:24+00:00"
+    "last_validated_date": "2025-05-06T18:20:25+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETS]": {
-    "last_validated_date": "2024-04-15T21:43:30+00:00"
+    "last_validated_date": "2025-05-06T18:20:36+00:00"
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -1382,13 +1382,14 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[ignore]": {
-    "recorded-date": "15-04-2024, 21:33:04",
+    "recorded-date": "06-05-2025, 18:24:25",
     "recorded-content": {
       "put-rest-api-swagger-json": {
         "apiKeySource": "HEADER",
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]
@@ -1765,13 +1766,14 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[prepend]": {
-    "recorded-date": "15-04-2024, 21:34:01",
+    "recorded-date": "06-05-2025, 18:25:39",
     "recorded-content": {
       "put-rest-api-swagger-json": {
         "apiKeySource": "HEADER",
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]
@@ -2154,13 +2156,14 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[split]": {
-    "recorded-date": "15-04-2024, 21:34:50",
+    "recorded-date": "06-05-2025, 18:26:25",
     "recorded-content": {
       "put-rest-api-swagger-json": {
         "apiKeySource": "HEADER",
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]
@@ -5303,6 +5306,151 @@
           "method.response.header.Access-Control-Allow-Origin": "'*'"
         },
         "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_put_rest_api_mode_binary_media_types[merge]": {
+    "recorded-date": "06-05-2025, 18:14:29",
+    "recorded-content": {
+      "create-rest-api": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/heif"
+        ],
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "ipAddressType": "ipv4",
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-rest-api": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/heif"
+        ],
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "ipAddressType": "ipv4",
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-api": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/heif",
+          "image/png",
+          "image/jpg"
+        ],
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "ipAddressType": "ipv4",
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:2>",
+        "rootResourceId": "<root-resource-id:1>",
+        "tags": {},
+        "version": "1.0.0",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_put_rest_api_mode_binary_media_types[overwrite]": {
+    "recorded-date": "06-05-2025, 18:15:09",
+    "recorded-content": {
+      "create-rest-api": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/heif"
+        ],
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "ipAddressType": "ipv4",
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-rest-api": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/heif"
+        ],
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "ipAddressType": "ipv4",
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-api": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/png",
+          "image/jpg"
+        ],
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "ipAddressType": "ipv4",
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:2>",
+        "rootResourceId": "<root-resource-id:1>",
+        "tags": {},
+        "version": "1.0.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -18,13 +18,13 @@
     "last_validated_date": "2024-12-12T22:45:20+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[ignore]": {
-    "last_validated_date": "2024-04-15T21:32:25+00:00"
+    "last_validated_date": "2025-05-06T18:23:50+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[prepend]": {
-    "last_validated_date": "2024-04-15T21:33:49+00:00"
+    "last_validated_date": "2025-05-06T18:25:10+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[split]": {
-    "last_validated_date": "2024-04-15T21:34:46+00:00"
+    "last_validated_date": "2025-05-06T18:26:24+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_swagger_api": {
     "last_validated_date": "2024-04-15T21:30:39+00:00"
@@ -49,5 +49,11 @@
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_stage_variables": {
     "last_validated_date": "2024-08-12T13:42:13+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_put_rest_api_mode_binary_media_types[merge]": {
+    "last_validated_date": "2025-05-06T18:14:28+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_put_rest_api_mode_binary_media_types[overwrite]": {
+    "last_validated_date": "2025-05-06T18:14:45+00:00"
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.py
@@ -3,6 +3,7 @@ import os.path
 from operator import itemgetter
 
 import requests
+from localstack_snapshot.snapshots.transformer import SortingTransformer
 
 from localstack import constants
 from localstack.aws.api.lambda_ import Runtime
@@ -326,12 +327,16 @@ def test_cfn_deploy_apigateway_integration(deploy_cfn_template, snapshot, aws_cl
         "$.get-stage.lastUpdatedDate",
         "$.get-stage.methodSettings",
         "$.get-stage.tags",
+        "$..endpointConfiguration.ipAddressType",
     ]
 )
 def test_cfn_deploy_apigateway_from_s3_swagger(
     deploy_cfn_template, snapshot, aws_client, s3_bucket
 ):
     snapshot.add_transformer(snapshot.transform.key_value("deploymentId"))
+    # FIXME: we need to sort the binaryMediaTypes as we don't return it in the same order as AWS, but this does not have
+    # behavior incidence
+    snapshot.add_transformer(SortingTransformer("binaryMediaTypes"))
     # put the swagger file in S3
     swagger_template = load_file(
         os.path.join(os.path.dirname(__file__), "../../../files/pets.json")

--- a/tests/aws/services/cloudformation/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.py
@@ -111,6 +111,12 @@ def test_cfn_apigateway_aws_integration(deploy_cfn_template, aws_client):
 
 
 @markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        # TODO: not returned by LS
+        "$..endpointConfiguration.ipAddressType",
+    ]
+)
 def test_cfn_apigateway_swagger_import(
     deploy_cfn_template, echo_http_server_post, aws_client, snapshot
 ):

--- a/tests/aws/services/cloudformation/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.py
@@ -6,11 +6,13 @@ import requests
 
 from localstack import constants
 from localstack.aws.api.lambda_ import Runtime
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
 from localstack.utils.files import load_file
 from localstack.utils.run import to_str
 from localstack.utils.strings import to_bytes
+from localstack.utils.sync import retry
 from tests.aws.services.apigateway.apigateway_fixtures import api_invoke_url
 
 PARENT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -108,7 +110,18 @@ def test_cfn_apigateway_aws_integration(deploy_cfn_template, aws_client):
 
 
 @markers.aws.validated
-def test_cfn_apigateway_swagger_import(deploy_cfn_template, echo_http_server_post, aws_client):
+def test_cfn_apigateway_swagger_import(
+    deploy_cfn_template, echo_http_server_post, aws_client, snapshot
+):
+    snapshot.add_transformers_list(
+        [
+            snapshot.transform.key_value("aws:cloudformation:stack-name"),
+            snapshot.transform.resource_name(),
+            snapshot.transform.key_value("id"),
+            snapshot.transform.key_value("name"),
+            snapshot.transform.key_value("rootResourceId"),
+        ]
+    )
     api_name = f"rest-api-{short_uid()}"
     deploy_cfn_template(
         template=TEST_TEMPLATE_1,
@@ -121,13 +134,25 @@ def test_cfn_apigateway_swagger_import(deploy_cfn_template, echo_http_server_pos
     ]
     assert len(apis) == 1
     api_id = apis[0]["id"]
+    snapshot.match("imported-api", apis[0])
 
     # construct API endpoint URL
     url = api_invoke_url(api_id, stage="dev", path="/test")
 
     # invoke API endpoint, assert results
-    result = requests.post(url, data="test 123")
-    assert result.ok
+    def _invoke():
+        _result = requests.post(url, data="test 123")
+        assert _result.ok
+        return _result
+
+    if is_aws_cloud():
+        sleep = 2
+        retries = 20
+    else:
+        sleep = 0.1
+        retries = 3
+
+    result = retry(_invoke, sleep=sleep, retries=retries)
     content = json.loads(to_str(result.content))
     assert content["data"] == "test 123"
     assert content["url"].endswith("/post")
@@ -344,7 +369,20 @@ def test_cfn_deploy_apigateway_from_s3_swagger(
 
 
 @markers.aws.validated
-def test_cfn_apigateway_rest_api(deploy_cfn_template, aws_client):
+@markers.snapshot.skip_snapshot_verify(
+    paths=["$..endpointConfiguration.ipAddressType"],
+)
+def test_cfn_apigateway_rest_api(deploy_cfn_template, aws_client, snapshot):
+    snapshot.add_transformers_list(
+        [
+            snapshot.transform.key_value("aws:cloudformation:logical-id"),
+            snapshot.transform.key_value("aws:cloudformation:stack-name"),
+            snapshot.transform.resource_name(),
+            snapshot.transform.key_value("id"),
+            snapshot.transform.key_value("rootResourceId"),
+        ]
+    )
+
     stack = deploy_cfn_template(
         template_path=os.path.join(os.path.dirname(__file__), "../../../templates/apigateway.json")
     )
@@ -362,6 +400,7 @@ def test_cfn_apigateway_rest_api(deploy_cfn_template, aws_client):
     rs = aws_client.apigateway.get_rest_apis()
     apis = [item for item in rs["items"] if item["name"] == "DemoApi_dev"]
     assert len(apis) == 1
+    snapshot.match("rest-api", apis[0])
 
     rs = aws_client.apigateway.get_models(restApiId=apis[0]["id"])
     assert len(rs["items"]) == 3

--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -107,13 +107,20 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "recorded-date": "24-09-2024, 20:22:38",
+    "recorded-date": "06-05-2025, 18:31:54",
     "recorded-content": {
       "rest-api": {
         "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "application/pdf",
+          "image/gif",
+          "image/jpg",
+          "image/png"
+        ],
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "REGIONAL"
           ]

--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -669,5 +669,61 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_apigateway_swagger_import": {
+    "recorded-date": "05-05-2025, 14:23:13",
+    "recorded-content": {
+      "imported-api": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "*/*"
+        ],
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "ipAddressType": "ipv4",
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
+        "tags": {
+          "aws:cloudformation:logical-id": "Api",
+          "aws:cloudformation:stack-id": "arn:<partition>:cloudformation:<region>:111111111111:stack/<aws:cloudformation:stack-name:1>/<resource:1>",
+          "aws:cloudformation:stack-name": "<aws:cloudformation:stack-name:1>"
+        },
+        "version": "1.0"
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_apigateway_rest_api": {
+    "recorded-date": "05-05-2025, 14:50:14",
+    "recorded-content": {
+      "rest-api": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/jpg",
+          "image/png"
+        ],
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "ipAddressType": "ipv4",
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "DemoApi_dev",
+        "rootResourceId": "<root-resource-id:1>",
+        "tags": {
+          "aws:cloudformation:logical-id": "<aws:cloudformation:logical-id:1>",
+          "aws:cloudformation:stack-id": "arn:<partition>:cloudformation:<region>:111111111111:stack/<aws:cloudformation:stack-name:1>/<resource:1>",
+          "aws:cloudformation:stack-name": "<aws:cloudformation:stack-name:1>"
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
@@ -6,7 +6,10 @@
     "last_validated_date": "2024-04-15T22:59:53+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_apigateway_rest_api": {
-    "last_validated_date": "2024-06-25T18:12:55+00:00"
+    "last_validated_date": "2025-05-05T14:50:14+00:00"
+  },
+  "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_apigateway_swagger_import": {
+    "last_validated_date": "2025-05-05T14:23:13+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
     "last_validated_date": "2024-09-24T20:22:37+00:00"

--- a/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
@@ -12,7 +12,7 @@
     "last_validated_date": "2025-05-05T14:23:13+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "last_validated_date": "2024-09-24T20:22:37+00:00"
+    "last_validated_date": "2025-05-06T18:31:53+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_integration": {
     "last_validated_date": "2024-02-21T12:54:34+00:00"

--- a/tests/aws/templates/apigateway.json
+++ b/tests/aws/templates/apigateway.json
@@ -54,7 +54,11 @@
                             }
                         ]
                     ]
-                }
+                },
+                "BinaryMediaTypes": [
+                    "image/jpg",
+                    "image/png"
+                ]
             },
             "Metadata": {
                 "AWS::CloudFormation::Designer": {

--- a/tests/aws/templates/apigateway_integration_from_s3.yml
+++ b/tests/aws/templates/apigateway_integration_from_s3.yml
@@ -12,6 +12,9 @@ Resources:
   ApiGatewayRestApi:
     Type: AWS::ApiGateway::RestApi
     Properties:
+      BinaryMediaTypes:
+        - "image/gif"
+        - "application/pdf"
       BodyS3Location:
         Bucket:
           Ref: S3BodyBucket


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've recently received a report that binary support for APIGW wasn't working when deploying a REST API through CloudFormation and using the `Body` attribute to use an OpenAPI spec file to define the API. 

The OpenAPI spec file didn't define binary media types via the `x-amazon-apigateway-binary-media-types`, but it did with the [CloudFormation parameter `BinaryMediaTypes`](https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-binarymediatypes).

After testing against AWS, it seems the behavior is defined by the `merge` mode when calling `PutRestApi` for an existing API, and it will be merged by default with the custom extension when using CloudFormation. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update support for binary media types when used with the CFN parameter and the `Body` parameter
- update test cases to recreate the scenario (both CFN parameter + body)
- add test case around `PutRestApi` depending on the merge mode
- refresh tests using the same OpenAPI spec file
- update export logic to return the binary media types extension

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
