### PR TITLE
Apigw/add support for response override in request

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -8,7 +8,7 @@ from werkzeug.datastructures import Headers
 from localstack.aws.api.apigateway import Integration, Method, Resource
 from localstack.services.apigateway.models import RestApiDeployment
 
-from .variables import ContextVariables, LoggingContextVariables
+from .variables import ContextVariableOverrides, ContextVariables, LoggingContextVariables
 
 
 class InvocationRequest(TypedDict, total=False):
@@ -98,6 +98,9 @@ class RestApiInvocationContext(RequestContext):
     """The Stage variables, also used in parameters mapping and mapping templates"""
     context_variables: Optional[ContextVariables]
     """The $context used in data models, authorizers, mapping templates, and CloudWatch access logging"""
+    context_variable_overrides: Optional[ContextVariableOverrides]
+    """requestOverrides and responseOverrides are passed from request templates to response templates but are
+    not in the integration context"""
     logging_context_variables: Optional[LoggingContextVariables]
     """Additional $context variables available only for access logging, not yet implemented"""
     invocation_request: Optional[InvocationRequest]

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -132,3 +132,4 @@ class RestApiInvocationContext(RequestContext):
         self.endpoint_response = None
         self.invocation_response = None
         self.trace_id = None
+        self.context_variable_overrides = None

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -125,10 +125,14 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
             # mutate the ContextVariables with the requestOverride result, as we copy the context when rendering the
             # template to avoid mutation on other fields
             # the VTL responseTemplate can access the requestOverride
-            request_override: ContextVarsRequestOverride = context_variables["requestOverride"]
+            request_override: ContextVarsRequestOverride = context_variables.get(
+                "requestOverride", {}
+            )
             context.context_variables["requestOverride"] = request_override
             # Response override attributes set in the request template will be available in the response template
-            context.context_variables["responseOverride"] = context_variables["responseOverride"]
+            context.context_variables["responseOverride"] = context_variables.get(
+                "responseOverride", {}
+            )
             # TODO: log every override that happens afterwards (in a loop on `request_override`)
             merge_recursive(request_override, request_data_mapping, overwrite=True)
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_request.py
@@ -22,7 +22,7 @@ from ..template_mapping import (
     MappingTemplateParams,
     MappingTemplateVariables,
 )
-from ..variables import ContextVariables, ContextVarsRequestOverride
+from ..variables import ContextVariableOverrides, ContextVarsRequestOverride
 
 LOG = logging.getLogger(__name__)
 
@@ -119,19 +119,15 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
 
             converted_body = self.convert_body(context)
 
-            body, mapped_context_variables = self.render_request_template_mapping(
+            body, mapped_overrides = self.render_request_template_mapping(
                 context=context, body=converted_body, template=request_template
             )
+            # Update the context with the returned mapped overrides
+            context.context_variable_overrides = mapped_overrides
             # mutate the ContextVariables with the requestOverride result, as we copy the context when rendering the
             # template to avoid mutation on other fields
-            # the VTL responseTemplate can access the requestOverride
-            request_override: ContextVarsRequestOverride = mapped_context_variables.get(
+            request_override: ContextVarsRequestOverride = mapped_overrides.get(
                 "requestOverride", {}
-            )
-            context.context_variables["requestOverride"] = request_override
-            # Response override attributes set in the request template will be available in the response template
-            context.context_variables["responseOverride"] = mapped_context_variables.get(
-                "responseOverride", {}
             )
             # TODO: log every override that happens afterwards (in a loop on `request_override`)
             merge_recursive(request_override, request_data_mapping, overwrite=True)
@@ -187,18 +183,18 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
         context: RestApiInvocationContext,
         body: str | bytes,
         template: str,
-    ) -> tuple[bytes, ContextVariables]:
+    ) -> tuple[bytes, ContextVariableOverrides]:
         request: InvocationRequest = context.invocation_request
 
         if not template:
