### PR TITLE
Improve security group fixture for EC2

### DIFF
--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -21,6 +21,7 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
 from localstack import config
+from localstack.aws.api.ec2 import CreateSecurityGroupRequest
 from localstack.aws.connect import ServiceLevelClientFactory
 from localstack.services.stores import (
     AccountRegionBundle,
@@ -42,7 +43,7 @@ from localstack.utils.aws.arns import get_partition
 from localstack.utils.aws.client import SigningHttpClient
 from localstack.utils.aws.resources import create_dynamodb_table
 from localstack.utils.bootstrap import is_api_enabled
-from localstack.utils.collections import ensure_list
+from localstack.utils.collections import ensure_list, select_from_typed_dict
 from localstack.utils.functions import call_safe, run_safe
 from localstack.utils.http import safe_requests as requests
 from localstack.utils.id_generator import ResourceIdentifier, localstack_id_manager
@@ -2001,24 +2002,39 @@ def setup_sender_email_address(ses_verify_identity):
 def ec2_create_security_group(aws_client):
     ec2_sgs = []
 
-    def factory(ports=None, **kwargs):
+    def factory(ports=None, ip_protocol: str = "tcp", **kwargs):
+        """
+        Create the target group and authorize the security group ingress.
+        :param ports: list of ports to be authorized for the ingress rule.
+        :param ip_protocol: the ip protocol for the permissions (tcp by default)
+        """
         if "GroupName" not in kwargs:
-            kwargs["GroupName"] = f"test-sg-{short_uid()}"
-        security_group = aws_client.ec2.create_security_group(**kwargs)
+            kwargs["GroupName"] = f"sg-{short_uid()}"
+        # Making sure the call to CreateSecurityGroup gets the right arguments
+        _args = select_from_typed_dict(CreateSecurityGroupRequest, kwargs)
+        security_group = aws_client.ec2.create_security_group(**_args)
 
         permissions = [
             {
                 "FromPort": port,
-                "IpProtocol": "tcp",
+                "IpProtocol": ip_protocol,
                 "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
                 "ToPort": port,
             }
             for port in ports or []
         ]
-        aws_client.ec2.authorize_security_group_ingress(
-            GroupName=kwargs["GroupName"],
-            IpPermissions=permissions,
-        )
+        if "VpcId" not in kwargs:
+            # default vpc group can use the group-name
+            aws_client.ec2.authorize_security_group_ingress(
+                GroupName=kwargs["GroupName"],
+                IpPermissions=permissions,
+            )
+        else:
+            # non default, has to use the group-id
+            aws_client.ec2.authorize_security_group_ingress(
+                GroupId=security_group["GroupId"],
+                IpPermissions=permissions,
+            )
 
         ec2_sgs.append(security_group["GroupId"])
         return security_group

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -2013,7 +2013,7 @@ def ec2_create_security_group(aws_client):
         # Making sure the call to CreateSecurityGroup gets the right arguments
         _args = select_from_typed_dict(CreateSecurityGroupRequest, kwargs)
         security_group = aws_client.ec2.create_security_group(**_args)
-
+        security_group_id = security_group["GroupId"]
         permissions = [
             {
                 "FromPort": port,
@@ -2023,20 +2023,12 @@ def ec2_create_security_group(aws_client):
             }
             for port in ports or []
         ]
-        if "VpcId" not in kwargs:
-            # default vpc group can use the group-name
-            aws_client.ec2.authorize_security_group_ingress(
-                GroupName=kwargs["GroupName"],
-                IpPermissions=permissions,
-            )
-        else:
-            # non default, has to use the group-id
-            aws_client.ec2.authorize_security_group_ingress(
-                GroupId=security_group["GroupId"],
-                IpPermissions=permissions,
-            )
+        aws_client.ec2.authorize_security_group_ingress(
+            GroupId=security_group_id,
+            IpPermissions=permissions,
+        )
 
-        ec2_sgs.append(security_group["GroupId"])
+        ec2_sgs.append(security_group_id)
         return security_group
 
     yield factory


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While working on [snapshotted tests](https://github.com/localstack/localstack-ext/pull/4480), I wanted to have the possibility to pass to `ec2_create_security_group` an IP protocol for the ingress permissions.

I also noticed that this fixture [is also duplicated](https://github.com/localstack/localstack-ext/blob/f6f2977e2d316782b0ab4afa6458e8176af9a840/localstack-pro-core/tests/aws/services/elb/test_elb.py#L106-L145) in the ELB test (I removed it in the linked PR);

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Adding the `ip_protocol` to the fixture's factory function;
- Added docstrings;

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
