### PR TITLE
fix: correct recognition of lambda path

### DIFF
--- a/localstack-core/localstack/aws/protocol/service_router.py
+++ b/localstack-core/localstack/aws/protocol/service_router.py
@@ -155,7 +155,7 @@ def custom_path_addressing_rules(path: str) -> Optional[ServiceModelIdentifier]:
     if is_sqs_queue_url(path):
         return ServiceModelIdentifier("sqs", protocol="query")
 
-    if path.startswith("/2015-03-31/functions/"):
+    if path.startswith("/2015-03-31/functions"):
         return ServiceModelIdentifier("lambda")
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The AWS Lambda SDK invokes `/2015-03-31/functions` to create a new Lambda function (see https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html) but the handler previously did not recognise it as a Lambda route due to a trailing slash in the path.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Localstack now recognises `/2015-03-31/functions` as a Lambda endpoint

<!-- Optional section: How to test these changes? -->
<!--
## Testing

Executing a `POST /2015-03-31/functions` against the IP of Localstack with an empty request body does not log "no service set in context, skipping request parsing"

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