-            return to_bytes(body), context.context_variables
+            return to_bytes(body), context.context_variable_overrides
 
         try:
             body_utf8 = to_str(body)
         except UnicodeError:
             raise InternalServerError("Internal server error")
 
-        body, mapped_context_variables = self._vtl_template.render_request(
+        body, mapped_overrides = self._vtl_template.render_request(
             template=template,
             variables=MappingTemplateVariables(
                 context=context.context_variables,
@@ -212,8 +208,9 @@ class IntegrationRequestHandler(RestApiGatewayHandler):
                     ),
                 ),
             ),
+            context_overrides=context.context_variable_overrides,
         )
-        return to_bytes(body), mapped_context_variables
+        return to_bytes(body), mapped_overrides
 
     @staticmethod
     def get_request_template(integration: Integration, request: InvocationRequest) -> str:

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
@@ -263,7 +263,7 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
         self, context: RestApiInvocationContext, template: str, body: bytes | str
     ) -> tuple[bytes, ContextVarsResponseOverride]:
         if not template:
-            return to_bytes(body), ContextVarsResponseOverride(status=0, header={})
+            return to_bytes(body), context.context_variables["responseOverride"]
 
         # if there are no template, we can pass binary data through
         if not isinstance(body, str):

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/integration_response.py
@@ -263,7 +263,7 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
         self, context: RestApiInvocationContext, template: str, body: bytes | str
     ) -> tuple[bytes, ContextVarsResponseOverride]:
         if not template:
-            return to_bytes(body), context.context_variables["responseOverride"]
+            return to_bytes(body), context.context_variable_overrides["responseOverride"]
 
         # if there are no template, we can pass binary data through
         if not isinstance(body, str):
@@ -284,6 +284,7 @@ class IntegrationResponseHandler(RestApiGatewayHandler):
                     ),
                 ),
             ),
+            context_overrides=context.context_variable_overrides,
         )
 
         # AWS ignores the status if the override isn't an integer between 100 and 599

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -19,6 +19,7 @@ from ..header_utils import should_drop_header_from_invocation
 from ..helpers import generate_trace_id, generate_trace_parent, parse_trace_id
 from ..moto_helpers import get_stage_variables
 from ..variables import (
+    ContextVariableOverrides,
     ContextVariables,
     ContextVarsIdentity,
     ContextVarsRequestOverride,
@@ -45,6 +46,10 @@ class InvocationRequestParser(RestApiGatewayHandler):
         # then we can create the ContextVariables, used throughout the invocation as payload and to render authorizer
         # payload, mapping templates and such.
         context.context_variables = self.create_context_variables(context)
+        context.context_variable_overrides = ContextVariableOverrides(
+            requestOverride=ContextVarsRequestOverride(header={}, querystring={}, path={}),
+            responseOverride=ContextVarsResponseOverride(header={}, status=0),
+        )
         # TODO: maybe adjust the logging
         LOG.debug("Initializing $context='%s'", context.context_variables)
         # then populate the stage variables
@@ -164,10 +169,8 @@ class InvocationRequestParser(RestApiGatewayHandler):
             path=f"/{context.stage}{invocation_request['raw_path']}",
             protocol="HTTP/1.1",
             requestId=long_uid(),
-            requestOverride=ContextVarsRequestOverride(querystring={}, header={}, path={}),
             requestTime=timestamp(time=now, format=REQUEST_TIME_DATE_FORMAT),
             requestTimeEpoch=int(now.timestamp() * 1000),
-            responseOverride=ContextVarsResponseOverride(header={}, status=0),
             stage=context.stage,
         )
         return context_variables

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -18,7 +18,12 @@ from ..context import InvocationRequest, RestApiInvocationContext
 from ..header_utils import should_drop_header_from_invocation
 from ..helpers import generate_trace_id, generate_trace_parent, parse_trace_id
 from ..moto_helpers import get_stage_variables
