### PR TITLE
Investigate CI analytics pollution

### DIFF
--- a/localstack-core/localstack/services/sns/analytics.py
+++ b/localstack-core/localstack/services/sns/analytics.py
@@ -7,3 +7,5 @@ from localstack.utils.analytics.metrics import Counter
 # number of times SNS internal endpoint per resource types
 # (e.g. PlatformMessage invoked 10x times, SMSMessage invoked 3x times, SubscriptionToken...)
 internal_api_calls = Counter(namespace="sns", name="internal_api_call", labels=["resource_type"])
+
+test_counter = Counter(namespace="test", name="test_ci_pollution")

--- a/localstack-core/localstack/services/sns/provider.py
+++ b/localstack-core/localstack/services/sns/provider.py
@@ -86,7 +86,7 @@ from localstack.utils.aws.arns import (
 from localstack.utils.collections import PaginatedList, select_from_typed_dict
 from localstack.utils.strings import short_uid, to_bytes, to_str
 
-from .analytics import internal_api_calls
+from .analytics import internal_api_calls, test_counter
 
 # set up logger
 LOG = logging.getLogger(__name__)
@@ -852,6 +852,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         data_protection_policy: attributeValue = None,
         **kwargs,
     ) -> CreateTopicResponse:
+        test_counter.increment()
         moto_response = call_moto(context)
         store = self.get_store(account_id=context.account_id, region_name=context.region)
         topic_arn = moto_response["TopicArn"]

--- a/localstack-core/localstack/utils/analytics/metrics.py
+++ b/localstack-core/localstack/utils/analytics/metrics.py
@@ -294,7 +294,7 @@ def publish_metrics() -> None:
     This function is automatically triggered on infrastructure shutdown.
     """
     if config.DISABLE_EVENTS:
-        LOG.info(f"Skip publishing metrics given DISABLE_EVENTS={config.DISABLE_EVENTS}")  # noqa
+        LOG.warning(f"Skip publishing metrics given DISABLE_EVENTS={config.DISABLE_EVENTS}")  # noqa
         return
 
     metadata = EventMetadata(
@@ -302,7 +302,7 @@ def publish_metrics() -> None:
         client_time=str(datetime.datetime.now()),
     )
     collected_metrics = MetricRegistry().collect()
-    LOG.info(
+    LOG.warning(
         f"Publish metrics given DISABLE_EVENTS={config.DISABLE_EVENTS}.Would publish:\n"  # noqa
         f"{metadata=}\n"  # noqa
         f"{collected_metrics=}"  # noqa

--- a/localstack-core/localstack/utils/analytics/metrics.py
+++ b/localstack-core/localstack/utils/analytics/metrics.py
@@ -294,7 +294,20 @@ def publish_metrics() -> None:
     This function is automatically triggered on infrastructure shutdown.
     """
     if config.DISABLE_EVENTS:
+        LOG.info(f"Skip publishing metrics given DISABLE_EVENTS={config.DISABLE_EVENTS}")  # noqa
         return
+
+    metadata = EventMetadata(
+        session_id=get_session_id(),
+        client_time=str(datetime.datetime.now()),
+    )
+    collected_metrics = MetricRegistry().collect()
+    LOG.info(
+        f"Publish metrics given DISABLE_EVENTS={config.DISABLE_EVENTS}.Would publish:\n"  # noqa
+        f"{metadata=}\n"  # noqa
+        f"{collected_metrics=}"  # noqa
+    )
+    raise Exception("Intentionally fail to debug CI analytics pollution")
 
     collected_metrics = MetricRegistry().collect()
     if not collected_metrics["metrics"]:  # Skip publishing if no metrics remain after filtering


### PR DESCRIPTION
**DO NOT MERGE, only for internal testing!**

## Motivation

Investigate why we receive analytic events in CI.

## Changes

Introduce new test counter and raise intentional exception upon trying to publish CI metrics