### PR TITLE
Add CloudFormation Lambda Version Provisioned Concurrency

### DIFF
--- a/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_version.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_version.py
@@ -66,6 +66,14 @@ class LambdaVersionProvider(ResourceProvider[LambdaVersionProperties]):
             response = lambda_client.publish_version(**params)
             model["Version"] = response["Version"]
             model["Id"] = response["FunctionArn"]
+            if model.get("ProvisionedConcurrencyConfig"):
+                lambda_client.put_provisioned_concurrency_config(
+                    FunctionName=model["FunctionName"],
+                    Qualifier=model["Version"],
+                    ProvisionedConcurrentExecutions=model["ProvisionedConcurrencyConfig"][
+                        "ProvisionedConcurrentExecutions"
+                    ],
+                )
             ctx[REPEATED_INVOCATION] = True
             return ProgressEvent(
                 status=OperationStatus.IN_PROGRESS,
@@ -73,25 +81,50 @@ class LambdaVersionProvider(ResourceProvider[LambdaVersionProperties]):
                 custom_context=request.custom_context,
             )
 
-        version = lambda_client.get_function(FunctionName=model["Id"])
-        if version["Configuration"]["State"] == "Pending":
-            return ProgressEvent(
-                status=OperationStatus.IN_PROGRESS,
-                resource_model=model,
-                custom_context=request.custom_context,
+        if model.get("ProvisionedConcurrencyConfig"):
+            # Assumption: Ready provisioned concurrency implies the function version is ready
+            provisioned_concurrency_config = lambda_client.get_provisioned_concurrency_config(
+                FunctionName=model["FunctionName"],
+                Qualifier=model["Version"],
             )
-        elif version["Configuration"]["State"] == "Active":
-            return ProgressEvent(
-                status=OperationStatus.SUCCESS,
-                resource_model=model,
-            )
+            if provisioned_concurrency_config["Status"] == "IN_PROGRESS":
+                return ProgressEvent(
+                    status=OperationStatus.IN_PROGRESS,
+                    resource_model=model,
+                    custom_context=request.custom_context,
+                )
+            elif provisioned_concurrency_config["Status"] == "READY":
+                return ProgressEvent(
+                    status=OperationStatus.SUCCESS,
+                    resource_model=model,
+                )
+            else:
+                return ProgressEvent(
+                    status=OperationStatus.FAILED,
+                    resource_model=model,
+                    message="",
+                    error_code="VersionStateFailure",  # TODO: not parity tested
+                )
         else:
-            return ProgressEvent(
-                status=OperationStatus.FAILED,
-                resource_model=model,
-                message="",
-                error_code="VersionStateFailure",  # TODO: not parity tested
-            )
+            version = lambda_client.get_function(FunctionName=model["Id"])
+            if version["Configuration"]["State"] == "Pending":
+                return ProgressEvent(
+                    status=OperationStatus.IN_PROGRESS,
+                    resource_model=model,
+                    custom_context=request.custom_context,
+                )
+            elif version["Configuration"]["State"] == "Active":
+                return ProgressEvent(
+                    status=OperationStatus.SUCCESS,
+                    resource_model=model,
+                )
+            else:
+                return ProgressEvent(
+                    status=OperationStatus.FAILED,
+                    resource_model=model,
+                    message="",
+                    error_code="VersionStateFailure",  # TODO: not parity tested
+                )
 
     def read(
         self,

--- a/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_version.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_version.py
@@ -150,6 +150,7 @@ class LambdaVersionProvider(ResourceProvider[LambdaVersionProperties]):
         lambda_client = request.aws_client_factory.lambda_
 
         # without qualifier entire function is deleted instead of just version
+        # provisioned concurrency is automatically deleted upon deleting a function or function version
         lambda_client.delete_function(FunctionName=model["Id"], Qualifier=model["Version"])
 
         return ProgressEvent(

--- a/localstack-core/localstack/services/lambda_/resource_providers/lambda_alias.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/lambda_alias.py
@@ -149,6 +149,7 @@ class LambdaAliasProvider(ResourceProvider[LambdaAliasProperties]):
         lambda_ = request.aws_client_factory.lambda_
 
         try:
+            # provisioned concurrency is automatically deleted upon deleting a function alias
             lambda_.delete_alias(
                 FunctionName=model["FunctionName"],
                 Name=model["Name"],

--- a/localstack-core/localstack/services/lambda_/resource_providers/lambda_alias.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/lambda_alias.py
@@ -84,7 +84,7 @@ class LambdaAliasProvider(ResourceProvider[LambdaAliasProperties]):
             if model.get("ProvisionedConcurrencyConfig"):
                 lambda_.put_provisioned_concurrency_config(
                     FunctionName=model["FunctionName"],
-                    Qualifier=model["Id"].split(":")[-1],
+                    Qualifier=model["FunctionVersion"],
                     ProvisionedConcurrentExecutions=model["ProvisionedConcurrencyConfig"][
                         "ProvisionedConcurrentExecutions"
                     ],
@@ -100,12 +100,24 @@ class LambdaAliasProvider(ResourceProvider[LambdaAliasProperties]):
             # get provisioned config status
             result = lambda_.get_provisioned_concurrency_config(
                 FunctionName=model["FunctionName"],
-                Qualifier=model["Id"].split(":")[-1],
+                Qualifier=model["FunctionVersion"],
             )
             if result["Status"] == "IN_PROGRESS":
                 return ProgressEvent(
                     status=OperationStatus.IN_PROGRESS,
                     resource_model=model,
+                )
+            elif result["Status"] == "READY":
+                return ProgressEvent(
+                    status=OperationStatus.SUCCESS,
+                    resource_model=model,
+                )
+            else:
+                return ProgressEvent(
+                    status=OperationStatus.FAILED,
+                    resource_model=model,
+                    message="",
+                    error_code="VersionStateFailure",  # TODO: not parity tested
                 )
 
         return ProgressEvent(

--- a/localstack-core/localstack/services/lambda_/resource_providers/lambda_alias.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/lambda_alias.py
@@ -84,7 +84,7 @@ class LambdaAliasProvider(ResourceProvider[LambdaAliasProperties]):
             if model.get("ProvisionedConcurrencyConfig"):
                 lambda_.put_provisioned_concurrency_config(
                     FunctionName=model["FunctionName"],
-                    Qualifier=model["FunctionVersion"],
+                    Qualifier=model["Name"],
                     ProvisionedConcurrentExecutions=model["ProvisionedConcurrencyConfig"][
                         "ProvisionedConcurrentExecutions"
                     ],
@@ -100,7 +100,7 @@ class LambdaAliasProvider(ResourceProvider[LambdaAliasProperties]):
             # get provisioned config status
             result = lambda_.get_provisioned_concurrency_config(
                 FunctionName=model["FunctionName"],
-                Qualifier=model["FunctionVersion"],
+                Qualifier=model["Name"],
             )
             if result["Status"] == "IN_PROGRESS":
                 return ProgressEvent(

--- a/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
@@ -68,8 +68,20 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_alias": {
-    "recorded-date": "09-04-2024, 07:19:19",
+    "recorded-date": "07-05-2025, 15:39:26",
     "recorded-content": {
+      "invoke_result": {
+        "ExecutedVersion": "1",
+        "Payload": {
+          "function_version": "1",
+          "initialization_type": null
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "stack_resource_descriptions": {
         "StackResources": [
           {
@@ -132,6 +144,17 @@
         "FunctionVersion": "1",
         "Name": "<alias-name>",
         "RevisionId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "provisioned_concurrency_config": {
+        "AllocatedProvisionedConcurrentExecutions": 1,
+        "AvailableProvisionedConcurrentExecutions": 1,
+        "LastModified": "date",
+        "RequestedProvisionedConcurrentExecutions": 1,
+        "Status": "READY",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
@@ -655,8 +655,19 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_version": {
-    "recorded-date": "09-04-2024, 07:21:37",
+    "recorded-date": "07-05-2025, 13:19:10",
     "recorded-content": {
+      "invoke_result": {
+        "ExecutedVersion": "1",
+        "Payload": {
+          "function_version": "1"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "stack_resources": {
         "StackResources": [
           {
@@ -725,7 +736,7 @@
             "PackageType": "Zip",
             "RevisionId": "<uuid:1>",
             "Role": "arn:<partition>:iam::111111111111:role/<resource:4>",
-            "Runtime": "python3.9",
+            "Runtime": "python3.12",
             "SnapStart": {
               "ApplyOn": "None",
               "OptimizationStatus": "Off"
@@ -758,7 +769,7 @@
             "PackageType": "Zip",
             "RevisionId": "<uuid:2>",
             "Role": "arn:<partition>:iam::111111111111:role/<resource:4>",
-            "Runtime": "python3.9",
+            "Runtime": "python3.12",
             "SnapStart": {
               "ApplyOn": "None",
               "OptimizationStatus": "Off"
@@ -803,7 +814,7 @@
           "PackageType": "Zip",
           "RevisionId": "<uuid:2>",
           "Role": "arn:<partition>:iam::111111111111:role/<resource:4>",
-          "Runtime": "python3.9",
+          "Runtime": "python3.12",
           "RuntimeVersionConfig": {
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:5>"
           },
@@ -1659,6 +1670,199 @@
         "LogFormat": "JSON",
         "LogGroup": "/aws/lambda/<function-name>",
         "SystemLogLevel": "INFO"
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_version_provisioned_concurrency": {
+    "recorded-date": "07-05-2025, 13:23:25",
+    "recorded-content": {
+      "invoke_result": {
+        "ExecutedVersion": "1",
+        "Payload": {
+          "initialization_type": "provisioned-concurrency"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stack_resources": {
+        "StackResources": [
+          {
+            "DriftInformation": {
+              "StackResourceDriftStatus": "NOT_CHECKED"
+            },
+            "LogicalResourceId": "fn5FF616E3",
+            "PhysicalResourceId": "<resource:3>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::Lambda::Function",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "DriftInformation": {
+              "StackResourceDriftStatus": "NOT_CHECKED"
+            },
+            "LogicalResourceId": "fnServiceRole5D180AFD",
+            "PhysicalResourceId": "<resource:4>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::IAM::Role",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "DriftInformation": {
+              "StackResourceDriftStatus": "NOT_CHECKED"
+            },
+            "LogicalResourceId": "fnVersion7BF8AE5A",
+            "PhysicalResourceId": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::Lambda::Version",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "versions_by_fn": {
+        "Versions": [
+          {
+            "Architectures": [
+              "x86_64"
+            ],
+            "CodeSha256": "<code-sha256:1>",
+            "CodeSize": "<code-size>",
+            "Description": "",
+            "EphemeralStorage": {
+              "Size": 512
+            },
+            "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:3>:$LATEST",
+            "FunctionName": "<resource:3>",
+            "Handler": "index.handler",
+            "LastModified": "date",
+            "LoggingConfig": {
+              "LogFormat": "Text",
+              "LogGroup": "/aws/lambda/<resource:3>"
+            },
+            "MemorySize": 128,
+            "PackageType": "Zip",
+            "RevisionId": "<uuid:1>",
+            "Role": "arn:<partition>:iam::111111111111:role/<resource:4>",
+            "Runtime": "python3.12",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
+            "Timeout": 3,
+            "TracingConfig": {
+              "Mode": "PassThrough"
+            },
+            "Version": "$LATEST"
+          },
+          {
+            "Architectures": [
+              "x86_64"
+            ],
+            "CodeSha256": "<code-sha256:1>",
+            "CodeSize": "<code-size>",
+            "Description": "test description",
+            "EphemeralStorage": {
+              "Size": 512
+            },
+            "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+            "FunctionName": "<resource:3>",
+            "Handler": "index.handler",
+            "LastModified": "date",
+            "LoggingConfig": {
+              "LogFormat": "Text",
+              "LogGroup": "/aws/lambda/<resource:3>"
+            },
+            "MemorySize": 128,
+            "PackageType": "Zip",
+            "RevisionId": "<uuid:2>",
+            "Role": "arn:<partition>:iam::111111111111:role/<resource:4>",
+            "Runtime": "python3.12",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
+            "Timeout": 3,
+            "TracingConfig": {
+              "Mode": "PassThrough"
+            },
+            "Version": "1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_version": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "test description",
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<resource:2>",
+          "FunctionName": "<resource:3>",
+          "Handler": "index.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<resource:3>"
+          },
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:<partition>:iam::111111111111:role/<resource:4>",
+          "Runtime": "python3.12",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:5>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 3,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "provisioned_concurrency_config": {
+        "AllocatedProvisionedConcurrentExecutions": 1,
+        "AvailableProvisionedConcurrentExecutions": 1,
+        "LastModified": "date",
+        "RequestedProvisionedConcurrentExecutions": 1,
+        "Status": "READY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   }

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -24,7 +24,7 @@
     "last_validated_date": "2024-04-09T07:20:36+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_alias": {
-    "last_validated_date": "2024-04-09T07:19:19+00:00"
+    "last_validated_date": "2025-05-07T15:39:26+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_cfn_dead_letter_config_async_invocation": {
     "last_validated_date": "2024-04-09T07:39:50+00:00"

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -45,7 +45,10 @@
     "last_validated_date": "2025-04-08T12:12:01+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_version": {
-    "last_validated_date": "2024-04-09T07:21:37+00:00"
+    "last_validated_date": "2025-05-07T13:19:10+00:00"
+  },
+  "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_version_provisioned_concurrency": {
+    "last_validated_date": "2025-05-07T13:23:25+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_w_dynamodb_event_filter_update": {
     "last_validated_date": "2024-12-11T09:03:52+00:00"

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -2621,7 +2621,7 @@ class TestLambdaConcurrency:
         )
         snapshot.match("get_provisioned_postwait", get_provisioned_postwait)
 
-        # Schedule Lambda to provisioned concurrency instead of launching a new on-demand instance
+        # Invoke should favor provisioned concurrency function over launching a new on-demand instance
         invoke_result = aws_client.lambda_.invoke(
             FunctionName=func_name,
             Qualifier=v1["Version"],

--- a/tests/aws/templates/cfn_lambda_alias.yml
+++ b/tests/aws/templates/cfn_lambda_alias.yml
@@ -30,18 +30,20 @@ Resources:
       FunctionName: !Ref FunctionName
       Code:
         ZipFile: |
-          exports.handler = function(event) {
-            return {
-              statusCode: 200,
-              body: "Hello, World!" 
-            };
-          };
+          import os
+
+          def handler(event, context):
+              function_version = os.environ["AWS_LAMBDA_FUNCTION_VERSION"]
+              print(f"{function_version=}")
+              init_type = os.environ.get("_XRAY_SDK_LAMBDA_PLACEMENT_INIT_TYPE", None)
+              print(f"{init_type=}")
+              return {"function_version": function_version, "initialization_type": init_type}
       Role:
         Fn::GetAtt:
           - MyFnServiceRole
           - Arn
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: python3.12
     DependsOn:
       - MyFnServiceRole
 

--- a/tests/aws/templates/cfn_lambda_version_provisioned_concurrency.yaml
+++ b/tests/aws/templates/cfn_lambda_version_provisioned_concurrency.yaml
@@ -23,9 +23,9 @@ Resources:
           import os
 
           def handler(event, context):
-              function_version = os.environ["AWS_LAMBDA_FUNCTION_VERSION"]
-              print(f"{function_version=}")
-              return {"function_version": function_version}
+              init_type = os.environ["AWS_LAMBDA_INITIALIZATION_TYPE"]
+              print(f"{init_type=}")
+              return {"initialization_type": init_type}
       Role:
         Fn::GetAtt:
           - fnServiceRole5D180AFD
@@ -40,6 +40,9 @@ Resources:
       FunctionName:
         Ref: fn5FF616E3
       Description: test description
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
+
 Outputs:
   FunctionName:
     Value:


### PR DESCRIPTION
Depends on https://github.com/localstack/localstack/pull/12592

## Motivation

Testing for a support issue revealed an auxiliary issue that provisioned concurrency is not implemented for the CloudFormation resource [AWS::Lambda::Version](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html).

## Changes

* Add support for provisioned concurrency config in the Lambda version CloudFormation resource provider
* Add aws-validated test case `test_lambda_version_provisioned_concurrency`. I opted for creating a separate test case for provisioned concurrency to ensure both paths work independently, especially given that provisioned concurrency includes different waiters (takes much longer). Feel free to suggest if combining them would be better.
* Improve test case `test_lambda_version` to validate actual behavior for provisioned concurrency (fixed in https://github.com/localstack/localstack/pull/12592)

