### PR TITLE
Stop handling help parsing with argparse

### DIFF
--- a/localstack-core/localstack/cli/profiles.py
+++ b/localstack-core/localstack/cli/profiles.py
@@ -31,7 +31,7 @@ def set_and_remove_profile_from_sys_argv():
               not passed to the localstack CLI. This allows the profile option
               to be set at any point on the command line.
     """
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--profile")
     namespace, sys.argv = parser.parse_known_args(sys.argv)
     profile = namespace.profile


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

#12500 added top level handling of profiles before they get to the click parsing. However, this inadvertently also caught the help option parsing. This leads to a shortened help message on `-h` like this:

```
usage: localstack [-h] [--profile PROFILE]

options:
  -h, --help         show this help message and exit
  --profile PROFILE
```

By disabling help message parsing in the preceding argparse, we pass that flag to click again and receive our full help output.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Disable help parsing in argparse so that it is handled by click again

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
