### PR TITLE
Autogenerate templates

### DIFF
--- a/localstack-core/localstack/services/cloudformation/autogen/cli.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/cli.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python
 import logging
+from typing import cast, IO
 
 import click
 import yaml
 
 from localstack.logging.setup import setup_logging_from_config
-from localstack.services.cloudformation.autogen import formatting, generation, patches, specs
+from localstack.services.cloudformation.autogen import (
+    formatting,
+    generation,
+    patches,
+    permutations,
+    specs,
+)
 from localstack.services.cloudformation.autogen.generation import generate_resources_from_spec
 
 setup_logging_from_config()
@@ -52,6 +59,12 @@ def template(resource_type: list[str], resource_count: tuple[int, int], output: 
 
     if output.name != "<stdout>":
         formatting.format_file(output.name)
+
+
+@main.command(name="permutations")
+@click.option("-o", "--output", type=click.File("w"), help="Output file", required=True)
+def gen_permutations(output: click.File):
+    permutations.generate_permutations(cast(IO[str], output))
 
 
 if __name__ == "__main__":

--- a/localstack-core/localstack/services/cloudformation/autogen/cli.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/cli.py
@@ -6,6 +6,7 @@ import yaml
 
 from localstack.logging.setup import setup_logging_from_config
 from localstack.services.cloudformation.autogen import formatting, generation, patches, specs
+from localstack.services.cloudformation.autogen.generation import generate_resources_from_spec
 
 setup_logging_from_config()
 
@@ -22,13 +23,32 @@ def main():
 @click.option("-r", "--resource", "resource_name", help="Which resource to generate")
 @click.option("-O", "--add-optionals", is_flag=True, help="Also generate additional properties")
 @click.option("-o", "--output", type=click.File("w"), help="Output file to write to", default="-")
-def generate(resource_name: str, add_optionals: bool, output: click.File) -> None:
+def single(resource_name: str, add_optionals: bool, output: click.File) -> None:
     LOG.info("Generating resource definition for '%s'", resource_name)
 
     spec = specs.read_spec_for(resource_name)
     spec = patches.apply_patch_for(spec)
     resource = generation.generate_resource_from_spec(spec, add_optionals)
     yaml.safe_dump({"Resources": {"MyResource": resource}}, output)
+
+    if output.name != "<stdout>":
+        formatting.format_file(output.name)
+
+
+@main.command()
+@click.option("-t", "--resource-type", multiple=True, help="Available resources to choose from")
+@click.option(
+    "-r",
+    "--range",
+    "resource_count",
+    nargs=2,
+    help="Min and max number of resources to generate",
+    default=(1, 5),
+)
+@click.option("-o", "--output", type=click.File("w"), help="Output file to write to", default="-")
+def template(resource_type: list[str], resource_count: tuple[int, int], output: click.File):
+    resources = generate_resources_from_spec(resource_type, resource_count)
+    yaml.safe_dump({"Resources": resources}, output)
 
     if output.name != "<stdout>":
         formatting.format_file(output.name)

--- a/localstack-core/localstack/services/cloudformation/autogen/cli.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/cli.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+import logging
+
+import click
+import yaml
+
+from localstack.logging.setup import setup_logging_from_config
+from localstack.services.cloudformation.autogen import formatting, generation, patches, specs
+
+setup_logging_from_config()
+
+LOG = logging.getLogger("localstack.services.cloudformation.autogen.cli")
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"], show_default=True)
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+def main():
+    pass
+
+
+@main.command()
+@click.option("-r", "--resource", "resource_name", help="Which resource to generate")
+@click.option("-O", "--add-optionals", is_flag=True, help="Also generate additional properties")
+@click.option("-o", "--output", type=click.File("w"), help="Output file to write to", default="-")
+def generate(resource_name: str, add_optionals: bool, output: click.File) -> None:
+    LOG.info("Generating resource definition for '%s'", resource_name)
+
+    spec = specs.read_spec_for(resource_name)
+    spec = patches.apply_patch_for(spec)
+    resource = generation.generate_resource_from_spec(spec, add_optionals)
+    yaml.safe_dump({"Resources": {"MyResource": resource}}, output)
+
+    if output.name != "<stdout>":
+        formatting.format_file(output.name)
+
+
+if __name__ == "__main__":
+    main()

--- a/localstack-core/localstack/services/cloudformation/autogen/cli.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import logging
-from typing import cast, IO
+from pathlib import Path
 
 import click
 import yaml
@@ -62,9 +62,13 @@ def template(resource_type: list[str], resource_count: tuple[int, int], output: 
 
 
 @main.command(name="permutations")
-@click.option("-o", "--output", type=click.File("w"), help="Output file", required=True)
-def gen_permutations(output: click.File):
-    permutations.generate_permutations(cast(IO[str], output))
+@click.option(
+    "-c", "--count", type=int, default=10, help="Number of template permutations to generate"
+)
+@click.option("-o", "--output", "output_path", type=Path, help="Output file", required=True)
+def gen_permutations(output_path: Path, count: int):
+    output_path.mkdir(parents=True, exist_ok=True)
+    permutations.generate_templates(output_path, count=count)
 
 
 if __name__ == "__main__":

--- a/localstack-core/localstack/services/cloudformation/autogen/data/patch_dynamodb_table.json
+++ b/localstack-core/localstack/services/cloudformation/autogen/data/patch_dynamodb_table.json
@@ -1,0 +1,15 @@
+[
+  {
+    "op": "remove",
+    "path": "/properties/KeySchema/oneOf/1"
+  },
+  {
+    "op": "replace",
+    "path": "/required",
+    "value": [
+      "KeySchema",
+      "AttributeDefinitions",
+      "BillingMode"
+    ]
+  }
+]

--- a/localstack-core/localstack/services/cloudformation/autogen/formatting.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/formatting.py
@@ -1,0 +1,18 @@
+import logging
+import shutil
+import subprocess as sp
+from pathlib import Path
+
+LOG = logging.getLogger(__name__)
+
+
+def format_file(path: str | Path):
+    if bin_path := shutil.which("rain"):
+        format_with_rain(bin_path, path)
+        return
+
+
+def format_with_rain(bin_path: str, path: str | Path):
+    LOG.debug("formatting output file '%s' with rain", path)
+    cmd = [bin_path, "fmt", "--write", str(path)]
+    sp.check_call(cmd)

--- a/localstack-core/localstack/services/cloudformation/autogen/generation.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/generation.py
@@ -1,9 +1,15 @@
 import logging
+import random
 
+from localstack.services.cloudformation.autogen import patches, specs
 from localstack.services.cloudformation.autogen.specs import (
     ResourceProviderDefinition,
 )
-from localstack.services.cloudformation.autogen.visitors.base import Resource, Visitor
+from localstack.services.cloudformation.autogen.visitors.base import (
+    Resource,
+    Visitor,
+    _random_short_string,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -28,3 +34,25 @@ def generate_resource_from_spec(
         return {"Type": spec["typeName"], "Properties": properties}
     else:
         return {"Type": spec["typeName"]}
+
+
+def generate_resources_from_spec(
+    resource_whitelist: list[str] | None = None,
+    resource_count: tuple[int, int] = (1, 5),
+) -> dict:
+    spec_cache: dict[str, ResourceProviderDefinition] = {}
+
+    resources = {}
+    for _ in range(*resource_count):
+        resource_name = _random_short_string()
+        current_resource_type = random.choice(resource_whitelist)
+        if current_resource_type not in spec_cache:
+            spec = specs.read_spec_for(current_resource_type)
+            spec = patches.apply_patch_for(spec)
+            spec_cache[current_resource_type] = spec
+
+        spec = spec_cache[current_resource_type]
+        resource = generate_resource_from_spec(spec, False)
+        resources[resource_name] = resource
+
+    return resources

--- a/localstack-core/localstack/services/cloudformation/autogen/generation.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/generation.py
@@ -1,0 +1,30 @@
+import logging
+
+from localstack.services.cloudformation.autogen.specs import (
+    ResourceProviderDefinition,
+)
+from localstack.services.cloudformation.autogen.visitors.base import Resource, Visitor
+
+LOG = logging.getLogger(__name__)
+
+
+def visitor_factory(spec: ResourceProviderDefinition) -> Visitor:
+    match spec["typeName"]:
+        case "AWS::DynamoDB::Table":
+            from localstack.services.cloudformation.autogen.visitors.dynamodb_table import (
+                DynamoDBTableVisitor,
+            )
+
+            return DynamoDBTableVisitor(spec)
+
+    return Visitor(spec)
+
+
+def generate_resource_from_spec(
+    spec: ResourceProviderDefinition, include_optionals: bool = False
+) -> Resource:
+    properties = visitor_factory(spec).get(include_optionals)
+    if properties:
+        return {"Type": spec["typeName"], "Properties": properties}
+    else:
+        return {"Type": spec["typeName"]}

--- a/localstack-core/localstack/services/cloudformation/autogen/generation.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/generation.py
@@ -8,7 +8,7 @@ from localstack.services.cloudformation.autogen.specs import (
 from localstack.services.cloudformation.autogen.visitors.base import (
     Resource,
     Visitor,
-    _random_short_string,
+    random_short_string,
 )
 
 LOG = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ def generate_resources_from_spec(
 
     resources = {}
     for _ in range(*resource_count):
-        resource_name = _random_short_string()
+        resource_name = random_short_string()
         current_resource_type = random.choice(resource_whitelist)
         if current_resource_type not in spec_cache:
             spec = specs.read_spec_for(current_resource_type)

--- a/localstack-core/localstack/services/cloudformation/autogen/patches.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/patches.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+from jsonpatch import JsonPatch
+
+from localstack.services.cloudformation.autogen.specs import ResourceProviderDefinition
+
+AUTOGEN_ROOT_DIR = Path(__file__).parent.resolve()
+
+
+def apply_patch_for(original_schema: ResourceProviderDefinition) -> ResourceProviderDefinition:
+    resource_name = original_schema["typeName"]
+    _, service, resource = resource_name.lower().split("::")
+    patch_path = AUTOGEN_ROOT_DIR / "data" / f"patch_{service}_{resource}.json"
+    if not patch_path.is_file():
+        return original_schema
+
+    with patch_path.open() as infile:
+        patch = JsonPatch(json.load(infile))
+
+    return patch.apply(original_schema)

--- a/localstack-core/localstack/services/cloudformation/autogen/permutations.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/permutations.py
@@ -1,0 +1,144 @@
+import io
+import random
+from dataclasses import dataclass
+from typing import IO
+
+import yaml
+
+from localstack.services.cloudformation.autogen.visitors.base import random_short_string
+
+NodeId = str
+EdgeId = str
+
+
+def gen_id() -> NodeId | EdgeId:
+    return random_short_string()
+
+
+@dataclass
+class Node:
+    id: NodeId
+
+
+@dataclass
+class Edge:
+    id: EdgeId
+
+    from_: NodeId
+    to: NodeId
+
+
+class CyclicGraphError(RuntimeError):
+    pass
+
+
+class Graph:
+    nodes: dict[NodeId, Node]
+    edges: dict[EdgeId, Edge]
+
+    def __init__(self):
+        self.nodes = {}
+        self.edges = {}
+
+    def add_node(self) -> NodeId:
+        node_id = gen_id()
+        node = Node(id=node_id)
+        self.nodes[node_id] = node
+        return node_id
+
+    def add_edge(self, from_: NodeId, to: NodeId) -> EdgeId:
+        edge_id = gen_id()
+        edge = Edge(id=edge_id, from_=from_, to=to)
+
+        if self.contains_cycle(edge):
+            raise CyclicGraphError("Graph contains cycle")
+
+        self.edges[edge_id] = edge
+        return edge_id
+
+    def random_node(self, excluding: set[NodeId] | None = None) -> NodeId:
+        # TODO: assume we have added all nodes
+        excluding = excluding or set()
+        valid_nodes = set(self.nodes.keys()) - excluding
+        if not valid_nodes:
+            raise RuntimeError("no nodes available to target")
+
+        return random.choice(list(valid_nodes))
+
+    def contains_cycle(self, new_edge: Edge) -> bool:
+        for edge in self.edges.values():
+            if new_edge.to == edge.from_ and new_edge.from_ == edge.to:
+                return True
+
+        return False
+
+    def __str__(self) -> str:
+        return self.to_dot()
+
+    def to_dot(self) -> str:
+        out = io.StringIO()
+
+        def render(text: str | None = None):
+            if text is None:
+                return print(file=out)
+            else:
+                return print(text, file=out)
+
+        render("digraph G {")
+
+        for node in self.nodes.values():
+            render(f"\t{node.id};")
+
+        render()
+
+        for edge in self.edges.values():
+            render(f"\t{edge.from_} -> {edge.to};")
+
+        render("}")
+
+        return out.getvalue()
+
+    def render_template(self) -> str:
+        template = {"Resources": {}}
+
+        for node in self.nodes.values():
+            resource_definition = {
+                "Type": "AWS::SSM::Parameter",
+                "Properties": {
+                    "Type": "String",
+                    "Value": node.id,
+                },
+            }
+            for edge in self.edges.values():
+                if edge.from_ == node.id:
+                    resource_definition["Properties"]["Description"] = {"Ref": edge.to}
+            template["Resources"][node.id] = resource_definition
+
+        return yaml.safe_dump(template)
+
+
+def generate_permutations(output: IO[str]):
+    g = Graph()
+    n_nodes = random.randint(5, 20)
+    node_ids = []
+    for _ in range(n_nodes):
+        node_ids.append(g.add_node())
+
+    n_edges = random.randint(2, n_nodes - 1)
+    for _ in range(n_edges):
+        success = False
+        for _ in range(10):
+            from_ = g.random_node()
+            to = g.random_node(excluding={from_})
+            try:
+                g.add_edge(from_, to)
+                success = True
+                break
+            except CyclicGraphError:
+                continue
+
+        if not success:
+            raise RuntimeError("Could not find non-acyclic graph combination")
+
+    print(g)
+    print(g.render_template(), file=output)

--- a/localstack-core/localstack/services/cloudformation/autogen/permutations.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/permutations.py
@@ -1,6 +1,7 @@
 import enum
 import io
 import random
+import subprocess as sp
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -77,7 +78,7 @@ class Graph:
             if new_edge.to == edge.from_ and new_edge.from_ == edge.to:
                 return True
 
-        return False
+        return new_edge.to == new_edge.from_
 
     def apply_operation(self, op: Operation):
         print(f"Applying operation {op}")
@@ -152,6 +153,16 @@ class Graph:
 
         return yaml.safe_dump(template)
 
+    def render_png(self, output_path: Path):
+        dot = self.to_dot()
+        sp.run(
+            ["dot", "-Tpng", "-o", str(output_path)],
+            input=dot,
+            text=True,
+            capture_output=False,
+            check=True,
+        )
+
 
 def generate_templates(output_path: Path, count: int = 10):
     # TODO: clear_files(output_path)
@@ -159,6 +170,7 @@ def generate_templates(output_path: Path, count: int = 10):
     for i in range(count):
         with (output_path / f"template_{i}.yml").open("w") as outfile:
             print(g.render_template(), file=outfile)
+        g.render_png(output_path / f"template_{i}.png")
         g = permute_existing_graph(g, count)
 
 

--- a/localstack-core/localstack/services/cloudformation/autogen/permutations.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/permutations.py
@@ -1,7 +1,7 @@
 import io
 import random
 from dataclasses import dataclass
-from typing import IO
+from pathlib import Path
 
 import yaml
 
@@ -117,7 +117,16 @@ class Graph:
         return yaml.safe_dump(template)
 
 
-def generate_permutations(output: IO[str]):
+def generate_templates(output_path: Path, count: int = 10):
+    # TODO: clear_files(output_path)
+    g = generate_new_graph()
+    for i in range(count):
+        with (output_path / f"template_{i}.yml").open("w") as outfile:
+            print(g.render_template(), file=outfile)
+        g = permute_existing_graph(g)
+
+
+def generate_new_graph() -> Graph:
     g = Graph()
     n_nodes = random.randint(5, 20)
     node_ids = []
@@ -140,5 +149,8 @@ def generate_permutations(output: IO[str]):
         if not success:
             raise RuntimeError("Could not find non-acyclic graph combination")
 
-    print(g)
-    print(g.render_template(), file=output)
+    return g
+
+
+def permute_existing_graph(g: Graph) -> Graph:
+    return g

--- a/localstack-core/localstack/services/cloudformation/autogen/specs.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/specs.py
@@ -74,14 +74,16 @@ class ArrayProperty(TypedDict, total=False):
 class BooleanProperty(TypedDict, total=False):
     type: Literal["boolean"]
 
+
 class IntegerProperty(TypedDict, total=False):
     type: Literal["integer"]
 
     # TODO: minValue, maxValue
 
 
-
-PropertyDefinition = StringProperty | ObjectProperty | ArrayProperty | BooleanProperty | IntegerProperty
+PropertyDefinition = (
+    StringProperty | ObjectProperty | ArrayProperty | BooleanProperty | IntegerProperty
+)
 
 
 class ResourceProviderDefinition(TypedDict):

--- a/localstack-core/localstack/services/cloudformation/autogen/specs.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/specs.py
@@ -1,0 +1,115 @@
+import json
+from pathlib import Path
+from typing import Any, Literal, NotRequired, TypedDict
+
+ROOT_DIR = Path(__file__).parent.parent.parent.resolve()
+
+
+class HandlerSchema(TypedDict, total=False):
+    properties: dict[str, Any]
+    required: list[str]
+    allOf: list[Any]
+    anyOf: list[Any]
+    oneOf: list[Any]
+
+
+class HandlerDefinitionWithSchemaOverride(TypedDict):
+    permissions: list[str]
+    handlerSchema: HandlerSchema
+    timeoutInMinutes: NotRequired[int]  # default 120, min=2, max=2160
+
+
+class HandlerDefinition(TypedDict):
+    permissions: list[str]
+    timeoutInMinutes: NotRequired[int]  # default 120, min=2, max=2160
+
+
+ReplacementStrategy = Literal["create_then_delete", "delete_then_create"]
+
+
+class Tagging(TypedDict, total=False):
+    taggable: bool  # default True
+    tagOnCreate: bool  # default True
+    tagUpdatable: bool  # default True
+    cloudFormationSystemTags: bool  # default True
+    tagProperty: str  # default "/properties/Tags"
+    permissions: list[str]
+
+
+class Handlers(TypedDict, total=False):
+    create: HandlerDefinition
+    read: HandlerDefinition
+    update: HandlerDefinition
+    delete: HandlerDefinition
+    list: HandlerDefinitionWithSchemaOverride
+
+
+class StringProperty(TypedDict, total=False):
+    type: Literal["string"]
+    description: NotRequired[str]
+    enum: NotRequired[list[str]]
+
+
+class ObjectProperty(TypedDict, total=False):
+    type: Literal["object"]
+    additionalProperties: bool
+
+    description: NotRequired[str]
+    patternProperties: NotRequired[dict]
+    properties: NotRequired[dict[str, Any]]
+    required: NotRequired[list[str]]
+
+
+ArrayReference = TypedDict("ArrayReference", {"$ref": str})
+
+
+class ArrayProperty(TypedDict, total=False):
+    type: Literal["array"]
+    items: ArrayReference
+
+    uniqueItems: NotRequired[bool]
+    insertionOrder: NotRequired[bool]
+
+
+class BooleanProperty(TypedDict, total=False):
+    type: Literal["boolean"]
+
+class IntegerProperty(TypedDict, total=False):
+    type: Literal["integer"]
+
+    # TODO: minValue, maxValue
+
+
+
+PropertyDefinition = StringProperty | ObjectProperty | ArrayProperty | BooleanProperty | IntegerProperty
+
+
+class ResourceProviderDefinition(TypedDict):
+    # required top‐level properties
+    typeName: str
+    properties: dict[str, PropertyDefinition]
+    description: str
+    primaryIdentifier: list[str]
+    additionalProperties: bool
+
+    # optional metadata and others
+    tagging: NotRequired[Tagging]
+    replacementStrategy: NotRequired[ReplacementStrategy]
+    definitions: NotRequired[dict[str, Any]]
+    handlers: NotRequired[Handlers]
+    readOnlyProperties: NotRequired[list[str]]
+    writeOnlyProperties: NotRequired[list[str]]
+    conditionalCreateOnlyProperties: NotRequired[list[str]]
+    createOnlyProperties: NotRequired[list[str]]
+    deprecatedProperties: NotRequired[list[str]]
+    additionalIdentifiers: NotRequired[list[list[str]]]
+    required: NotRequired[list[str]]
+
+
+def read_spec_for(resource_name: str) -> ResourceProviderDefinition:
+    _, service, resource = resource_name.lower().split("::")
+    schema_path = (
+        ROOT_DIR / service / "resource_providers" / f"aws_{service}_{resource}.schema.json"
+    )
+    with schema_path.open() as infile:
+        return json.load(infile)

--- a/localstack-core/localstack/services/cloudformation/autogen/visitors/base.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/visitors/base.py
@@ -18,6 +18,10 @@ LOG = logging.getLogger(__name__)
 Resource = dict[str, Any]
 
 
+def _random_short_string(count: int = 10, character_set: str = string.ascii_letters) -> str:
+    return "".join(random.choices(character_set, k=count))
+
+
 class Visitor:
     resource_type: Final[str]
     definition: Resource
@@ -99,7 +103,7 @@ class Visitor:
         if allowed_values := property_definition.get("enum"):
             return random.choice(allowed_values)
         else:
-            return "".join(random.choices(string.ascii_letters, k=10))
+            return _random_short_string()
 
     def _gen_property_array(self, name: str, property_definition: ArrayProperty) -> list[Any]:
         result = []

--- a/localstack-core/localstack/services/cloudformation/autogen/visitors/base.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/visitors/base.py
@@ -18,7 +18,7 @@ LOG = logging.getLogger(__name__)
 Resource = dict[str, Any]
 
 
-def _random_short_string(count: int = 10, character_set: str = string.ascii_letters) -> str:
+def random_short_string(count: int = 10, character_set: str = string.ascii_letters) -> str:
     return "".join(random.choices(character_set, k=count))
 
 
@@ -103,7 +103,7 @@ class Visitor:
         if allowed_values := property_definition.get("enum"):
             return random.choice(allowed_values)
         else:
-            return _random_short_string()
+            return random_short_string()
 
     def _gen_property_array(self, name: str, property_definition: ArrayProperty) -> list[Any]:
         result = []

--- a/localstack-core/localstack/services/cloudformation/autogen/visitors/base.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/visitors/base.py
@@ -1,0 +1,139 @@
+import logging
+import random
+import string
+from typing import Any, Final
+
+from localstack.services.cloudformation.autogen.specs import (
+    ArrayProperty,
+    BooleanProperty,
+    IntegerProperty,
+    ObjectProperty,
+    ResourceProviderDefinition,
+    StringProperty,
+)
+from localstack.services.cloudformation.scaffolding.__main__ import resolve_ref
+
+LOG = logging.getLogger(__name__)
+
+Resource = dict[str, Any]
+
+
+class Visitor:
+    resource_type: Final[str]
+    definition: Resource
+
+    def __init__(self, spec: ResourceProviderDefinition):
+        self.spec = spec
+        self.resource_type = spec["typeName"]
+        self.definition = {}
+
+        # internal tracking state
+        self._added_fields: set[str] = set()
+
+    def visit(self, include_optionals: bool):
+        self.definition.clear()
+
+        self._visit_required()
+        if include_optionals:
+            num_optional = random.randint(0, self.num_optional_fields)
+            for _ in range(num_optional):
+                self._add_optional()
+
+    def get(self, include_optionals: bool) -> Resource:
+        self.visit(include_optionals)
+        return self.definition
+
+    def _visit_required(self):
+        for field_name in self.required_field_names:
+            property_definition = self.spec["properties"][field_name]
+            value = self._visit_property_definition(field_name, property_definition)
+            self._set_value(field_name, value)
+
+    def _add_optional(self):
+        remaining_properties = (
+            set(self.spec["properties"].keys())
+            - set(self.required_field_names)
+            - self._added_fields
+        )
+        chosen_prop_name = random.choice(list(remaining_properties))
+        property_definition = self.spec["properties"][chosen_prop_name]
+        value = self._visit_property_definition(chosen_prop_name, property_definition)
+        self._set_value(chosen_prop_name, value)
+
+    def _visit_property_definition(self, name: str, property_definition: dict) -> Any:
+        LOG.debug("Visiting property '%s'", name)
+        if property_type := property_definition.get("type"):
+            method_name = f"_gen_property_{property_type}"
+            method = getattr(self, method_name, None)
+            if not method:
+                raise NotImplementedError(
+                    f"No visit method '{method_name}' found for spec '{property_definition}'"
+                )
+            return method(name, property_definition)
+        elif definition_path := property_definition.get("$ref"):
+            # we need to look up the property from the definitions array
+            definition = resolve_ref(self.spec, definition_path)
+
+            try:
+                return self._visit_property_definition(name, definition)
+            except KeyError:
+                raise RuntimeError(f"Missing field 'properties' in definition '{definition}'")
+        elif one_of := property_definition.get("oneOf"):
+            definition = random.choice(one_of)
+            return self._visit_property_definition(name, definition)
+        else:
+            raise NotImplementedError(f"Unhandled definition: {property_definition}")
+
+    @property
+    def num_optional_fields(self) -> int:
+        num_required_fields = len(self.required_field_names)
+        total_num_fields = len(self.spec["properties"])
+        return total_num_fields - num_required_fields
+
+    @property
+    def required_field_names(self) -> list[str]:
+        return self.spec.get("required", [])
+
+    def _gen_property_string(self, name, property_definition: StringProperty) -> str:
+        assert property_definition["type"] == "string"
+        if allowed_values := property_definition.get("enum"):
+            return random.choice(allowed_values)
+        else:
+            return "".join(random.choices(string.ascii_letters, k=10))
+
+    def _gen_property_array(self, name: str, property_definition: ArrayProperty) -> list[Any]:
+        result = []
+
+        if item_ref := property_definition.get("items"):
+            for _ in range(random.randint(1, 3)):
+                value = self._visit_property_definition(name, item_ref)
+                result.append(value)
+        else:
+            raise NotImplementedError
+
+        return result
+
+    def _gen_property_boolean(self, name: str, property_definition: BooleanProperty) -> bool:
+        return random.uniform(0.0, 1.0) < 0.5
+
+    def _gen_property_integer(self, name: str, property_definition: IntegerProperty) -> int:
+        return random.randint(0, 100)
+
+    def _gen_property_object(
+        self, name: str, property_definition: ObjectProperty
+    ) -> dict[str, Any]:
+        result = {}
+        if required_prop_names := property_definition.get("required"):
+            for prop_name in required_prop_names:
+                prop_defn = property_definition["properties"][prop_name]
+                value = self._visit_property_definition(prop_name, prop_defn)
+                result[prop_name] = value
+        else:
+            for prop_name, prop_defn in property_definition.get("properties", {}).items():
+                value = self._visit_property_definition(prop_name, prop_defn)
+                result[prop_name] = value
+        return result
+
+    def _set_value(self, name: str, value: str):
+        self.definition[name] = value
+        self._added_fields.add(name)

--- a/localstack-core/localstack/services/cloudformation/autogen/visitors/dynamodb_table.py
+++ b/localstack-core/localstack/services/cloudformation/autogen/visitors/dynamodb_table.py
@@ -1,0 +1,40 @@
+import random
+from typing import Any
+
+from localstack.services.cloudformation.autogen.specs import ResourceProviderDefinition
+from localstack.services.cloudformation.autogen.visitors.base import Visitor
+
+
+class DynamoDBTableVisitor(Visitor):
+    def __init__(self, spec: ResourceProviderDefinition):
+        super().__init__(spec)
+
+        def random_attribute_name() -> str:
+            return self._gen_property_string("AttributeName", {"type": "string"})
+
+        self.keys = {
+            random_attribute_name(): {
+                "type": "S",
+                "key_type": "HASH",
+            },
+        }
+        if random.uniform(0.0, 1.0) < 0.5:
+            self.keys[random_attribute_name()] = {
+                "type": "S",
+                "key_type": "RANGE",
+            }
+
+    def _visit_property_definition(self, name: str, property_definition: dict) -> Any:
+        match name:
+            case "KeySchema":
+                return [
+                    {"AttributeName": k, "KeyType": v["key_type"]} for (k, v) in self.keys.items()
+                ]
+            case "AttributeDefinitions":
+                return [
+                    {"AttributeName": k, "AttributeType": v["type"]} for (k, v) in self.keys.items()
+                ]
+            case "BillingMode":
+                return "PAY_PER_REQUEST"
+
+        return super()._visit_property_definition(name, property_definition)

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -73,7 +73,7 @@ def find_change_set_v2(
                     # TODO: check for active stacks
                     if (
                         stack_candidate.stack_name == stack_name
-                        and stack.status != StackStatus.DELETE_COMPLETE
+                        and stack_candidate.status != StackStatus.DELETE_COMPLETE
                     ):
                         stack = stack_candidate
                         break
@@ -223,7 +223,7 @@ class CloudformationProviderV2(CloudformationProvider):
         )
         change_set.set_change_set_status(ChangeSetStatus.CREATE_COMPLETE)
         stack.change_set_id = change_set.change_set_id
-        stack.change_set_id = change_set.change_set_id
+        stack.change_set_ids.append(change_set.change_set_id)
         state.change_sets[change_set.change_set_id] = change_set
 
         return CreateChangeSetOutput(StackId=stack.stack_id, Id=change_set.change_set_id)

--- a/tests/aws/services/cloudformation/autogen/test_autogen.py
+++ b/tests/aws/services/cloudformation/autogen/test_autogen.py
@@ -1,0 +1,48 @@
+import json
+from typing import Callable
+
+import pytest
+
+from localstack.services.cloudformation.autogen import generation, patches, specs
+from localstack.testing.pytest import markers
+
+
+@pytest.fixture
+def autogen_resource():
+    def _autogen(resource_type: str) -> dict:
+        spec = specs.read_spec_for(resource_type)
+        spec = patches.apply_patch_for(spec)
+        resource = generation.generate_resource_from_spec(spec)
+
+        return {
+            "Resources": {
+                "MyResource": resource,
+            },
+            "Outputs": {
+                "MyResourceRef": {
+                    "Value": {"Ref": "MyResource"},
+                },
+            },
+        }
+
+    return _autogen
+
+
+@markers.aws.only_localstack
+@pytest.mark.parametrize(
+    "resource_type",
+    [
+        "AWS::DynamoDB::Table",
+        "AWS::SNS::Topic",
+        "AWS::S3::Bucket",
+    ],
+)
+def test_autogen(
+    autogen_resource: Callable[[str], dict],
+    deploy_cfn_template,
+    resource_type: str,
+):
+    template = autogen_resource(resource_type)
+    stack = deploy_cfn_template(template=json.dumps(template))
+    ref = stack.outputs["MyResourceRef"]
+    _ = ref

--- a/tests/aws/services/cloudformation/autogen/test_autogen.py
+++ b/tests/aws/services/cloudformation/autogen/test_autogen.py
@@ -3,8 +3,17 @@ from typing import Callable
 
 import pytest
 
+from localstack import config
 from localstack.services.cloudformation.autogen import generation, patches, specs
+from localstack.services.cloudformation.autogen.generation import generate_resources_from_spec
 from localstack.testing.pytest import markers
+
+SUPPORTED_RESOURCES = [
+    "AWS::DynamoDB::Table",
+    "AWS::SNS::Topic",
+    "AWS::S3::Bucket",
+]
+NON_HOST_MODE_RESOURCES = {"AWS::DynamoDB::Table"}
 
 
 @pytest.fixture
@@ -28,21 +37,43 @@ def autogen_resource():
     return _autogen
 
 
+@pytest.fixture
+def autogen_template():
+    def _autogen(resource_types: list[str], count: tuple[int, int] = (1, 5)) -> dict:
+        resources = generate_resources_from_spec(resource_types, count)
+        return {
+            "Resources": resources,
+        }
+
+    return _autogen
+
+
 @markers.aws.only_localstack
 @pytest.mark.parametrize(
     "resource_type",
-    [
-        "AWS::DynamoDB::Table",
-        "AWS::SNS::Topic",
-        "AWS::S3::Bucket",
-    ],
+    SUPPORTED_RESOURCES,
 )
-def test_autogen(
+def test_autogen_resource(
     autogen_resource: Callable[[str], dict],
     deploy_cfn_template,
     resource_type: str,
 ):
+    if resource_type == "AWS::DynamoDB::Table" and not config.is_in_docker:
+        pytest.skip(reason="DynamoDB tables not supported in host mode")
+
     template = autogen_resource(resource_type)
     stack = deploy_cfn_template(template=json.dumps(template))
     ref = stack.outputs["MyResourceRef"]
     _ = ref
+
+
+@markers.aws.only_localstack
+def test_autogen_template(
+    autogen_template: Callable[[list[str]], dict],
+    deploy_cfn_template,
+):
+    resources = SUPPORTED_RESOURCES
+    if not config.is_in_docker:
+        resources = list(set(SUPPORTED_RESOURCES) - NON_HOST_MODE_RESOURCES)
+    template = autogen_template(resources)
+    deploy_cfn_template(template=json.dumps(template))


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When testing CFn deployments, we need valid templates. These are sometimes annoying to write. 

We have access to the [specifications for all resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-type-schemas.html), can we generate valid templates?

Moreover, can we generate _permutations_ of templates so we can test our update process in the V2 engine?

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

TBD

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