-from ..variables import ContextVariables, ContextVarsIdentity
+from ..variables import (
+    ContextVariables,
+    ContextVarsIdentity,
+    ContextVarsRequestOverride,
+    ContextVarsResponseOverride,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -159,8 +164,10 @@ class InvocationRequestParser(RestApiGatewayHandler):
             path=f"/{context.stage}{invocation_request['raw_path']}",
             protocol="HTTP/1.1",
             requestId=long_uid(),
+            requestOverride=ContextVarsRequestOverride(querystring={}, header={}, path={}),
             requestTime=timestamp(time=now, format=REQUEST_TIME_DATE_FORMAT),
             requestTimeEpoch=int(now.timestamp() * 1000),
+            responseOverride=ContextVarsResponseOverride(header={}, status=0),
             stage=context.stage,
         )
         return context_variables

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -27,7 +27,6 @@ from airspeed.operators import dict_to_string
 from localstack import config
 from localstack.services.apigateway.next_gen.execute_api.variables import (
     ContextVariables,
-    ContextVarsRequestOverride,
     ContextVarsResponseOverride,
 )
 from localstack.utils.aws.templating import APIGW_SOURCE, VelocityUtil, VtlTemplate
@@ -264,12 +263,6 @@ class ApiGatewayVtlTemplate(VtlTemplate):
         self, template: str, variables: MappingTemplateVariables
     ) -> tuple[str, ContextVariables]:
         variables_copy: MappingTemplateVariables = copy.deepcopy(variables)
-        variables_copy["context"]["requestOverride"] = ContextVarsRequestOverride(
-            querystring={}, header={}, path={}
-        )
-        variables_copy["context"]["responseOverride"] = ContextVarsResponseOverride(
-            header={}, status=0
-        )
         result = self.render_vtl(template=template.strip(), variables=variables_copy)
         return result, variables_copy["context"]
 
@@ -277,10 +270,6 @@ class ApiGatewayVtlTemplate(VtlTemplate):
         self, template: str, variables: MappingTemplateVariables
     ) -> tuple[str, ContextVarsResponseOverride]:
         variables_copy: MappingTemplateVariables = copy.deepcopy(variables)
-        if not variables_copy["context"].get("responseOverride"):
-            variables_copy["context"]["responseOverride"] = ContextVarsResponseOverride(
-                header={}, status=0
-            )
         result = self.render_vtl(template=template.strip(), variables=variables_copy)
         return result, variables_copy["context"]["responseOverride"]
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -277,6 +277,10 @@ class ApiGatewayVtlTemplate(VtlTemplate):
         self, template: str, variables: MappingTemplateVariables
     ) -> tuple[str, ContextVarsResponseOverride]:
         variables_copy: MappingTemplateVariables = copy.deepcopy(variables)
+        if not variables_copy["context"].get("responseOverride"):
+            variables_copy["context"]["responseOverride"] = ContextVarsResponseOverride(
+                header={}, status=0
+            )
         result = self.render_vtl(template=template.strip(), variables=variables_copy)
         return result, variables_copy["context"]["responseOverride"]
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -262,21 +262,21 @@ class ApiGatewayVtlTemplate(VtlTemplate):
 
     def render_request(
         self, template: str, variables: MappingTemplateVariables
-    ) -> tuple[str, ContextVarsRequestOverride]:
+    ) -> tuple[str, ContextVariables]:
         variables_copy: MappingTemplateVariables = copy.deepcopy(variables)
         variables_copy["context"]["requestOverride"] = ContextVarsRequestOverride(
             querystring={}, header={}, path={}
         )
+        variables_copy["context"]["responseOverride"] = ContextVarsResponseOverride(
+            header={}, status=0
+        )
         result = self.render_vtl(template=template.strip(), variables=variables_copy)
-        return result, variables_copy["context"]["requestOverride"]
+        return result, variables_copy["context"]
 
     def render_response(
         self, template: str, variables: MappingTemplateVariables
     ) -> tuple[str, ContextVarsResponseOverride]:
         variables_copy: MappingTemplateVariables = copy.deepcopy(variables)
