### PR TITLE
Added pagination and filtering for s3 list buckets operation

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -617,10 +617,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             buckets.append(output_bucket)
             count += 1
 
-        # Weird behavior of AWS that we need to reproduce to keep parity
-        if len(buckets) == 0 and not prefix:
-            del owner["DisplayName"]
-
         return ListBucketsOutput(
             Owner=owner, Buckets=buckets, Prefix=prefix, ContinuationToken=next_continuation_token
         )

--- a/tests/aws/services/s3/test_s3_list_operations.snapshot.json
+++ b/tests/aws/services/s3/test_s3_list_operations.snapshot.json
@@ -3087,7 +3087,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListBuckets::test_list_buckets_with_max_buckets": {
-    "recorded-date": "13-05-2025, 17:26:52",
+    "recorded-date": "14-05-2025, 09:10:49",
     "recorded-content": {
       "list-objects-with-max-buckets": {
         "Buckets": [
@@ -3110,7 +3110,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListBuckets::test_list_buckets_with_continuation_token": {
-    "recorded-date": "13-05-2025, 17:27:02",
+    "recorded-date": "14-05-2025, 09:10:59",
     "recorded-content": {
       "list-objects-with-continuation": {
         "Buckets": [
@@ -3133,7 +3133,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListBuckets::test_list_buckets_when_continuation_token_is_empty": {
-    "recorded-date": "13-05-2025, 17:26:55",
+    "recorded-date": "14-05-2025, 09:10:50",
     "recorded-content": {
       "list-objects-with-empty-continuation-token": {
         "Buckets": [
@@ -3156,7 +3156,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListBuckets::test_list_buckets_by_prefix_with_case_sensitivity": {
-    "recorded-date": "13-05-2025, 17:26:49",
+    "recorded-date": "14-05-2025, 09:10:46",
     "recorded-content": {
       "list-objects-by-prefix-empty": {
         "Buckets": [],
@@ -3191,13 +3191,14 @@
     }
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListBuckets::test_list_buckets_by_bucket_region": {
-    "recorded-date": "13-05-2025, 17:26:59",
+    "recorded-date": "14-05-2025, 09:10:54",
     "recorded-content": {
       "list-objects-by-bucket-region-empty": {
         "Buckets": [],
         "Owner": {
           "ID": "<owner-id>"
         },
+        "Prefix": "<bucket-name:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3215,6 +3216,7 @@
           "DisplayName": "<display-name>",
           "ID": "<owner-id>"
         },
+        "Prefix": "<bucket-name:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/s3/test_s3_list_operations.validation.json
+++ b/tests/aws/services/s3/test_s3_list_operations.validation.json
@@ -1,18 +1,18 @@
 {
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListBuckets::test_list_buckets_by_bucket_region": {
-    "last_validated_date": "2025-05-13T17:26:59+00:00"
+    "last_validated_date": "2025-05-14T09:11:19+00:00"
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListBuckets::test_list_buckets_by_prefix_with_case_sensitivity": {
-    "last_validated_date": "2025-05-13T17:27:56+00:00"
+    "last_validated_date": "2025-05-14T09:11:11+00:00"
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListBuckets::test_list_buckets_when_continuation_token_is_empty": {
-    "last_validated_date": "2025-05-13T17:28:00+00:00"
+    "last_validated_date": "2025-05-14T09:11:17+00:00"
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListBuckets::test_list_buckets_with_continuation_token": {
-    "last_validated_date": "2025-05-13T17:27:32+00:00"
+    "last_validated_date": "2025-05-14T09:11:24+00:00"
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListBuckets::test_list_buckets_with_max_buckets": {
-    "last_validated_date": "2025-05-13T17:27:59+00:00"
+    "last_validated_date": "2025-05-14T09:11:14+00:00"
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListMultipartUploads::test_list_multipart_uploads_marker_common_prefixes": {
     "last_validated_date": "2025-01-21T18:15:14+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Right now, the list buckets operation is ignoring the `Prefix`, `MaxBuckets`, `BucketRegion` and `ContinuationToken` which results in the operation always returning all buckets.

Closes #12585

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Process correctly `Prefix`, `MaxBuckets`, `BucketRegion` and `ContinuationToken` to filter and paginate accordingly.
- Added integration tests + parity validations for these scenarios

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
