### PR TITLE
Added secrets definition for docker pull action in aws-tests and aws-mamr tests

### DIFF
--- a/.github/workflows/aws-tests-mamr.yml
+++ b/.github/workflows/aws-tests-mamr.yml
@@ -58,3 +58,6 @@ jobs:
       testAWSRegion: ${{ needs.generate-random-creds.outputs.region }}
       testAWSAccountId: ${{ needs.generate-random-creds.outputs.account_id }}
       testAWSAccessKeyId: ${{ needs.generate-random-creds.outputs.account_id }}
+    secrets:
+      DOCKERHUB_PULL_USERNAME: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
+      DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}

--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -90,6 +90,13 @@ on:
         required: false
         type: string
         default: 'test'
+    secrets:
+      DOCKERHUB_PULL_USERNAME:
+        description: 'A DockerHub username - Used to avoid rate limiting issues.'
+        required: true
+      DOCKERHUB_PULL_TOKEN:
+        description: 'A DockerHub token - Used to avoid rate limiting issues.'
+        required: true
 
 env:
   PYTEST_LOGLEVEL: ${{ inputs.PYTEST_LOGLEVEL || 'WARNING' }}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The `aws-main.yml` workflow was failing due to missing secrets input in `aws-tests.yml`; this has been fixed. I also noticed the MA/MR tests lack secrets definition for the reusable workflow `aws-tests.yml` and added them

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Added secrets input to the `workflow_call` event to enable passing Docker pull secrets into `aws-tests.yml`
- Added docker pull secrets to the MA/MR tests because it reuses `aws-tests.yml` workflow

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
