### PR TITLE
add testing for Fn::Transform in CFn v2

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -624,7 +624,7 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             raise RuntimeError("Invalid or missing Fn::Transform 'Parameters' argument")
 
         if transform_name in transformers:
-            # TODO: port and refactor this 'transformers' logic to this package.https://lmstudio.ai/
+            # TODO: port and refactor this 'transformers' logic to this package.
             builtin_transformer_class = transformers[transform_name]
             builtin_transformer: Transformer = builtin_transformer_class()
             transform_output: Any = builtin_transformer.transform(

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -609,22 +609,22 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
         )
         return delta
 
-    def _compute_fn_transform(self, args: dict[str, Any]) -> Any:
+    def _compute_fn_transform(self, macro_definition: dict[str, Any]) -> Any:
         # TODO: add typing to arguments before this level.
         # TODO: add schema validation
         # TODO: add support for other transform types
 
         account_id = self._change_set.account_id
         region_name = self._change_set.region_name
-        transform_name: str = args.get("Name")
+        transform_name: str = macro_definition.get("Name")
         if not isinstance(transform_name, str):
             raise RuntimeError("Invalid or missing Fn::Transform 'Name' argument")
-        transform_parameters: dict = args.get("Parameters")
+        transform_parameters: dict = macro_definition.get("Parameters")
         if not isinstance(transform_parameters, dict):
             raise RuntimeError("Invalid or missing Fn::Transform 'Parameters' argument")
 
         if transform_name in transformers:
-            # TODO: port and refactor this 'transformers' logic to this package.
+            # TODO: port and refactor this 'transformers' logic to this package.https://lmstudio.ai/
             builtin_transformer_class = transformers[transform_name]
             builtin_transformer: Transformer = builtin_transformer_class()
             transform_output: Any = builtin_transformer.transform(
@@ -638,17 +638,36 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
         if transform_name in macros_store:
             # TODO: this formatting of stack parameters is odd but required to integrate with v1 execute_macro util.
             #  consider porting this utils and passing the plain list of parameters instead.
-            stack_parameters = {
-                parameter["ParameterKey"]: parameter
-                for parameter in self._change_set.stack.parameters
+
+            resolved_parameters = {
+                **self._change_set.stack.resolved_parameters,
+                **self.visit_node_parameters(
+                    self._change_set.update_model.node_template.parameters
+                ).after,
             }
+
+            template_parameters = {
+                **self._change_set.stack.template.get("Parameters", {}),
+                **(self._change_set.template or {}).get("Parameters", {}),
+            }
+
+            for key, value in resolved_parameters.items():
+                template_parameters[key]["ParameterValue"] = value
+
+            # -2 removes: divergence/Fn::transform, -3 returns the path until the parent
+            scope = macro_definition.get("Scope").split("/")[:-3]
+            template = self._change_set.template or {}
+            for key in scope:
+                if key:
+                    template = template.get(key)
+
             transform_output: Any = execute_macro(
                 account_id=account_id,
                 region_name=region_name,
-                parsed_template=dict(),  # TODO: review the requirements for this argument.
-                macro=args,  # TODO: review support for non dict bindings (v1).
-                stack_parameters=stack_parameters,
-                transformation_parameters=transform_parameters,
+                parsed_template=template,  # TODO: review the requirements for this argument.
+                macro=macro_definition,  # TODO: review support for non dict bindings (v1).
+                stack_parameters=template_parameters,
+                transformation_parameters=macro_definition.get("Parameters"),
                 is_intrinsic=True,
             )
             return transform_output
@@ -661,6 +680,15 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
         self, node_intrinsic_function: NodeIntrinsicFunction
     ) -> PreprocEntityDelta:
         arguments_delta = self.visit(node_intrinsic_function.arguments)
+
+        # TODO find better manage of this
+        # The scope of a transformation is important to determine the template passed to the macro
+        if arguments_delta.before:
+            arguments_delta.before["Scope"] = node_intrinsic_function.scope
+
+        if arguments_delta.after:
+            arguments_delta.after["Scope"] = node_intrinsic_function.scope
+
         delta = self._cached_apply(
             scope=node_intrinsic_function.scope,
             arguments_delta=arguments_delta,

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_transform.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_transform.py
@@ -252,11 +252,12 @@ class ChangeSetModelTransform(ChangeSetModelPreproc):
             if not transformed_before_template:
                 transformed_before_template = self._before_template
                 for before_global_transform in transform_before:
-                    transformed_before_template = self._apply_global_transform(
-                        global_transform=before_global_transform,
-                        parameters=parameters_before,
-                        template=transformed_before_template,
-                    )
+                    if not is_nothing(before_global_transform.name):
+                        transformed_before_template = self._apply_global_transform(
+                            global_transform=before_global_transform,
+                            parameters=parameters_before,
+                            template=transformed_before_template,
+                        )
                 self._before_cache[_SCOPE_TRANSFORM_TEMPLATE_OUTCOME] = transformed_before_template
 
         transformed_after_template = self._after_template
@@ -265,11 +266,12 @@ class ChangeSetModelTransform(ChangeSetModelPreproc):
             if not transformed_after_template:
                 transformed_after_template = self._after_template
                 for after_global_transform in transform_after:
-                    transformed_after_template = self._apply_global_transform(
-                        global_transform=after_global_transform,
-                        parameters=parameters_after,
-                        template=transformed_after_template,
-                    )
+                    if not is_nothing(after_global_transform.name):
+                        transformed_after_template = self._apply_global_transform(
+                            global_transform=after_global_transform,
+                            parameters=parameters_after,
+                            template=transformed_after_template,
+                        )
                 self._after_cache[_SCOPE_TRANSFORM_TEMPLATE_OUTCOME] = transformed_after_template
 
         self._save_runtime_cache()

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_transform.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_transform.py
@@ -324,9 +324,9 @@ class ChangeSetModelTransform(ChangeSetModelPreproc):
             )
 
             for parameter_key, parameter_value in macro_parameters.items():
-                if isinstance(parameter_value, dict):
-                    parameter_value = resolve_refs_recursively.resolve(parameter_value)
-                resolved_parameters[parameter_key] = parameter_value
+                resolved_parameters[parameter_key] = resolve_refs_recursively.resolve(
+                    parameter_value
+                )
 
             return resolved_parameters
 
@@ -345,7 +345,13 @@ class ChangeSetModelTransform(ChangeSetModelPreproc):
 
                     if transformer_class:
                         transformer = transformer_class()
-                        transformed = transformer.transform(account_id, region_name, parameters)
+                        transformed = transformer.transform(
+                            account_id,
+                            region_name,
+                            _resolve_macro_parameters(
+                                macro_parameters=parameters, stack_parameters=stack_parameters
+                            ),
+                        )
                         obj_copy = copy.deepcopy(obj)
                         obj_copy.pop("Fn::Transform", "")
                         obj_copy.update(transformed)

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -1,5 +1,4 @@
 import copy
-import json
 import logging
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -1264,7 +1263,7 @@ class CloudformationProviderV2(CloudformationProvider):
         change_set = ChangeSet(stack, {"ChangeSetName": f"delete-stack_{stack.stack_name}"})  # noqa
         self._setup_change_set_model(
             change_set=change_set,
-            before_template=json.loads(stack.template_body or "{}"),
+            before_template=template_preparer.parse_template(template=stack.template_body),
             after_template=None,
             before_parameters=stack.resolved_parameters,
             after_parameters=None,

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -463,6 +463,8 @@ class CloudformationProviderV2(CloudformationProvider):
                 # which was just deployed
                 change_set.stack.template = change_set.template
             except Exception as e:
+                import traceback
+                traceback.print_exc()
                 LOG.error(
                     "Execute change set failed: %s", e, exc_info=LOG.isEnabledFor(logging.WARNING)
                 )
@@ -1261,7 +1263,7 @@ class CloudformationProviderV2(CloudformationProvider):
         change_set = ChangeSet(stack, {"ChangeSetName": f"delete-stack_{stack.stack_name}"})  # noqa
         self._setup_change_set_model(
             change_set=change_set,
-            before_template=stack.template,
+            before_template=json.loads(stack.template_body or "{}"),
             after_template=None,
             before_parameters=stack.resolved_parameters,
             after_parameters=None,

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -1277,6 +1277,9 @@ class CloudformationProviderV2(CloudformationProvider):
                 stack.set_stack_status(StackStatus.DELETE_COMPLETE)
                 stack.deletion_time = datetime.now(tz=timezone.utc)
             except Exception as e:
+                import traceback
+
+                traceback.print_exc()
                 LOG.warning(
                     "Failed to delete stack '%s': %s",
                     stack.stack_name,

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import logging
 from collections import defaultdict
 from datetime import datetime, timezone

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -463,9 +463,6 @@ class CloudformationProviderV2(CloudformationProvider):
                 # which was just deployed
                 change_set.stack.template = change_set.template
             except Exception as e:
-                import traceback
-
-                traceback.print_exc()
                 LOG.error(
                     "Execute change set failed: %s", e, exc_info=LOG.isEnabledFor(logging.WARNING)
                 )
@@ -1264,7 +1261,7 @@ class CloudformationProviderV2(CloudformationProvider):
         change_set = ChangeSet(stack, {"ChangeSetName": f"delete-stack_{stack.stack_name}"})  # noqa
         self._setup_change_set_model(
             change_set=change_set,
-            before_template=template_preparer.parse_template(template=stack.template_body),
+            before_template=stack.template,
             after_template=None,
             before_parameters=stack.resolved_parameters,
             after_parameters=None,

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -1277,9 +1277,6 @@ class CloudformationProviderV2(CloudformationProvider):
                 stack.set_stack_status(StackStatus.DELETE_COMPLETE)
                 stack.deletion_time = datetime.now(tz=timezone.utc)
             except Exception as e:
-                import traceback
-
-                traceback.print_exc()
                 LOG.warning(
                     "Failed to delete stack '%s': %s",
                     stack.stack_name,

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -464,6 +464,7 @@ class CloudformationProviderV2(CloudformationProvider):
                 change_set.stack.template = change_set.template
             except Exception as e:
                 import traceback
+
                 traceback.print_exc()
                 LOG.error(
                     "Execute change set failed: %s", e, exc_info=LOG.isEnabledFor(logging.WARNING)

--- a/localstack-core/localstack/testing/pytest/cloudformation/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/cloudformation/fixtures.py
@@ -131,6 +131,11 @@ def capture_update_process(aws_client_no_retry, cleanups, capture_per_resource_e
             ChangeSetName=change_set_name,
             TemplateBody=t1,
             ChangeSetType="CREATE",
+            Capabilities=[
+                "CAPABILITY_IAM",
+                "CAPABILITY_NAMED_IAM",
+                "CAPABILITY_AUTO_EXPAND",
+            ],
             Parameters=[{"ParameterKey": k, "ParameterValue": v} for (k, v) in p1.items()],
         )
         snapshot.match("create-change-set-1", change_set_details)
@@ -189,6 +194,11 @@ def capture_update_process(aws_client_no_retry, cleanups, capture_per_resource_e
             TemplateBody=t2,
             ChangeSetType="UPDATE",
             Parameters=[{"ParameterKey": k, "ParameterValue": v} for (k, v) in p2.items()],
+            Capabilities=[
+                "CAPABILITY_IAM",
+                "CAPABILITY_NAMED_IAM",
+                "CAPABILITY_AUTO_EXPAND",
+            ],
         )
         snapshot.match("create-change-set-2", change_set_details)
         stack_id = change_set_details["StackId"]

--- a/tests/aws/services/cloudformation/api/test_transformers.py
+++ b/tests/aws/services/cloudformation/api/test_transformers.py
@@ -14,6 +14,7 @@ from localstack.utils.functions import call_safe
 from localstack.utils.strings import short_uid, to_bytes
 
 
+@skip_if_v2_provider(reason="transform not implemented")
 @markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(paths=["$..tags"])
 def test_duplicate_resources(deploy_cfn_template, s3_bucket, snapshot, aws_client):

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.py
@@ -1,0 +1,81 @@
+import pytest
+from localstack_snapshot.snapshots.transformer import RegexTransformer
+
+from localstack.services.cloudformation.v2.utils import is_v2_engine
+from localstack.testing.aws.util import is_aws_cloud
+from localstack.testing.pytest import markers
+from localstack.utils.strings import long_uid
+
+
+@pytest.mark.skipif(
+    condition=not is_v2_engine() and not is_aws_cloud(), reason="Requires the V2 engine"
+)
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        "per-resource-events..*",
+        "delete-describe..*",
+        #
+        # Before/After Context
+        "$..Capabilities",
+        "$..NotificationARNs",
+        "$..IncludeNestedStacks",
+        "$..Scope",
+        "$..Details",
+        "$..Parameters",
+        "$..Replacement",
+        "$..PolicyAction",
+    ]
+)
+class TestChangeSetFnTransform:
+    @markers.aws.validated
+    @pytest.mark.parametrize("include_format", ["yml", "json"])
+    def test_embedded_fn_transform_include(
+        self, include_format, snapshot, capture_update_process, s3_bucket, aws_client, tmp_path
+    ):
+        name1 = f"topic-name-1-{long_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+
+        bucket = s3_bucket
+        file = tmp_path / "bucket_definition.yml"
+
+        if include_format == "json":
+            template = '{"Topic2":{"Type":"AWS::SNS::Topic","Properties":{"TopicName": "topic-2"}}}'
+        else:
+            template = """
+            Topic2:
+                Type: AWS::SNS::Topic
+                Properties:
+                    TopicName: topic-2
+            """
+
+        file.write_text(data=template)
+        aws_client.s3.upload_file(
+            Bucket=bucket,
+            Key="template",
+            Filename=str(file.absolute()),
+        )
+
+        template_1 = {
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {"TopicName": name1, "DisplayName": "display-value-1"},
+                },
+            }
+        }
+        template_2 = {
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::Sub": "The stack name is ${AWS::StackName}"},
+                    },
+                },
+                "Fn::Transform": {
+                    "Name": "AWS::Include",
+                    "Parameters": {"Location": f"s3://{bucket}/template"},
+                },
+            },
+        }
+        capture_update_process(snapshot, template_1, template_2)

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.py
@@ -240,7 +240,7 @@ class TestChangeSetFnTransform:
         create_macro,
     ):
         name1 = f"topic-name-1-{short_uid()}"
