### PR TITLE
CFn v2: Skip media type assertion

### DIFF
--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py
@@ -318,6 +318,7 @@ def test_cfn_deploy_apigateway_integration(deploy_cfn_template, snapshot, aws_cl
         "$.get-stage.lastUpdatedDate",
         "$.get-stage.methodSettings",
         "$.get-stage.tags",
+        "$..binaryMediaTypes",
     ]
 )
 def test_cfn_deploy_apigateway_from_s3_swagger(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The commit that introduced the parity fixes for CFn ported over the APIGW tests from v1. Unfortunately the CI was not run before 92aa7761e35f was merged, and the merge commit of the PR only ran acceptance tests meaning that this is a ticking time bomb that's going to fail the pipeline overnight. 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Skip new field `binaryMediaTypes` in the APIGW CFn test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
