### PR TITLE
Add Github Action job to publish test results to coveralls and uploading test results to artifacts

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -91,8 +91,9 @@ jobs:
         - name: Load all test results
           uses: actions/download-artifact@v4
           with:
-            name: test-results-*
+            pattern: test-results-*
             path: target/coverage/
+            merge-multiple: true
 
         - name: Combine coverage results from acceptance tests
           run: |
@@ -112,7 +113,10 @@ jobs:
             mv .coverage ../../
 
         - name: Report coverage statistics
+          env:
+            COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           run: |
+            source .venv/bin/activate
             coverage report || true
             coverage html || true
             coveralls || true

--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -68,8 +68,50 @@ jobs:
       DOCKERHUB_PULL_USERNAME: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
       DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
+  report:
+    name: "Publish test results"
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+            python-version-file: '.python-version'
+            cache: 'pip'
+            cache-dependency-path: 'requirements-dev.txt'
+
+        - name: Install Community Dependencies
+          shell: bash
+          run: make install-dev
+
+        - name: Combine coverage results from acceptance tests
+          run: |
+            source .venv/bin/activate
+            mkdir target/coverage/acceptance
+            cp target/coverage/.coverage.acceptance* target/coverage/acceptance
+            cd target/coverage/acceptance
+            coverage combine
+            mv .coverage ../../../.coverage.acceptance
+
+        - name: Combine all coverage results
+          run: |
+            source .venv/bin/activate
+            cd target/coverage
+            ls -la
+            coverage combine
+            mv .coverage ../../
+
+        - name: Report coverage statistics
+          run: |
+            python -m coverage report || true
+            python -m coverage html || true
+            coveralls || true
+
+
   push:
-    name: "Push Images"
+    name: "Push images"
     runs-on: ubuntu-latest
     # push image on master, target branch not set, and the dependent steps were either successful or skipped
     # TO-DO: enable job after workflow in CircleCI is disabled

--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -71,6 +71,8 @@ jobs:
   report:
     name: "Publish test results"
     runs-on: ubuntu-latest
+    needs:
+      - test
     steps:
         - name: Checkout
           uses: actions/checkout@v4
@@ -105,10 +107,51 @@ jobs:
 
         - name: Report coverage statistics
           run: |
-            python -m coverage report || true
-            python -m coverage html || true
+            coverage report || true
+            coverage html || true
             coveralls || true
 
+        - name: Create Coverage Diff (Code Coverage)
+          # pycobertura diff will return with exit code 0-3 -> we currently expect 2 (2: the changes worsened the overall coverage),
+          # but we still want cirecleci to continue with the tasks, so we return 0.
+          # From the docs:
+          # Upon exit, the diff command may return various exit codes:
+          #    0: all changes are covered, no new uncovered statements have been introduced
+          #    1: some exception occurred (likely due to inappropriate usage or a bug in pycobertura)
+          #    2: the changes worsened the overall coverage
+          #    3: the changes introduced uncovered statements but the overall coverage is still better than before
+          run: |
+            source .venv/bin/activate
+            pip install pycobertura
+            coverage xml --data-file=.coverage -o all.coverage.report.xml --include="localstack-core/localstack/services/*/**" --omit="*/**/__init__.py"
+            coverage xml --data-file=.coverage.acceptance -o acceptance.coverage.report.xml --include="localstack-core/localstack/services/*/**"  --omit="*/**/__init__.py"
+            pycobertura show --format html acceptance.coverage.report.xml -o coverage-acceptance.html
+            bash -c "pycobertura diff --format html all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html; if [[ \$? -eq 1 ]] ; then exit 1 ; else exit 0 ; fi"
+
+        - name: Create Metric Coverage Diff (API Coverage)
+          env:
+            COVERAGE_DIR_ALL: "parity_metrics"
+            COVERAGE_DIR_ACCEPTANCE: "acceptance_parity_metrics"
+            OUTPUT_DIR: "api-coverage"
+          run: |
+            source .venv/bin/activate
+            mkdir $OUTPUT_DIR
+            python -m scripts.metrics_coverage.diff_metrics_coverage
+
+        - name: Archive test artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: coverage-and-parity-metrics
+            path: |
+              .coverage
+              api-coverage/
+              coverage-acceptance.html
+              coverage-diff.html
+              parity_metrics/
+              acceptance_parity_metrics/
+              scripts/implementation_coverage_aggregated.csv
+              scripts/implementation_coverage_full.csv
+            retention-days: 7
 
   push:
     name: "Push images"

--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -88,6 +88,12 @@ jobs:
           shell: bash
           run: make install-dev
 
+        - name: Load all test results
+          uses: actions/download-artifact@v4
+          with:
+            name: test-results-*
+            path: target/coverage/
+
         - name: Combine coverage results from acceptance tests
           run: |
             source .venv/bin/activate
@@ -138,7 +144,7 @@ jobs:
             mkdir $OUTPUT_DIR
             python -m scripts.metrics_coverage.diff_metrics_coverage
 
-        - name: Archive test artifacts
+        - name: Archive coverage and parity metrics
           uses: actions/upload-artifact@v4
           with:
             name: coverage-and-parity-metrics

--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -69,7 +69,7 @@ jobs:
       DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
   report:
-    name: "Publish test results"
+    name: "Publish coverage and parity metrics"
     runs-on: ubuntu-latest
     needs:
       - test

--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -119,7 +119,8 @@ jobs:
             source .venv/bin/activate
             coverage report || true
             coverage html || true
-            coveralls || true
+# TO-DO: enable job after workflow in CircleCI is disabled
+#            coveralls || true
 
         - name: Create Coverage Diff (Code Coverage)
           # pycobertura diff will return with exit code 0-3 -> we currently expect 2 (2: the changes worsened the overall coverage),


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR is part of initiative to migrate from CircleCI to GithubActions. This job combines coverage data, pushes them to coveralls, generates coverage diff and uploads it to artifacts

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Combine and upload coverage results 
- Push coverage results to coveralls
- Create coverage diff and upload to artifacts

## Testing

- Tested this workflow with artifacts from another passed workflow here: https://github.com/k-a-il/localstack/actions/runs/14993589117
- Upload to coveralls from testing repository: https://coveralls.io/jobs/164913085
- Full run workflow with report job (in progress): https://github.com/k-a-il/localstack/actions/runs/14993888745

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
