### PR TITLE
EC2: fix describe-availability-zones filtering

### DIFF
--- a/localstack-core/localstack/services/ec2/provider.py
+++ b/localstack-core/localstack/services/ec2/provider.py
@@ -117,11 +117,9 @@ class Ec2Provider(Ec2Api, ABC, ServiceLifecycleHook):
         zone_names = describe_availability_zones_request.get("ZoneNames")
         zone_ids = describe_availability_zones_request.get("ZoneIds")
         if zone_names or zone_ids:
-            filters = {
-                "zone-name": zone_names,
-                "zone-id": zone_ids,
-            }
-            filtered_zones = backend.describe_availability_zones(filters)
+            filtered_zones = backend.describe_availability_zones(
+                zone_names=zone_names, zone_ids=zone_ids
+            )
             availability_zones = [
                 AvailabilityZone(
                     State="available",

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -974,3 +974,50 @@ def test_raise_create_volume_without_size(snapshot, aws_client):
     with pytest.raises(ClientError) as e:
         aws_client.ec2.create_volume(AvailabilityZone="eu-central-1a")
     snapshot.match("request-missing-size", e.value.response)
+
+
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        # not implemented in LS
+        "$..AvailabilityZones..GroupLongName",
+        "$..AvailabilityZones..GroupName",
+        "$..AvailabilityZones..NetworkBorderGroup",
+        "$..AvailabilityZones..OptInStatus",
+    ]
+)
+@markers.aws.validated
+def test_describe_availability_zones_filter_with_zone_names(snapshot, aws_client):
+    availability_zones = aws_client.ec2.describe_availability_zones(ZoneNames=["us-east-1a"])
+    snapshot.match("availability_zones", availability_zones)
+
+
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        # not implemented in LS
+        "$..AvailabilityZones..GroupLongName",
+        "$..AvailabilityZones..GroupName",
+        "$..AvailabilityZones..NetworkBorderGroup",
+        "$..AvailabilityZones..OptInStatus",
+    ]
+)
+@markers.aws.validated
+def test_describe_availability_zones_filter_with_zone_ids(snapshot, aws_client):
+    availability_zones = aws_client.ec2.describe_availability_zones(ZoneIds=["use1-az1"])
+    snapshot.match("availability_zones", availability_zones)
+
+
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        # not implemented in LS
+        "$..AvailabilityZones..GroupLongName",
+        "$..AvailabilityZones..GroupName",
+        "$..AvailabilityZones..NetworkBorderGroup",
+        "$..AvailabilityZones..OptInStatus",
+    ]
+)
+@markers.aws.validated
+def test_describe_availability_zones_filters(snapshot, aws_client):
+    availability_zones = aws_client.ec2.describe_availability_zones(
+        Filters=[{"Name": "zone-name", "Values": ["us-east-1a"]}]
+    )
+    snapshot.match("availability_zones", availability_zones)

--- a/tests/aws/services/ec2/test_ec2.snapshot.json
+++ b/tests/aws/services/ec2/test_ec2.snapshot.json
@@ -419,5 +419,80 @@
         }
       }
     }
+  },
+  "tests/aws/services/ec2/test_ec2.py::test_describe_availability_zones_filter_with_zone_names": {
+    "recorded-date": "26-05-2025, 13:36:03",
+    "recorded-content": {
+      "availability_zones": {
+        "AvailabilityZones": [
+          {
+            "GroupLongName": "US East (N. Virginia) 1",
+            "GroupName": "<region>-zg-1",
+            "Messages": [],
+            "NetworkBorderGroup": "<region>",
+            "OptInStatus": "opt-in-not-required",
+            "RegionName": "<region>",
+            "State": "available",
+            "ZoneId": "use1-az6",
+            "ZoneName": "<region>a",
+            "ZoneType": "availability-zone"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/ec2/test_ec2.py::test_describe_availability_zones_filter_with_zone_ids": {
+    "recorded-date": "26-05-2025, 13:34:49",
+    "recorded-content": {
+      "availability_zones": {
+        "AvailabilityZones": [
+          {
+            "GroupLongName": "US East (N. Virginia) 1",
+            "GroupName": "<region>-zg-1",
+            "Messages": [],
+            "NetworkBorderGroup": "<region>",
+            "OptInStatus": "opt-in-not-required",
+            "RegionName": "<region>",
+            "State": "available",
+            "ZoneId": "use1-az1",
+            "ZoneName": "<region>b",
+            "ZoneType": "availability-zone"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/ec2/test_ec2.py::test_describe_availability_zones_filters": {
+    "recorded-date": "26-05-2025, 13:48:29",
+    "recorded-content": {
+      "availability_zones": {
+        "AvailabilityZones": [
+          {
+            "GroupLongName": "US East (N. Virginia) 1",
+            "GroupName": "<region>-zg-1",
+            "Messages": [],
+            "NetworkBorderGroup": "<region>",
+            "OptInStatus": "opt-in-not-required",
+            "RegionName": "<region>",
+            "State": "available",
+            "ZoneId": "use1-az6",
+            "ZoneName": "<region>a",
+            "ZoneType": "availability-zone"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/ec2/test_ec2.validation.json
+++ b/tests/aws/services/ec2/test_ec2.validation.json
@@ -17,6 +17,15 @@
   "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_vcp_peering_difference_regions": {
     "last_validated_date": "2024-06-07T21:28:25+00:00"
   },
+  "tests/aws/services/ec2/test_ec2.py::test_describe_availability_zones_filter_with_zone_ids": {
+    "last_validated_date": "2025-05-26T13:34:49+00:00"
+  },
+  "tests/aws/services/ec2/test_ec2.py::test_describe_availability_zones_filter_with_zone_names": {
+    "last_validated_date": "2025-05-26T13:36:03+00:00"
+  },
+  "tests/aws/services/ec2/test_ec2.py::test_describe_availability_zones_filters": {
+    "last_validated_date": "2025-05-26T13:48:29+00:00"
+  },
   "tests/aws/services/ec2/test_ec2.py::test_raise_create_volume_without_size": {
     "last_validated_date": "2025-02-04T12:53:29+00:00"
   }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Customer reported some issue trying to run a tf script where they were getting this error: `Error: no matching EC2 Availability Zone found`.
The reason for that is that this operation implementation in the ec2 provider.py filters doesn't work against moto, resulting into an empty list.

<img width="583" alt="image" src="https://github.com/user-attachments/assets/ff2d84ee-42c3-4ad2-8849-5199ee4043df" />

More context in the notion [ticket](https://www.notion.so/localstack/Oleg-Tyaglo-No-matching-EC2-Availability-Zone-found-1fcfc2a23431817abe14c63939ee03f7?d=173fc2a234318207919e83a394a8a046).
<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Change how filters are passed for the call done to moto.
Added aws validated tests.
`test_describe_availability_zones_filter_with_zone_names` fails against LS with the old code, and passes now.


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