-        variables_copy["context"]["responseOverride"] = ContextVarsResponseOverride(
-            header={}, status=0
-        )
         result = self.render_vtl(template=template.strip(), variables=variables_copy)
         return result, variables_copy["context"]["responseOverride"]
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -26,6 +26,7 @@ from airspeed.operators import dict_to_string
 
 from localstack import config
 from localstack.services.apigateway.next_gen.execute_api.variables import (
+    ContextVariableOverrides,
     ContextVariables,
     ContextVarsResponseOverride,
 )
@@ -260,16 +261,27 @@ class ApiGatewayVtlTemplate(VtlTemplate):
         return namespace
 
     def render_request(
-        self, template: str, variables: MappingTemplateVariables
-    ) -> tuple[str, ContextVariables]:
+        self,
+        template: str,
+        variables: MappingTemplateVariables,
+        context_overrides: ContextVariableOverrides,
+    ) -> tuple[str, ContextVariableOverrides]:
         variables_copy: MappingTemplateVariables = copy.deepcopy(variables)
+        variables_copy["context"].update(copy.deepcopy(context_overrides))
         result = self.render_vtl(template=template.strip(), variables=variables_copy)
-        return result, variables_copy["context"]
+        return result, ContextVariableOverrides(
+            requestOverride=variables_copy["context"]["requestOverride"],
+            responseOverride=variables_copy["context"]["responseOverride"],
+        )
 
     def render_response(
-        self, template: str, variables: MappingTemplateVariables
+        self,
+        template: str,
+        variables: MappingTemplateVariables,
+        context_overrides: ContextVariableOverrides,
     ) -> tuple[str, ContextVarsResponseOverride]:
         variables_copy: MappingTemplateVariables = copy.deepcopy(variables)
+        variables_copy["context"].update(copy.deepcopy(context_overrides))
         result = self.render_vtl(template=template.strip(), variables=variables_copy)
         return result, variables_copy["context"]["responseOverride"]
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
@@ -16,6 +16,11 @@ from .context import InvocationRequest, RestApiInvocationContext
 from .handlers.resource_router import RestAPIResourceRouter
 from .header_utils import build_multi_value_headers
 from .template_mapping import dict_to_string
+from .variables import (
+    ContextVariableOverrides,
+    ContextVarsRequestOverride,
+    ContextVarsResponseOverride,
+)
 
 # TODO: we probably need to write and populate those logs as part of the handler chain itself
 #  and store it in the InvocationContext. That way, we could also retrieve in when calling TestInvoke
