### PR TITLE
ffmpeg: Update build source to use BtbN GitHub Releases

### DIFF
--- a/localstack-core/localstack/packages/ffmpeg.py
+++ b/localstack-core/localstack/packages/ffmpeg.py
@@ -5,20 +5,22 @@ from localstack.packages import Package
 from localstack.packages.core import ArchiveDownloadAndExtractInstaller
 from localstack.utils.platform import get_arch
 
-FFMPEG_STATIC_BIN_URL = (
-    "https://www.johnvansickle.com/ffmpeg/releases/ffmpeg-{version}-{arch}-static.tar.xz"
-)
+# Mapping LocalStack architecture to BtbN's naming convention
+ARCH_MAPPING = {"amd64": "linux64", "arm64": "linuxarm64"}
+
+# Download URL template for ffmpeg 7.1 LGPL builds from BtbN GitHub Releases
+FFMPEG_STATIC_BIN_URL = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n{version}-latest-{arch}-lgpl-{version}.tar.xz"
 
 
 class FfmpegPackage(Package["FfmpegPackageInstaller"]):
     def __init__(self) -> None:
-        super().__init__(name="ffmpeg", default_version="7.0.1")
+        super().__init__(name="ffmpeg", default_version="7.1")
 
     def _get_installer(self, version: str) -> "FfmpegPackageInstaller":
         return FfmpegPackageInstaller(version)
 
     def get_versions(self) -> List[str]:
-        return ["7.0.1"]
+        return ["7.1"]
 
 
 class FfmpegPackageInstaller(ArchiveDownloadAndExtractInstaller):
@@ -26,19 +28,19 @@ class FfmpegPackageInstaller(ArchiveDownloadAndExtractInstaller):
         super().__init__("ffmpeg", version)
 
     def _get_download_url(self) -> str:
-        return FFMPEG_STATIC_BIN_URL.format(arch=get_arch(), version=self.version)
+        return FFMPEG_STATIC_BIN_URL.format(arch=ARCH_MAPPING.get(get_arch()), version=self.version)
 
     def _get_install_marker_path(self, install_dir: str) -> str:
         return os.path.join(install_dir, self._get_archive_subdir())
 
     def _get_archive_subdir(self) -> str:
-        return f"ffmpeg-{self.version}-{get_arch()}-static"
+        return f"ffmpeg-n{self.version}-latest-{ARCH_MAPPING.get(get_arch())}-lgpl-{self.version}"
 
     def get_ffmpeg_path(self) -> str:
-        return os.path.join(self.get_installed_dir(), "ffmpeg")  # type: ignore[arg-type]
+        return os.path.join(self.get_installed_dir(), "bin", "ffmpeg")  # type: ignore[arg-type]
 
     def get_ffprobe_path(self) -> str:
-        return os.path.join(self.get_installed_dir(), "ffprobe")  # type: ignore[arg-type]
+        return os.path.join(self.get_installed_dir(), "bin", "ffprobe")  # type: ignore[arg-type]
 
 
 ffmpeg_package = FfmpegPackage()

--- a/localstack-core/localstack/packages/ffmpeg.py
+++ b/localstack-core/localstack/packages/ffmpeg.py
@@ -3,10 +3,10 @@ from typing import List
 
 from localstack.packages import Package
 from localstack.packages.core import ArchiveDownloadAndExtractInstaller
-from localstack.utils.platform import get_arch
+from localstack.utils.platform import Arch, get_arch
 
 # Mapping LocalStack architecture to BtbN's naming convention
-ARCH_MAPPING = {"amd64": "linux64", "arm64": "linuxarm64"}
+ARCH_MAPPING = {Arch.amd64: "linux64", Arch.arm64: "linuxarm64"}
 
 # Download URL template for ffmpeg 7.1 LGPL builds from BtbN GitHub Releases
 FFMPEG_STATIC_BIN_URL = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n{version}-latest-{arch}-lgpl-{version}.tar.xz"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The current `ffmpeg` installer in LocalStack downloads binaries from [johnvansickle.com](https://johnvansickle.com/ffmpeg/), a privately hosted site that has exhibited timeout issues, likely due to bandwidth limitations or rate throttling.

To address this, we are switching to [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds) — a well-maintained, GitHub-hosted source for `ffmpeg` binaries with:
- Actively maintained nightly and tagged releases
- LGPL-compliant builds suitable for LocalStack’s hybrid licensing model

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Uses the latest build of a specific major version and replaces `ffmpeg` download URL with BtbN-hosted static LGPL `7.1` builds. 
- Resolves architecture dynamically based on the host (e.g., linux64, linuxarm64)
- Updates the structure handling to match BtbN’s layout (`bin/ffmpeg`, `bin/ffprobe`)

## Testing
Successful installation tested in local setup-
![Screenshot 2025-05-16 at 3 14 22 PM](https://github.com/user-attachments/assets/65d968ba-a41e-4421-be7a-837f6f4bf594)

Successful installation tested in CI-
https://app.circleci.com/pipelines/github/localstack/localstack/32720/workflows/4f5455cf-dddb-4d27-b11b-75c52c3c604a
