### PR TITLE
Include reserved_concurrent_executions in get_function response

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1543,7 +1543,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             )
         concurrency = None
         if fn.reserved_concurrent_executions:
-            concurrency = GetFunctionConcurrencyResponse(
+            concurrency = Concurrency(
                 ReservedConcurrentExecutions=fn.reserved_concurrent_executions
             )
 
@@ -1552,8 +1552,8 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 version, return_qualified_arn=bool(qualifier), alias_name=alias_name
             ),
             Code=code_location,  # TODO
-            **additional_fields,
             Concurrency=concurrency,
+            **additional_fields,
         )
 
     def get_function_configuration(

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1541,6 +1541,11 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 RepositoryType=image.repository_type,
                 ResolvedImageUri=image.resolved_image_uri,
             )
+        concurrency = None
+        if fn.reserved_concurrent_executions:
+            concurrency = GetFunctionConcurrencyResponse(
+                ReservedConcurrentExecutions=fn.reserved_concurrent_executions
+            )
 
         return GetFunctionResponse(
             Configuration=api_utils.map_config_out(
@@ -1548,7 +1553,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             ),
             Code=code_location,  # TODO
             **additional_fields,
-            # Concurrency={},  # TODO
+            Concurrency=concurrency,
         )
 
     def get_function_configuration(

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -2279,6 +2279,12 @@ class TestLambdaConcurrency:
         snapshot.match("get_function_concurrency_updated", updated_concurrency_result)
         assert updated_concurrency_result["ReservedConcurrentExecutions"] == 0
 
+        function_concurrency_info = aws_client.lambda_.get_function(FunctionName=func_name)[
+            "Concurrency"
+        ]
+        assert function_concurrency_info is not None
+        assert function_concurrency_info["ReservedConcurrentExecutions"] == 0
+
         aws_client.lambda_.delete_function_concurrency(FunctionName=func_name)
 
         deleted_concurrency_result = aws_client.lambda_.get_function_concurrency(

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -2286,6 +2286,7 @@ class TestLambdaConcurrency:
         )
         snapshot.match("get_function_concurrency_deleted", deleted_concurrency_result)
 
+    @pytest.mark.skip_snapshot_verify(paths=["$..Configuration", "$..Code"])
     @markers.aws.validated
     def test_lambda_concurrency_update(self, snapshot, create_lambda_function, aws_client):
         func_name = f"fn-concurrency-{short_uid()}"
@@ -2309,11 +2310,7 @@ class TestLambdaConcurrency:
         )
 
         function_concurrency_info = aws_client.lambda_.get_function(FunctionName=func_name)
-        assert function_concurrency_info["Concurrency"] is not None
-        assert (
-            function_concurrency_info["Concurrency"]["ReservedConcurrentExecutions"]
-            == new_reserved_concurrency
-        )
+        snapshot.match("get_function_concurrency_info", function_concurrency_info)
 
         aws_client.lambda_.delete_function_concurrency(FunctionName=func_name)
 

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4503,7 +4503,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_concurrency_update": {
-    "recorded-date": "22-05-2025, 13:11:43",
+    "recorded-date": "22-05-2025, 14:11:12",
     "recorded-content": {
       "put_function_concurrency": {
         "ReservedConcurrentExecutions": 3,
@@ -4514,6 +4514,60 @@
       },
       "get_function_concurrency_updated": {
         "ReservedConcurrentExecutions": 3,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_concurrency_info": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Concurrency": {
+          "ReservedConcurrentExecutions": 3
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "code-sha256",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.12",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4501,5 +4501,30 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_concurrency_update": {
+    "recorded-date": "22-05-2025, 13:11:43",
+    "recorded-content": {
+      "put_function_concurrency": {
+        "ReservedConcurrentExecutions": 3,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_concurrency_updated": {
+        "ReservedConcurrentExecutions": 3,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_concurrency_deleted": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -2362,7 +2362,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_concurrency_crud": {
-    "recorded-date": "08-04-2024, 16:59:43",
+    "recorded-date": "22-05-2025, 08:04:13",
     "recorded-content": {
       "get_function_concurrency_default": {
         "ResponseMetadata": {

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -65,6 +65,9 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_concurrency_crud": {
     "last_validated_date": "2025-05-22T08:04:13+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_concurrency_update": {
+    "last_validated_date": "2025-05-22T13:11:42+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_provisioned_concurrency_moves_with_alias": {
     "last_validated_date": "2023-03-21T07:47:38+00:00"
   },

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -66,7 +66,7 @@
     "last_validated_date": "2025-05-22T08:04:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_concurrency_update": {
-    "last_validated_date": "2025-05-22T13:11:42+00:00"
+    "last_validated_date": "2025-05-22T14:11:12+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_provisioned_concurrency_moves_with_alias": {
     "last_validated_date": "2023-03-21T07:47:38+00:00"

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -63,7 +63,7 @@
     "last_validated_date": "2024-04-08T17:02:06+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_concurrency_crud": {
-    "last_validated_date": "2024-04-08T16:59:42+00:00"
+    "last_validated_date": "2025-05-22T08:04:13+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_provisioned_concurrency_moves_with_alias": {
     "last_validated_date": "2023-03-21T07:47:38+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR fixes a bug reported by a user. The issue was that when a Lambda function was created in Localstack using Terraform, the `reserved_concurrent_executions` value always reset to -1 in tfstate after apply.

While trying to reproduce the issue, I saw that the `reserved_concurrent_executions` value was saved correctly in the created lambda, but  `reserved_concurrent_executions` wasn’t returned in the [`AWSLambda::GetFunction` response.](https://docs.aws.amazon.com/lambda/latest/api/API_GetFunction.html) Because the response didn’t include the value, [Terraform set the value to default -1 ](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#reserved_concurrent_executions-1) and saved that in the tfstate file.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Added code to return the function's `reserved_concurrent_executions` value if it is set

## Testing

- Added new integration test to test that after `reserved_concurrent_executions` value is updated it is also being returned in response of `AWSLambda::GetFunction` 

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