@@ -150,8 +155,10 @@ def create_test_invocation_context(
     invocation_context.context_variables = parse_handler.create_context_variables(
         invocation_context
     )
-    invocation_context.trace_id = parse_handler.populate_trace_id({})
-
+    invocation_context.context_variable_overrides = ContextVariableOverrides(
+        requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
+        responseOverride=ContextVarsResponseOverride(header={}, status=0),
+    )
     resource = deployment.rest_api.resources[test_request["resourceId"]]
     resource_method = resource["resourceMethods"][http_method]
     invocation_context.resource = resource

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
@@ -159,6 +159,7 @@ def create_test_invocation_context(
         requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
         responseOverride=ContextVarsResponseOverride(header={}, status=0),
     )
+    invocation_context.trace_id = parse_handler.populate_trace_id({})
     resource = deployment.rest_api.resources[test_request["resourceId"]]
     resource_method = resource["resourceMethods"][http_method]
     invocation_context.resource = resource

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
@@ -75,6 +75,11 @@ class ContextVarsResponseOverride(TypedDict):
     status: int
 
 
+class ContextVariableOverrides(TypedDict):
+    requestOverride: ContextVarsRequestOverride
+    responseOverride: ContextVarsResponseOverride
+
+
 class GatewayResponseContextVarsError(TypedDict, total=False):
     # This variable can only be used for simple variable substitution in a GatewayResponse body-mapping template,
     # which is not processed by the Velocity Template Language engine, and in access logging.

--- a/tests/aws/services/apigateway/test_apigateway_integrations.py
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.py
@@ -725,8 +725,9 @@ def test_integration_mock_with_request_overrides_in_response_template(
 
 
 @markers.aws.validated
+@pytest.mark.parametrize("create_response_template", [True, False])
 def test_integration_mock_with_response_override_in_request_template(
-    create_rest_apigw, aws_client, snapshot
+    create_rest_apigw, aws_client, snapshot, create_response_template
 ):
     expected_status = 444
     api_id, _, root_id = create_rest_apigw(
@@ -780,7 +781,9 @@ def test_integration_mock_with_response_override_in_request_template(
         httpMethod="GET",
         statusCode="200",
         selectionPattern="2\\d{2}",
-        responseTemplates={"application/json": response_template},
+        responseTemplates={"application/json": response_template}
+        if create_response_template
+        else {},
     )
     stage_name = "dev"
     aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
@@ -797,7 +800,7 @@ def test_integration_mock_with_response_override_in_request_template(
     snapshot.match(
         "response",
         {
-            "body": response_data.json(),
+            "body": response_data.json() if create_response_template else response_data.content,
             "status_code": response_data.status_code,
         },
     )

--- a/tests/aws/services/apigateway/test_apigateway_integrations.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.snapshot.json
@@ -1078,5 +1078,18 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_response_override_in_request_template": {
+    "recorded-date": "16-05-2025, 09:46:05",
+    "recorded-content": {
+      "response": {
+        "body": {
+          "custom": "is also passed around",
+          "fooHeader": "bar",
+          "statusOverride": "444"
+        },
+        "status_code": 444
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_integrations.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.snapshot.json
@@ -1079,8 +1079,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_response_override_in_request_template": {
-    "recorded-date": "16-05-2025, 09:46:05",
+  "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_response_override_in_request_template[True]": {
+    "recorded-date": "16-05-2025, 10:22:21",
     "recorded-content": {
       "response": {
         "body": {
@@ -1088,6 +1088,15 @@
           "fooHeader": "bar",
           "statusOverride": "444"
         },
+        "status_code": 444
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_response_override_in_request_template[False]": {
+    "recorded-date": "16-05-2025, 10:22:27",
+    "recorded-content": {
+      "response": {
+        "body": "b''",
         "status_code": 444
       }
     }

--- a/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
@@ -20,8 +20,11 @@
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_request_overrides_in_response_template": {
     "last_validated_date": "2024-11-06T23:09:04+00:00"
   },
-  "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_response_override_in_request_template": {
-    "last_validated_date": "2025-05-16T09:46:05+00:00"
+  "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_response_override_in_request_template[False]": {
+    "last_validated_date": "2025-05-16T10:22:27+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_response_override_in_request_template[True]": {
+    "last_validated_date": "2025-05-16T10:22:21+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_put_integration_response_with_response_template": {
     "last_validated_date": "2024-05-30T16:15:58+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
@@ -20,6 +20,9 @@
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_request_overrides_in_response_template": {
     "last_validated_date": "2024-11-06T23:09:04+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_response_override_in_request_template": {
+    "last_validated_date": "2025-05-16T09:46:05+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_put_integration_response_with_response_template": {
     "last_validated_date": "2024-05-30T16:15:58+00:00"
   },

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -20,6 +20,7 @@ from localstack.services.apigateway.next_gen.execute_api.handlers.integration_re
     PassthroughBehavior,
 )
 from localstack.services.apigateway.next_gen.execute_api.variables import (
+    ContextVariableOverrides,
     ContextVariables,
     ContextVarsRequestOverride,
     ContextVarsResponseOverride,
@@ -82,6 +83,8 @@ def default_context():
         path=f"{TEST_API_STAGE}/resource/{{proxy}}",
         resourcePath="/resource/{proxy}",
         stage=TEST_API_STAGE,
+    )
+    context.context_variable_overrides = ContextVariableOverrides(
         requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
         responseOverride=ContextVarsResponseOverride(header={}, status=0),
     )

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -21,6 +21,8 @@ from localstack.services.apigateway.next_gen.execute_api.handlers.integration_re
 )
 from localstack.services.apigateway.next_gen.execute_api.variables import (
     ContextVariables,
+    ContextVarsRequestOverride,
+    ContextVarsResponseOverride,
 )
 from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 
@@ -80,6 +82,8 @@ def default_context():
         path=f"{TEST_API_STAGE}/resource/{{proxy}}",
         resourcePath="/resource/{proxy}",
         stage=TEST_API_STAGE,
+        requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
+        responseOverride=ContextVarsResponseOverride(header={}, status=0),
     )
 
     return context

--- a/tests/unit/services/apigateway/test_handler_integration_response.py
+++ b/tests/unit/services/apigateway/test_handler_integration_response.py
@@ -16,7 +16,10 @@ from localstack.services.apigateway.next_gen.execute_api.handlers import (
     IntegrationResponseHandler,
     InvocationRequestParser,
 )
-from localstack.services.apigateway.next_gen.execute_api.variables import ContextVariables
+from localstack.services.apigateway.next_gen.execute_api.variables import (
+    ContextVariables,
+    ContextVarsResponseOverride,
+)
 from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 
 TEST_API_ID = "test-api"
@@ -141,7 +144,9 @@ def ctx():
     context.invocation_request = request
 
     context.integration = Integration(type=IntegrationType.HTTP)
-    context.context_variables = ContextVariables()
+    context.context_variables = ContextVariables(
+        responseOverride=ContextVarsResponseOverride(header={}, status=0)
+    )
     context.endpoint_response = EndpointResponse(
         body=b'{"foo":"bar"}',
         status_code=200,

--- a/tests/unit/services/apigateway/test_handler_integration_response.py
+++ b/tests/unit/services/apigateway/test_handler_integration_response.py
@@ -17,7 +17,8 @@ from localstack.services.apigateway.next_gen.execute_api.handlers import (
     InvocationRequestParser,
 )
 from localstack.services.apigateway.next_gen.execute_api.variables import (
-    ContextVariables,
+    ContextVariableOverrides,
+    ContextVarsRequestOverride,
     ContextVarsResponseOverride,
 )
 from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
@@ -144,8 +145,10 @@ def ctx():
     context.invocation_request = request
 
     context.integration = Integration(type=IntegrationType.HTTP)
-    context.context_variables = ContextVariables(
-        responseOverride=ContextVarsResponseOverride(header={}, status=0)
+    context.context_variables = {}
+    context.context_variable_overrides = ContextVariableOverrides(
+        requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
+        responseOverride=ContextVarsResponseOverride(header={}, status=0),
     )
     context.endpoint_response = EndpointResponse(
         body=b'{"foo":"bar"}',

--- a/tests/unit/services/apigateway/test_template_mapping.py
+++ b/tests/unit/services/apigateway/test_template_mapping.py
@@ -122,9 +122,10 @@ class TestApiGatewayVtlTemplate:
         template = TEMPLATE_JSON if format == APPLICATION_JSON else TEMPLATE_XML
         template += REQUEST_OVERRIDE
 
-        rendered_request, request_override = ApiGatewayVtlTemplate().render_request(
+        rendered_request, context_variable = ApiGatewayVtlTemplate().render_request(
             template=template, variables=variables
         )
+        request_override = context_variable["requestOverride"]
         if format == APPLICATION_JSON:
             rendered_request = json.loads(rendered_request)
             assert rendered_request.get("body") == {"spam": "eggs"}

--- a/tests/unit/services/apigateway/test_template_mapping.py
+++ b/tests/unit/services/apigateway/test_template_mapping.py
@@ -13,6 +13,7 @@ from localstack.services.apigateway.next_gen.execute_api.template_mapping import
     VelocityUtilApiGateway,
 )
 from localstack.services.apigateway.next_gen.execute_api.variables import (
+    ContextVariableOverrides,
     ContextVariables,
     ContextVarsAuthorizer,
     ContextVarsIdentity,
@@ -117,16 +118,19 @@ class TestApiGatewayVtlTemplate:
                 authorizer=ContextVarsAuthorizer(principalId="12233"),
                 identity=ContextVarsIdentity(accountId="00000", apiKey="11111"),
                 resourcePath="/{proxy}",
-                requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
             ),
             stageVariables={"stageVariable1": "value1", "stageVariable2": "value2"},
+        )
+        context_overrides = ContextVariableOverrides(
+            requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
+            responseOverride=ContextVarsResponseOverride(header={}, status=0),
         )
 
         template = TEMPLATE_JSON if format == APPLICATION_JSON else TEMPLATE_XML
         template += REQUEST_OVERRIDE
 
         rendered_request, context_variable = ApiGatewayVtlTemplate().render_request(
-            template=template, variables=variables
+            template=template, variables=variables, context_overrides=context_overrides
         )
         request_override = context_variable["requestOverride"]
         if format == APPLICATION_JSON:
@@ -197,16 +201,18 @@ class TestApiGatewayVtlTemplate:
                 authorizer=ContextVarsAuthorizer(principalId="12233"),
                 identity=ContextVarsIdentity(accountId="00000", apiKey="11111"),
                 resourcePath="/{proxy}",
-                responseOverride=ContextVarsResponseOverride(header={}, status=0),
             ),
             stageVariables={"stageVariable1": "value1", "stageVariable2": "value2"},
         )
-
+        context_overrides = ContextVariableOverrides(
+            requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
+            responseOverride=ContextVarsResponseOverride(header={}, status=0),
+        )
         template = TEMPLATE_JSON if format == APPLICATION_JSON else TEMPLATE_XML
         template += RESPONSE_OVERRIDE
 
         rendered_response, response_override = ApiGatewayVtlTemplate().render_response(
-            template=template, variables=variables
+            template=template, variables=variables, context_overrides=context_overrides
         )
         if format == APPLICATION_JSON:
             rendered_response = json.loads(rendered_response)

--- a/tests/unit/services/apigateway/test_template_mapping.py
+++ b/tests/unit/services/apigateway/test_template_mapping.py
@@ -16,6 +16,8 @@ from localstack.services.apigateway.next_gen.execute_api.variables import (
     ContextVariables,
     ContextVarsAuthorizer,
     ContextVarsIdentity,
+    ContextVarsRequestOverride,
+    ContextVarsResponseOverride,
 )
 
 
@@ -115,6 +117,7 @@ class TestApiGatewayVtlTemplate:
                 authorizer=ContextVarsAuthorizer(principalId="12233"),
                 identity=ContextVarsIdentity(accountId="00000", apiKey="11111"),
                 resourcePath="/{proxy}",
+                requestOverride=ContextVarsRequestOverride(header={}, path={}, querystring={}),
             ),
             stageVariables={"stageVariable1": "value1", "stageVariable2": "value2"},
         )
@@ -194,6 +197,7 @@ class TestApiGatewayVtlTemplate:
                 authorizer=ContextVarsAuthorizer(principalId="12233"),
                 identity=ContextVarsIdentity(accountId="00000", apiKey="11111"),
                 resourcePath="/{proxy}",
+                responseOverride=ContextVarsResponseOverride(header={}, status=0),
             ),
             stageVariables={"stageVariable1": "value1", "stageVariable2": "value2"},
         )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This is a partial solve for #12621. 

This pr will allow to use `responseOverride` in a request template and have it's value passed to the context of the response template and possibly affecting the response.

There are 2 issues described by the user. I will work on the VTL template update in a follow up.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Move responsibility of creating the overrides context variable to the parser. Those values are accessible in the context and that will prevent needing to check for their existence everywhere in the code
- Pass the full return of the context variables from the request mapping to properly update the context that is passed down
- Added validated test to confirm the behavior

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
