### PR TITLE
Bump moto-ext to 5.1.5.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.1.4.post2",
+    "moto-ext[all]==5.1.5.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -250,7 +250,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.4.post2
+moto-ext==5.1.5.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.4.post2
+moto-ext==5.1.5.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -234,7 +234,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.4.post2
+moto-ext==5.1.5.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -254,7 +254,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.4.post2
+moto-ext==5.1.5.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.1.5.post1 in preparation for LocalStack 4.5.0.

Contains:

- https://github.com/getmoto/moto/pull/8917
- https://github.com/getmoto/moto/pull/8933 @dfangl 

## To do

- [x] Ext compatibility (Ext integration tests) AWS / Ext Integration Tests # 4940 :green_circle: 
- [x] Multi-account/region compatibility ([Randomised credentials test run](https://app.circleci.com/pipelines/github/localstack/localstack/32894/workflows/00548cc4-2b80-4ef6-a39f-05f84156a3fb)) :green_circle: 