-        name2 = f"topic-name-2-{short_uid()}"
+        name2 = f"topic-name-2-{short_uid()}.fifo"
         snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
 
         macro_function_path = os.path.join(
@@ -249,7 +249,7 @@ class TestChangeSetFnTransform:
         macro_name = "MakeFifo"
         create_macro(macro_name, macro_function_path)
 
-        template_2 = {
+        template_1 = {
             "Resources": {
                 "Topic1": {
                     "Type": "AWS::SNS::Topic",
@@ -258,9 +258,9 @@ class TestChangeSetFnTransform:
             }
         }
 
-        template_1 = {
+        template_2 = {
             "Resources": {
-                "Topic": {
+                "Topic1": {
                     "Type": "AWS::SNS::Topic",
                     "Properties": {"TopicName": name2, "Fn::Transform": macro_name},
                 }
@@ -268,7 +268,101 @@ class TestChangeSetFnTransform:
         }
         capture_update_process(snapshot, template_1, template_2)
 
-    # TODO:
-    # - Attribute with macro
-    # - Macro with parameters
-    # - Executing order of transformations
+    @markers.aws.validated
+    def test_embedded_macro_for_attribute_fn_transform(
+        self,
+        snapshot,
+        capture_update_process,
+        create_macro,
+    ):
+        name1 = f"parameter-{short_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "parameter-name"))
+        snapshot.add_transformer(snapshot.transform.key_value("Value", "value"))
+
+        macro_function_path = os.path.join(
+            os.path.dirname(__file__), "../../../templates/macros/return_random_string.py"
+        )
+        macro_name = "GenerateRandom"
+        create_macro(macro_name, macro_function_path)
+
+        template_1 = {
+            "Resources": {
+                "Parameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {"Name": name1, "Type": "String", "Value": "foo"},
+                }
+            }
+        }
+
+        template_2 = {
+            "Parameters": {"Input": {"Type": "String"}},
+            "Resources": {
+                "Parameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Name": name1,
+                        "Type": "String",
+                        "Value": {
+                            "Fn::Transform": {
+                                "Name": "GenerateRandom",
+                                "Parameters": {"Prefix": {"Ref": "Input"}},
+                            }
+                        },
+                    },
+                }
+            },
+        }
+
+        capture_update_process(snapshot, template_1, template_2, p2={"Input": "test"})
+
+    @markers.aws.validated
+    def test_multiple_fn_transform_order(
+        self,
+        snapshot,
+        capture_update_process,
+        create_macro,
+    ):
+        name1 = f"parameter-{short_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "parameter-name"))
+        snapshot.add_transformer(snapshot.transform.key_value("Value", "value"))
+
+        macro_function_path = os.path.join(
+            os.path.dirname(__file__), "../../../templates/macros/replace_string.py"
+        )
+        macro_name = "ReplaceString"
+        create_macro(macro_name, macro_function_path)
+
+        template_1 = {
+            "Resources": {
+                "Parameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {"Name": name1, "Type": "String", "Value": "foo"},
+                }
+            }
+        }
+
+        template_2 = {
+            "Resources": {
+                "Parameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Name": name1,
+                        "Value": "<replace-this>",
+                        "Type": "String",
+                        "Fn::Transform": [
+                            {"Name": "ReplaceString", "Parameters": {"Input": "snippet-transform"}},
+                            {
+                                "Name": "ReplaceString",
+                                "Parameters": {"Input": "second-snippet-transform"},
+                            },
+                        ],
+                    },
+                }
+            },
+            "Transform": [
+                {"Name": "ReplaceString", "Parameters": {"Input": "global-transform"}},
+                {"Name": "ReplaceString", "Parameters": {"Input": "second-global-transform"}},
+            ],
+        }
+
+        capture_update_process(snapshot, template_1, template_2)

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.py
@@ -427,7 +427,7 @@ class TestChangeSetFnTransform:
         capture_update_process(snapshot, template_1, template_2, p2={"Transform": transform})
 
     @markers.aws.validated
