### PR TITLE
GH Actions: fix order of path filters for push and pull-request events

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -6,6 +6,7 @@ on:
   push:
     paths:
       - '**'
+      - '!.github/**'
       - '.github/actions/**'
       - '.github/workflows/aws-main.yml'
       - '.github/workflows/aws-tests.yml'
@@ -13,13 +14,13 @@ on:
       - '!README.md'
       - '!.gitignore'
       - '!.git-blame-ignore-revs'
-      - '!.github/**'
       - '!docs/**'
     branches:
       - master
   pull_request:
     paths:
       - '**'
+      - '!.github/**'
       - '.github/actions/**'
       - '.github/workflows/aws-main.yml'
       - '.github/workflows/aws-tests.yml'
@@ -27,7 +28,6 @@ on:
       - '!README.md'
       - '!.gitignore'
       - '!.git-blame-ignore-revs'
-      - '!.github/**'
       - '!docs/**'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -739,7 +739,7 @@ jobs:
           retention-days: 30
 
   test-cfn-v2-engine:
-    name: Test CloudFront Engine v2
+    name: Test CloudFormation Engine v2
     if: ${{ !inputs.onlyAcceptanceTests }}
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -739,7 +739,7 @@ jobs:
           retention-days: 30
 
   test-cfn-v2-engine:
-    name: Test CloudFormation Engine v2
+    name: Test CloudFront Engine v2
     if: ${{ !inputs.onlyAcceptanceTests }}
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Thanks to [this PR](https://github.com/localstack/localstack/pull/12683), it was discovered that the order of path filters for push and pull_request triggers was incorrect. As a result, the `aws-main.yml` workflow was not triggered when `aws-tests.yml` was updated in the PR.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Fix path ordering not to trigger a workflow for all `.github` files except files in the `actions` folder, `aws_main.yml`, and `aws_tests.yml`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
