### PR TITLE
Change cleanup job condition in main pipeline in Github Actions

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -286,7 +286,7 @@ jobs:
     runs-on: ubuntu-latest
     # only remove the image artifacts if the build was successful
     # (this allows a re-build of failed jobs until for the time of the retention period)
-    if: success()
+    if: always() && !failure() && !cancelled()
     needs: push
     steps:
       - uses: geekyeggo/delete-artifact@v5


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Because docker image and lambda artifacts use a lot of Github storage space, we try to keep only the ones we actually need. I added a cleanup job a while ago, but it only runs if the `push` job succeeds. Since the `push` job was skipped, the `cleanup` job was skipped too. 
This PR changes when the cleanup runs — now it will delete docker-image and lambda artifacts every time, except if earlier workflow jobs failed or were cancelled (this will allow to rerun failed jobs without needing to rerun the whole pipeline to regenerate the docker image or lambda artifacts)

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Changed condition of `cleanup` job

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