-    def test_macro_with_intrisic_function(
+    def test_macro_with_intrinsic_function(
         self,
         snapshot,
         capture_update_process,

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.py
@@ -52,6 +52,9 @@ class TestChangeSetFnTransform:
 
     @markers.aws.validated
     @pytest.mark.parametrize("include_format", ["yml", "json"])
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Changes..ResourceChange.AfterContext.Properties.Name"]
+    )
     def test_embedded_fn_transform_include(
         self, include_format, snapshot, capture_update_process, s3_bucket, aws_client, tmp_path
     ):
@@ -424,7 +427,7 @@ class TestChangeSetFnTransform:
         capture_update_process(snapshot, template_1, template_2, p2={"Transform": transform})
 
     @markers.aws.validated
-    def test_macro_with_function(
+    def test_macro_with_intrisic_function(
         self,
         snapshot,
         capture_update_process,

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.py
@@ -1,10 +1,13 @@
+import os
+
 import pytest
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
+from localstack.aws.api.lambda_ import Runtime
 from localstack.services.cloudformation.v2.utils import is_v2_engine
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
-from localstack.utils.strings import long_uid
+from localstack.utils.strings import short_uid
 
 
 @pytest.mark.skipif(
@@ -27,25 +30,48 @@ from localstack.utils.strings import long_uid
     ]
 )
 class TestChangeSetFnTransform:
+    @pytest.fixture(scope="function")
+    def create_macro(self, aws_client, deploy_cfn_template, create_lambda_function):
+        def _inner(macro_name, code_path):
+            func_name = f"test_lambda_{short_uid()}"
+            create_lambda_function(
+                func_name=func_name,
+                handler_file=code_path,
+                runtime=Runtime.python3_12,
+                client=aws_client.lambda_,
+            )
+
+            deploy_cfn_template(
+                template_path=os.path.join(
+                    os.path.dirname(__file__), "../../../templates/macro_resource.yml"
+                ),
+                parameters={"FunctionName": func_name, "MacroName": macro_name},
+            )
+
+        yield _inner
+
     @markers.aws.validated
     @pytest.mark.parametrize("include_format", ["yml", "json"])
     def test_embedded_fn_transform_include(
         self, include_format, snapshot, capture_update_process, s3_bucket, aws_client, tmp_path
     ):
-        name1 = f"topic-name-1-{long_uid()}"
+        name1 = f"topic-name-1-{short_uid()}"
+        name2 = f"topic-name-2-{short_uid()}"
         snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
 
         bucket = s3_bucket
         file = tmp_path / "bucket_definition.yml"
 
         if include_format == "json":
-            template = '{"Topic2":{"Type":"AWS::SNS::Topic","Properties":{"TopicName": "topic-2"}}}'
+            template = (
+                '{"Topic2":{"Type":"AWS::SNS::Topic","Properties":{"TopicName": "%s"}}}' % name2
+            )
         else:
-            template = """
+            template = f"""
             Topic2:
                 Type: AWS::SNS::Topic
                 Properties:
-                    TopicName: topic-2
+                    TopicName: {name2}
             """
 
         file.write_text(data=template)
@@ -85,7 +111,7 @@ class TestChangeSetFnTransform:
     def test_global_fn_transform_include(
         self, include_format, snapshot, capture_update_process, s3_bucket, aws_client, tmp_path
     ):
-        name1 = f"topic-name-1-{long_uid()}"
+        name1 = f"topic-name-1-{short_uid()}"
         snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
 
         bucket = s3_bucket
@@ -132,3 +158,117 @@ class TestChangeSetFnTransform:
             },
         }
         capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    def test_serverless_fn_transform(
+        self, snapshot, capture_update_process, s3_bucket, aws_client, tmp_path
+    ):
+        name1 = f"topic-name-1-{short_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+
+        template_1 = {
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {"TopicName": name1, "DisplayName": "display-value-1"},
+                },
+            }
+        }
+        template_2 = {
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "HelloWorldFunction": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": {
+                        "Handler": "index.handler",
+                        "Runtime": "nodejs18.x",
+                        "InlineCode": "exports.handler = async (event) => {\n  return {\n    statusCode: 200,\n    body: JSON.stringify({ message: 'Hello from SAM inline function!' })\n  };\n};",
+                        "Events": {
+                            "ApiEvent": {
+                                "Type": "Api",
+                                "Properties": {"Path": "/hello", "Method": "get"},
+                            }
+                        },
+                    },
+                }
+            },
+        }
+        capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    def test_global_macro_fn_transform(
+        self,
+        snapshot,
+        capture_update_process,
+        create_macro,
+    ):
+        name1 = f"topic-name-1-{short_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+
+        macro_function_path = os.path.join(
+            os.path.dirname(__file__), "../../../templates/macros/replace_string.py"
+        )
+        macro_name = "Substitution"
+        create_macro(macro_name, macro_function_path)
+
+        template_1 = {
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {"TopicName": name1, "DisplayName": "display-value-1"},
+                },
+            }
+        }
+
+        template_2 = {
+            "Parameters": {"Substitution": {"Type": "String", "Default": "SubstitutionDefault"}},
+            "Resources": {
+                "Parameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {"Value": "{Substitution}", "Type": "String"},
+                }
+            },
+            "Transform": {"Name": macro_name},
+        }
+        capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    def test_embedded_macro_fn_transform(
+        self,
+        snapshot,
+        capture_update_process,
+        create_macro,
+    ):
+        name1 = f"topic-name-1-{short_uid()}"
+        name2 = f"topic-name-2-{short_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+
+        macro_function_path = os.path.join(
+            os.path.dirname(__file__), "../../../templates/macros/add_standard_attributes.py"
+        )
+        macro_name = "MakeFifo"
+        create_macro(macro_name, macro_function_path)
+
+        template_2 = {
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {"TopicName": name1},
+                },
+            }
+        }
+
+        template_1 = {
+            "Resources": {
+                "Topic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {"TopicName": name2, "Fn::Transform": macro_name},
+                }
+            }
+        }
+        capture_update_process(snapshot, template_1, template_2)
+
+    # TODO:
+    # - Attribute with macro
+    # - Macro with parameters
+    # - Executing order of transformations

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.py
@@ -371,11 +371,11 @@ class TestChangeSetFnTransform:
     @markers.aws.validated
     @pytest.mark.parametrize("transform", ["true", "false"])
     def test_conditional_transform(
-            self,
-            transform,
-            snapshot,
-            capture_update_process,
-            create_macro,
+        self,
+        transform,
+        snapshot,
+        capture_update_process,
+        create_macro,
     ):
         name1 = f"parameter-{short_uid()}"
         snapshot.add_transformer(RegexTransformer(name1, "parameter-name"))
@@ -397,21 +397,8 @@ class TestChangeSetFnTransform:
         }
 
         template_2 = {
-            "Parameters": {
-                "Transform": {
-                    "Type": "String"
-                }
-            },
-            "Conditions": {
-                "Deploy": {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "Transform"
-                        },
-                        "true"
-                    ]
-                }
-            },
+            "Parameters": {"Transform": {"Type": "String"}},
+            "Conditions": {"Deploy": {"Fn::Equals": [{"Ref": "Transform"}, "true"]}},
             "Resources": {
                 "Parameter": {
                     "Type": "AWS::SSM::Parameter",
@@ -425,17 +412,17 @@ class TestChangeSetFnTransform:
                         ],
                     },
                 }
-            }
+            },
         }
 
         capture_update_process(snapshot, template_1, template_2, p2={"Transform": transform})
 
     @markers.aws.validated
     def test_macro_with_function(
-            self,
-            snapshot,
-            capture_update_process,
-            create_macro,
+        self,
+        snapshot,
+        capture_update_process,
+        create_macro,
     ):
         name1 = f"parameter-{short_uid()}"
         snapshot.add_transformer(RegexTransformer(name1, "parameter-name"))
@@ -465,7 +452,10 @@ class TestChangeSetFnTransform:
                         "Value": "<replace-this>",
                         "Type": "String",
                         "Fn::Transform": [
-                            {"Name": macro_name, "Parameters": {"Input":{"Fn::Join": ["-", ["test", "string"]]}}},
+                            {
+                                "Name": macro_name,
+                                "Parameters": {"Input": {"Fn::Join": ["-", ["test", "string"]]}},
+                            },
                         ],
                     },
                 }

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.py
@@ -157,6 +157,12 @@ class TestChangeSetFnTransform:
         capture_update_process(snapshot, template_1, template_2)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..Changes..ResourceChange.AfterContext.Properties.Body.paths",
+            "$..Changes..ResourceChange.AfterContext.Properties.SourceArn",
+        ]
+    )
     def test_serverless_fn_transform(
         self, snapshot, capture_update_process, s3_bucket, aws_client, tmp_path
     ):

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.py
@@ -468,3 +468,106 @@ class TestChangeSetFnTransform:
         }
 
         capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    def test_remove_transform_in_update_change_set(
+        self,
+        snapshot,
+        capture_update_process,
+        create_macro,
+    ):
+        name1 = f"parameter-{short_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "parameter-name"))
+        snapshot.add_transformer(snapshot.transform.key_value("Value", "value"))
+
+        macro_function_path = os.path.join(
+            os.path.dirname(__file__), "../../../templates/macros/return_random_string.py"
+        )
+        macro_name = "GenerateRandom"
+        create_macro(macro_name, macro_function_path)
+
+        template_1 = {
+            "Parameters": {"Input": {"Type": "String"}},
+            "Resources": {
+                "Parameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Name": name1,
+                        "Type": "String",
+                        "Value": {
+                            "Fn::Transform": {
+                                "Name": "GenerateRandom",
+                            }
+                        },
+                    },
+                }
+            },
+        }
+
+        template_2 = {
+            "Resources": {
+                "Parameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {"Name": name1, "Type": "String", "Value": "foo"},
+                }
+            }
+        }
+
+        capture_update_process(snapshot, template_1, template_2, p1={"Input": "test"})
+
+    @markers.aws.validated
+    def test_update_parameter_transform_in_update_change_set(
+        self,
+        snapshot,
+        capture_update_process,
+        create_macro,
+    ):
+        name1 = f"parameter-{short_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "parameter-name"))
+        snapshot.add_transformer(snapshot.transform.key_value("Value", "value"))
+
+        macro_function_path = os.path.join(
+            os.path.dirname(__file__), "../../../templates/macros/return_random_string.py"
+        )
+        macro_name = "GenerateRandom"
+        create_macro(macro_name, macro_function_path)
+
+        template_1 = {
+            "Parameters": {"Input": {"Type": "String"}},
+            "Resources": {
+                "Parameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Name": name1,
+                        "Type": "String",
+                        "Value": {
+                            "Fn::Transform": {
+                                "Name": "GenerateRandom",
+                            }
+                        },
+                    },
+                }
+            },
+        }
+
+        template_2 = {
+            "Parameters": {"Input": {"Type": "String"}},
+            "Resources": {
+                "Parameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Name": name1,
+                        "Type": "String",
+                        "Value": {
+                            "Fn::Transform": {
+                                "Name": "GenerateRandom",
+                            }
+                        },
+                    },
+                }
+            },
+        }
+
+        capture_update_process(
+            snapshot, template_1, template_2, p1={"Input": "test"}, p2={"Input": "test2"}
+        )

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.py
@@ -4,15 +4,11 @@ import pytest
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
 from localstack.aws.api.lambda_ import Runtime
-from localstack.services.cloudformation.v2.utils import is_v2_engine
-from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 
 
-@pytest.mark.skipif(
-    condition=not is_v2_engine() and not is_aws_cloud(), reason="Requires the V2 engine"
-)
+@pytest.mark.skip("CFnv2 implementation missing")
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         "per-resource-events..*",

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
@@ -904,5 +904,801 @@
         "Tags": []
       }
     }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[json]": {
+    "recorded-date": "29-05-2025, 18:53:46",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "The stack name is <stack-name:1>",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "The stack name is <stack-name:1>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "display-value-1",
+                    "Name": "DisplayName",
+                    "Path": "/Properties/DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Outputs": [
+          {
+            "OutputKey": "TopicRef",
+            "OutputValue": "arn:<partition>:sns:<region>:111111111111:topic-name-1"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Topic1": [
+          {
+            "EventId": "Topic1-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "The stack name is <stack-name:1>",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "The stack name is <stack-name:1>",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Outputs": [
+          {
+            "OutputKey": "TopicRef",
+            "OutputValue": "arn:<partition>:sns:<region>:111111111111:topic-name-1"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[yml]": {
+    "recorded-date": "29-05-2025, 18:52:15",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "The stack name is <stack-name:1>",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "The stack name is <stack-name:1>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "display-value-1",
+                    "Name": "DisplayName",
+                    "Path": "/Properties/DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Outputs": [
+          {
+            "OutputKey": "TopicRef",
+            "OutputValue": "arn:<partition>:sns:<region>:111111111111:topic-name-1"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Topic1": [
+          {
+            "EventId": "Topic1-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "The stack name is <stack-name:1>",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "The stack name is <stack-name:1>",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Outputs": [
+          {
+            "OutputKey": "TopicRef",
+            "OutputValue": "arn:<partition>:sns:<region>:111111111111:topic-name-1"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
@@ -5395,7 +5395,7 @@
       }
     }
   },
-  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_macro_with_function": {
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_macro_with_intrinsic_function": {
     "recorded-date": "20-06-2025, 22:19:25",
     "recorded-content": {
       "create-change-set-1": {

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[yml]": {
-    "recorded-date": "29-05-2025, 18:20:46",
+    "recorded-date": "30-05-2025, 19:11:21",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -11,7 +11,11 @@
         }
       },
       "describe-change-set-1-prop-values": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -46,7 +50,11 @@
         }
       },
       "describe-change-set-1": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -81,6 +89,11 @@
         }
       },
       "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
         "CreationTime": "datetime",
         "DisableRollback": false,
@@ -105,7 +118,11 @@
         }
       },
       "describe-change-set-2-prop-values": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -179,7 +196,11 @@
         }
       },
       "describe-change-set-2": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -238,6 +259,11 @@
         }
       },
       "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "CreationTime": "datetime",
         "DisableRollback": false,
@@ -436,6 +462,11 @@
         ]
       },
       "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
         "DisableRollback": false,
@@ -453,7 +484,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[json]": {
-    "recorded-date": "29-05-2025, 18:22:18",
+    "recorded-date": "30-05-2025, 19:12:51",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -464,7 +495,11 @@
         }
       },
       "describe-change-set-1-prop-values": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -499,7 +534,11 @@
         }
       },
       "describe-change-set-1": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -534,6 +573,11 @@
         }
       },
       "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
         "CreationTime": "datetime",
         "DisableRollback": false,
@@ -558,7 +602,11 @@
         }
       },
       "describe-change-set-2-prop-values": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -632,7 +680,11 @@
         }
       },
       "describe-change-set-2": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -691,6 +743,11 @@
         }
       },
       "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "CreationTime": "datetime",
         "DisableRollback": false,
@@ -889,6 +946,11 @@
         ]
       },
       "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
         "DisableRollback": false,
@@ -906,7 +968,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[json]": {
-    "recorded-date": "29-05-2025, 18:53:46",
+    "recorded-date": "30-05-2025, 19:15:53",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -917,7 +979,11 @@
         }
       },
       "describe-change-set-1-prop-values": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -952,7 +1018,11 @@
         }
       },
       "describe-change-set-1": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -987,6 +1057,11 @@
         }
       },
       "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
         "CreationTime": "datetime",
         "DisableRollback": false,
@@ -1011,7 +1086,11 @@
         }
       },
       "describe-change-set-2-prop-values": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -1070,7 +1149,11 @@
         }
       },
       "describe-change-set-2": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -1119,6 +1202,11 @@
         }
       },
       "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "CreationTime": "datetime",
         "DisableRollback": false,
@@ -1281,6 +1369,11 @@
         ]
       },
       "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
         "DisableRollback": false,
@@ -1304,7 +1397,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[yml]": {
-    "recorded-date": "29-05-2025, 18:52:15",
+    "recorded-date": "30-05-2025, 19:14:21",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -1315,7 +1408,11 @@
         }
       },
       "describe-change-set-1-prop-values": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -1350,7 +1447,11 @@
         }
       },
       "describe-change-set-1": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -1385,6 +1486,11 @@
         }
       },
       "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
         "CreationTime": "datetime",
         "DisableRollback": false,
@@ -1409,7 +1515,11 @@
         }
       },
       "describe-change-set-2-prop-values": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -1468,7 +1578,11 @@
         }
       },
       "describe-change-set-2": {
-        "Capabilities": [],
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-id:1>",
         "Changes": [
@@ -1517,6 +1631,11 @@
         }
       },
       "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "CreationTime": "datetime",
         "DisableRollback": false,
@@ -1679,6 +1798,11 @@
         ]
       },
       "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
         "DisableRollback": false,
@@ -1691,6 +1815,1493 @@
           {
             "OutputKey": "TopicRef",
             "OutputValue": "arn:<partition>:sns:<region>:111111111111:topic-name-1"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_serverless_fn_transform": {
+    "recorded-date": "30-05-2025, 19:17:58",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Role": "{{changeSet:KNOWN_AFTER_APPLY}}",
+                  "Handler": "index.handler",
+                  "Runtime": "nodejs18.x",
+                  "Code": {
+                    "ZipFile": "exports.handler = async (event) => {\n  return {\n    statusCode: 200,\n    body: JSON.stringify({ message: 'Hello from SAM inline function!' })\n  };\n};"
+                  },
+                  "Tags": [
+                    {
+                      "Value": "SAM",
+                      "Key": "lambda:createdBy"
+                    }
+                  ]
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "HelloWorldFunction",
+              "ResourceType": "AWS::Lambda::Function",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "FunctionName": "{{changeSet:KNOWN_AFTER_APPLY}}",
+                  "Action": "lambda:InvokeFunction",
+                  "SourceArn": "{{changeSet:KNOWN_AFTER_APPLY}}",
+                  "Principal": "apigateway.amazonaws.com"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "HelloWorldFunctionApiEventPermissionProd",
+              "ResourceType": "AWS::Lambda::Permission",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "ManagedPolicyArns": [
+                    "arn:<partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                  ],
+                  "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                      {
+                        "Action": [
+                          "sts:AssumeRole"
+                        ],
+                        "Effect": "Allow",
+                        "Principal": {
+                          "Service": [
+                            "lambda.amazonaws.com"
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "Tags": [
+                    {
+                      "Value": "SAM",
+                      "Key": "lambda:createdBy"
+                    }
+                  ]
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "HelloWorldFunctionRole",
+              "ResourceType": "AWS::IAM::Role",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Body": {
+                    "paths": {
+                      "/<resource:6>": {
+                        "get": {
+                          "responses": {},
+                          "x-amazon-apigateway-integration": {
+                            "httpMethod": "POST",
+                            "type": "aws_proxy",
+                            "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/{{changeSet:KNOWN_AFTER_APPLY}}/invocations"
+                          }
+                        }
+                      }
+                    },
+                    "swagger": "2.0",
+                    "info": {
+                      "title": "<stack-name:1>",
+                      "version": "1.0"
+                    }
+                  }
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "ServerlessRestApi",
+              "ResourceType": "AWS::ApiGateway::RestApi",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "RestApiId": "{{changeSet:KNOWN_AFTER_APPLY}}",
+                  "Description": "RestApi deployment id: 47fc2d5f9d21ad56f83937abe2779d0e26d7095e",
+                  "StageName": "Stage"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "ServerlessRestApiDeployment47fc2d5f9d",
+              "ResourceType": "AWS::ApiGateway::Deployment",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "RestApiId": "{{changeSet:KNOWN_AFTER_APPLY}}",
+                  "DeploymentId": "{{changeSet:KNOWN_AFTER_APPLY}}",
+                  "StageName": "Prod"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "ServerlessRestApiProdStage",
+              "ResourceType": "AWS::ApiGateway::Stage",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Remove",
+              "BeforeContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "PolicyAction": "Delete",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "HelloWorldFunction",
+              "ResourceType": "AWS::Lambda::Function",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "HelloWorldFunctionApiEventPermissionProd",
+              "ResourceType": "AWS::Lambda::Permission",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "HelloWorldFunctionRole",
+              "ResourceType": "AWS::IAM::Role",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "ServerlessRestApi",
+              "ResourceType": "AWS::ApiGateway::RestApi",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "ServerlessRestApiDeployment47fc2d5f9d",
+              "ResourceType": "AWS::ApiGateway::Deployment",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "ServerlessRestApiProdStage",
+              "ResourceType": "AWS::ApiGateway::Stage",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Remove",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "PolicyAction": "Delete",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "HelloWorldFunction": [
+          {
+            "EventId": "HelloWorldFunction-CREATE_COMPLETE-date",
+            "LogicalResourceId": "HelloWorldFunction",
+            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1",
+            "ResourceProperties": {
+              "Role": "arn:<partition>:iam::111111111111:role/<resource:5>",
+              "Runtime": "nodejs18.x",
+              "Handler": "index.handler",
+              "Code": {
+                "ZipFile": "exports.handler = async (event) => {\n  return {\n    statusCode: 200,\n    body: JSON.stringify({ message: 'Hello from SAM inline function!' })\n  };\n};"
+              },
+              "Tags": [
+                {
+                  "Value": "SAM",
+                  "Key": "lambda:createdBy"
+                }
+              ]
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::Lambda::Function",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "HelloWorldFunction-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "HelloWorldFunction",
+            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1",
+            "ResourceProperties": {
+              "Role": "arn:<partition>:iam::111111111111:role/<resource:5>",
+              "Runtime": "nodejs18.x",
+              "Handler": "index.handler",
+              "Code": {
+                "ZipFile": "exports.handler = async (event) => {\n  return {\n    statusCode: 200,\n    body: JSON.stringify({ message: 'Hello from SAM inline function!' })\n  };\n};"
+              },
+              "Tags": [
+                {
+                  "Value": "SAM",
+                  "Key": "lambda:createdBy"
+                }
+              ]
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::Lambda::Function",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "HelloWorldFunction-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "HelloWorldFunction",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "Role": "arn:<partition>:iam::111111111111:role/<resource:5>",
+              "Runtime": "nodejs18.x",
+              "Handler": "index.handler",
+              "Code": {
+                "ZipFile": "exports.handler = async (event) => {\n  return {\n    statusCode: 200,\n    body: JSON.stringify({ message: 'Hello from SAM inline function!' })\n  };\n};"
+              },
+              "Tags": [
+                {
+                  "Value": "SAM",
+                  "Key": "lambda:createdBy"
+                }
+              ]
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::Lambda::Function",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "HelloWorldFunctionApiEventPermissionProd": [
+          {
+            "EventId": "HelloWorldFunctionApiEventPermissionProd-CREATE_COMPLETE-date",
+            "LogicalResourceId": "HelloWorldFunctionApiEventPermissionProd",
+            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunctionApiEventPermissionProd-He3072PnKtRX",
+            "ResourceProperties": {
+              "FunctionName": "<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1",
+              "Action": "lambda:InvokeFunction",
+              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:yn2f9dmisl/*/GET/<resource:6>",
+              "Principal": "apigateway.amazonaws.com"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::Lambda::Permission",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "HelloWorldFunctionApiEventPermissionProd-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "HelloWorldFunctionApiEventPermissionProd",
+            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunctionApiEventPermissionProd-He3072PnKtRX",
+            "ResourceProperties": {
+              "FunctionName": "<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1",
+              "Action": "lambda:InvokeFunction",
+              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:yn2f9dmisl/*/GET/<resource:6>",
+              "Principal": "apigateway.amazonaws.com"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::Lambda::Permission",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "HelloWorldFunctionApiEventPermissionProd-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "HelloWorldFunctionApiEventPermissionProd",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "FunctionName": "<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1",
+              "Action": "lambda:InvokeFunction",
+              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:yn2f9dmisl/*/GET/<resource:6>",
+              "Principal": "apigateway.amazonaws.com"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::Lambda::Permission",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "HelloWorldFunctionRole": [
+          {
+            "EventId": "HelloWorldFunctionRole-CREATE_COMPLETE-date",
+            "LogicalResourceId": "HelloWorldFunctionRole",
+            "PhysicalResourceId": "<resource:5>",
+            "ResourceProperties": {
+              "ManagedPolicyArns": [
+                "arn:<partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ],
+              "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Action": [
+                      "sts:AssumeRole"
+                    ],
+                    "Effect": "Allow",
+                    "Principal": {
+                      "Service": [
+                        "lambda.amazonaws.com"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "Tags": [
+                {
+                  "Value": "SAM",
+                  "Key": "lambda:createdBy"
+                }
+              ]
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::IAM::Role",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "HelloWorldFunctionRole-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "HelloWorldFunctionRole",
+            "PhysicalResourceId": "<resource:5>",
+            "ResourceProperties": {
+              "ManagedPolicyArns": [
+                "arn:<partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ],
+              "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Action": [
+                      "sts:AssumeRole"
+                    ],
+                    "Effect": "Allow",
+                    "Principal": {
+                      "Service": [
+                        "lambda.amazonaws.com"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "Tags": [
+                {
+                  "Value": "SAM",
+                  "Key": "lambda:createdBy"
+                }
+              ]
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::IAM::Role",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "HelloWorldFunctionRole-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "HelloWorldFunctionRole",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "ManagedPolicyArns": [
+                "arn:<partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ],
+              "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Action": [
+                      "sts:AssumeRole"
+                    ],
+                    "Effect": "Allow",
+                    "Principal": {
+                      "Service": [
+                        "lambda.amazonaws.com"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "Tags": [
+                {
+                  "Value": "SAM",
+                  "Key": "lambda:createdBy"
+                }
+              ]
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::IAM::Role",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ServerlessRestApi": [
+          {
+            "EventId": "ServerlessRestApi-CREATE_COMPLETE-date",
+            "LogicalResourceId": "ServerlessRestApi",
+            "PhysicalResourceId": "yn2f9dmisl",
+            "ResourceProperties": {
+              "Body": {
+                "paths": {
+                  "/<resource:6>": {
+                    "get": {
+                      "responses": {},
+                      "x-amazon-apigateway-integration": {
+                        "httpMethod": "POST",
+                        "type": "aws_proxy",
+                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1/invocations"
+                      }
+                    }
+                  }
+                },
+                "swagger": "2.0",
+                "info": {
+                  "title": "<stack-name:1>",
+                  "version": "1.0"
+                }
+              }
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::ApiGateway::RestApi",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "ServerlessRestApi-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "ServerlessRestApi",
+            "PhysicalResourceId": "yn2f9dmisl",
+            "ResourceProperties": {
+              "Body": {
+                "paths": {
+                  "/<resource:6>": {
+                    "get": {
+                      "responses": {},
+                      "x-amazon-apigateway-integration": {
+                        "httpMethod": "POST",
+                        "type": "aws_proxy",
+                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1/invocations"
+                      }
+                    }
+                  }
+                },
+                "swagger": "2.0",
+                "info": {
+                  "title": "<stack-name:1>",
+                  "version": "1.0"
+                }
+              }
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::ApiGateway::RestApi",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "ServerlessRestApi-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "ServerlessRestApi",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "Body": {
+                "paths": {
+                  "/<resource:6>": {
+                    "get": {
+                      "responses": {},
+                      "x-amazon-apigateway-integration": {
+                        "httpMethod": "POST",
+                        "type": "aws_proxy",
+                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1/invocations"
+                      }
+                    }
+                  }
+                },
+                "swagger": "2.0",
+                "info": {
+                  "title": "<stack-name:1>",
+                  "version": "1.0"
+                }
+              }
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::ApiGateway::RestApi",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ServerlessRestApiDeployment47fc2d5f9d": [
+          {
+            "EventId": "ServerlessRestApiDeployment47fc2d5f9d-CREATE_COMPLETE-date",
+            "LogicalResourceId": "ServerlessRestApiDeployment47fc2d5f9d",
+            "PhysicalResourceId": "p4f5gj",
+            "ResourceProperties": {
+              "Description": "RestApi deployment id: 47fc2d5f9d21ad56f83937abe2779d0e26d7095e",
+              "StageName": "Stage",
+              "RestApiId": "yn2f9dmisl"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::ApiGateway::Deployment",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "ServerlessRestApiDeployment47fc2d5f9d-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "ServerlessRestApiDeployment47fc2d5f9d",
+            "PhysicalResourceId": "p4f5gj",
+            "ResourceProperties": {
+              "Description": "RestApi deployment id: 47fc2d5f9d21ad56f83937abe2779d0e26d7095e",
+              "StageName": "Stage",
+              "RestApiId": "yn2f9dmisl"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::ApiGateway::Deployment",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "ServerlessRestApiDeployment47fc2d5f9d-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "ServerlessRestApiDeployment47fc2d5f9d",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "Description": "RestApi deployment id: 47fc2d5f9d21ad56f83937abe2779d0e26d7095e",
+              "StageName": "Stage",
+              "RestApiId": "yn2f9dmisl"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::ApiGateway::Deployment",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ServerlessRestApiProdStage": [
+          {
+            "EventId": "ServerlessRestApiProdStage-CREATE_COMPLETE-date",
+            "LogicalResourceId": "ServerlessRestApiProdStage",
+            "PhysicalResourceId": "Prod",
+            "ResourceProperties": {
+              "DeploymentId": "p4f5gj",
+              "StageName": "Prod",
+              "RestApiId": "yn2f9dmisl"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::ApiGateway::Stage",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "ServerlessRestApiProdStage-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "ServerlessRestApiProdStage",
+            "PhysicalResourceId": "Prod",
+            "ResourceProperties": {
+              "DeploymentId": "p4f5gj",
+              "StageName": "Prod",
+              "RestApiId": "yn2f9dmisl"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::ApiGateway::Stage",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "ServerlessRestApiProdStage-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "ServerlessRestApiProdStage",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DeploymentId": "p4f5gj",
+              "StageName": "Prod",
+              "RestApiId": "yn2f9dmisl"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::ApiGateway::Stage",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Topic1": [
+          {
+            "EventId": "Topic1-bc7f9092-e33e-4b75-9ab9-0b05a1eca865",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-53c44796-6014-4724-bf4e-398b5792343b",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_macro_fn_transform": {
+    "recorded-date": "30-05-2025, 19:19:36",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "{Substitution}",
+                  "Type": "String"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Remove",
+              "BeforeContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "PolicyAction": "Delete",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Substitution",
+            "ParameterValue": "SubstitutionDefault"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Remove",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "PolicyAction": "Delete",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Substitution",
+            "ParameterValue": "SubstitutionDefault"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Substitution",
+            "ParameterValue": "SubstitutionDefault"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Parameter": [
+          {
+            "EventId": "Parameter-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-RKPmUsCVodiF",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "{Substitution}"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-RKPmUsCVodiF",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "{Substitution}"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "{Substitution}"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Topic1": [
+          {
+            "EventId": "Topic1-d999817d-18b1-45e2-b4f2-ff6a275ad13f",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-ad6d008a-83b5-44f0-b20a-6f5106380a58",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Substitution",
+            "ParameterValue": "SubstitutionDefault"
           }
         ],
         "RollbackConfiguration": {},

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[yml]": {
-    "recorded-date": "02-06-2025, 17:36:48",
+    "recorded-date": "03-06-2025, 21:29:28",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -24,13 +24,14 @@
               "Action": "Add",
               "AfterContext": {
                 "Properties": {
-                  "DisplayName": "display-value-1",
-                  "TopicName": "topic-name-1"
+                  "Value": "foo",
+                  "Type": "String",
+                  "Name": "topic-name-1"
                 }
               },
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -62,8 +63,8 @@
             "ResourceChange": {
               "Action": "Add",
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -128,55 +129,17 @@
         "Changes": [
           {
             "ResourceChange": {
-              "Action": "Modify",
-              "AfterContext": {
-                "Properties": {
-                  "DisplayName": "The stack name is <stack-name:1>",
-                  "TopicName": "topic-name-1"
-                }
-              },
-              "BeforeContext": {
-                "Properties": {
-                  "DisplayName": "display-value-1",
-                  "TopicName": "topic-name-1"
-                }
-              },
-              "Details": [
-                {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Static",
-                  "Target": {
-                    "AfterValue": "The stack name is <stack-name:1>",
-                    "Attribute": "Properties",
-                    "AttributeChangeType": "Modify",
-                    "BeforeValue": "display-value-1",
-                    "Name": "DisplayName",
-                    "Path": "/Properties/DisplayName",
-                    "RequiresRecreation": "Never"
-                  }
-                }
-              ],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "Replacement": "False",
-              "ResourceType": "AWS::SNS::Topic",
-              "Scope": [
-                "Properties"
-              ]
-            },
-            "Type": "Resource"
-          },
-          {
-            "ResourceChange": {
               "Action": "Add",
               "AfterContext": {
                 "Properties": {
-                  "TopicName": "<resource:5>"
+                  "Value": "foo",
+                  "Type": "String",
+                  "Name": "name-2-bd1e2d36"
                 }
               },
               "Details": [],
-              "LogicalResourceId": "Topic2",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter2",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -206,34 +169,10 @@
         "Changes": [
           {
             "ResourceChange": {
-              "Action": "Modify",
-              "Details": [
-                {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Static",
-                  "Target": {
-                    "Attribute": "Properties",
-                    "Name": "DisplayName",
-                    "RequiresRecreation": "Never"
-                  }
-                }
-              ],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "Replacement": "False",
-              "ResourceType": "AWS::SNS::Topic",
-              "Scope": [
-                "Properties"
-              ]
-            },
-            "Type": "Resource"
-          },
-          {
-            "ResourceChange": {
               "Action": "Add",
               "Details": [],
-              "LogicalResourceId": "Topic2",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter2",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -280,116 +219,97 @@
         "Tags": []
       },
       "per-resource-events": {
-        "Topic1": [
+        "Parameter": [
           {
-            "EventId": "Topic1-UPDATE_COMPLETE-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "EventId": "Parameter-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
             "ResourceProperties": {
-              "DisplayName": "The stack name is <stack-name:1>",
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "DisplayName": "The stack name is <stack-name:1>",
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "topic-name-1"
             },
             "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
             "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "topic-name-1"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
             "PhysicalResourceId": "",
             "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "topic-name-1"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
         ],
-        "Topic2": [
+        "Parameter2": [
           {
-            "EventId": "Topic2-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Topic2",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:5>",
+            "EventId": "Parameter2-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter2",
+            "PhysicalResourceId": "name-2-bd1e2d36",
             "ResourceProperties": {
-              "TopicName": "<resource:5>"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "name-2-bd1e2d36"
             },
             "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic2",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:5>",
+            "EventId": "Parameter2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter2",
+            "PhysicalResourceId": "name-2-bd1e2d36",
             "ResourceProperties": {
-              "TopicName": "<resource:5>"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "name-2-bd1e2d36"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic2",
+            "EventId": "Parameter2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter2",
             "PhysicalResourceId": "",
             "ResourceProperties": {
-              "TopicName": "<resource:5>"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "name-2-bd1e2d36"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
@@ -484,7 +404,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[json]": {
-    "recorded-date": "02-06-2025, 17:38:17",
+    "recorded-date": "03-06-2025, 21:29:58",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -508,13 +428,14 @@
               "Action": "Add",
               "AfterContext": {
                 "Properties": {
-                  "DisplayName": "display-value-1",
-                  "TopicName": "topic-name-1"
+                  "Value": "foo",
+                  "Type": "String",
+                  "Name": "topic-name-1"
                 }
               },
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -546,8 +467,8 @@
             "ResourceChange": {
               "Action": "Add",
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -615,14 +536,16 @@
               "Action": "Modify",
               "AfterContext": {
                 "Properties": {
-                  "DisplayName": "The stack name is <stack-name:1>",
-                  "TopicName": "topic-name-1"
+                  "Value": "foo",
+                  "Type": "String",
+                  "Name": "name-2-3e00e97a"
                 }
               },
               "BeforeContext": {
                 "Properties": {
-                  "DisplayName": "display-value-1",
-                  "TopicName": "topic-name-1"
+                  "Value": "foo",
+                  "Type": "String",
+                  "Name": "topic-name-1"
                 }
               },
               "Details": [
@@ -630,38 +553,24 @@
                   "ChangeSource": "DirectModification",
                   "Evaluation": "Static",
                   "Target": {
-                    "AfterValue": "The stack name is <stack-name:1>",
+                    "AfterValue": "name-2-3e00e97a",
                     "Attribute": "Properties",
                     "AttributeChangeType": "Modify",
-                    "BeforeValue": "display-value-1",
-                    "Name": "DisplayName",
-                    "Path": "/Properties/DisplayName",
-                    "RequiresRecreation": "Never"
+                    "BeforeValue": "topic-name-1",
+                    "Name": "Name",
+                    "Path": "/Properties/Name",
+                    "RequiresRecreation": "Always"
                   }
                 }
               ],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "Replacement": "False",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "topic-name-1",
+              "PolicyAction": "ReplaceAndDelete",
+              "Replacement": "True",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
                 "Properties"
               ]
-            },
-            "Type": "Resource"
-          },
-          {
-            "ResourceChange": {
-              "Action": "Add",
-              "AfterContext": {
-                "Properties": {
-                  "TopicName": "<resource:5>"
-                }
-              },
-              "Details": [],
-              "LogicalResourceId": "Topic2",
-              "ResourceType": "AWS::SNS::Topic",
-              "Scope": []
             },
             "Type": "Resource"
           }
@@ -697,28 +606,19 @@
                   "Evaluation": "Static",
                   "Target": {
                     "Attribute": "Properties",
-                    "Name": "DisplayName",
-                    "RequiresRecreation": "Never"
+                    "Name": "Name",
+                    "RequiresRecreation": "Always"
                   }
                 }
               ],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "Replacement": "False",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "topic-name-1",
+              "PolicyAction": "ReplaceAndDelete",
+              "Replacement": "True",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
                 "Properties"
               ]
-            },
-            "Type": "Resource"
-          },
-          {
-            "ResourceChange": {
-              "Action": "Add",
-              "Details": [],
-              "LogicalResourceId": "Topic2",
-              "ResourceType": "AWS::SNS::Topic",
-              "Scope": []
             },
             "Type": "Resource"
           }
@@ -764,116 +664,116 @@
         "Tags": []
       },
       "per-resource-events": {
-        "Topic1": [
+        "Parameter": [
           {
-            "EventId": "Topic1-UPDATE_COMPLETE-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "EventId": "Parameter-5cbf35a2-4a92-4554-a111-1f96269d3814",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-06c1c753-8966-4dc1-9a39-cfbe492abedb",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "name-2-3e00e97a",
             "ResourceProperties": {
-              "DisplayName": "The stack name is <stack-name:1>",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "name-2-3e00e97a"
             },
             "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "EventId": "Parameter-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "name-2-3e00e97a",
             "ResourceProperties": {
-              "DisplayName": "The stack name is <stack-name:1>",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "name-2-3e00e97a"
             },
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "EventId": "Parameter-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
             "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "name-2-3e00e97a"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "Requested update requires the creation of a new physical resource; hence creating one.",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "foo",
+              "Name": "topic-name-1"
             },
             "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
             "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "topic-name-1"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
             "PhysicalResourceId": "",
             "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "topic-name-1"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          }
-        ],
-        "Topic2": [
-          {
-            "EventId": "Topic2-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Topic2",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:5>",
-            "ResourceProperties": {
-              "TopicName": "<resource:5>"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic2",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:5>",
-            "ResourceProperties": {
-              "TopicName": "<resource:5>"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic2",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "TopicName": "<resource:5>"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
@@ -968,7 +868,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[json]": {
-    "recorded-date": "02-06-2025, 17:41:20",
+    "recorded-date": "03-06-2025, 21:30:48",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -992,13 +892,14 @@
               "Action": "Add",
               "AfterContext": {
                 "Properties": {
-                  "DisplayName": "display-value-1",
-                  "TopicName": "topic-name-1"
+                  "Value": "foo",
+                  "Type": "String",
+                  "Name": "topic-name-1"
                 }
               },
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -1030,8 +931,8 @@
             "ResourceChange": {
               "Action": "Add",
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -1093,48 +994,7 @@
         ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-id:1>",
-        "Changes": [
-          {
-            "ResourceChange": {
-              "Action": "Modify",
-              "AfterContext": {
-                "Properties": {
-                  "DisplayName": "The stack name is <stack-name:1>",
-                  "TopicName": "topic-name-1"
-                }
-              },
-              "BeforeContext": {
-                "Properties": {
-                  "DisplayName": "display-value-1",
-                  "TopicName": "topic-name-1"
-                }
-              },
-              "Details": [
-                {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Static",
-                  "Target": {
-                    "AfterValue": "The stack name is <stack-name:1>",
-                    "Attribute": "Properties",
-                    "AttributeChangeType": "Modify",
-                    "BeforeValue": "display-value-1",
-                    "Name": "DisplayName",
-                    "Path": "/Properties/DisplayName",
-                    "RequiresRecreation": "Never"
-                  }
-                }
-              ],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "Replacement": "False",
-              "ResourceType": "AWS::SNS::Topic",
-              "Scope": [
-                "Properties"
-              ]
-            },
-            "Type": "Resource"
-          }
-        ],
+        "Changes": [],
         "CreationTime": "datetime",
         "ExecutionStatus": "AVAILABLE",
         "IncludeNestedStacks": false,
@@ -1156,32 +1016,7 @@
         ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-id:1>",
-        "Changes": [
-          {
-            "ResourceChange": {
-              "Action": "Modify",
-              "Details": [
-                {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Static",
-                  "Target": {
-                    "Attribute": "Properties",
-                    "Name": "DisplayName",
-                    "RequiresRecreation": "Never"
-                  }
-                }
-              ],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "Replacement": "False",
-              "ResourceType": "AWS::SNS::Topic",
-              "Scope": [
-                "Properties"
-              ]
-            },
-            "Type": "Resource"
-          }
-        ],
+        "Changes": [],
         "CreationTime": "datetime",
         "ExecutionStatus": "AVAILABLE",
         "IncludeNestedStacks": false,
@@ -1218,8 +1053,8 @@
         "NotificationARNs": [],
         "Outputs": [
           {
-            "OutputKey": "TopicRef",
-            "OutputValue": "arn:<partition>:sns:<region>:111111111111:topic-name-1"
+            "OutputKey": "ParameterRef",
+            "OutputValue": "topic-name-1"
           }
         ],
         "RollbackConfiguration": {},
@@ -1229,74 +1064,49 @@
         "Tags": []
       },
       "per-resource-events": {
-        "Topic1": [
+        "Parameter": [
           {
-            "EventId": "Topic1-UPDATE_COMPLETE-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "EventId": "Parameter-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
             "ResourceProperties": {
-              "DisplayName": "The stack name is <stack-name:1>",
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "DisplayName": "The stack name is <stack-name:1>",
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "topic-name-1"
             },
             "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
             "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "topic-name-1"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
             "PhysicalResourceId": "",
             "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "topic-name-1"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
@@ -1384,8 +1194,8 @@
         "NotificationARNs": [],
         "Outputs": [
           {
-            "OutputKey": "TopicRef",
-            "OutputValue": "arn:<partition>:sns:<region>:111111111111:topic-name-1"
+            "OutputKey": "ParameterRef",
+            "OutputValue": "topic-name-1"
           }
         ],
         "RollbackConfiguration": {},
@@ -1397,7 +1207,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[yml]": {
-    "recorded-date": "02-06-2025, 17:39:48",
+    "recorded-date": "03-06-2025, 21:30:23",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -1421,13 +1231,14 @@
               "Action": "Add",
               "AfterContext": {
                 "Properties": {
-                  "DisplayName": "display-value-1",
-                  "TopicName": "topic-name-1"
+                  "Value": "foo",
+                  "Type": "String",
+                  "Name": "topic-name-1"
                 }
               },
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -1459,8 +1270,8 @@
             "ResourceChange": {
               "Action": "Add",
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -1522,48 +1333,7 @@
         ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-id:1>",
-        "Changes": [
-          {
-            "ResourceChange": {
-              "Action": "Modify",
-              "AfterContext": {
-                "Properties": {
-                  "DisplayName": "The stack name is <stack-name:1>",
-                  "TopicName": "topic-name-1"
-                }
-              },
-              "BeforeContext": {
-                "Properties": {
-                  "DisplayName": "display-value-1",
-                  "TopicName": "topic-name-1"
-                }
-              },
-              "Details": [
-                {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Static",
-                  "Target": {
-                    "AfterValue": "The stack name is <stack-name:1>",
-                    "Attribute": "Properties",
-                    "AttributeChangeType": "Modify",
-                    "BeforeValue": "display-value-1",
-                    "Name": "DisplayName",
-                    "Path": "/Properties/DisplayName",
-                    "RequiresRecreation": "Never"
-                  }
-                }
-              ],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "Replacement": "False",
-              "ResourceType": "AWS::SNS::Topic",
-              "Scope": [
-                "Properties"
-              ]
-            },
-            "Type": "Resource"
-          }
-        ],
+        "Changes": [],
         "CreationTime": "datetime",
         "ExecutionStatus": "AVAILABLE",
         "IncludeNestedStacks": false,
@@ -1585,32 +1355,7 @@
         ],
         "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-id:1>",
-        "Changes": [
-          {
-            "ResourceChange": {
-              "Action": "Modify",
-              "Details": [
-                {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Static",
-                  "Target": {
-                    "Attribute": "Properties",
-                    "Name": "DisplayName",
-                    "RequiresRecreation": "Never"
-                  }
-                }
-              ],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "Replacement": "False",
-              "ResourceType": "AWS::SNS::Topic",
-              "Scope": [
-                "Properties"
-              ]
-            },
-            "Type": "Resource"
-          }
-        ],
+        "Changes": [],
         "CreationTime": "datetime",
         "ExecutionStatus": "AVAILABLE",
         "IncludeNestedStacks": false,
@@ -1647,8 +1392,8 @@
         "NotificationARNs": [],
         "Outputs": [
           {
-            "OutputKey": "TopicRef",
-            "OutputValue": "arn:<partition>:sns:<region>:111111111111:topic-name-1"
+            "OutputKey": "ParameterRef",
+            "OutputValue": "topic-name-1"
           }
         ],
         "RollbackConfiguration": {},
@@ -1658,74 +1403,49 @@
         "Tags": []
       },
       "per-resource-events": {
-        "Topic1": [
+        "Parameter": [
           {
-            "EventId": "Topic1-UPDATE_COMPLETE-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "EventId": "Parameter-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
             "ResourceProperties": {
-              "DisplayName": "The stack name is <stack-name:1>",
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "DisplayName": "The stack name is <stack-name:1>",
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "topic-name-1"
             },
             "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
             "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "topic-name-1"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
             "PhysicalResourceId": "",
             "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "topic-name-1"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
@@ -1813,8 +1533,8 @@
         "NotificationARNs": [],
         "Outputs": [
           {
-            "OutputKey": "TopicRef",
-            "OutputValue": "arn:<partition>:sns:<region>:111111111111:topic-name-1"
+            "OutputKey": "ParameterRef",
+            "OutputValue": "topic-name-1"
           }
         ],
         "RollbackConfiguration": {},
@@ -1826,7 +1546,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_serverless_fn_transform": {
-    "recorded-date": "02-06-2025, 17:43:23",
+    "recorded-date": "03-06-2025, 21:32:10",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -1850,13 +1570,14 @@
               "Action": "Add",
               "AfterContext": {
                 "Properties": {
-                  "DisplayName": "display-value-1",
-                  "TopicName": "topic-name-1"
+                  "Value": "{Substitution}",
+                  "Type": "String",
+                  "Name": "topic-name-1"
                 }
               },
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -1888,8 +1609,8 @@
             "ResourceChange": {
               "Action": "Add",
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -2037,12 +1758,31 @@
           },
           {
             "ResourceChange": {
+              "Action": "Remove",
+              "BeforeContext": {
+                "Properties": {
+                  "Value": "{Substitution}",
+                  "Type": "String",
+                  "Name": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "topic-name-1",
+              "PolicyAction": "Delete",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
               "Action": "Add",
               "AfterContext": {
                 "Properties": {
                   "Body": {
                     "paths": {
-                      "/<resource:6>": {
+                      "/<resource:5>": {
                         "get": {
                           "responses": {},
                           "x-amazon-apigateway-integration": {
@@ -2098,24 +1838,6 @@
               "Details": [],
               "LogicalResourceId": "ServerlessRestApiProdStage",
               "ResourceType": "AWS::ApiGateway::Stage",
-              "Scope": []
-            },
-            "Type": "Resource"
-          },
-          {
-            "ResourceChange": {
-              "Action": "Remove",
-              "BeforeContext": {
-                "Properties": {
-                  "DisplayName": "display-value-1",
-                  "TopicName": "topic-name-1"
-                }
-              },
-              "Details": [],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "PolicyAction": "Delete",
-              "ResourceType": "AWS::SNS::Topic",
               "Scope": []
             },
             "Type": "Resource"
@@ -2175,6 +1897,18 @@
           },
           {
             "ResourceChange": {
+              "Action": "Remove",
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "topic-name-1",
+              "PolicyAction": "Delete",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
               "Action": "Add",
               "Details": [],
               "LogicalResourceId": "ServerlessRestApi",
@@ -2199,18 +1933,6 @@
               "Details": [],
               "LogicalResourceId": "ServerlessRestApiProdStage",
               "ResourceType": "AWS::ApiGateway::Stage",
-              "Scope": []
-            },
-            "Type": "Resource"
-          },
-          {
-            "ResourceChange": {
-              "Action": "Remove",
-              "Details": [],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "PolicyAction": "Delete",
-              "ResourceType": "AWS::SNS::Topic",
               "Scope": []
             },
             "Type": "Resource"
@@ -2261,9 +1983,9 @@
           {
             "EventId": "HelloWorldFunction-CREATE_COMPLETE-date",
             "LogicalResourceId": "HelloWorldFunction",
-            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunction-3tFROESvgtFK",
+            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunction-EdXB90Au1l86",
             "ResourceProperties": {
-              "Role": "arn:<partition>:iam::111111111111:role/<resource:5>",
+              "Role": "arn:<partition>:iam::111111111111:role/<resource:4>",
               "Runtime": "nodejs18.x",
               "Handler": "index.handler",
               "Code": {
@@ -2285,9 +2007,9 @@
           {
             "EventId": "HelloWorldFunction-CREATE_IN_PROGRESS-date",
             "LogicalResourceId": "HelloWorldFunction",
-            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunction-3tFROESvgtFK",
+            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunction-EdXB90Au1l86",
             "ResourceProperties": {
-              "Role": "arn:<partition>:iam::111111111111:role/<resource:5>",
+              "Role": "arn:<partition>:iam::111111111111:role/<resource:4>",
               "Runtime": "nodejs18.x",
               "Handler": "index.handler",
               "Code": {
@@ -2312,7 +2034,7 @@
             "LogicalResourceId": "HelloWorldFunction",
             "PhysicalResourceId": "",
             "ResourceProperties": {
-              "Role": "arn:<partition>:iam::111111111111:role/<resource:5>",
+              "Role": "arn:<partition>:iam::111111111111:role/<resource:4>",
               "Runtime": "nodejs18.x",
               "Handler": "index.handler",
               "Code": {
@@ -2336,11 +2058,11 @@
           {
             "EventId": "HelloWorldFunctionApiEventPermissionProd-CREATE_COMPLETE-date",
             "LogicalResourceId": "HelloWorldFunctionApiEventPermissionProd",
-            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunctionApiEventPermissionProd-5fBzi1JcOwIe",
+            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunctionApiEventPermissionProd-xfMFMMYChbqn",
             "ResourceProperties": {
-              "FunctionName": "<stack-name:1>-HelloWorldFunction-3tFROESvgtFK",
+              "FunctionName": "<stack-name:1>-HelloWorldFunction-EdXB90Au1l86",
               "Action": "lambda:InvokeFunction",
-              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:g59lz4kkbg/*/GET/<resource:6>",
+              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:317w2e8pc3/*/GET/<resource:5>",
               "Principal": "apigateway.amazonaws.com"
             },
             "ResourceStatus": "CREATE_COMPLETE",
@@ -2352,11 +2074,11 @@
           {
             "EventId": "HelloWorldFunctionApiEventPermissionProd-CREATE_IN_PROGRESS-date",
             "LogicalResourceId": "HelloWorldFunctionApiEventPermissionProd",
-            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunctionApiEventPermissionProd-5fBzi1JcOwIe",
+            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunctionApiEventPermissionProd-xfMFMMYChbqn",
             "ResourceProperties": {
-              "FunctionName": "<stack-name:1>-HelloWorldFunction-3tFROESvgtFK",
+              "FunctionName": "<stack-name:1>-HelloWorldFunction-EdXB90Au1l86",
               "Action": "lambda:InvokeFunction",
-              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:g59lz4kkbg/*/GET/<resource:6>",
+              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:317w2e8pc3/*/GET/<resource:5>",
               "Principal": "apigateway.amazonaws.com"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
@@ -2371,9 +2093,9 @@
             "LogicalResourceId": "HelloWorldFunctionApiEventPermissionProd",
             "PhysicalResourceId": "",
             "ResourceProperties": {
-              "FunctionName": "<stack-name:1>-HelloWorldFunction-3tFROESvgtFK",
+              "FunctionName": "<stack-name:1>-HelloWorldFunction-EdXB90Au1l86",
               "Action": "lambda:InvokeFunction",
-              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:g59lz4kkbg/*/GET/<resource:6>",
+              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:317w2e8pc3/*/GET/<resource:5>",
               "Principal": "apigateway.amazonaws.com"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
@@ -2387,7 +2109,7 @@
           {
             "EventId": "HelloWorldFunctionRole-CREATE_COMPLETE-date",
             "LogicalResourceId": "HelloWorldFunctionRole",
-            "PhysicalResourceId": "<resource:5>",
+            "PhysicalResourceId": "<resource:4>",
             "ResourceProperties": {
               "ManagedPolicyArns": [
                 "arn:<partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -2424,7 +2146,7 @@
           {
             "EventId": "HelloWorldFunctionRole-CREATE_IN_PROGRESS-date",
             "LogicalResourceId": "HelloWorldFunctionRole",
-            "PhysicalResourceId": "<resource:5>",
+            "PhysicalResourceId": "<resource:4>",
             "ResourceProperties": {
               "ManagedPolicyArns": [
                 "arn:<partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -2497,21 +2219,89 @@
             "Timestamp": "timestamp"
           }
         ],
+        "Parameter": [
+          {
+            "EventId": "Parameter-af425eba-d8e2-4ad9-9ebc-153095f8161d",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-adcb9c2b-0276-4487-9df6-5f12bf586323",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "{Substitution}",
+              "Name": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "topic-name-1",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "{Substitution}",
+              "Name": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "{Substitution}",
+              "Name": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
         "ServerlessRestApi": [
           {
             "EventId": "ServerlessRestApi-CREATE_COMPLETE-date",
             "LogicalResourceId": "ServerlessRestApi",
-            "PhysicalResourceId": "g59lz4kkbg",
+            "PhysicalResourceId": "317w2e8pc3",
             "ResourceProperties": {
               "Body": {
                 "paths": {
-                  "/<resource:6>": {
+                  "/<resource:5>": {
                     "get": {
                       "responses": {},
                       "x-amazon-apigateway-integration": {
                         "httpMethod": "POST",
                         "type": "aws_proxy",
-                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-3tFROESvgtFK/invocations"
+                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-EdXB90Au1l86/invocations"
                       }
                     }
                   }
@@ -2532,17 +2322,17 @@
           {
             "EventId": "ServerlessRestApi-CREATE_IN_PROGRESS-date",
             "LogicalResourceId": "ServerlessRestApi",
-            "PhysicalResourceId": "g59lz4kkbg",
+            "PhysicalResourceId": "317w2e8pc3",
             "ResourceProperties": {
               "Body": {
                 "paths": {
-                  "/<resource:6>": {
+                  "/<resource:5>": {
                     "get": {
                       "responses": {},
                       "x-amazon-apigateway-integration": {
                         "httpMethod": "POST",
                         "type": "aws_proxy",
-                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-3tFROESvgtFK/invocations"
+                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-EdXB90Au1l86/invocations"
                       }
                     }
                   }
@@ -2568,13 +2358,13 @@
             "ResourceProperties": {
               "Body": {
                 "paths": {
-                  "/<resource:6>": {
+                  "/<resource:5>": {
                     "get": {
                       "responses": {},
                       "x-amazon-apigateway-integration": {
                         "httpMethod": "POST",
                         "type": "aws_proxy",
-                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-3tFROESvgtFK/invocations"
+                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-EdXB90Au1l86/invocations"
                       }
                     }
                   }
@@ -2597,11 +2387,11 @@
           {
             "EventId": "ServerlessRestApiDeployment47fc2d5f9d-CREATE_COMPLETE-date",
             "LogicalResourceId": "ServerlessRestApiDeployment47fc2d5f9d",
-            "PhysicalResourceId": "qcrqox",
+            "PhysicalResourceId": "5oj1e3",
             "ResourceProperties": {
               "Description": "RestApi deployment id: 47fc2d5f9d21ad56f83937abe2779d0e26d7095e",
               "StageName": "Stage",
-              "RestApiId": "g59lz4kkbg"
+              "RestApiId": "317w2e8pc3"
             },
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::ApiGateway::Deployment",
@@ -2612,11 +2402,11 @@
           {
             "EventId": "ServerlessRestApiDeployment47fc2d5f9d-CREATE_IN_PROGRESS-date",
             "LogicalResourceId": "ServerlessRestApiDeployment47fc2d5f9d",
-            "PhysicalResourceId": "qcrqox",
+            "PhysicalResourceId": "5oj1e3",
             "ResourceProperties": {
               "Description": "RestApi deployment id: 47fc2d5f9d21ad56f83937abe2779d0e26d7095e",
               "StageName": "Stage",
-              "RestApiId": "g59lz4kkbg"
+              "RestApiId": "317w2e8pc3"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceStatusReason": "Resource creation Initiated",
@@ -2632,7 +2422,7 @@
             "ResourceProperties": {
               "Description": "RestApi deployment id: 47fc2d5f9d21ad56f83937abe2779d0e26d7095e",
               "StageName": "Stage",
-              "RestApiId": "g59lz4kkbg"
+              "RestApiId": "317w2e8pc3"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceType": "AWS::ApiGateway::Deployment",
@@ -2647,9 +2437,9 @@
             "LogicalResourceId": "ServerlessRestApiProdStage",
             "PhysicalResourceId": "Prod",
             "ResourceProperties": {
-              "DeploymentId": "qcrqox",
+              "DeploymentId": "5oj1e3",
               "StageName": "Prod",
-              "RestApiId": "g59lz4kkbg"
+              "RestApiId": "317w2e8pc3"
             },
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::ApiGateway::Stage",
@@ -2662,9 +2452,9 @@
             "LogicalResourceId": "ServerlessRestApiProdStage",
             "PhysicalResourceId": "Prod",
             "ResourceProperties": {
-              "DeploymentId": "qcrqox",
+              "DeploymentId": "5oj1e3",
               "StageName": "Prod",
-              "RestApiId": "g59lz4kkbg"
+              "RestApiId": "317w2e8pc3"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceStatusReason": "Resource creation Initiated",
@@ -2678,77 +2468,12 @@
             "LogicalResourceId": "ServerlessRestApiProdStage",
             "PhysicalResourceId": "",
             "ResourceProperties": {
-              "DeploymentId": "qcrqox",
+              "DeploymentId": "5oj1e3",
               "StageName": "Prod",
-              "RestApiId": "g59lz4kkbg"
+              "RestApiId": "317w2e8pc3"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceType": "AWS::ApiGateway::Stage",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          }
-        ],
-        "Topic1": [
-          {
-            "EventId": "Topic1-a79bb536-e5a8-4385-830c-0057881c0043",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceStatus": "DELETE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-e811be29-1d08-47d9-a9a3-7fd72bbf09eb",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceStatus": "DELETE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
@@ -2843,7 +2568,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_macro_fn_transform": {
-    "recorded-date": "02-06-2025, 17:44:59",
+    "recorded-date": "03-06-2025, 21:42:32",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -2867,13 +2592,14 @@
               "Action": "Add",
               "AfterContext": {
                 "Properties": {
-                  "DisplayName": "display-value-1",
-                  "TopicName": "topic-name-1"
+                  "Value": "original",
+                  "Type": "String",
+                  "Name": "name-1"
                 }
               },
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -2905,8 +2631,8 @@
             "ResourceChange": {
               "Action": "Add",
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -2971,35 +2697,43 @@
         "Changes": [
           {
             "ResourceChange": {
-              "Action": "Add",
+              "Action": "Modify",
               "AfterContext": {
                 "Properties": {
                   "Value": "{Substitution}",
-                  "Type": "String"
+                  "Type": "String",
+                  "Name": "name-1"
                 }
               },
-              "Details": [],
-              "LogicalResourceId": "Parameter",
-              "ResourceType": "AWS::SSM::Parameter",
-              "Scope": []
-            },
-            "Type": "Resource"
-          },
-          {
-            "ResourceChange": {
-              "Action": "Remove",
               "BeforeContext": {
                 "Properties": {
-                  "DisplayName": "display-value-1",
-                  "TopicName": "topic-name-1"
+                  "Value": "original",
+                  "Type": "String",
+                  "Name": "name-1"
                 }
               },
-              "Details": [],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "PolicyAction": "Delete",
-              "ResourceType": "AWS::SNS::Topic",
-              "Scope": []
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "{Substitution}",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "original",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
             },
             "Type": "Resource"
           }
@@ -3034,23 +2768,25 @@
         "Changes": [
           {
             "ResourceChange": {
-              "Action": "Add",
-              "Details": [],
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
               "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "name-1",
+              "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
-              "Scope": []
-            },
-            "Type": "Resource"
-          },
-          {
-            "ResourceChange": {
-              "Action": "Remove",
-              "Details": [],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "PolicyAction": "Delete",
-              "ResourceType": "AWS::SNS::Topic",
-              "Scope": []
+              "Scope": [
+                "Properties"
+              ]
             },
             "Type": "Resource"
           }
@@ -3110,12 +2846,43 @@
       "per-resource-events": {
         "Parameter": [
           {
+            "EventId": "Parameter-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "name-1",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "{Substitution}",
+              "Name": "name-1"
+            },
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "name-1",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "{Substitution}",
+              "Name": "name-1"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
             "EventId": "Parameter-CREATE_COMPLETE-date",
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-lnSABVaxQdt8",
+            "PhysicalResourceId": "name-1",
             "ResourceProperties": {
               "Type": "String",
-              "Value": "{Substitution}"
+              "Value": "original",
+              "Name": "name-1"
             },
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
@@ -3126,10 +2893,11 @@
           {
             "EventId": "Parameter-CREATE_IN_PROGRESS-date",
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-lnSABVaxQdt8",
+            "PhysicalResourceId": "name-1",
             "ResourceProperties": {
               "Type": "String",
-              "Value": "{Substitution}"
+              "Value": "original",
+              "Name": "name-1"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceStatusReason": "Resource creation Initiated",
@@ -3144,75 +2912,11 @@
             "PhysicalResourceId": "",
             "ResourceProperties": {
               "Type": "String",
-              "Value": "{Substitution}"
+              "Value": "original",
+              "Name": "name-1"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          }
-        ],
-        "Topic1": [
-          {
-            "EventId": "Topic1-d7cdeb51-69c0-4cb2-a5dc-c64c81b220e6",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceStatus": "DELETE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-2dc6b6ab-bd65-47b5-ada9-d7252c9babda",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceStatus": "DELETE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "DisplayName": "display-value-1",
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
@@ -3313,7 +3017,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_macro_fn_transform": {
-    "recorded-date": "02-06-2025, 18:07:36",
+    "recorded-date": "03-06-2025, 21:51:11",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -3337,12 +3041,14 @@
               "Action": "Add",
               "AfterContext": {
                 "Properties": {
-                  "TopicName": "topic-name-1"
+                  "Value": "foo",
+                  "Type": "String",
+                  "Name": "name-1"
                 }
               },
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -3374,8 +3080,8 @@
             "ResourceChange": {
               "Action": "Add",
               "Details": [],
-              "LogicalResourceId": "Topic1",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
             "Type": "Resource"
@@ -3443,14 +3149,19 @@
               "Action": "Modify",
               "AfterContext": {
                 "Properties": {
-                  "FifoTopic": "true",
-                  "ContentBasedDeduplication": "true",
-                  "TopicName": "<resource:5>"
+                  "Value": "foo",
+                  "Type": "String",
+                  "Tags": {
+                    "MacroAdded": "True"
+                  },
+                  "Name": "name-1"
                 }
               },
               "BeforeContext": {
                 "Properties": {
-                  "TopicName": "topic-name-1"
+                  "Value": "foo",
+                  "Type": "String",
+                  "Name": "name-1"
                 }
               },
               "Details": [
@@ -3458,45 +3169,21 @@
                   "ChangeSource": "DirectModification",
                   "Evaluation": "Static",
                   "Target": {
-                    "AfterValue": "true",
+                    "AfterValue": {
+                      "MacroAdded": "True"
+                    },
                     "Attribute": "Properties",
                     "AttributeChangeType": "Add",
-                    "Name": "FifoTopic",
-                    "Path": "/Properties/FifoTopic",
-                    "RequiresRecreation": "Always"
-                  }
-                },
-                {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Static",
-                  "Target": {
-                    "AfterValue": "true",
-                    "Attribute": "Properties",
-                    "AttributeChangeType": "Add",
-                    "Name": "ContentBasedDeduplication",
-                    "Path": "/Properties/ContentBasedDeduplication",
+                    "Name": "Tags",
+                    "Path": "/Properties/Tags",
                     "RequiresRecreation": "Never"
-                  }
-                },
-                {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Static",
-                  "Target": {
-                    "AfterValue": "<resource:5>",
-                    "Attribute": "Properties",
-                    "AttributeChangeType": "Modify",
-                    "BeforeValue": "topic-name-1",
-                    "Name": "TopicName",
-                    "Path": "/Properties/TopicName",
-                    "RequiresRecreation": "Always"
                   }
                 }
               ],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "PolicyAction": "ReplaceAndDelete",
-              "Replacement": "True",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
                 "Properties"
               ]
@@ -3535,34 +3222,15 @@
                   "Evaluation": "Static",
                   "Target": {
                     "Attribute": "Properties",
-                    "Name": "FifoTopic",
-                    "RequiresRecreation": "Always"
-                  }
-                },
-                {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Static",
-                  "Target": {
-                    "Attribute": "Properties",
-                    "Name": "ContentBasedDeduplication",
+                    "Name": "Tags",
                     "RequiresRecreation": "Never"
-                  }
-                },
-                {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Static",
-                  "Target": {
-                    "Attribute": "Properties",
-                    "Name": "TopicName",
-                    "RequiresRecreation": "Always"
                   }
                 }
               ],
-              "LogicalResourceId": "Topic1",
-              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-              "PolicyAction": "ReplaceAndDelete",
-              "Replacement": "True",
-              "ResourceType": "AWS::SNS::Topic",
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
                 "Properties"
               ]
@@ -3611,110 +3279,85 @@
         "Tags": []
       },
       "per-resource-events": {
-        "Topic1": [
+        "Parameter": [
           {
-            "EventId": "Topic1-4d2714dd-004a-47d7-b011-be0fa6fe8abb",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceStatus": "DELETE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-c481534a-a8c9-4ebb-9654-de44ab49fc4a",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceStatus": "DELETE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-UPDATE_COMPLETE-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:5>",
+            "EventId": "Parameter-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "name-1",
             "ResourceProperties": {
-              "FifoTopic": "true",
-              "ContentBasedDeduplication": "true",
-              "TopicName": "<resource:5>"
+              "Type": "String",
+              "Value": "foo",
+              "Tags": {
+                "MacroAdded": "True"
+              },
+              "Name": "name-1"
             },
             "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:5>",
+            "EventId": "Parameter-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "name-1",
             "ResourceProperties": {
-              "FifoTopic": "true",
-              "ContentBasedDeduplication": "true",
-              "TopicName": "<resource:5>"
+              "Type": "String",
+              "Value": "foo",
+              "Tags": {
+                "MacroAdded": "True"
+              },
+              "Name": "name-1"
             },
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "EventId": "Parameter-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "name-1",
             "ResourceProperties": {
-              "FifoTopic": "true",
-              "ContentBasedDeduplication": "true",
-              "TopicName": "<resource:5>"
-            },
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "Requested update requires the creation of a new physical resource; hence creating one.",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Topic1-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "name-1"
             },
             "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "name-1",
             "ResourceProperties": {
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "name-1"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Topic1",
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
             "PhysicalResourceId": "",
             "ResourceProperties": {
-              "TopicName": "topic-name-1"
+              "Type": "String",
+              "Value": "foo",
+              "Name": "name-1"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
+            "ResourceType": "AWS::SSM::Parameter",
             "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
@@ -3809,7 +3452,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_macro_for_attribute_fn_transform": {
-    "recorded-date": "02-06-2025, 20:02:13",
+    "recorded-date": "03-06-2025, 21:34:07",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -4258,7 +3901,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_multiple_fn_transform_order": {
-    "recorded-date": "02-06-2025, 20:36:50",
+    "recorded-date": "03-06-2025, 21:34:52",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
@@ -5394,5 +5394,354 @@
         ]
       }
     }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_macro_with_function": {
+    "recorded-date": "20-06-2025, 22:19:25",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:2>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "<value:2>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "<value:1>",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
@@ -1,0 +1,908 @@
+{
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[yml]": {
+    "recorded-date": "29-05-2025, 18:20:46",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "The stack name is <stack-name:1>",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "The stack name is <stack-name:1>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "display-value-1",
+                    "Name": "DisplayName",
+                    "Path": "/Properties/DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "TopicName": "<resource:5>"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic2",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic2",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Topic1": [
+          {
+            "EventId": "Topic1-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "The stack name is <stack-name:1>",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "The stack name is <stack-name:1>",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Topic2": [
+          {
+            "EventId": "Topic2-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:5>",
+            "ResourceProperties": {
+              "TopicName": "<resource:5>"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:5>",
+            "ResourceProperties": {
+              "TopicName": "<resource:5>"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "TopicName": "<resource:5>"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[json]": {
+    "recorded-date": "29-05-2025, 18:22:18",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "The stack name is <stack-name:1>",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "The stack name is <stack-name:1>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "display-value-1",
+                    "Name": "DisplayName",
+                    "Path": "/Properties/DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "TopicName": "<resource:5>"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic2",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic2",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Topic1": [
+          {
+            "EventId": "Topic1-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "The stack name is <stack-name:1>",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "The stack name is <stack-name:1>",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Topic2": [
+          {
+            "EventId": "Topic2-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:5>",
+            "ResourceProperties": {
+              "TopicName": "<resource:5>"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:5>",
+            "ResourceProperties": {
+              "TopicName": "<resource:5>"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "TopicName": "<resource:5>"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  }
+}

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
@@ -4324,5 +4324,1075 @@
         "Tags": []
       }
     }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_conditional_transform": {
+    "recorded-date": "20-06-2025, 21:12:31",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:2>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "<value:2>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "<value:1>",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Transform",
+            "ParameterValue": "true"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Transform",
+            "ParameterValue": "true"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Transform",
+            "ParameterValue": "true"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Transform",
+            "ParameterValue": "true"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_conditional_transform[true]": {
+    "recorded-date": "20-06-2025, 21:15:45",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:2>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "<value:2>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "<value:1>",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Transform",
+            "ParameterValue": "true"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Transform",
+            "ParameterValue": "true"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Transform",
+            "ParameterValue": "true"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Transform",
+            "ParameterValue": "true"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_conditional_transform[false]": {
+    "recorded-date": "20-06-2025, 21:16:29",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Remove",
+              "BeforeContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "PolicyAction": "Delete",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Transform",
+            "ParameterValue": "false"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Remove",
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "PolicyAction": "Delete",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Transform",
+            "ParameterValue": "false"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Transform",
+            "ParameterValue": "false"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Transform",
+            "ParameterValue": "false"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[yml]": {
-    "recorded-date": "30-05-2025, 19:11:21",
+    "recorded-date": "02-06-2025, 17:36:48",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -484,7 +484,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[json]": {
-    "recorded-date": "30-05-2025, 19:12:51",
+    "recorded-date": "02-06-2025, 17:38:17",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -968,7 +968,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[json]": {
-    "recorded-date": "30-05-2025, 19:15:53",
+    "recorded-date": "02-06-2025, 17:41:20",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -1397,7 +1397,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[yml]": {
-    "recorded-date": "30-05-2025, 19:14:21",
+    "recorded-date": "02-06-2025, 17:39:48",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -1826,7 +1826,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_serverless_fn_transform": {
-    "recorded-date": "30-05-2025, 19:17:58",
+    "recorded-date": "02-06-2025, 17:43:23",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -2261,7 +2261,7 @@
           {
             "EventId": "HelloWorldFunction-CREATE_COMPLETE-date",
             "LogicalResourceId": "HelloWorldFunction",
-            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1",
+            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunction-3tFROESvgtFK",
             "ResourceProperties": {
               "Role": "arn:<partition>:iam::111111111111:role/<resource:5>",
               "Runtime": "nodejs18.x",
@@ -2285,7 +2285,7 @@
           {
             "EventId": "HelloWorldFunction-CREATE_IN_PROGRESS-date",
             "LogicalResourceId": "HelloWorldFunction",
-            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1",
+            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunction-3tFROESvgtFK",
             "ResourceProperties": {
               "Role": "arn:<partition>:iam::111111111111:role/<resource:5>",
               "Runtime": "nodejs18.x",
@@ -2336,11 +2336,11 @@
           {
             "EventId": "HelloWorldFunctionApiEventPermissionProd-CREATE_COMPLETE-date",
             "LogicalResourceId": "HelloWorldFunctionApiEventPermissionProd",
-            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunctionApiEventPermissionProd-He3072PnKtRX",
+            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunctionApiEventPermissionProd-5fBzi1JcOwIe",
             "ResourceProperties": {
-              "FunctionName": "<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1",
+              "FunctionName": "<stack-name:1>-HelloWorldFunction-3tFROESvgtFK",
               "Action": "lambda:InvokeFunction",
-              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:yn2f9dmisl/*/GET/<resource:6>",
+              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:g59lz4kkbg/*/GET/<resource:6>",
               "Principal": "apigateway.amazonaws.com"
             },
             "ResourceStatus": "CREATE_COMPLETE",
@@ -2352,11 +2352,11 @@
           {
             "EventId": "HelloWorldFunctionApiEventPermissionProd-CREATE_IN_PROGRESS-date",
             "LogicalResourceId": "HelloWorldFunctionApiEventPermissionProd",
-            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunctionApiEventPermissionProd-He3072PnKtRX",
+            "PhysicalResourceId": "<stack-name:1>-HelloWorldFunctionApiEventPermissionProd-5fBzi1JcOwIe",
             "ResourceProperties": {
-              "FunctionName": "<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1",
+              "FunctionName": "<stack-name:1>-HelloWorldFunction-3tFROESvgtFK",
               "Action": "lambda:InvokeFunction",
-              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:yn2f9dmisl/*/GET/<resource:6>",
+              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:g59lz4kkbg/*/GET/<resource:6>",
               "Principal": "apigateway.amazonaws.com"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
@@ -2371,9 +2371,9 @@
             "LogicalResourceId": "HelloWorldFunctionApiEventPermissionProd",
             "PhysicalResourceId": "",
             "ResourceProperties": {
-              "FunctionName": "<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1",
+              "FunctionName": "<stack-name:1>-HelloWorldFunction-3tFROESvgtFK",
               "Action": "lambda:InvokeFunction",
-              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:yn2f9dmisl/*/GET/<resource:6>",
+              "SourceArn": "arn:<partition>:execute-api:<region>:111111111111:g59lz4kkbg/*/GET/<resource:6>",
               "Principal": "apigateway.amazonaws.com"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
@@ -2501,7 +2501,7 @@
           {
             "EventId": "ServerlessRestApi-CREATE_COMPLETE-date",
             "LogicalResourceId": "ServerlessRestApi",
-            "PhysicalResourceId": "yn2f9dmisl",
+            "PhysicalResourceId": "g59lz4kkbg",
             "ResourceProperties": {
               "Body": {
                 "paths": {
@@ -2511,7 +2511,7 @@
                       "x-amazon-apigateway-integration": {
                         "httpMethod": "POST",
                         "type": "aws_proxy",
-                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1/invocations"
+                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-3tFROESvgtFK/invocations"
                       }
                     }
                   }
@@ -2532,7 +2532,7 @@
           {
             "EventId": "ServerlessRestApi-CREATE_IN_PROGRESS-date",
             "LogicalResourceId": "ServerlessRestApi",
-            "PhysicalResourceId": "yn2f9dmisl",
+            "PhysicalResourceId": "g59lz4kkbg",
             "ResourceProperties": {
               "Body": {
                 "paths": {
@@ -2542,7 +2542,7 @@
                       "x-amazon-apigateway-integration": {
                         "httpMethod": "POST",
                         "type": "aws_proxy",
-                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1/invocations"
+                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-3tFROESvgtFK/invocations"
                       }
                     }
                   }
@@ -2574,7 +2574,7 @@
                       "x-amazon-apigateway-integration": {
                         "httpMethod": "POST",
                         "type": "aws_proxy",
-                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-rHxmhaPeJGt1/invocations"
+                        "uri": "arn:<partition>:apigateway:<region>:lambda:path/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<stack-name:1>-HelloWorldFunction-3tFROESvgtFK/invocations"
                       }
                     }
                   }
@@ -2597,11 +2597,11 @@
           {
             "EventId": "ServerlessRestApiDeployment47fc2d5f9d-CREATE_COMPLETE-date",
             "LogicalResourceId": "ServerlessRestApiDeployment47fc2d5f9d",
-            "PhysicalResourceId": "p4f5gj",
+            "PhysicalResourceId": "qcrqox",
             "ResourceProperties": {
               "Description": "RestApi deployment id: 47fc2d5f9d21ad56f83937abe2779d0e26d7095e",
               "StageName": "Stage",
-              "RestApiId": "yn2f9dmisl"
+              "RestApiId": "g59lz4kkbg"
             },
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::ApiGateway::Deployment",
@@ -2612,11 +2612,11 @@
           {
             "EventId": "ServerlessRestApiDeployment47fc2d5f9d-CREATE_IN_PROGRESS-date",
             "LogicalResourceId": "ServerlessRestApiDeployment47fc2d5f9d",
-            "PhysicalResourceId": "p4f5gj",
+            "PhysicalResourceId": "qcrqox",
             "ResourceProperties": {
               "Description": "RestApi deployment id: 47fc2d5f9d21ad56f83937abe2779d0e26d7095e",
               "StageName": "Stage",
-              "RestApiId": "yn2f9dmisl"
+              "RestApiId": "g59lz4kkbg"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceStatusReason": "Resource creation Initiated",
@@ -2632,7 +2632,7 @@
             "ResourceProperties": {
               "Description": "RestApi deployment id: 47fc2d5f9d21ad56f83937abe2779d0e26d7095e",
               "StageName": "Stage",
-              "RestApiId": "yn2f9dmisl"
+              "RestApiId": "g59lz4kkbg"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceType": "AWS::ApiGateway::Deployment",
@@ -2647,9 +2647,9 @@
             "LogicalResourceId": "ServerlessRestApiProdStage",
             "PhysicalResourceId": "Prod",
             "ResourceProperties": {
-              "DeploymentId": "p4f5gj",
+              "DeploymentId": "qcrqox",
               "StageName": "Prod",
-              "RestApiId": "yn2f9dmisl"
+              "RestApiId": "g59lz4kkbg"
             },
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::ApiGateway::Stage",
@@ -2662,9 +2662,9 @@
             "LogicalResourceId": "ServerlessRestApiProdStage",
             "PhysicalResourceId": "Prod",
             "ResourceProperties": {
-              "DeploymentId": "p4f5gj",
+              "DeploymentId": "qcrqox",
               "StageName": "Prod",
-              "RestApiId": "yn2f9dmisl"
+              "RestApiId": "g59lz4kkbg"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceStatusReason": "Resource creation Initiated",
@@ -2678,9 +2678,9 @@
             "LogicalResourceId": "ServerlessRestApiProdStage",
             "PhysicalResourceId": "",
             "ResourceProperties": {
-              "DeploymentId": "p4f5gj",
+              "DeploymentId": "qcrqox",
               "StageName": "Prod",
-              "RestApiId": "yn2f9dmisl"
+              "RestApiId": "g59lz4kkbg"
             },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceType": "AWS::ApiGateway::Stage",
@@ -2691,7 +2691,7 @@
         ],
         "Topic1": [
           {
-            "EventId": "Topic1-bc7f9092-e33e-4b75-9ab9-0b05a1eca865",
+            "EventId": "Topic1-a79bb536-e5a8-4385-830c-0057881c0043",
             "LogicalResourceId": "Topic1",
             "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
             "ResourceStatus": "DELETE_COMPLETE",
@@ -2701,7 +2701,7 @@
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-53c44796-6014-4724-bf4e-398b5792343b",
+            "EventId": "Topic1-e811be29-1d08-47d9-a9a3-7fd72bbf09eb",
             "LogicalResourceId": "Topic1",
             "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
             "ResourceStatus": "DELETE_IN_PROGRESS",
@@ -2843,7 +2843,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_macro_fn_transform": {
-    "recorded-date": "30-05-2025, 19:19:36",
+    "recorded-date": "02-06-2025, 17:44:59",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -3112,7 +3112,7 @@
           {
             "EventId": "Parameter-CREATE_COMPLETE-date",
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-RKPmUsCVodiF",
+            "PhysicalResourceId": "CFN-Parameter-lnSABVaxQdt8",
             "ResourceProperties": {
               "Type": "String",
               "Value": "{Substitution}"
@@ -3126,7 +3126,7 @@
           {
             "EventId": "Parameter-CREATE_IN_PROGRESS-date",
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-RKPmUsCVodiF",
+            "PhysicalResourceId": "CFN-Parameter-lnSABVaxQdt8",
             "ResourceProperties": {
               "Type": "String",
               "Value": "{Substitution}"
@@ -3155,7 +3155,7 @@
         ],
         "Topic1": [
           {
-            "EventId": "Topic1-d999817d-18b1-45e2-b4f2-ff6a275ad13f",
+            "EventId": "Topic1-d7cdeb51-69c0-4cb2-a5dc-c64c81b220e6",
             "LogicalResourceId": "Topic1",
             "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
             "ResourceStatus": "DELETE_COMPLETE",
@@ -3165,7 +3165,7 @@
             "Timestamp": "timestamp"
           },
           {
-            "EventId": "Topic1-ad6d008a-83b5-44f0-b20a-6f5106380a58",
+            "EventId": "Topic1-2dc6b6ab-bd65-47b5-ada9-d7252c9babda",
             "LogicalResourceId": "Topic1",
             "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
             "ResourceStatus": "DELETE_IN_PROGRESS",
@@ -3304,6 +3304,1376 @@
             "ParameterValue": "SubstitutionDefault"
           }
         ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_macro_fn_transform": {
+    "recorded-date": "02-06-2025, 18:07:36",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "FifoTopic": "true",
+                  "ContentBasedDeduplication": "true",
+                  "TopicName": "<resource:5>"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "true",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Add",
+                    "Name": "FifoTopic",
+                    "Path": "/Properties/FifoTopic",
+                    "RequiresRecreation": "Always"
+                  }
+                },
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "true",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Add",
+                    "Name": "ContentBasedDeduplication",
+                    "Path": "/Properties/ContentBasedDeduplication",
+                    "RequiresRecreation": "Never"
+                  }
+                },
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "<resource:5>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "topic-name-1",
+                    "Name": "TopicName",
+                    "Path": "/Properties/TopicName",
+                    "RequiresRecreation": "Always"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "PolicyAction": "ReplaceAndDelete",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "FifoTopic",
+                    "RequiresRecreation": "Always"
+                  }
+                },
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "ContentBasedDeduplication",
+                    "RequiresRecreation": "Never"
+                  }
+                },
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "TopicName",
+                    "RequiresRecreation": "Always"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "PolicyAction": "ReplaceAndDelete",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Topic1": [
+          {
+            "EventId": "Topic1-4d2714dd-004a-47d7-b011-be0fa6fe8abb",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-c481534a-a8c9-4ebb-9654-de44ab49fc4a",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:5>",
+            "ResourceProperties": {
+              "FifoTopic": "true",
+              "ContentBasedDeduplication": "true",
+              "TopicName": "<resource:5>"
+            },
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:5>",
+            "ResourceProperties": {
+              "FifoTopic": "true",
+              "ContentBasedDeduplication": "true",
+              "TopicName": "<resource:5>"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "FifoTopic": "true",
+              "ContentBasedDeduplication": "true",
+              "TopicName": "<resource:5>"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "Requested update requires the creation of a new physical resource; hence creating one.",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_macro_for_attribute_fn_transform": {
+    "recorded-date": "02-06-2025, 20:02:13",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:2>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "<value:2>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "<value:1>",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Parameter": [
+          {
+            "EventId": "Parameter-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "<value:2>",
+              "Name": "parameter-name"
+            },
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "<value:2>",
+              "Name": "parameter-name"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "<value:1>",
+              "Name": "parameter-name"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "<value:1>",
+              "Name": "parameter-name"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "<value:1>",
+              "Name": "parameter-name"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_multiple_fn_transform_order": {
+    "recorded-date": "02-06-2025, 20:36:50",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:2>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "<value:2>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "<value:1>",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Parameter": [
+          {
+            "EventId": "Parameter-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "<value:2>",
+              "Name": "parameter-name"
+            },
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "<value:2>",
+              "Name": "parameter-name"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "<value:1>",
+              "Name": "parameter-name"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "<value:1>",
+              "Name": "parameter-name"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "Type": "String",
+              "Value": "<value:1>",
+              "Name": "parameter-name"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
         "RollbackConfiguration": {},
         "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
         "StackName": "<stack-name:1>",

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.snapshot.json
@@ -5743,5 +5743,763 @@
         ]
       }
     }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_remove_transform_in_update_change_set": {
+    "recorded-date": "31-07-2025, 21:36:49",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:2>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "<value:2>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "<value:1>",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_update_parameter_transform_in_update_change_set": {
+    "recorded-date": "31-07-2025, 21:38:55",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Parameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<value:2>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "Value": "<value:1>",
+                  "Type": "String",
+                  "Name": "parameter-name"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "<value:2>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "<value:1>",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test2"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Parameter",
+              "PhysicalResourceId": "parameter-name",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test2"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test2"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Input",
+            "ParameterValue": "test2"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "parameter-name",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
@@ -1,0 +1,8 @@
+{
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[json]": {
+    "last_validated_date": "2025-05-29T18:22:17+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[yml]": {
+    "last_validated_date": "2025-05-29T18:20:45+00:00"
+  }
+}

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
@@ -1,14 +1,20 @@
 {
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[json]": {
-    "last_validated_date": "2025-05-29T18:22:17+00:00"
+    "last_validated_date": "2025-05-30T19:12:50+00:00"
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[yml]": {
-    "last_validated_date": "2025-05-29T18:20:45+00:00"
+    "last_validated_date": "2025-05-30T19:11:21+00:00"
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[json]": {
-    "last_validated_date": "2025-05-29T18:53:46+00:00"
+    "last_validated_date": "2025-05-30T19:15:52+00:00"
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[yml]": {
-    "last_validated_date": "2025-05-29T18:52:14+00:00"
+    "last_validated_date": "2025-05-30T19:14:20+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_macro_fn_transform": {
+    "last_validated_date": "2025-05-30T19:19:31+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_serverless_fn_transform": {
+    "last_validated_date": "2025-05-30T19:17:57+00:00"
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
@@ -89,6 +89,15 @@
       "total": 53.77
     }
   },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_macro_with_function": {
+    "last_validated_date": "2025-06-20T22:19:25+00:00",
+    "durations_in_seconds": {
+      "setup": 10.9,
+      "call": 36.99,
+      "teardown": 5.46,
+      "total": 53.35
+    }
+  },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_multiple_fn_transform_order": {
     "last_validated_date": "2025-06-03T21:34:52+00:00",
     "durations_in_seconds": {

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
@@ -1,83 +1,83 @@
 {
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[json]": {
-    "last_validated_date": "2025-06-02T17:38:17+00:00",
+    "last_validated_date": "2025-06-03T21:29:58+00:00",
     "durations_in_seconds": {
       "setup": 0.39,
-      "call": 88.23,
-      "teardown": 0.87,
-      "total": 89.49
+      "call": 29.05,
+      "teardown": 0.82,
+      "total": 30.26
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[yml]": {
-    "last_validated_date": "2025-06-02T17:36:48+00:00",
+    "last_validated_date": "2025-06-03T21:29:28+00:00",
     "durations_in_seconds": {
       "setup": 0.62,
-      "call": 88.13,
-      "teardown": 0.84,
-      "total": 89.59
+      "call": 26.34,
+      "teardown": 0.8,
+      "total": 27.76
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_macro_fn_transform": {
-    "last_validated_date": "2025-06-02T18:07:37+00:00",
+    "last_validated_date": "2025-06-03T21:51:12+00:00",
     "durations_in_seconds": {
-      "setup": 10.82,
-      "call": 130.7,
-      "teardown": 5.79,
-      "total": 147.31
+      "setup": 10.68,
+      "call": 35.35,
+      "teardown": 5.52,
+      "total": 51.55
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_macro_for_attribute_fn_transform": {
-    "last_validated_date": "2025-06-02T20:02:13+00:00",
+    "last_validated_date": "2025-06-03T21:34:07+00:00",
     "durations_in_seconds": {
-      "setup": 10.8,
-      "call": 37.67,
-      "teardown": 5.5,
-      "total": 53.97
+      "setup": 0.0,
+      "call": 36.99,
+      "teardown": 5.18,
+      "total": 42.17
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[json]": {
-    "last_validated_date": "2025-06-02T17:41:20+00:00",
+    "last_validated_date": "2025-06-03T21:30:48+00:00",
     "durations_in_seconds": {
-      "setup": 0.4,
-      "call": 90.2,
-      "teardown": 0.83,
-      "total": 91.43
+      "setup": 0.39,
+      "call": 23.99,
+      "teardown": 0.8,
+      "total": 25.18
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[yml]": {
-    "last_validated_date": "2025-06-02T17:39:48+00:00",
+    "last_validated_date": "2025-06-03T21:30:23+00:00",
     "durations_in_seconds": {
       "setup": 0.37,
-      "call": 90.22,
-      "teardown": 0.81,
-      "total": 91.4
+      "call": 24.02,
+      "teardown": 0.89,
+      "total": 25.28
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_macro_fn_transform": {
-    "last_validated_date": "2025-06-02T17:44:59+00:00",
+    "last_validated_date": "2025-06-03T21:42:32+00:00",
     "durations_in_seconds": {
-      "setup": 10.52,
-      "call": 80.2,
-      "teardown": 5.08,
-      "total": 95.8
+      "setup": 10.81,
+      "call": 37.62,
+      "teardown": 5.34,
+      "total": 53.77
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_multiple_fn_transform_order": {
-    "last_validated_date": "2025-06-02T20:36:50+00:00",
+    "last_validated_date": "2025-06-03T21:34:52+00:00",
     "durations_in_seconds": {
-      "setup": 10.74,
-      "call": 39.63,
-      "teardown": 5.49,
-      "total": 55.86
+      "setup": 0.0,
+      "call": 39.28,
+      "teardown": 5.61,
+      "total": 44.89
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_serverless_fn_transform": {
-    "last_validated_date": "2025-06-02T17:43:23+00:00",
+    "last_validated_date": "2025-06-03T21:32:10+00:00",
     "durations_in_seconds": {
       "setup": 0.35,
-      "call": 122.37,
-      "teardown": 0.63,
-      "total": 123.35
+      "call": 80.57,
+      "teardown": 0.71,
+      "total": 81.63
     }
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
@@ -1,20 +1,83 @@
 {
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[json]": {
-    "last_validated_date": "2025-05-30T19:12:50+00:00"
+    "last_validated_date": "2025-06-02T17:38:17+00:00",
+    "durations_in_seconds": {
+      "setup": 0.39,
+      "call": 88.23,
+      "teardown": 0.87,
+      "total": 89.49
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[yml]": {
-    "last_validated_date": "2025-05-30T19:11:21+00:00"
+    "last_validated_date": "2025-06-02T17:36:48+00:00",
+    "durations_in_seconds": {
+      "setup": 0.62,
+      "call": 88.13,
+      "teardown": 0.84,
+      "total": 89.59
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_macro_fn_transform": {
+    "last_validated_date": "2025-06-02T18:07:37+00:00",
+    "durations_in_seconds": {
+      "setup": 10.82,
+      "call": 130.7,
+      "teardown": 5.79,
+      "total": 147.31
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_macro_for_attribute_fn_transform": {
+    "last_validated_date": "2025-06-02T20:02:13+00:00",
+    "durations_in_seconds": {
+      "setup": 10.8,
+      "call": 37.67,
+      "teardown": 5.5,
+      "total": 53.97
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[json]": {
-    "last_validated_date": "2025-05-30T19:15:52+00:00"
+    "last_validated_date": "2025-06-02T17:41:20+00:00",
+    "durations_in_seconds": {
+      "setup": 0.4,
+      "call": 90.2,
+      "teardown": 0.83,
+      "total": 91.43
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[yml]": {
-    "last_validated_date": "2025-05-30T19:14:20+00:00"
+    "last_validated_date": "2025-06-02T17:39:48+00:00",
+    "durations_in_seconds": {
+      "setup": 0.37,
+      "call": 90.22,
+      "teardown": 0.81,
+      "total": 91.4
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_macro_fn_transform": {
-    "last_validated_date": "2025-05-30T19:19:31+00:00"
+    "last_validated_date": "2025-06-02T17:44:59+00:00",
+    "durations_in_seconds": {
+      "setup": 10.52,
+      "call": 80.2,
+      "teardown": 5.08,
+      "total": 95.8
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_multiple_fn_transform_order": {
+    "last_validated_date": "2025-06-02T20:36:50+00:00",
+    "durations_in_seconds": {
+      "setup": 10.74,
+      "call": 39.63,
+      "teardown": 5.49,
+      "total": 55.86
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_serverless_fn_transform": {
-    "last_validated_date": "2025-05-30T19:17:57+00:00"
+    "last_validated_date": "2025-06-02T17:43:23+00:00",
+    "durations_in_seconds": {
+      "setup": 0.35,
+      "call": 122.37,
+      "teardown": 0.63,
+      "total": 123.35
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
@@ -1,4 +1,31 @@
 {
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_conditional_transform": {
+    "last_validated_date": "2025-06-20T21:12:32+00:00",
+    "durations_in_seconds": {
+      "setup": 10.79,
+      "call": 35.71,
+      "teardown": 5.56,
+      "total": 52.06
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_conditional_transform[false]": {
+    "last_validated_date": "2025-06-20T21:16:29+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 38.41,
+      "teardown": 5.71,
+      "total": 44.12
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_conditional_transform[true]": {
+    "last_validated_date": "2025-06-20T21:15:45+00:00",
+    "durations_in_seconds": {
+      "setup": 10.81,
+      "call": 38.04,
+      "teardown": 5.12,
+      "total": 53.97
+    }
+  },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[json]": {
     "last_validated_date": "2025-06-03T21:29:58+00:00",
     "durations_in_seconds": {

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
@@ -4,5 +4,11 @@
   },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_embedded_fn_transform_include[yml]": {
     "last_validated_date": "2025-05-29T18:20:45+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[json]": {
+    "last_validated_date": "2025-05-29T18:53:46+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_global_fn_transform_include[yml]": {
+    "last_validated_date": "2025-05-29T18:52:14+00:00"
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.validation.json
@@ -107,6 +107,15 @@
       "total": 44.89
     }
   },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_remove_transform_in_update_change_set": {
+    "last_validated_date": "2025-07-31T21:36:50+00:00",
+    "durations_in_seconds": {
+      "setup": 10.72,
+      "call": 36.7,
+      "teardown": 5.53,
+      "total": 52.95
+    }
+  },
   "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_serverless_fn_transform": {
     "last_validated_date": "2025-06-03T21:32:10+00:00",
     "durations_in_seconds": {
@@ -114,6 +123,15 @@
       "call": 80.57,
       "teardown": 0.71,
       "total": 81.63
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_fn_transform.py::TestChangeSetFnTransform::test_update_parameter_transform_in_update_change_set": {
+    "last_validated_date": "2025-07-31T21:38:55+00:00",
+    "durations_in_seconds": {
+      "setup": 10.84,
+      "call": 36.02,
+      "teardown": 5.42,
+      "total": 52.28
     }
   }
 }

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -791,6 +791,7 @@ class TestMacros:
         assert "test-" in resulting_value
 
     @markers.aws.validated
+    @pytest.mark.skip(reason="Fn::Transform does not support array of transformations")
     def test_scope_order_and_parameters(
         self, deploy_cfn_template, create_lambda_function, snapshot, aws_client
     ):

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -756,6 +756,7 @@ class TestMacros:
         snapshot.match("original_template", original_template)
         snapshot.match("processed_template", processed_template)
 
+    @skip_if_v2_provider(reason="Fn::Transform")
     @markers.aws.validated
     def test_attribute_uses_macro(self, deploy_cfn_template, create_lambda_function, aws_client):
         macro_function_path = os.path.join(

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -791,7 +791,6 @@ class TestMacros:
         assert "test-" in resulting_value
 
     @markers.aws.validated
-    @pytest.mark.skip(reason="Fn::Transform does not support array of transformations")
     def test_scope_order_and_parameters(
         self, deploy_cfn_template, create_lambda_function, snapshot, aws_client
     ):

--- a/tests/aws/templates/macros/add_standard_tags.py
+++ b/tests/aws/templates/macros/add_standard_tags.py
@@ -1,0 +1,10 @@
+def handler(event, context):
+    fragment = add_standard_attributes(event["fragment"])
+
+    return {"requestId": event["requestId"], "status": "success", "fragment": fragment}
+
+
+def add_standard_attributes(fragment):
+    fragment["Tags"] = {"MacroAdded": "True"}
+
+    return fragment


### PR DESCRIPTION
## Motivation
This PR adds a collection of tests to validate the behavior of intrinsic transformation in a template. The tests are due to be unskipped when the feature is implemented in another PR.

## Testing
-  New AWS validated tests to confirm that the function works with change sets.