### PR TITLE
Activate new GHA pipeline on PRs

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -14,8 +14,21 @@ on:
       - '!.gitignore'
       - '!.git-blame-ignore-revs'
       - '!.github/**'
+      - '!docs/**'
     branches:
       - master
+  pull_request:
+    paths:
+      - '**'
+      - '.github/actions/**'
+      - '.github/workflows/aws-main.yml'
+      - '.github/workflows/aws-tests.yml'
+      - '!CODEOWNERS'
+      - '!README.md'
+      - '!.gitignore'
+      - '!.git-blame-ignore-revs'
+      - '!.github/**'
+      - '!docs/**'
   workflow_dispatch:
     inputs:
       onlyAcceptanceTests:

--- a/.github/workflows/aws-tests-mamr.yml
+++ b/.github/workflows/aws-tests-mamr.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - '.github/workflows/aws-mamr.yml'
       - '.github/workflows/aws-tests.yml'
+      - '.github/actions/**'
   workflow_dispatch:
     inputs:
       disableCaching:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This is one of the final steps of moving towards the new GHA pipelines. It activates the new main pipeline to run against all PRs. 
After a week of stability, the old CircleCI pipelines will be disabled

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Add pull request trigger for main pipeline
- Remove the docs from the triggers

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
