### PR TITLE
Transcribe: Enable MyPy

### DIFF
--- a/localstack-core/localstack/services/transcribe/models.py
+++ b/localstack-core/localstack/services/transcribe/models.py
@@ -3,7 +3,7 @@ from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttr
 
 
 class TranscribeStore(BaseStore):
-    transcription_jobs: dict[TranscriptionJobName, TranscriptionJob] = LocalAttribute(default=dict)
+    transcription_jobs: dict[TranscriptionJobName, TranscriptionJob] = LocalAttribute(default=dict)  # type: ignore[assignment]
 
 
 transcribe_stores = AccountRegionBundle("transcribe", TranscribeStore)

--- a/localstack-core/localstack/services/transcribe/packages.py
+++ b/localstack-core/localstack/services/transcribe/packages.py
@@ -1,16 +1,16 @@
 from typing import List
 
-from localstack.packages import Package, PackageInstaller
+from localstack.packages import Package
 from localstack.packages.core import PythonPackageInstaller
 
 _VOSK_DEFAULT_VERSION = "0.3.43"
 
 
-class VoskPackage(Package):
+class VoskPackage(Package[PythonPackageInstaller]):
     def __init__(self, default_version: str = _VOSK_DEFAULT_VERSION):
         super().__init__(name="Vosk", default_version=default_version)
 
-    def _get_installer(self, version: str) -> PackageInstaller:
+    def _get_installer(self, version: str) -> PythonPackageInstaller:
         return VoskPackageInstaller(version)
 
     def get_versions(self) -> List[str]:

--- a/localstack-core/localstack/services/transcribe/plugins.py
+++ b/localstack-core/localstack/services/transcribe/plugins.py
@@ -1,8 +1,9 @@
 from localstack.packages import Package, package
+from localstack.packages.core import PythonPackageInstaller
 
 
 @package(name="vosk")
-def vosk_package() -> Package:
+def vosk_package() -> Package[PythonPackageInstaller]:
     from localstack.services.transcribe.packages import vosk_package
 
     return vosk_package

--- a/localstack-core/localstack/services/transcribe/provider.py
+++ b/localstack-core/localstack/services/transcribe/provider.py
@@ -5,7 +5,7 @@ import threading
 import wave
 from functools import cache
 from pathlib import Path
-from typing import Tuple
+from typing import Any, Tuple
 from zipfile import ZipFile
 
 from localstack import config
@@ -102,16 +102,16 @@ _DL_LOCK = threading.Lock()
 
 class TranscribeProvider(TranscribeApi):
     def get_transcription_job(
-        self, context: RequestContext, transcription_job_name: TranscriptionJobName, **kwargs
+        self, context: RequestContext, transcription_job_name: TranscriptionJobName, **kwargs: Any
     ) -> GetTranscriptionJobResponse:
         store = transcribe_stores[context.account_id][context.region]
 
         if job := store.transcription_jobs.get(transcription_job_name):
             # fetch output key and output bucket
             output_bucket, output_key = get_bucket_and_key_from_presign_url(
-                job["Transcript"]["TranscriptFileUri"]
+                job["Transcript"]["TranscriptFileUri"]  # type: ignore[index,arg-type]
             )
