### PR TITLE
Docker registry customisation

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1007,7 +1007,6 @@ LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT = int(os.environ.get("LAMBDA_RUNTIME_ENVIRONM
 # b) json dict mapping the <runtime> to an image, e.g. {"python3.9": "custom-repo/lambda-py:thon3.9"}
 LAMBDA_RUNTIME_IMAGE_MAPPING = os.environ.get("LAMBDA_RUNTIME_IMAGE_MAPPING", "").strip()
 
-DOCKER_GLOBAL_IMAGE_PREFIX = os.environ.get("DOCKER_GLOBAL_IMAGE_PREFIX", "").strip()
 
 # PUBLIC: 0 (default)
 # Whether to disable usage of deprecated runtimes

--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1007,6 +1007,8 @@ LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT = int(os.environ.get("LAMBDA_RUNTIME_ENVIRONM
 # b) json dict mapping the <runtime> to an image, e.g. {"python3.9": "custom-repo/lambda-py:thon3.9"}
 LAMBDA_RUNTIME_IMAGE_MAPPING = os.environ.get("LAMBDA_RUNTIME_IMAGE_MAPPING", "").strip()
 
+DOCKER_GLOBAL_IMAGE_PREFIX = os.environ.get("DOCKER_GLOBAL_IMAGE_PREFIX", "").strip()
+
 # PUBLIC: 0 (default)
 # Whether to disable usage of deprecated runtimes
 LAMBDA_RUNTIME_VALIDATION = int(os.environ.get("LAMBDA_RUNTIME_VALIDATION") or 0)

--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -589,9 +589,21 @@ class DockerRunFlags:
     dns: Optional[List[str]]
 
 
+class RegistryResolverStrategy(Protocol):
+    def resolve(self, image_name: str) -> str: ...
+
+
+class HardCodedResolver:
+    def resolve(self, image_name: str) -> str:  # noqa
+        return image_name
+
+
 # TODO: remove Docker/Podman compatibility switches (in particular strip_wellknown_repo_prefixes=...)
 #  from the container client base interface and introduce derived Podman client implementations instead!
 class ContainerClient(metaclass=ABCMeta):
+    def __init__(self):
+        self.registry_resolver_strategy: RegistryResolverStrategy = HardCodedResolver()
+
     @abstractmethod
     def get_system_info(self) -> dict:
         """Returns the docker system-wide information as dictionary (``docker info``)."""

--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -601,8 +601,7 @@ class HardCodedResolver:
 # TODO: remove Docker/Podman compatibility switches (in particular strip_wellknown_repo_prefixes=...)
 #  from the container client base interface and introduce derived Podman client implementations instead!
 class ContainerClient(metaclass=ABCMeta):
-    def __init__(self):
-        self.registry_resolver_strategy: RegistryResolverStrategy = HardCodedResolver()
+    registry_resolver_strategy: RegistryResolverStrategy = HardCodedResolver()
 
     @abstractmethod
     def get_system_info(self) -> dict:

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -356,6 +356,7 @@ class CmdDockerClient(ContainerClient):
 
     def pull_image(self, docker_image: str, platform: Optional[DockerPlatform] = None) -> None:
         cmd = self._docker_cmd()
+        docker_image = self.registry_resolver_strategy.resolve(docker_image)
         cmd += ["pull", docker_image]
         if platform:
             cmd += ["--platform", platform]
@@ -518,6 +519,7 @@ class CmdDockerClient(ContainerClient):
         pull: bool = True,
         strip_wellknown_repo_prefixes: bool = True,
     ) -> Dict[str, Union[dict, list, str]]:
+        image_name = self.registry_resolver_strategy.resolve(image_name)
         try:
             result = self._inspect_object(image_name)
             if strip_wellknown_repo_prefixes:
@@ -656,6 +658,7 @@ class CmdDockerClient(ContainerClient):
             return False
 
     def create_container(self, image_name: str, **kwargs) -> str:
+        image_name = self.registry_resolver_strategy.resolve(image_name)
         cmd, env_file = self._build_run_create_cmd("create", image_name, **kwargs)
         LOG.debug("Create container with cmd: %s", cmd)
         try:
@@ -674,6 +677,7 @@ class CmdDockerClient(ContainerClient):
             Util.rm_env_vars_file(env_file)
 
     def run_container(self, image_name: str, stdin=None, **kwargs) -> Tuple[bytes, bytes]:
+        image_name = self.registry_resolver_strategy.resolve(image_name)
         cmd, env_file = self._build_run_create_cmd("run", image_name, **kwargs)
         LOG.debug("Run container with cmd: %s", cmd)
         try:

--- a/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
@@ -59,7 +59,6 @@ class SdkDockerClient(ContainerClient):
     docker_client: Optional[DockerClient]
 
     def __init__(self):
-        super().__init__()
         try:
             self.docker_client = self._create_client()
             logging.getLogger("urllib3").setLevel(logging.INFO)
@@ -468,6 +467,7 @@ class SdkDockerClient(ContainerClient):
         pull: bool = True,
         strip_wellknown_repo_prefixes: bool = True,
     ) -> Dict[str, Union[dict, list, str]]:
+        image_name = self.registry_resolver_strategy.resolve(image_name)
         try:
             result = self.client().images.get(image_name).attrs
             if strip_wellknown_repo_prefixes:

--- a/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
@@ -59,6 +59,7 @@ class SdkDockerClient(ContainerClient):
     docker_client: Optional[DockerClient]
 
     def __init__(self):
+        super().__init__()
         try:
             self.docker_client = self._create_client()
             logging.getLogger("urllib3").setLevel(logging.INFO)

--- a/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
@@ -337,6 +337,8 @@ class SdkDockerClient(ContainerClient):
     def pull_image(self, docker_image: str, platform: Optional[DockerPlatform] = None) -> None:
         LOG.debug("Pulling Docker image: %s", docker_image)
         # some path in the docker image string indicates a custom repository
+
+        docker_image = self.registry_resolver_strategy.resolve(docker_image)
         try:
             self.client().images.pull(docker_image, platform=platform)
         except ImageNotFound:
@@ -777,6 +779,8 @@ class SdkDockerClient(ContainerClient):
             mounts = None
             if volumes:
                 mounts = Util.convert_mount_list_to_dict(volumes)
+
+            image_name = self.registry_resolver_strategy.resolve(image_name)
 
             def create_container():
                 return self.client().containers.create(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Some customers work in airgapped environments, and require customisation of the Docker image registries used. This PR enables a flexible method for adding customisation to the Docker image pulling strategy.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Introduce the `RegistryResolverStrategy` protocol to support custom image resolving
* Add an implementation `HardCodedResolver` which is a no-op
* Use this resolver when pulling images, or creating containers

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
