### PR TITLE
DDB Global Tables: add failing test to expose the missing stream on replicas

### DIFF
--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -14,7 +14,11 @@ from botocore.exceptions import ClientError
 from localstack_snapshot.snapshots.transformer import SortingTransformer
 
 from localstack import config
-from localstack.aws.api.dynamodb import PointInTimeRecoverySpecification
+from localstack.aws.api.dynamodb import (
+    PointInTimeRecoverySpecification,
+    StreamSpecification,
+    StreamViewType,
+)
 from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
 from localstack.testing.aws.lambda_utils import _await_dynamodb_table_active
@@ -1130,6 +1134,58 @@ class TestDynamoDB:
         )
         response = dynamodb_ap_south_1.describe_table(TableName=table_name)
         assert "Replicas" not in response["Table"]
+
+    @markers.aws.validated
+    @pytest.mark.skipif(
+        condition=not is_aws_cloud(), reason="Streams do not work on the regional replica"
+    )
+    def test_streams_on_global_tables(
+        self, aws_client_factory, dynamodb_wait_for_table_active, cleanups, snapshot
+    ):
+        us_east_factory = aws_client_factory(region_name="us-east-1")
+        eu_central_factory = aws_client_factory(region_name="eu-central-1")
+        snapshot.add_transformer(snapshot.transform.regex("eu-central-1", "<region-2>"))
+        snapshot.add_transformer(
+            snapshot.transform.jsonpath("$..Streams..StreamLabel", "stream-label")
+        )
+
+        # Create table in US_EAST_1
+        table_name = f"table-{short_uid()}"
+        snapshot.add_transformer(snapshot.transform.regex(table_name, "<table-name>"))
+        us_east_factory.dynamodb.create_table(
+            TableName=table_name,
+            KeySchema=[
+                {"AttributeName": "Artist", "KeyType": "HASH"},
+                {"AttributeName": "SongTitle", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "Artist", "AttributeType": "S"},
+                {"AttributeName": "SongTitle", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+            StreamSpecification=StreamSpecification(
+                StreamEnabled=True, StreamViewType=StreamViewType.NEW_AND_OLD_IMAGES
+            ),
+        )
+        cleanups.append(lambda: us_east_factory.dynamodb.delete_table(TableName=table_name))
+        # Note: we might be unable to delete tables that act as source region immediately on AWS
+        waiter = us_east_factory.dynamodb.get_waiter("table_exists")
+        waiter.wait(TableName=table_name, WaiterConfig={"Delay": 5, "MaxAttempts": 20})
+        # Update the Table by adding a replica
+        us_east_factory.dynamodb.update_table(
+            TableName=table_name,
+            ReplicaUpdates=[{"Create": {"RegionName": "eu-central-1"}}],
+        )
+        cleanups.append(lambda: eu_central_factory.dynamodb.delete_table(TableName=table_name))
+        waiter = eu_central_factory.dynamodb.get_waiter("table_exists")
+        waiter.wait(TableName=table_name, WaiterConfig={"Delay": 5, "MaxAttempts": 20})
+        dynamodb_wait_for_table_active(table_name=table_name, client=eu_central_factory.dynamodb)
+
+        us_streams = us_east_factory.dynamodbstreams.list_streams(TableName=table_name)
+        snapshot.match("us-streams", us_streams)
+        # FIXME: LS doesn't have a stream on the replica region
+        eu_streams = eu_central_factory.dynamodbstreams.list_streams(TableName=table_name)
+        snapshot.match("eu-streams", eu_streams)
 
     @markers.aws.only_localstack
     def test_global_tables(self, aws_client, ddb_test_table):

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -38,6 +38,8 @@ TEST_DDB_TAGS = [
     {"Key": "TestKey", "Value": "true"},
 ]
 
+WAIT_SEC = 10 if is_aws_cloud() else 1
+
 
 @pytest.fixture(autouse=True)
 def dynamodb_snapshot_transformer(snapshot):
@@ -1170,7 +1172,7 @@ class TestDynamoDB:
         cleanups.append(lambda: us_east_factory.dynamodb.delete_table(TableName=table_name))
         # Note: we might be unable to delete tables that act as source region immediately on AWS
         waiter = us_east_factory.dynamodb.get_waiter("table_exists")
-        waiter.wait(TableName=table_name, WaiterConfig={"Delay": 5, "MaxAttempts": 20})
+        waiter.wait(TableName=table_name, WaiterConfig={"Delay": WAIT_SEC, "MaxAttempts": 20})
         # Update the Table by adding a replica
         us_east_factory.dynamodb.update_table(
             TableName=table_name,
@@ -1178,8 +1180,7 @@ class TestDynamoDB:
         )
         cleanups.append(lambda: eu_central_factory.dynamodb.delete_table(TableName=table_name))
         waiter = eu_central_factory.dynamodb.get_waiter("table_exists")
-        waiter.wait(TableName=table_name, WaiterConfig={"Delay": 5, "MaxAttempts": 20})
-        dynamodb_wait_for_table_active(table_name=table_name, client=eu_central_factory.dynamodb)
+        waiter.wait(TableName=table_name, WaiterConfig={"Delay": WAIT_SEC, "MaxAttempts": 20})
 
         us_streams = us_east_factory.dynamodbstreams.list_streams(TableName=table_name)
         snapshot.match("us-streams", us_streams)

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -1142,19 +1142,30 @@ class TestDynamoDB:
         condition=not is_aws_cloud(), reason="Streams do not work on the regional replica"
     )
     def test_streams_on_global_tables(
-        self, aws_client_factory, dynamodb_wait_for_table_active, cleanups, snapshot
+        self,
+        aws_client_factory,
+        dynamodb_wait_for_table_active,
+        cleanups,
+        snapshot,
+        region_name,
+        secondary_region_name,
     ):
-        us_east_factory = aws_client_factory(region_name="us-east-1")
-        eu_central_factory = aws_client_factory(region_name="eu-central-1")
-        snapshot.add_transformer(snapshot.transform.regex("eu-central-1", "<region-2>"))
+        """
+        This test exposes an issue in LocalStack with Global tables and streams. In AWS, each regional replica should
+        get a separate DynamoDB Stream. This does not happen in LocalStack since DynamoDB Stream does not have any
+        redirect logic towards the original region (unlike DDB).
+        """
+        region_1_factory = aws_client_factory(region_name=region_name)
+        region_2_factory = aws_client_factory(region_name=secondary_region_name)
+        snapshot.add_transformer(snapshot.transform.regex(secondary_region_name, "<region-2>"))
         snapshot.add_transformer(
             snapshot.transform.jsonpath("$..Streams..StreamLabel", "stream-label")
         )
 
-        # Create table in US_EAST_1
+        # Create table in the original region
         table_name = f"table-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.regex(table_name, "<table-name>"))
-        us_east_factory.dynamodb.create_table(
+        region_1_factory.dynamodb.create_table(
             TableName=table_name,
             KeySchema=[
                 {"AttributeName": "Artist", "KeyType": "HASH"},
@@ -1169,24 +1180,24 @@ class TestDynamoDB:
                 StreamEnabled=True, StreamViewType=StreamViewType.NEW_AND_OLD_IMAGES
             ),
         )
-        cleanups.append(lambda: us_east_factory.dynamodb.delete_table(TableName=table_name))
+        cleanups.append(lambda: region_1_factory.dynamodb.delete_table(TableName=table_name))
         # Note: we might be unable to delete tables that act as source region immediately on AWS
-        waiter = us_east_factory.dynamodb.get_waiter("table_exists")
+        waiter = region_1_factory.dynamodb.get_waiter("table_exists")
         waiter.wait(TableName=table_name, WaiterConfig={"Delay": WAIT_SEC, "MaxAttempts": 20})
         # Update the Table by adding a replica
-        us_east_factory.dynamodb.update_table(
+        region_1_factory.dynamodb.update_table(
             TableName=table_name,
-            ReplicaUpdates=[{"Create": {"RegionName": "eu-central-1"}}],
+            ReplicaUpdates=[{"Create": {"RegionName": secondary_region_name}}],
         )
-        cleanups.append(lambda: eu_central_factory.dynamodb.delete_table(TableName=table_name))
-        waiter = eu_central_factory.dynamodb.get_waiter("table_exists")
+        cleanups.append(lambda: region_2_factory.dynamodb.delete_table(TableName=table_name))
+        waiter = region_2_factory.dynamodb.get_waiter("table_exists")
         waiter.wait(TableName=table_name, WaiterConfig={"Delay": WAIT_SEC, "MaxAttempts": 20})
 
-        us_streams = us_east_factory.dynamodbstreams.list_streams(TableName=table_name)
-        snapshot.match("us-streams", us_streams)
+        us_streams = region_1_factory.dynamodbstreams.list_streams(TableName=table_name)
+        snapshot.match("region-streams", us_streams)
         # FIXME: LS doesn't have a stream on the replica region
-        eu_streams = eu_central_factory.dynamodbstreams.list_streams(TableName=table_name)
-        snapshot.match("eu-streams", eu_streams)
+        eu_streams = region_2_factory.dynamodbstreams.list_streams(TableName=table_name)
+        snapshot.match("secondary-region-streams", eu_streams)
 
     @markers.aws.only_localstack
     def test_global_tables(self, aws_client, ddb_test_table):

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1729,37 +1729,6 @@
       }
     }
   },