-            job["Transcript"]["TranscriptFileUri"] = connect_to().s3.generate_presigned_url(
+            job["Transcript"]["TranscriptFileUri"] = connect_to().s3.generate_presigned_url(  # type: ignore[index]
                 "get_object",
                 Params={"Bucket": output_bucket, "Key": output_key},
                 ExpiresIn=60 * 15,
@@ -128,13 +128,13 @@ class TranscribeProvider(TranscribeApi):
         # Install and configure vosk
         vosk_package.install()
 
-        from vosk import SetLogLevel  # noqa
+        from vosk import SetLogLevel  # type: ignore[import-not-found]  # noqa
 
         # Suppress Vosk logging
         SetLogLevel(-1)
 
     @handler("StartTranscriptionJob", expand=False)
-    def start_transcription_job(
+    def start_transcription_job(  # type: ignore[override]
         self,
         context: RequestContext,
         request: StartTranscriptionJobRequest,
@@ -157,7 +157,7 @@ class TranscribeProvider(TranscribeApi):
             )
 
         s3_path = request["Media"]["MediaFileUri"]
-        output_bucket = request.get("OutputBucketName", get_bucket_and_key_from_s3_uri(s3_path)[0])
+        output_bucket = request.get("OutputBucketName", get_bucket_and_key_from_s3_uri(s3_path)[0])  # type: ignore[arg-type]
         output_key = request.get("OutputKey")
 
         if not output_key:
@@ -196,7 +196,7 @@ class TranscribeProvider(TranscribeApi):
         job_name_contains: TranscriptionJobName | None = None,
         next_token: NextToken | None = None,
         max_results: MaxResults | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> ListTranscriptionJobsResponse:
         store = transcribe_stores[context.account_id][context.region]
         summaries = []
@@ -216,7 +216,7 @@ class TranscribeProvider(TranscribeApi):
         return ListTranscriptionJobsResponse(TranscriptionJobSummaries=summaries)
 
     def delete_transcription_job(
-        self, context: RequestContext, transcription_job_name: TranscriptionJobName, **kwargs
+        self, context: RequestContext, transcription_job_name: TranscriptionJobName, **kwargs: Any
     ) -> None:
         store = transcribe_stores[context.account_id][context.region]
 
@@ -277,7 +277,7 @@ class TranscribeProvider(TranscribeApi):
     # Threads
     #
 
-    def _run_transcription_job(self, args: Tuple[TranscribeStore, str]):
+    def _run_transcription_job(self, args: Tuple[TranscribeStore, str]) -> None:
         store, job_name = args
 
         job = store.transcription_jobs[job_name]
@@ -292,7 +292,7 @@ class TranscribeProvider(TranscribeApi):
             # Get file from S3
             file_path = new_tmp_file()
             s3_client = connect_to().s3
-            s3_path = job["Media"]["MediaFileUri"]
+            s3_path: str = job["Media"]["MediaFileUri"]  # type: ignore[index,assignment]
             bucket, _, key = s3_path.removeprefix("s3://").partition("/")
             s3_client.download_file(Bucket=bucket, Key=key, Filename=file_path)
 
@@ -303,7 +303,7 @@ class TranscribeProvider(TranscribeApi):
             LOG.debug("Determining media format")
             # TODO set correct failure_reason if ffprobe execution fails
             ffprobe_output = json.loads(
-                run(
+                run(  # type: ignore[arg-type]
                     f"{ffprobe_bin} -show_streams -show_format -print_format json -hide_banner -v error {file_path}"
                 )
             )
@@ -346,8 +346,8 @@ class TranscribeProvider(TranscribeApi):
                 raise RuntimeError()
 
             # Prepare transcriber
-            language_code = job["LanguageCode"]
-            model_name = LANGUAGE_MODELS[language_code]
+            language_code: str = job["LanguageCode"]  # type: ignore[assignment]
+            model_name = LANGUAGE_MODELS[language_code]  # type: ignore[index]
             self._setup_vosk()
             model_path = self.download_model(model_name)
             from vosk import KaldiRecognizer, Model  # noqa
@@ -397,7 +397,7 @@ class TranscribeProvider(TranscribeApi):
             }
 
             # Save to S3
-            output_s3_path = job["Transcript"]["TranscriptFileUri"]
+            output_s3_path: str = job["Transcript"]["TranscriptFileUri"]  # type: ignore[index,assignment]
             output_bucket, output_key = get_bucket_and_key_from_presign_url(output_s3_path)
             s3_client.put_object(Bucket=output_bucket, Key=output_key, Body=json.dumps(output))
 

--- a/localstack-core/localstack/testing/aws/asf_utils.py
+++ b/localstack-core/localstack/testing/aws/asf_utils.py
@@ -148,6 +148,12 @@ def check_provider_signature(sub_class: type, base_class: type, method_name: str
                 #    arg: ArgType | None = None
                 # These should be considered equal, so until the API is fixed, we remove any Optionals
                 # This also gives us the flexibility to correct the API without fixing all implementations at the same time
+
+                if kwarg not in base_spec.annotations:
+                    # Typically happens when the implementation uses '**kwargs: Any'
+                    # This parameter is not part of the base spec, so we can't compare types
+                    continue
+
                 sub_type = _remove_optional(sub_spec.annotations[kwarg])
                 base_type = _remove_optional(base_spec.annotations[kwarg])
                 assert sub_type == base_type, (

--- a/localstack-core/mypy.ini
+++ b/localstack-core/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 explicit_package_bases = true
 mypy_path=localstack-core
-files=localstack/aws/api/core.py,localstack/packages,localstack/services/kinesis/packages.py
+files=localstack/aws/api/core.py,localstack/packages,localstack/services/transcribe,localstack/services/kinesis/packages.py
 ignore_missing_imports = False
 follow_imports = silent
 ignore_errors = False


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Part of a broader push to enforce typing support everywhere (see #12532). One of the areas that I wanted to focus next on was adding correct types to the `BaseStore`/`AccountRegionBundle`/etc, because it is such a fundamental concept that all emulators would benefit from improved type support.

However, before improving types there, it makes sense to first ensure that the usage of `BaseStore` is typed and validated. Only then can we be improve the types in `BaseStore` and be sure they are correct.

Hence this PR: enforcing type checks in one of the smaller services, for the sole purpose of checking that `BaseStore` is used/typed correctly.

## History
- Optional API arguments (`param: X | None = None`) were added in #12614 
- Proper types for `context.account_id`/`region_name` were set in #12617 

An earlier version of this PR tackled everything at once, but with the above PR's already in place, this PR has been simplified to only change the Transcribe-specific types.