### PR TITLE
Bump moto-ext to 5.1.4.post2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.1.4.post1",
+    "moto-ext[all]==5.1.4.post2",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -14,7 +14,7 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.2
     # via requests
-click==8.2.0
+click==8.2.1
     # via localstack-core (pyproject.toml)
 cryptography==45.0.2
     # via localstack-core (pyproject.toml)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -250,7 +250,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.4.post1
+moto-ext==5.1.4.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.4.post1
+moto-ext==5.1.4.post2
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -234,7 +234,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.4.post1
+moto-ext==5.1.4.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -254,7 +254,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.4.post1
+moto-ext==5.1.4.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.1.4.post2

Contains:

- https://github.com/getmoto/moto/pull/8894
- https://github.com/getmoto/moto/pull/8879
- https://github.com/getmoto/moto/pull/8856

## To do

- [x] Ext compatibility (Ext integration tests) AWS / Ext Integration Tests # 4793 :green_circle: 
- [x] Multi-account/region compatibility ([Randomised credentials test run](https://app.circleci.com/pipelines/github/localstack/localstack/32790/workflows/dbb170a7-3e80-46dd-8642-baf9fe87b381)) :green_circle: 