### PR TITLE
Feature: implement list rule names by target

### DIFF
--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2573,5 +2573,133 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target[custom]": {
+    "recorded-date": "16-05-2025, 11:55:27",
+    "recorded-content": {
+      "list_rule_names_by_target": {
+        "RuleNames": [
+          "<rule-prefix>0",
+          "<rule-prefix>1",
+          "<rule-prefix>2"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target[default]": {
+    "recorded-date": "16-05-2025, 11:55:28",
+    "recorded-content": {
+      "list_rule_names_by_target": {
+        "RuleNames": [
+          "<rule-prefix>0",
+          "<rule-prefix>1",
+          "<rule-prefix>2"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_with_limit[custom]": {
+    "recorded-date": "16-05-2025, 20:05:21",
+    "recorded-content": {
+      "first_page": {
+        "NextToken": "<next-token>",
+        "RuleNames": [
+          "<rule-prefix>0",
+          "<rule-prefix>1"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_page": {
+        "NextToken": "<next-token>",
+        "RuleNames": [
+          "<rule-prefix>2",
+          "<rule-prefix>3"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "third_page": {
+        "RuleNames": [
+          "<rule-prefix>4"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_with_limit[default]": {
+    "recorded-date": "16-05-2025, 20:05:22",
+    "recorded-content": {
+      "first_page": {
+        "NextToken": "<next-token>",
+        "RuleNames": [
+          "<rule-prefix>0",
+          "<rule-prefix>1"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_page": {
+        "NextToken": "<next-token>",
+        "RuleNames": [
+          "<rule-prefix>2",
+          "<rule-prefix>3"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "third_page": {
+        "RuleNames": [
+          "<rule-prefix>4"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_no_matches[custom]": {
+    "recorded-date": "16-05-2025, 20:34:26",
+    "recorded-content": {
+      "list_rule_names_by_target_no_matches": {
+        "RuleNames": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_no_matches[default]": {
+    "recorded-date": "16-05-2025, 20:34:27",
+    "recorded-content": {
+      "list_rule_names_by_target_no_matches": {
+        "RuleNames": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -2575,7 +2575,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target[custom]": {
-    "recorded-date": "16-05-2025, 11:55:27",
+    "recorded-date": "19-05-2025, 07:53:33",
     "recorded-content": {
       "list_rule_names_by_target": {
         "RuleNames": [
@@ -2591,7 +2591,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target[default]": {
-    "recorded-date": "16-05-2025, 11:55:28",
+    "recorded-date": "19-05-2025, 07:53:34",
     "recorded-content": {
       "list_rule_names_by_target": {
         "RuleNames": [
@@ -2607,10 +2607,10 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_with_limit[custom]": {
-    "recorded-date": "16-05-2025, 20:05:21",
+    "recorded-date": "19-05-2025, 07:54:06",
     "recorded-content": {
       "first_page": {
-        "NextToken": "<next-token>",
+        "NextToken": "<<next-token>:1>",
         "RuleNames": [
           "<rule-prefix>0",
           "<rule-prefix>1"
@@ -2621,7 +2621,7 @@
         }
       },
       "second_page": {
-        "NextToken": "<next-token>",
+        "NextToken": "<<next-token>:2>",
         "RuleNames": [
           "<rule-prefix>2",
           "<rule-prefix>3"
@@ -2643,10 +2643,10 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_with_limit[default]": {
-    "recorded-date": "16-05-2025, 20:05:22",
+    "recorded-date": "19-05-2025, 07:54:07",
     "recorded-content": {
       "first_page": {
-        "NextToken": "<next-token>",
+        "NextToken": "<<next-token>:1>",
         "RuleNames": [
           "<rule-prefix>0",
           "<rule-prefix>1"
@@ -2657,7 +2657,7 @@
         }
       },
       "second_page": {
-        "NextToken": "<next-token>",
+        "NextToken": "<<next-token>:2>",
         "RuleNames": [
           "<rule-prefix>2",
           "<rule-prefix>3"
@@ -2679,7 +2679,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_no_matches[custom]": {
-    "recorded-date": "16-05-2025, 20:34:26",
+    "recorded-date": "19-05-2025, 07:54:49",
     "recorded-content": {
       "list_rule_names_by_target_no_matches": {
         "RuleNames": [],
@@ -2691,7 +2691,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_no_matches[default]": {
-    "recorded-date": "16-05-2025, 20:34:27",
+    "recorded-date": "19-05-2025, 07:54:50",
     "recorded-content": {
       "list_rule_names_by_target_no_matches": {
         "RuleNames": [],

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -86,6 +86,24 @@
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[default]": {
     "last_validated_date": "2025-01-08T15:28:56+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target[custom]": {
+    "last_validated_date": "2025-05-16T11:55:33+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target[default]": {
+    "last_validated_date": "2025-05-16T11:55:34+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_no_matches[custom]": {
+    "last_validated_date": "2025-05-16T20:34:26+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_no_matches[default]": {
+    "last_validated_date": "2025-05-16T20:34:27+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_with_limit[custom]": {
+    "last_validated_date": "2025-05-16T20:05:36+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_with_limit[default]": {
+    "last_validated_date": "2025-05-16T20:05:37+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_with_limit": {
     "last_validated_date": "2025-01-08T15:28:51+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -87,22 +87,22 @@
     "last_validated_date": "2025-01-08T15:28:56+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target[custom]": {
-    "last_validated_date": "2025-05-16T11:55:33+00:00"
+    "last_validated_date": "2025-05-19T07:53:33+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target[default]": {
-    "last_validated_date": "2025-05-16T11:55:34+00:00"
+    "last_validated_date": "2025-05-19T07:53:34+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_no_matches[custom]": {
-    "last_validated_date": "2025-05-16T20:34:26+00:00"
+    "last_validated_date": "2025-05-19T07:54:49+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_no_matches[default]": {
-    "last_validated_date": "2025-05-16T20:34:27+00:00"
+    "last_validated_date": "2025-05-19T07:54:50+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_with_limit[custom]": {
-    "last_validated_date": "2025-05-16T20:05:36+00:00"
+    "last_validated_date": "2025-05-19T07:54:06+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_names_by_target_with_limit[default]": {
-    "last_validated_date": "2025-05-16T20:05:37+00:00"
+    "last_validated_date": "2025-05-19T07:54:07+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_with_limit": {
     "last_validated_date": "2025-01-08T15:28:51+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
I'm raising this PR to increase LocalStack's coverage of AWS APIs. Currently ListRuleNamesByTarget is not implemented.

It fixes issue #12631 .

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This PR makes it so that instead of returning `NotImplementedError`, LocalStack will start returning the actual list of EventBus rules for a given target.

<!-- Optional section: How to test these changes? -->
## Testing
The changes are covered by snapshot/parity tests.

The happy path can also be tested manually by spinning up LocalStack and following these steps:
```bash
awslocal sqs create-queue --queue-name test-sqs-queue
QUEUE_ARN=$(awslocal sqs get-queue-attributes \
  --queue-url http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/test-sqs-queue \
  --attribute-names QueueArn \
  --query 'Attributes.QueueArn' \
  --output text)
awslocal events create-event-bus --name test-event-bus
awslocal events put-rule \
  --name rule-to-sqs \
  --event-bus-name test-event-bus \
  --event-pattern '{"source": ["test-source"]}'
RULE_ARN=$(aws events describe-rule \
  --name rule-to-sqs \
  --event-bus-name test-event-bus \
  --query 'Arn' \
  --output text)
awslocal events put-targets \
  --rule rule-to-sqs \
  --event-bus-name test-event-bus \
  --targets "Id"="1","Arn"="$QUEUE_ARN"

# Verify that the correct target ARN returns the rule:
awslocal events list-rule-names-by-target --target-arn $QUEUE_ARN --event-bus-name test-event-bus

# Verify that a non-existant target ARN returns an empty rule list:
awslocal events list-rule-names-by-target --target-arn "non-existant-arn" --event-bus-name test-event-bus
```

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
