### PR TITLE
S3: fix IfMatch/IfNoneMatch in pre-signed URLs

### DIFF
--- a/localstack-core/localstack/services/s3/presigned_url.py
+++ b/localstack-core/localstack/services/s3/presigned_url.py
@@ -70,6 +70,14 @@ SIGNATURE_V4_POST_FIELDS = [
     "x-amz-date",
 ]
 
+# Boto3 has some issues with some headers that it disregards and does not validate or adds to the signature
+# we need to manually define them
+# see https://github.com/boto/boto3/issues/4367
+SIGNATURE_V4_BOTO_IGNORED_PARAMS = [
+    "if-none-match",
+    "if-match",
+]
+
 # headers to blacklist from request_dict.signed_headers
 BLACKLISTED_HEADERS = ["X-Amz-Security-Token"]
 
@@ -645,7 +653,10 @@ class S3SigV4SignatureContext:
             qs_param_low = qs_parameter.lower()
             if (
                 qs_parameter not in SIGNATURE_V4_PARAMS
-                and qs_param_low.startswith("x-amz-")
+                and (
+                    qs_param_low.startswith("x-amz-")
+                    or qs_param_low in SIGNATURE_V4_BOTO_IGNORED_PARAMS
+                )
                 and qs_param_low not in headers
             ):
                 if qs_param_low in signed_headers:

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -788,6 +788,12 @@
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_pre_signed_url_forward_slash_bucket": {
     "last_validated_date": "2025-01-21T18:25:38+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_pre_signed_url_if_match": {
+    "last_validated_date": "2025-05-15T13:08:44+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_pre_signed_url_if_none_match": {
+    "last_validated_date": "2025-05-15T12:51:09+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presign_with_additional_query_params": {
     "last_validated_date": "2025-01-21T18:22:43+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've got a report in our Community Slack that we were not enforcing the `IfNoneMatch` parameter with pre-signed URLs. After a quick investigation, it showed that boto3 was disregarding those parameters during the signing process, leading to us ignoring them and not passing them down to our parser; thus them not being enforced. 

This issue shows that Boto3 is not even passing those to the query string parameters of the pre-signed URL: https://github.com/boto/boto3/issues/4367

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a new field in the pre-signed URL code to manually pick those values from the query string to pass it back to the headers, for them to be enforced
- add a test directly using `botocore` because as reported in the boto GH issue, using botocore allows you to properly create a pre-signed URL with the `If-None-Match` header in the query string

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
