### PR TITLE
Add stack option for CLI start command

### DIFF
--- a/localstack-core/localstack/cli/localstack.py
+++ b/localstack-core/localstack/cli/localstack.py
@@ -475,7 +475,7 @@ def _print_service_table(services: Dict[str, str]) -> None:
 @click.option(
     "--stack",
     "-s",
-    type=str,
+    type=click.Choice(["snowflake"], case_sensitive=False),
     help="Use a specific LocalStack stack",
     required=False,
 )

--- a/localstack-core/localstack/cli/localstack.py
+++ b/localstack-core/localstack/cli/localstack.py
@@ -507,10 +507,9 @@ def cmd_start(
     if stack:
         # Validate allowed stacks
         stack_name = stack.split(":")[0]
-        if stack_name.lower() not in ["localstack", "snowflake"]:
-            raise CLIError(
-                f"Invalid stack '{stack_name}'. Only 'localstack' and 'snowflake' are supported."
-            )
+        allowed_stacks = ("localstack", "localstack-pro", "snowflake")
+        if stack_name.lower() not in allowed_stacks:
+            raise CLIError(f"Invalid stack '{stack_name}'. Allowed stacks: {allowed_stacks}.")
 
         # Set IMAGE_NAME, defaulting to :latest if no version specified
         if ":" not in stack:

--- a/localstack-core/localstack/cli/localstack.py
+++ b/localstack-core/localstack/cli/localstack.py
@@ -472,6 +472,13 @@ def _print_service_table(services: Dict[str, str]) -> None:
     is_flag=True,
     default=False,
 )
+@click.option(
+    "--stack",
+    "-s",
+    type=str,
+    help="Use a specific LocalStack stack",
+    required=False,
+)
 @publish_invocation
 def cmd_start(
     docker: bool,
@@ -483,6 +490,7 @@ def cmd_start(
     publish: Tuple = (),
     volume: Tuple = (),
     host_dns: bool = False,
+    stack: str = None,
 ) -> None:
     """
     Start the LocalStack runtime.
@@ -495,6 +503,9 @@ def cmd_start(
         raise CLIError("Please specify either --docker or --host")
     if host and detached:
         raise CLIError("Cannot start detached in host mode")
+
+    if stack:
+        os.environ["IMAGE_NAME"] = f"localstack/{stack}:latest"
 
     if not no_banner:
         print_banner()

--- a/localstack-core/localstack/cli/localstack.py
+++ b/localstack-core/localstack/cli/localstack.py
@@ -475,8 +475,8 @@ def _print_service_table(services: Dict[str, str]) -> None:
 @click.option(
     "--stack",
     "-s",
-    type=click.Choice(["snowflake"], case_sensitive=False),
-    help="Use a specific LocalStack stack",
+    type=str,
+    help="Use a specific LocalStack stack with optional version.",
     required=False,
 )
 @publish_invocation
@@ -505,7 +505,17 @@ def cmd_start(
         raise CLIError("Cannot start detached in host mode")
 
     if stack:
-        os.environ["IMAGE_NAME"] = f"localstack/{stack}:latest"
+        # Validate allowed stacks
+        stack_name = stack.split(":")[0]
+        if stack_name.lower() not in ["localstack", "snowflake"]:
+            raise CLIError(
+                f"Invalid stack '{stack_name}'. Only 'localstack' and 'snowflake' are supported."
+            )
+
+        # Set IMAGE_NAME, defaulting to :latest if no version specified
+        if ":" not in stack:
+            stack = f"{stack}:latest"
+        os.environ["IMAGE_NAME"] = f"localstack/{stack}"
 
     if not no_banner:
         print_banner()

--- a/localstack-core/localstack/cli/localstack.py
+++ b/localstack-core/localstack/cli/localstack.py
@@ -476,7 +476,7 @@ def _print_service_table(services: Dict[str, str]) -> None:
     "--stack",
     "-s",
     type=str,
-    help="Use a specific LocalStack stack with optional version.",
+    help="Use a specific stack with optional version. Examples: [localstack:4.5, snowflake]",
     required=False,
 )
 @publish_invocation


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Following up from a [relevant discussion](https://localstack-cloud.slack.com/archives/C0550DW38CT/p1748416788025209), this is an attempt to add a CLI option for selecting a stack (image, emulator).

1. The command to start LocalStack for Snowflake is quite verbose by using the IMAGE_NAME environment variable. 
2. Selecting a different image version also required the IMAGE_NAME variable, see [relevant docs](https://docs.localstack.cloud/references/configuration/#core).

```sh
IMAGE_NAME=localstack/snowflake:latest localstack start
IMAGE_NAME=localstack/localstack-pro:4.1 localstack start
```

See also [relevant discussion](https://localstack-cloud.slack.com/archives/C06CV9US815/p1744792391948849) for more context.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

This will add **--stack** and **-s** as a shorthand for selecting the image and optional a version.

```sh
localstack start                      # default, starts localstack for aws (localstack image)
localstack start --stack snowflake    # starts localstack for snowflake (snowflake image)
localstack start -s snowflake         # starts localstack for snowflake (snowflake image)
localstack start -s snowflake:0.3     # starts localstack for snowflake (snowflake image, 0.3 version)
localstack start -s localstack:4.4     # starts localstack for aws (localstack image, 4.4 version)
```

Heads-up: We are experimenting with the _Stacks_ terminology also in the Console, see https://github.com/localstack/localstack-web/pull/1787.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
