### PR TITLE
Restrict tinybird reporting to master branch only

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -37,11 +37,11 @@ on:
         type: choice
         description: Loglevel for PyTest
         options:
-        - DEBUG
-        - INFO
-        - WARNING
-        - ERROR
-        - CRITICAL
+          - DEBUG
+          - INFO
+          - WARNING
+          - ERROR
+          - CRITICAL
         default: WARNING
 
 env:
@@ -172,7 +172,7 @@ jobs:
     # push image on master, target branch not set, and the dependent steps were either successful or skipped
     # TO-DO: enable job after workflow in CircleCI is disabled
     if: false
-#    if: github.ref == 'refs/heads/master' && !failure() && !cancelled()
+    #    if: github.ref == 'refs/heads/master' && !failure() && !cancelled()
     needs:
       # all tests need to be successful for the image to be pushed
       - test
@@ -252,7 +252,7 @@ jobs:
 
   push-to-tinybird:
     name: Push Workflow Status to Tinybird
-    if: always() # && github.ref == 'refs/heads/master'
+    if: always() && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs:
       - test

--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -121,9 +121,8 @@ env:
   CI_COMMIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
-  # report to tinybird if executed on master on ext AND community (targetRef not set) AND additional environment variables/pytest args are not set.
-  # TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
-  TINYBIRD_PYTEST_ARGS: '--report-to-tinybird '
+  # report to tinybird if executed on master
+  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
 
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

To not swarm the tinybird workspace with branch executions, we restrict the tinybird reporting to `master` only. 

I messed up by not re-activating it before merging in #12610 - sorry 😅 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Re-add guard for sending data to tinybird only on master

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
