### PR TITLE
test(esm/sqs): Skip resource intensive flaky SQS message override test

### DIFF
--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py
@@ -7,6 +7,7 @@ from botocore.exceptions import ClientError
 from localstack_snapshot.snapshots.transformer import KeyValueBasedTransformer, SortingTransformer
 
 from localstack.aws.api.lambda_ import InvalidParameterValueException, Runtime
+from localstack.config import is_env_true
 from localstack.testing.aws.lambda_utils import _await_event_source_mapping_enabled
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
@@ -1601,7 +1602,14 @@ class TestSQSEventSourceMapping:
             20,
             100,
             1_000,
-            10_000,
+            pytest.param(
+                10_000,
+                id="10000",
+                marks=pytest.mark.skipif(
+                    condition=not is_env_true("TEST_PERFORMANCE"),
+                    reason="Too resource intensive to be randomly allocated to a runner.",
+                ),
+            ),
         ],
     )
     @markers.aws.only_localstack


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The case of reading 10 000 records in a single SQS call was made possible via a custom override header. While the functionality works, this is a resource intensive task requiring 10K records to be read into SQS, followed by invocations of a target lambda of up to 2.5K records at a time.

Hence, this test should only be run on particular runners that better cater for these memory/compute requirements.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Skips the case of 10 000 records being read and processed unless the `TEST_PERFORMANCE` environment variable is set.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
