### PR TITLE
Fix acceptance test workflow name for Tinybird workflow push

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -261,7 +261,7 @@ jobs:
         uses: localstack/tinybird-workflow-push@v3
         with:
           # differentiate between "acceptance only" and "proper / full" runs
-          workflow_id: ${{ inputs.onlyAcceptanceTests && 'tests_acceptance' || 'tests_full' }}
+          workflow_id: ${{ (inputs.onlyAcceptanceTests == true || github.event_name == 'push') && 'tests_acceptance' || 'tests_full' }}
           tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tinybird_datasource: "ci_workflows"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Acceptance tests executed on `master` are currently sent as `tests_full` to tinybird, which is wrong. The reason is a faulty name selection for the workflow push action which does not consider push events.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Adapt the workflow push action to use the same logic as the call to the tests

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
