### PR TITLE
Fix provisioned concurrency set on Lambda alias

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/counting_service.py
+++ b/localstack-core/localstack/services/lambda_/invocation/counting_service.py
@@ -157,11 +157,14 @@ class CountingService:
                     function_version.id.qualifier
                 )
                 if not provisioned_concurrency_config:
+                    # check if any aliases point to the current version, and check the provisioned concurrency config
+                    # for them. There can be only one config for a version, not matter if defined on the alias or version itself.
                     for alias in function.aliases.values():
                         if alias.function_version == function_version.id.qualifier:
                             provisioned_concurrency_config = (
                                 function.provisioned_concurrency_configs.get(alias.name)
                             )
+                            break
                 if provisioned_concurrency_config:
                     available_provisioned_concurrency = (
                         provisioned_concurrency_config.provisioned_concurrent_executions

--- a/localstack-core/localstack/services/lambda_/invocation/counting_service.py
+++ b/localstack-core/localstack/services/lambda_/invocation/counting_service.py
@@ -156,6 +156,12 @@ class CountingService:
                 provisioned_concurrency_config = function.provisioned_concurrency_configs.get(
                     function_version.id.qualifier
                 )
+                if not provisioned_concurrency_config:
+                    for alias in function.aliases.values():
+                        if alias.function_version == function_version.id.qualifier:
+                            provisioned_concurrency_config = (
+                                function.provisioned_concurrency_configs.get(alias.name)
+                            )
                 if provisioned_concurrency_config:
                     available_provisioned_concurrency = (
                         provisioned_concurrency_config.provisioned_concurrent_executions

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -2544,7 +2544,7 @@ class TestLambdaConcurrency:
         """
         Tests provisioned concurrency created and invoked using an alias
         """
-        # TODO can you set provisioned concurrency on both alias and function version?
+        # TODO add test that you cannot set provisioned concurrency on both alias and version it points to
         # TODO can you set provisioned concurrency on multiple aliases pointing to the same function version?
         min_concurrent_executions = 10 + 5
         check_concurrency_quota(aws_client, min_concurrent_executions)

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -2544,6 +2544,8 @@ class TestLambdaConcurrency:
         """
         Tests provisioned concurrency created and invoked using an alias
         """
+        # TODO can you set provisioned concurrency on both alias and function version?
+        # TODO can you set provisioned concurrency on multiple aliases pointing to the same function version?
         min_concurrent_executions = 10 + 5
         check_concurrency_quota(aws_client, min_concurrent_executions)
 

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4463,5 +4463,43 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_provisioned_concurrency_on_alias": {
+    "recorded-date": "07-05-2025, 09:26:54",
+    "recorded-content": {
+      "put_provisioned_5": {
+        "AllocatedProvisionedConcurrentExecutions": 0,
+        "AvailableProvisionedConcurrentExecutions": 0,
+        "LastModified": "date",
+        "RequestedProvisionedConcurrentExecutions": 5,
+        "Status": "IN_PROGRESS",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "get_provisioned_prewait": {
+        "AllocatedProvisionedConcurrentExecutions": 0,
+        "AvailableProvisionedConcurrentExecutions": 0,
+        "LastModified": "date",
+        "RequestedProvisionedConcurrentExecutions": 5,
+        "Status": "IN_PROGRESS",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_provisioned_postwait": {
+        "AllocatedProvisionedConcurrentExecutions": 5,
+        "AvailableProvisionedConcurrentExecutions": 5,
+        "LastModified": "date",
+        "RequestedProvisionedConcurrentExecutions": 5,
+        "Status": "READY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -74,6 +74,9 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_provisioned_concurrency": {
     "last_validated_date": "2024-04-08T17:04:20+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_provisioned_concurrency_on_alias": {
+    "last_validated_date": "2025-05-07T09:26:54+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_reserved_concurrency": {
     "last_validated_date": "2024-04-08T17:08:10+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, when setting provisioned concurrency on a lambda alias pointing to a version, and then invoking it, there will still be another container spawned up on demand.

This happens due to an error in the lookup of the provisioned concurrency config in the counting service, which issues leases for environments.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Provisioned concurrency environments of a config set on an alias should now work as expected

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