-  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_stream_on_global_table": {
-    "recorded-date": "14-05-2025, 15:16:41",
-    "recorded-content": {
-      "us-streams": {
-        "Streams": [
-          {
-            "StreamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/table-c862ab47/stream/2025-05-14T15:16:14.104",
-            "StreamLabel": "2025-05-14T15:16:14.104",
-            "TableName": "table-c862ab47"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "eu-streams": {
-        "Streams": [
-          {
-            "StreamArn": "arn:<partition>:dynamodb:eu-central-1:111111111111:table/table-c862ab47/stream/2025-05-14T15:16:28.677",
-            "StreamLabel": "2025-05-14T15:16:28.677",
-            "TableName": "table-c862ab47"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_streams_on_global_tables": {
     "recorded-date": "15-05-2025, 09:45:31",
     "recorded-content": {

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1730,7 +1730,7 @@
     }
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_streams_on_global_tables": {
-    "recorded-date": "15-05-2025, 09:45:31",
+    "recorded-date": "15-05-2025, 10:02:29",
     "recorded-content": {
       "us-streams": {
         "Streams": [

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1730,9 +1730,9 @@
     }
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_streams_on_global_tables": {
-    "recorded-date": "15-05-2025, 10:02:29",
+    "recorded-date": "15-05-2025, 13:42:48",
     "recorded-content": {
-      "us-streams": {
+      "region-streams": {
         "Streams": [
           {
             "StreamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table-name>/stream/<stream-label:1>",
@@ -1745,7 +1745,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "eu-streams": {
+      "secondary-region-streams": {
         "Streams": [
           {
             "StreamArn": "arn:<partition>:dynamodb:<region-2>:111111111111:table/<table-name>/stream/<stream-label:2>",

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1728,5 +1728,67 @@
         }
       }
     }
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_stream_on_global_table": {
+    "recorded-date": "14-05-2025, 15:16:41",
+    "recorded-content": {
+      "us-streams": {
+        "Streams": [
+          {
+            "StreamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/table-c862ab47/stream/2025-05-14T15:16:14.104",
+            "StreamLabel": "2025-05-14T15:16:14.104",
+            "TableName": "table-c862ab47"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "eu-streams": {
+        "Streams": [
+          {
+            "StreamArn": "arn:<partition>:dynamodb:eu-central-1:111111111111:table/table-c862ab47/stream/2025-05-14T15:16:28.677",
+            "StreamLabel": "2025-05-14T15:16:28.677",
+            "TableName": "table-c862ab47"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_streams_on_global_tables": {
+    "recorded-date": "15-05-2025, 09:45:31",
+    "recorded-content": {
+      "us-streams": {
+        "Streams": [
+          {
+            "StreamArn": "arn:<partition>:dynamodb:<region>:111111111111:table/<table-name>/stream/<stream-label:1>",
+            "StreamLabel": "<stream-label:1>",
+            "TableName": "<table-name>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "eu-streams": {
+        "Streams": [
+          {
+            "StreamArn": "arn:<partition>:dynamodb:<region-2>:111111111111:table/<table-name>/stream/<stream-label:2>",
+            "StreamLabel": "<stream-label:2>",
+            "TableName": "<table-name>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -75,7 +75,7 @@
     "last_validated_date": "2024-01-03T17:52:19+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_streams_on_global_tables": {
-    "last_validated_date": "2025-05-15T09:45:30+00:00"
+    "last_validated_date": "2025-05-15T10:02:28+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_transact_get_items": {
     "last_validated_date": "2023-08-23T14:33:37+00:00"

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -74,6 +74,12 @@
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_return_values_on_conditions_check_failure": {
     "last_validated_date": "2024-01-03T17:52:19+00:00"
   },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_stream_on_global_table": {
+    "last_validated_date": "2025-05-14T15:16:40+00:00"
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_streams_on_global_tables": {
+    "last_validated_date": "2025-05-15T09:45:30+00:00"
+  },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_transact_get_items": {
     "last_validated_date": "2023-08-23T14:33:37+00:00"
   },

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -75,7 +75,7 @@
     "last_validated_date": "2024-01-03T17:52:19+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_streams_on_global_tables": {
-    "last_validated_date": "2025-05-15T10:02:28+00:00"
+    "last_validated_date": "2025-05-15T13:42:45+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_transact_get_items": {
     "last_validated_date": "2023-08-23T14:33:37+00:00"

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -74,9 +74,6 @@
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_return_values_on_conditions_check_failure": {
     "last_validated_date": "2024-01-03T17:52:19+00:00"
   },
-  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_stream_on_global_table": {
-    "last_validated_date": "2025-05-14T15:16:40+00:00"
-  },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_streams_on_global_tables": {
     "last_validated_date": "2025-05-15T09:45:30+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Global tables in DynamoDB get a separate DynamoDB Stream, one for each regional replica of the table.
In LocalStack, we implement global tables by redirecting the DDB calls to the original region. A similar approach is not extended to the associated streams. Therefore, we don't have such streams associated with the regional replicas.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Adding a (failing, therefore skipped) validated test that exposes the issue.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
