### PR TITLE
ASF: Ignore optional-ness when comparing argument types

### DIFF
--- a/localstack-core/localstack/services/transcribe/provider.py
+++ b/localstack-core/localstack/services/transcribe/provider.py
@@ -192,10 +192,10 @@ class TranscribeProvider(TranscribeApi):
     def list_transcription_jobs(
         self,
         context: RequestContext,
-        status: TranscriptionJobStatus = None,
-        job_name_contains: TranscriptionJobName = None,
-        next_token: NextToken = None,
-        max_results: MaxResults = None,
+        status: TranscriptionJobStatus | None = None,
+        job_name_contains: TranscriptionJobName | None = None,
+        next_token: NextToken | None = None,
+        max_results: MaxResults | None = None,
         **kwargs,
     ) -> ListTranscriptionJobsResponse:
         store = transcribe_stores[context.account_id][context.region]


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The API currently marks everything as required, and optional args are configured as:
```python
arg: ArgType = None
```
which is obviously incorrect.

Implementations should be allowed to do this correctly:
```
arg: ArgType | None = None
```
But in order for that to work, we need to change the `test_asf_providers.py`. That test verifies that the signature is exactly the same. This PR makes the test assertions more flexible, so that an argument type of `X | None` is considered equal to `X`.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
 - Make the comparison function more flexible to ignore None-types in argument types
 - Add some more specific error messages when the comparison fails
 - Changes the argument types in the Transcribe provider to verify that new assertions work

## Testing
Some manual testing was done to verify that the new assertions work, i.e. that a useful error message is thrown when the types are actually different:

```bash
>        assert sub_type == base_type, f"Types for {kwarg} are different - {sub_type} instead of {base_type}"
E        AssertionError: Types for job_name_contains are different - [<class 'str'>, <class 'int'>] instead of [<class 'str'>]
```

## TODO
Follow up PR's will:
- Correct the API generation to have the correct argument types
- Correct the implementation of all services to have the correct argument types

## Related
See #12588 where we kicked this conversation first off.