### PR TITLE
GithubActions: skip tinybird, docker push and docker login in forks

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -172,7 +172,7 @@ jobs:
     # push image on master, target branch not set, and the dependent steps were either successful or skipped
     # TO-DO: enable job after workflow in CircleCI is disabled
     if: false
-    #    if: github.ref == 'refs/heads/master' && !failure() && !cancelled()
+    #    if: github.ref == 'refs/heads/master' && !failure() && !cancelled() && github.repository == 'localstack/localstack'
     needs:
       # all tests need to be successful for the image to be pushed
       - test
@@ -252,7 +252,7 @@ jobs:
 
   push-to-tinybird:
     name: Push Workflow Status to Tinybird
-    if: always() && github.ref == 'refs/heads/master'
+    if: always() && github.ref == 'refs/heads/master' && github.repository == 'localstack/localstack'
     runs-on: ubuntu-latest
     needs:
       - test

--- a/.github/workflows/aws-tests-mamr.yml
+++ b/.github/workflows/aws-tests-mamr.yml
@@ -66,7 +66,7 @@ jobs:
 
   push-to-tinybird:
     name: Push Workflow Status to Tinybird
-    if: always() && github.ref == 'refs/heads/master'
+    if: always() && github.ref == 'refs/heads/master' && github.repository == 'localstack/localstack'
     runs-on: ubuntu-latest
     needs:
       - test-ma-mr

--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -284,6 +284,7 @@ jobs:
 
       - name: Login to Docker Hub
         # login to DockerHub to avoid rate limiting issues on custom runners
+        if: github.repository_owner == 'localstack'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
@@ -431,6 +432,7 @@ jobs:
 
       - name: Login to Docker Hub
         # login to DockerHub to avoid rate limiting issues on custom runners
+        if: github.repository_owner == 'localstack'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
@@ -679,6 +681,7 @@ jobs:
     steps:
       - name: Login to Docker Hub
         # login to DockerHub to avoid rate limiting issues on custom runners
+        if: github.repository_owner == 'localstack'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR introduces conditions to GitHub Actions steps and jobs to skip Docker login, Docker push, and pushing to Tinybird for forked repositories outside the LocalStack organization. This will allow contributors to run tests in forked repositories without needing to define secrets or modifying the testing workflows.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Check that repository is `localstack/localstack` in docker and tinybird push steps, if not - skip these steps.
- Check that organization owner is `localstack` in docker pull steps, if not - skip these steps. Checking organization owner because we plan to re-use `aws-tests.yml` workflow in another LocalStack repository in the future.

## Testing

- Tested on this branch ✅ 
- Tested in forked repo ✅  : https://github.com/k-a-il/localstack/actions/runs/15114565967/job/42483019964

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
