### PR TITLE
APIGW: implement Canary Deployments CRUD logic

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/provider.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/provider.py
@@ -174,12 +174,13 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
                 }
                 default_settings.update(canary_settings)
                 moto_stage.canary_settings = default_settings
+            else:
+                moto_stage.canary_settings = None
 
             if variables:
                 moto_stage.variables = variables
 
-            if stage_description:
-                moto_stage.description = stage_description
+            moto_stage.description = stage_description
 
             if cache_cluster_enabled is not None:
                 moto_stage.cache_cluster_enabled = cache_cluster_enabled

--- a/localstack-core/localstack/services/apigateway/next_gen/provider.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/provider.py
@@ -1,4 +1,6 @@
 import copy
+import datetime
+import re
 
 from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.apigateway import (
@@ -26,7 +28,11 @@ from localstack.services.apigateway.helpers import (
     get_moto_rest_api,
     get_rest_api_container,
 )
-from localstack.services.apigateway.legacy.provider import ApigatewayProvider
+from localstack.services.apigateway.legacy.provider import (
+    STAGE_UPDATE_PATHS,
+    ApigatewayProvider,
+    patch_api_gateway_entity,
+)
 from localstack.services.apigateway.patches import apply_patches
 from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
@@ -69,13 +75,35 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
 
     @handler("CreateStage", expand=False)
     def create_stage(self, context: RequestContext, request: CreateStageRequest) -> Stage:
-        response = super().create_stage(context, request)
+        # TODO: we need to internalize Stages and Deployments in LocalStack, we have a lot of split logic
+        super().create_stage(context, request)
+        rest_api_id = request["restApiId"].lower()
+        stage_name = request["stageName"]
+        moto_api = get_moto_rest_api(context, rest_api_id)
+        stage = moto_api.stages[stage_name]
+
+        if canary_settings := request.get("canarySettings"):
+            if (
+                deployment_id := canary_settings.get("deploymentId")
+            ) and deployment_id not in moto_api.deployments:
+                raise BadRequestException("Deployment id does not exist")
+
+            default_settings = {
+                "deploymentId": stage.deployment_id,
+                "percentTraffic": 0.0,
+                "useStageCache": False,
+            }
+            default_settings.update(canary_settings)
+            stage.canary_settings = default_settings
+        else:
+            stage.canary_settings = None
+
         store = get_apigateway_store(context=context)
 
-        rest_api_id = request["restApiId"].lower()
         store.active_deployments.setdefault(rest_api_id, {})
-        store.active_deployments[rest_api_id][request["stageName"]] = request["deploymentId"]
-
+        store.active_deployments[rest_api_id][stage_name] = request["deploymentId"]
+        response: Stage = stage.to_json()
+        self._patch_stage_response(response)
         return response
 
     @handler("UpdateStage")
@@ -87,20 +115,121 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
         patch_operations: ListOfPatchOperation = None,
         **kwargs,
     ) -> Stage:
-        response = super().update_stage(
-            context, rest_api_id, stage_name, patch_operations, **kwargs
-        )
+        moto_rest_api = get_moto_rest_api(context, rest_api_id)
+        if not (moto_stage := moto_rest_api.stages.get(stage_name)):
+            raise NotFoundException("Invalid Stage identifier specified")
 
+        # construct list of path regexes for validation
+        path_regexes = [re.sub("{[^}]+}", ".+", path) for path in STAGE_UPDATE_PATHS]
+
+        # copy the patch operations to not mutate them, so that we're logging the correct input
+        patch_operations = copy.deepcopy(patch_operations) or []
+        # we are only passing a subset of operations to Moto as it does not handle properly all of them
+        moto_patch_operations = []
+        moto_stage_copy = copy.deepcopy(moto_stage)
         for patch_operation in patch_operations:
+            skip_moto_apply = False
             patch_path = patch_operation["path"]
+            patch_op = patch_operation["op"]
 
-            if patch_path == "/deploymentId" and patch_operation["op"] == "replace":
-                if deployment_id := patch_operation.get("value"):
-                    store = get_apigateway_store(context=context)
-                    store.active_deployments.setdefault(rest_api_id.lower(), {})[stage_name] = (
-                        deployment_id
+            # special case: handle updates (op=remove) for wildcard method settings
+            patch_path_stripped = patch_path.strip("/")
+            if patch_path_stripped == "*/*" and patch_op == "remove":
+                if not moto_stage.method_settings.pop(patch_path_stripped, None):
+                    raise BadRequestException(
+                        "Cannot remove method setting */* because there is no method setting for this method "
+                    )
+                response = moto_stage.to_json()
+                self._patch_stage_response(response)
+                return response
+
+            path_valid = patch_path in STAGE_UPDATE_PATHS or any(
+                re.match(regex, patch_path) for regex in path_regexes
+            )
+            if is_canary := patch_path.startswith("/canarySettings"):
+                skip_moto_apply = True
+                path_valid = is_canary_settings_update_patch_valid(op=patch_op, path=patch_path)
+                # it seems our JSON Patch utility does not handle replace properly if the value does not exists before
+                # it seems to maybe be a Stage-only thing, so replacing it here
+                if patch_op == "replace":
+                    patch_operation["op"] = "add"
+
+            if patch_op == "copy":
+                copy_from = patch_operation.get("from")
+                if patch_path not in ("/deploymentId", "/variables") or copy_from not in (
+                    "/canarySettings/deploymentId",
+                    "/canarySettings/stageVariableOverrides",
+                ):
+                    raise BadRequestException(
+                        "Invalid copy operation with path: /canarySettings/stageVariableOverrides and from /variables. Valid copy:path are [/deploymentId, /variables] and valid copy:from are [/canarySettings/deploymentId, /canarySettings/stageVariableOverrides]"
                     )
 
+                if copy_from.startswith("/canarySettings") and not getattr(
+                    moto_stage_copy, "canary_settings", None
+                ):
+                    raise BadRequestException("Promotion not available. Canary does not exist.")
+
+                if patch_path == "/variables":
+                    moto_stage_copy.variables.update(
+                        moto_stage_copy.canary_settings.get("stageVariableOverrides", {})
+                    )
+                elif patch_path == "/deploymentId":
+                    moto_stage_copy.deployment_id = moto_stage_copy.canary_settings["deploymentId"]
+
+                # we manually assign `copy` ops, no need to apply them
+                continue
+
+            if not path_valid:
+                valid_paths = f"[{', '.join(STAGE_UPDATE_PATHS)}]"
+                # note: weird formatting in AWS - required for snapshot testing
+                valid_paths = valid_paths.replace(
+                    "/{resourcePath}/{httpMethod}/throttling/burstLimit, /{resourcePath}/{httpMethod}/throttling/rateLimit, /{resourcePath}/{httpMethod}/caching/ttlInSeconds",
+                    "/{resourcePath}/{httpMethod}/throttling/burstLimit/{resourcePath}/{httpMethod}/throttling/rateLimit/{resourcePath}/{httpMethod}/caching/ttlInSeconds",
+                )
+                valid_paths = valid_paths.replace("/burstLimit, /", "/burstLimit /")
+                valid_paths = valid_paths.replace("/rateLimit, /", "/rateLimit /")
+                raise BadRequestException(
+                    f"Invalid method setting path: {patch_operation['path']}. Must be one of: {valid_paths}"
+                )
+
+            # TODO: check if there are other boolean, maybe add a global step in _patch_api_gateway_entity
+            if patch_path == "/tracingEnabled" and (value := patch_operation.get("value")):
+                patch_operation["value"] = value and value.lower() == "true" or False
+
+            elif patch_path in ("/canarySettings/deploymentId", "/deploymentId"):
+                if patch_op != "copy" and not moto_rest_api.deployments.get(
+                    patch_operation.get("value")
+                ):
+                    raise BadRequestException("Deployment id does not exist")
+
+            if not skip_moto_apply:
+                # we need to copy the patch operation because `_patch_api_gateway_entity` is mutating it in place
+                moto_patch_operations.append(dict(patch_operation))
+
+            # we need to apply patch operation individually to be able to validate the logic
+            # TODO: rework the patching logic
+            patch_api_gateway_entity(moto_stage_copy, [patch_operation])
+            if is_canary and (canary_settings := getattr(moto_stage_copy, "canary_settings", None)):
+                default_canary_settings = {
+                    "deploymentId": moto_stage_copy.deployment_id,
+                    "percentTraffic": 0.0,
+                    "useStageCache": False,
+                }
+                default_canary_settings.update(canary_settings)
+                moto_stage_copy.canary_settings = default_canary_settings
+
+        moto_rest_api.stages[stage_name] = moto_stage_copy
+        moto_stage_copy.apply_operations(moto_patch_operations)
+        if moto_stage.deployment_id != moto_stage_copy.deployment_id:
+            store = get_apigateway_store(context=context)
+            store.active_deployments.setdefault(rest_api_id.lower(), {})[stage_name] = (
+                moto_stage_copy.deployment_id
+            )
+
+        moto_stage_copy.last_updated_date = datetime.datetime.now(tz=datetime.UTC)
+
+        response = moto_stage_copy.to_json()
+        self._patch_stage_response(response)
         return response
 
     def delete_stage(
@@ -180,7 +309,7 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
             if variables:
                 moto_stage.variables = variables
 
-            moto_stage.description = stage_description
+            moto_stage.description = stage_description or moto_stage.description or None
 
             if cache_cluster_enabled is not None:
                 moto_stage.cache_cluster_enabled = cache_cluster_enabled
@@ -313,6 +442,33 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
         )
 
         return response
+
+
+def is_canary_settings_update_patch_valid(op: str, path: str) -> bool:
+    path_regexes = (
+        r"\/canarySettings\/percentTraffic",
+        r"\/canarySettings\/deploymentId",
+        r"\/canarySettings\/stageVariableOverrides\/.+",
+        r"\/canarySettings\/useStageCache",
+    )
+    if path == "/canarySettings" and op == "remove":
+        return True
+
+    matches_path = any(re.match(regex, path) for regex in path_regexes)
+
+    if op not in ("replace", "copy"):
+        if matches_path:
+            raise BadRequestException(f"Invalid {op} operation with path: {path}")
+
+        raise BadRequestException(
+            f"Cannot {op} method setting {path.lstrip('/')} because there is no method setting for this method "
+        )
+
+    # stageVariableOverrides is a bit special as it's nested, it doesn't return the same error message
+    if not matches_path and path != "/canarySettings/stageVariableOverrides":
+        return False
+
+    return True
 
 
 def _get_gateway_response_or_default(

--- a/localstack-core/localstack/services/apigateway/patches.py
+++ b/localstack-core/localstack/services/apigateway/patches.py
@@ -165,6 +165,10 @@ def apply_patches():
 
         return result
 
+    @patch(apigateway_models.Stage._str2bool, pass_target=False)
+    def apigateway_models_stage_str_to_bool(self, v: bool | str) -> bool:
+        return str_to_bool(v)
+
     # TODO remove this patch when the behavior is implemented in moto
     @patch(apigateway_models.APIGatewayBackend.create_rest_api)
     def create_rest_api(fn, self, *args, tags=None, **kwargs):

--- a/localstack-core/localstack/services/apigateway/patches.py
+++ b/localstack-core/localstack/services/apigateway/patches.py
@@ -143,6 +143,8 @@ def apply_patches():
         if "documentationVersion" not in result:
             result["documentationVersion"] = getattr(self, "documentation_version", None)
 
+        # TODO: add canarySettings
+
         return result
 
     # TODO remove this patch when the behavior is implemented in moto

--- a/localstack-core/localstack/services/apigateway/patches.py
+++ b/localstack-core/localstack/services/apigateway/patches.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 
@@ -34,6 +35,10 @@ def apply_patches():
 
         if (cacheClusterSize or cacheClusterEnabled) and not self.cache_cluster_status:
             self.cache_cluster_status = "AVAILABLE"
+
+        now = datetime.datetime.now(tz=datetime.UTC)
+        self.created_date = now
+        self.last_updated_date = now
 
     apigateway_models_Stage_init_orig = apigateway_models.Stage.__init__
     apigateway_models.Stage.__init__ = apigateway_models_Stage_init
@@ -143,7 +148,20 @@ def apply_patches():
         if "documentationVersion" not in result:
             result["documentationVersion"] = getattr(self, "documentation_version", None)
 
-        # TODO: add canarySettings
+        if "canarySettings" not in result:
+            result["canarySettings"] = getattr(self, "canary_settings", None)
+
+        if "createdDate" not in result:
+            created_date = getattr(self, "created_date", None)
+            if created_date:
+                created_date = int(created_date.timestamp())
+            result["createdDate"] = created_date
+
+        if "lastUpdatedDate" not in result:
+            last_updated_date = getattr(self, "last_updated_date", None)
+            if last_updated_date:
+                last_updated_date = int(last_updated_date.timestamp())
+            result["lastUpdatedDate"] = last_updated_date
 
         return result
 

--- a/tests/aws/services/apigateway/test_apigateway_canary.py
+++ b/tests/aws/services/apigateway/test_apigateway_canary.py
@@ -1,99 +1,406 @@
 # TODO: also see .test_apigateway_common.TestStages
+import json
+
 import pytest
 from botocore.exceptions import ClientError
 
 from localstack.testing.pytest import markers
 
-# @pytest.fixture
-# def _create_api_with_stage(
-#     self, aws_client, create_rest_apigw, apigw_add_transformers, snapshot
-# ):
-#     client = aws_client.apigateway
-#     use that
-#
-#     def _create():
-#         # create API, method, integration, deployment
-#         api_id, api_name, root_id = create_rest_apigw()
-#         client.put_method(
-#             restApiId=api_id, resourceId=root_id, httpMethod="GET", authorizationType="NONE"
-#         )
-#         client.put_integration(
-#             restApiId=api_id, resourceId=root_id, httpMethod="GET", type="MOCK"
-#         )
-#         response = client.create_deployment(restApiId=api_id)
-#         deployment_id = response["id"]
 # TODO: think of a way to assert we are in a canary deployment? returning different MOCK response + stage variable over
+
+
+@pytest.fixture
+def create_api_for_deployment(aws_client, create_rest_apigw):
+    def _create():
+        # create API, method, integration, deployment
+        api_id, _, root_id = create_rest_apigw()
+
+        aws_client.apigateway.put_method(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="GET",
+            authorizationType="NONE",
+        )
+
+        aws_client.apigateway.put_method_response(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="GET",
+            statusCode="200",
+        )
+
+        aws_client.apigateway.put_integration(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="GET",
+            type="MOCK",
+            requestTemplates={"application/json": '{"statusCode": 200}'},
+        )
+
+        aws_client.apigateway.put_integration_response(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="GET",
+            statusCode="200",
+            selectionPattern="",
+            responseTemplates={
+                "application/json": json.dumps({"statusCode": 200, "message": "default deployment"})
+            },
+        )
+
+        return api_id, root_id
+
+    return _create
+
+
+# TODO:
+# You create a canary release deployment when deploying the API with canary settings as an additional input to the deployment creation operation.
 #
-#         # create stage
-#         response = client.create_stage(
-#             restApiId=api_id,
-#             stageName="s1",
-#             deploymentId=deployment_id,
-#             description="my stage",
-#         )
-#         snapshot.match("create-stage", response)
+# You can also create a canary release deployment from an existing non-canary deployment by making a stage:update request to add the canary settings on the stage.
 #
-#         return api_id
-#
-#     return _create
+# When creating a non-canary release deployment, you can specify a non-existing stage name. API Gateway creates one if the specified stage does not exist. However, you cannot specify any non-existing stage name when creating a canary release deployment. You will get an error and API Gateway will not create any canary release deployment.
 
 
 class TestStageCrudCanary:
     @markers.aws.validated
     def test_create_update_stages(
-        self, _create_api_with_stage, aws_client, create_rest_apigw, snapshot
+        self, create_api_for_deployment, aws_client, create_rest_apigw, snapshot
     ):
-        client = aws_client.apigateway
-        api_id = _create_api_with_stage()
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("deploymentId"),
+                snapshot.transform.key_value("id"),
+            ]
+        )
+        api_id, resource_id = create_api_for_deployment()
 
-        # negative tests for immutable/non-updateable attributes
+        create_deployment_1 = aws_client.apigateway.create_deployment(restApiId=api_id)
+        snapshot.match("create-deployment-1", create_deployment_1)
+        deployment_id = create_deployment_1["id"]
 
-        with pytest.raises(ClientError) as ctx:
-            client.update_stage(
-                restApiId=api_id,
-                stageName="s1",
-                patchOperations=[
-                    {"op": "replace", "path": "/documentation_version", "value": "123"}
-                ],
-            )
-        snapshot.match("error-update-doc-version", ctx.value.response)
-
-        with pytest.raises(ClientError) as ctx:
-            client.update_stage(
-                restApiId=api_id,
-                stageName="s1",
-                patchOperations=[
-                    {"op": "replace", "path": "/tags/tag1", "value": "value1"},
-                ],
-            )
-        snapshot.match("error-update-tags", ctx.value.response)
-
-        # update & get stage
-        response = client.update_stage(
+        aws_client.apigateway.update_integration_response(
             restApiId=api_id,
-            stageName="s1",
+            resourceId=resource_id,
+            httpMethod="GET",
+            statusCode="200",
             patchOperations=[
-                {"op": "replace", "path": "/description", "value": "stage new"},
-                {"op": "replace", "path": "/variables/var1", "value": "test"},
-                {"op": "replace", "path": "/variables/var2", "value": "test2"},
-                {"op": "replace", "path": "/*/*/throttling/burstLimit", "value": "123"},
-                {"op": "replace", "path": "/*/*/caching/enabled", "value": "true"},
-                {"op": "replace", "path": "/tracingEnabled", "value": "true"},
-                {"op": "replace", "path": "/test/GET/throttling/burstLimit", "value": "124"},
+                {
+                    "op": "replace",
+                    "path": "/responseTemplates/application~1json",
+                    "value": json.dumps({"statusCode": 200, "message": "second deployment"}),
+                }
             ],
         )
-        snapshot.match("update-stage", response)
 
-        response = client.get_stage(restApiId=api_id, stageName="s1")
-        snapshot.match("get-stage", response)
+        create_deployment_2 = aws_client.apigateway.create_deployment(restApiId=api_id)
+        snapshot.match("create-deployment-2", create_deployment_2)
+        deployment_id_2 = create_deployment_2["id"]
 
-        # show that updating */* does not override previously set values, only
-        # provides default values then like shown above
-        response = client.update_stage(
+        stage_name = "dev"
+        create_stage = aws_client.apigateway.create_stage(
             restApiId=api_id,
-            stageName="s1",
+            stageName=stage_name,
+            deploymentId=deployment_id,
+            description="dev stage",
+            variables={
+                "testVar": "default",
+            },
+            canarySettings={
+                "deploymentId": deployment_id_2,
+                "percentTraffic": 50,
+                "stageVariableOverrides": {
+                    "testVar": "canary",
+                },
+            },
+        )
+        snapshot.match("create-stage", create_stage)
+
+        get_stage = aws_client.apigateway.get_stage(
+            restApiId=api_id,
+            stageName=stage_name,
+        )
+        snapshot.match("get-stage", get_stage)
+
+        update_stage = aws_client.apigateway.update_stage(
+            restApiId=api_id,
+            stageName=stage_name,
             patchOperations=[
-                {"op": "replace", "path": "/*/*/throttling/burstLimit", "value": "100"},
+                {
+                    "op": "replace",
+                    "path": "/canarySettings/stageVariableOverrides/testVar",
+                    "value": "updated",
+                },
             ],
         )
-        snapshot.match("update-stage-override", response)
+        snapshot.match("update-stage-canary-settings-overrides", update_stage)
+
+        # TODO: this fails because no more overrides, add in validation test
+        # update_stage = aws_client.apigateway.update_stage(
+        #     restApiId=api_id,
+        #     stageName=stage_name,
+        #     patchOperations=[
+        #         {"op": "remove", "path": "/canarySettings/stageVariableOverrides"},
+        #     ],
+        # )
+        # snapshot.match("update-stage-canary-settings-remove-overrides", update_stage)
+
+        # remove canary settings
+        update_stage = aws_client.apigateway.update_stage(
+            restApiId=api_id,
+            stageName=stage_name,
+            patchOperations=[
+                {"op": "remove", "path": "/canarySettings"},
+            ],
+        )
+        snapshot.match("update-stage-remove-canary-settings", update_stage)
+
+        get_stage = aws_client.apigateway.get_stage(
+            restApiId=api_id,
+            stageName=stage_name,
+        )
+        snapshot.match("get-stage-after-remove", get_stage)
+
+    @markers.aws.validated
+    def test_create_canary_deployment_with_stage(
+        self, create_api_for_deployment, aws_client, create_rest_apigw, snapshot
+    ):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("deploymentId"),
+                snapshot.transform.key_value("id"),
+            ]
+        )
+        api_id, resource_id = create_api_for_deployment()
+
+        create_deployment = aws_client.apigateway.create_deployment(restApiId=api_id)
+        snapshot.match("create-deployment", create_deployment)
+        deployment_id = create_deployment["id"]
+
+        stage_name = "dev"
+        create_stage = aws_client.apigateway.create_stage(
+            restApiId=api_id,
+            stageName=stage_name,
+            deploymentId=deployment_id,
+            description="dev stage",
+            variables={
+                "testVar": "default",
+            },
+        )
+        snapshot.match("create-stage", create_stage)
+
+        create_canary_deployment = aws_client.apigateway.create_deployment(
+            restApiId=api_id,
+            stageName=stage_name,
+            canarySettings={
+                "percentTraffic": 50,
+                "stageVariableOverrides": {
+                    "testVar": "canary",
+                },
+            },
+        )
+        snapshot.match("create-canary-deployment", create_canary_deployment)
+
+        get_stage = aws_client.apigateway.get_stage(
+            restApiId=api_id,
+            stageName=stage_name,
+        )
+        snapshot.match("get-stage", get_stage)
+
+    @markers.aws.validated
+    def test_create_canary_deployment(
+        self, create_api_for_deployment, aws_client, create_rest_apigw, snapshot
+    ):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("deploymentId"),
+                snapshot.transform.key_value("id"),
+            ]
+        )
+        api_id, resource_id = create_api_for_deployment()
+
+        create_deployment = aws_client.apigateway.create_deployment(restApiId=api_id)
+        snapshot.match("create-deployment", create_deployment)
+        deployment_id = create_deployment["id"]
+
+        stage_name_1 = "dev1"
+        create_stage = aws_client.apigateway.create_stage(
+            restApiId=api_id,
+            stageName=stage_name_1,
+            deploymentId=deployment_id,
+            description="dev stage",
+            variables={
+                "testVar": "default",
+            },
+            canarySettings={
+                "deploymentId": deployment_id,
+                "percentTraffic": 40,
+                "stageVariableOverrides": {
+                    "testVar": "canary1",
+                },
+            },
+        )
+        snapshot.match("create-stage", create_stage)
+
+        create_canary_deployment = aws_client.apigateway.create_deployment(
+            restApiId=api_id,
+            stageName=stage_name_1,
+            canarySettings={
+                "percentTraffic": 50,
+                "stageVariableOverrides": {
+                    "testVar": "canary2",
+                },
+            },
+        )
+        snapshot.match("create-canary-deployment", create_canary_deployment)
+        canary_deployment_id = create_canary_deployment["id"]
+
+        get_stage_1 = aws_client.apigateway.get_stage(
+            restApiId=api_id,
+            stageName=stage_name_1,
+        )
+        snapshot.match("get-stage-1", get_stage_1)
+
+        stage_name_2 = "dev2"
+        create_stage_2 = aws_client.apigateway.create_stage(
+            restApiId=api_id,
+            stageName=stage_name_2,
+            deploymentId=deployment_id,
+            description="dev stage",
+            variables={
+                "testVar": "default",
+            },
+            canarySettings={
+                "deploymentId": canary_deployment_id,
+                "percentTraffic": 60,
+                "stageVariableOverrides": {
+                    "testVar": "canary-overridden",
+                },
+            },
+        )
+        snapshot.match("create-stage-2", create_stage_2)
+
+    @markers.aws.validated
+    def test_create_canary_deployment_by_stage_update(
+        self, create_api_for_deployment, aws_client, create_rest_apigw, snapshot
+    ):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("deploymentId"),
+                snapshot.transform.key_value("id"),
+            ]
+        )
+        api_id, resource_id = create_api_for_deployment()
+
+        create_deployment = aws_client.apigateway.create_deployment(restApiId=api_id)
+        snapshot.match("create-deployment", create_deployment)
+        deployment_id = create_deployment["id"]
+
+        stage_name = "dev"
+        create_stage = aws_client.apigateway.create_stage(
+            restApiId=api_id,
+            stageName=stage_name,
+            deploymentId=deployment_id,
+            description="dev stage",
+            variables={
+                "testVar": "default",
+            },
+        )
+        snapshot.match("create-stage", create_stage)
+
+        update_stage = aws_client.apigateway.update_stage(
+            restApiId=api_id,
+            stageName=stage_name,
+            patchOperations=[
+                {
+                    "op": "add",
+                    "path": "/canarySettings/deploymentId",
+                    "value": deployment_id,
+                },
+            ],
+        )
+        snapshot.match("update-stage", update_stage)
+
+    @markers.aws.validated
+    def test_create_canary_deployment_validation(
+        self, create_api_for_deployment, aws_client, create_rest_apigw, snapshot
+    ):
+        api_id, resource_id = create_api_for_deployment()
+
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.create_deployment(
+                restApiId=api_id,
+                canarySettings={
+                    "percentTraffic": 50,
+                    "stageVariableOverrides": {
+                        "testVar": "canary",
+                    },
+                },
+            )
+        snapshot.match("create-canary-deployment-no-stage", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.create_deployment(
+                restApiId=api_id,
+                stageName="non-existing",
+                canarySettings={
+                    "percentTraffic": 50,
+                    "stageVariableOverrides": {
+                        "testVar": "canary",
+                    },
+                },
+            )
+        snapshot.match("create-canary-deployment-non-existing-stage", e.value.response)
+
+        # create_canary_deployment = aws_client.apigateway.create_deployment(restApiId=api_id)
+        # snapshot.match("create-canary-deployment", create_deployment_1)
+        # canary_deployment_id = create_deployment_1["id"]
+
+        # with pytest.raises(ClientError) as e:
+        #     aws_client.apigateway.update_stage(
+        #         restApiId=api_id,
+        #         stageName="s1",
+        #         patchOperations=[
+        #             {"op": "replace", "path": "/documentation_version", "value": "123"}
+        #         ],
+        #     )
+        # snapshot.match("error-update-doc-version", e.value.response)
+        #
+        # with pytest.raises(ClientError) as ctx:
+        #     client.update_stage(
+        #         restApiId=api_id,
+        #         stageName="s1",
+        #         patchOperations=[
+        #             {"op": "replace", "path": "/tags/tag1", "value": "value1"},
+        #         ],
+        #     )
+        # snapshot.match("error-update-tags", ctx.value.response)
+        #
+        # # update & get stage
+        # response = client.update_stage(
+        #     restApiId=api_id,
+        #     stageName="s1",
+        #     patchOperations=[
+        #         {"op": "replace", "path": "/description", "value": "stage new"},
+        #         {"op": "replace", "path": "/variables/var1", "value": "test"},
+        #         {"op": "replace", "path": "/variables/var2", "value": "test2"},
+        #         {"op": "replace", "path": "/*/*/throttling/burstLimit", "value": "123"},
+        #         {"op": "replace", "path": "/*/*/caching/enabled", "value": "true"},
+        #         {"op": "replace", "path": "/tracingEnabled", "value": "true"},
+        #         {"op": "replace", "path": "/test/GET/throttling/burstLimit", "value": "124"},
+        #     ],
+        # )
+        # snapshot.match("update-stage", response)
+        #
+        # response = client.get_stage(restApiId=api_id, stageName="s1")
+        # snapshot.match("get-stage", response)
+        #
+        # # show that updating */* does not override previously set values, only
+        # # provides default values then like shown above
+        # response = client.update_stage(
+        #     restApiId=api_id,
+        #     stageName="s1",
+        #     patchOperations=[
+        #         {"op": "replace", "path": "/*/*/throttling/burstLimit", "value": "100"},
+        #     ],
+        # )
+        # snapshot.match("update-stage-override", response)

--- a/tests/aws/services/apigateway/test_apigateway_canary.py
+++ b/tests/aws/services/apigateway/test_apigateway_canary.py
@@ -443,6 +443,7 @@ class TestCanaryDeployments:
                 "message": "default deployment",
                 "variable": "$stageVariables.testVar",
                 "nonExistingDefault": "$stageVariables.noStageVar",
+                "nonOverridden": "$stageVariables.defaultVar",
                 "isCanary": "$context.isCanaryRequest",
             }
         )
@@ -451,7 +452,10 @@ class TestCanaryDeployments:
         create_deployment_1 = aws_client.apigateway.create_deployment(
             restApiId=api_id,
             stageName=stage_name,
-            variables={"testVar": "default"},
+            variables={
+                "testVar": "default",
+                "defaultVar": "default",
+            },
         )
         snapshot.match("create-deployment-1", create_deployment_1)
 
@@ -470,6 +474,7 @@ class TestCanaryDeployments:
                             "message": "canary deployment",
                             "variable": "$stageVariables.testVar",
                             "nonExistingDefault": "$stageVariables.noStageVar",
+                            "nonOverridden": "$stageVariables.defaultVar",
                             "isCanary": "$context.isCanaryRequest",
                         }
                     ),

--- a/tests/aws/services/apigateway/test_apigateway_canary.py
+++ b/tests/aws/services/apigateway/test_apigateway_canary.py
@@ -361,6 +361,19 @@ class TestStageCrudCanary:
         with pytest.raises(ClientError) as e:
             aws_client.apigateway.create_deployment(
                 restApiId=api_id,
+                stageName="",
+                canarySettings={
+                    "percentTraffic": 50,
+                    "stageVariableOverrides": {
+                        "testVar": "canary",
+                    },
+                },
+            )
+        snapshot.match("create-canary-deployment-empty-stage", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.create_deployment(
+                restApiId=api_id,
                 stageName="non-existing",
                 canarySettings={
                     "percentTraffic": 50,

--- a/tests/aws/services/apigateway/test_apigateway_canary.py
+++ b/tests/aws/services/apigateway/test_apigateway_canary.py
@@ -1,0 +1,99 @@
+# TODO: also see .test_apigateway_common.TestStages
+import pytest
+from botocore.exceptions import ClientError
+
+from localstack.testing.pytest import markers
+
+# @pytest.fixture
+# def _create_api_with_stage(
+#     self, aws_client, create_rest_apigw, apigw_add_transformers, snapshot
+# ):
+#     client = aws_client.apigateway
+#     use that
+#
+#     def _create():
+#         # create API, method, integration, deployment
+#         api_id, api_name, root_id = create_rest_apigw()
+#         client.put_method(
+#             restApiId=api_id, resourceId=root_id, httpMethod="GET", authorizationType="NONE"
+#         )
+#         client.put_integration(
+#             restApiId=api_id, resourceId=root_id, httpMethod="GET", type="MOCK"
+#         )
+#         response = client.create_deployment(restApiId=api_id)
+#         deployment_id = response["id"]
+# TODO: think of a way to assert we are in a canary deployment? returning different MOCK response + stage variable over
+#
+#         # create stage
+#         response = client.create_stage(
+#             restApiId=api_id,
+#             stageName="s1",
+#             deploymentId=deployment_id,
+#             description="my stage",
+#         )
+#         snapshot.match("create-stage", response)
+#
+#         return api_id
+#
+#     return _create
+
+
+class TestStageCrudCanary:
+    @markers.aws.validated
+    def test_create_update_stages(
+        self, _create_api_with_stage, aws_client, create_rest_apigw, snapshot
+    ):
+        client = aws_client.apigateway
+        api_id = _create_api_with_stage()
+
+        # negative tests for immutable/non-updateable attributes
+
+        with pytest.raises(ClientError) as ctx:
+            client.update_stage(
+                restApiId=api_id,
+                stageName="s1",
+                patchOperations=[
+                    {"op": "replace", "path": "/documentation_version", "value": "123"}
+                ],
+            )
+        snapshot.match("error-update-doc-version", ctx.value.response)
+
+        with pytest.raises(ClientError) as ctx:
+            client.update_stage(
+                restApiId=api_id,
+                stageName="s1",
+                patchOperations=[
+                    {"op": "replace", "path": "/tags/tag1", "value": "value1"},
+                ],
+            )
+        snapshot.match("error-update-tags", ctx.value.response)
+
+        # update & get stage
+        response = client.update_stage(
+            restApiId=api_id,
+            stageName="s1",
+            patchOperations=[
+                {"op": "replace", "path": "/description", "value": "stage new"},
+                {"op": "replace", "path": "/variables/var1", "value": "test"},
+                {"op": "replace", "path": "/variables/var2", "value": "test2"},
+                {"op": "replace", "path": "/*/*/throttling/burstLimit", "value": "123"},
+                {"op": "replace", "path": "/*/*/caching/enabled", "value": "true"},
+                {"op": "replace", "path": "/tracingEnabled", "value": "true"},
+                {"op": "replace", "path": "/test/GET/throttling/burstLimit", "value": "124"},
+            ],
+        )
+        snapshot.match("update-stage", response)
+
+        response = client.get_stage(restApiId=api_id, stageName="s1")
+        snapshot.match("get-stage", response)
+
+        # show that updating */* does not override previously set values, only
+        # provides default values then like shown above
+        response = client.update_stage(
+            restApiId=api_id,
+            stageName="s1",
+            patchOperations=[
+                {"op": "replace", "path": "/*/*/throttling/burstLimit", "value": "100"},
+            ],
+        )
+        snapshot.match("update-stage-override", response)

--- a/tests/aws/services/apigateway/test_apigateway_canary.py
+++ b/tests/aws/services/apigateway/test_apigateway_canary.py
@@ -395,10 +395,17 @@ class TestStageCrudCanary:
     def test_update_stage_canary_deployment_validation(
         self, create_api_for_deployment, aws_client, create_rest_apigw, snapshot
     ):
+        snapshot.add_transformer(snapshot.transform.key_value("deploymentId"))
         api_id, resource_id = create_api_for_deployment()
 
         stage_name = "dev"
         aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
+
+        get_stage = aws_client.apigateway.get_stage(
+            restApiId=api_id,
+            stageName=stage_name,
+        )
+        snapshot.match("get-stage", get_stage)
 
         aws_client.apigateway.create_deployment(
             restApiId=api_id,

--- a/tests/aws/services/apigateway/test_apigateway_canary.py
+++ b/tests/aws/services/apigateway/test_apigateway_canary.py
@@ -589,6 +589,7 @@ class TestStageCrudCanary:
         snapshot.match("update-stage-with-copy-2", update_stage_2)
 
 
+@pytest.mark.skip(reason="Not yet implemented")
 class TestCanaryDeployments:
     @markers.aws.validated
     def test_invoking_canary_deployment(self, aws_client, create_api_for_deployment, snapshot):

--- a/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
@@ -1,0 +1,236 @@
+{
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_update_stages": {
+    "recorded-date": "30-05-2025, 13:00:01",
+    "recorded-content": {
+      "create-deployment-1": {
+        "createdDate": "datetime",
+        "id": "e3ddus",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-deployment-2": {
+        "createdDate": "datetime",
+        "id": "g27dxg",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "g27dxg",
+          "percentTraffic": 50.0,
+          "stageVariableOverrides": {
+            "testVar": "canary"
+          },
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "e3ddus",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "g27dxg",
+          "percentTraffic": 50.0,
+          "stageVariableOverrides": {
+            "testVar": "canary"
+          },
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "e3ddus",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-stage-canary-settings-overrides": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "g27dxg",
+          "percentTraffic": 50.0,
+          "stageVariableOverrides": {
+            "testVar": "updated"
+          },
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "e3ddus",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-stage-remove-canary-settings": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "e3ddus",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stage-after-remove": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "e3ddus",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment": {
+    "recorded-date": "30-05-2025, 15:32:07",
+    "recorded-content": {
+      "create-deployment": {
+        "createdDate": "datetime",
+        "id": "vjnf3h",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "vjnf3h",
+          "percentTraffic": 40.0,
+          "stageVariableOverrides": {
+            "testVar": "canary1"
+          },
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "vjnf3h",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev1",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-canary-deployment": {
+        "createdDate": "datetime",
+        "id": "9g3p39",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-stage-1": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "9g3p39",
+          "percentTraffic": 50.0,
+          "stageVariableOverrides": {
+            "testVar": "canary2"
+          },
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "vjnf3h",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev1",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-stage-2": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "9g3p39",
+          "percentTraffic": 60.0,
+          "stageVariableOverrides": {
+            "testVar": "canary-overridden"
+          },
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "vjnf3h",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev2",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
@@ -299,7 +299,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_by_stage_update": {
-    "recorded-date": "30-05-2025, 16:52:40",
+    "recorded-date": "30-05-2025, 19:03:13",
     "recorded-content": {
       "create-deployment": {
         "createdDate": "datetime",
@@ -398,6 +398,17 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "wrong-deployment-id": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Deployment id does not exist"
+        },
+        "message": "Deployment id does not exist",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
       }
     }
   },
@@ -429,7 +440,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_canary_deployment_validation": {
-    "recorded-date": "30-05-2025, 16:56:23",
+    "recorded-date": "30-05-2025, 19:00:50",
     "recorded-content": {
       "update-stage-canary-settings-remove-overrides": {
         "Error": {
@@ -470,6 +481,17 @@
           "Message": "Invalid add operation with path: /canarySettings/deploymentId"
         },
         "message": "Invalid add operation with path: /canarySettings/deploymentId",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-stage-no-deployment": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Deployment id does not exist"
+        },
+        "message": "Deployment id does not exist",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -538,6 +560,45 @@
         "nonOverridden": "default",
         "statusCode": 200,
         "variable": "canary"
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_with_copy_ops": {
+    "recorded-date": "30-05-2025, 18:06:48",
+    "recorded-content": {
+      "copy-with-no-replace": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Promotion not available. Canary does not exist."
+        },
+        "message": "Promotion not available. Canary does not exist.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-stage-with-copy": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "<deployment-id:1>",
+          "percentTraffic": 0.0,
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "test",
+          "testVar2": "test2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   }

--- a/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
@@ -1,10 +1,10 @@
 {
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_update_stages": {
-    "recorded-date": "30-05-2025, 13:00:01",
+    "recorded-date": "30-05-2025, 16:53:20",
     "recorded-content": {
       "create-deployment-1": {
         "createdDate": "datetime",
-        "id": "e3ddus",
+        "id": "<deployment-id:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -12,7 +12,7 @@
       },
       "create-deployment-2": {
         "createdDate": "datetime",
-        "id": "g27dxg",
+        "id": "<deployment-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -22,7 +22,7 @@
         "cacheClusterEnabled": false,
         "cacheClusterStatus": "NOT_AVAILABLE",
         "canarySettings": {
-          "deploymentId": "g27dxg",
+          "deploymentId": "<deployment-id:1>",
           "percentTraffic": 50.0,
           "stageVariableOverrides": {
             "testVar": "canary"
@@ -30,7 +30,7 @@
           "useStageCache": false
         },
         "createdDate": "datetime",
-        "deploymentId": "e3ddus",
+        "deploymentId": "<deployment-id:2>",
         "description": "dev stage",
         "lastUpdatedDate": "datetime",
         "methodSettings": {},
@@ -48,7 +48,7 @@
         "cacheClusterEnabled": false,
         "cacheClusterStatus": "NOT_AVAILABLE",
         "canarySettings": {
-          "deploymentId": "g27dxg",
+          "deploymentId": "<deployment-id:1>",
           "percentTraffic": 50.0,
           "stageVariableOverrides": {
             "testVar": "canary"
@@ -56,7 +56,7 @@
           "useStageCache": false
         },
         "createdDate": "datetime",
-        "deploymentId": "e3ddus",
+        "deploymentId": "<deployment-id:2>",
         "description": "dev stage",
         "lastUpdatedDate": "datetime",
         "methodSettings": {},
@@ -74,7 +74,7 @@
         "cacheClusterEnabled": false,
         "cacheClusterStatus": "NOT_AVAILABLE",
         "canarySettings": {
-          "deploymentId": "g27dxg",
+          "deploymentId": "<deployment-id:1>",
           "percentTraffic": 50.0,
           "stageVariableOverrides": {
             "testVar": "updated"
@@ -82,7 +82,7 @@
           "useStageCache": false
         },
         "createdDate": "datetime",
-        "deploymentId": "e3ddus",
+        "deploymentId": "<deployment-id:2>",
         "description": "dev stage",
         "lastUpdatedDate": "datetime",
         "methodSettings": {},
@@ -100,7 +100,7 @@
         "cacheClusterEnabled": false,
         "cacheClusterStatus": "NOT_AVAILABLE",
         "createdDate": "datetime",
-        "deploymentId": "e3ddus",
+        "deploymentId": "<deployment-id:2>",
         "description": "dev stage",
         "lastUpdatedDate": "datetime",
         "methodSettings": {},
@@ -118,7 +118,72 @@
         "cacheClusterEnabled": false,
         "cacheClusterStatus": "NOT_AVAILABLE",
         "createdDate": "datetime",
-        "deploymentId": "e3ddus",
+        "deploymentId": "<deployment-id:2>",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_with_stage": {
+    "recorded-date": "30-05-2025, 16:54:10",
+    "recorded-content": {
+      "create-deployment": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-canary-deployment": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "<deployment-id:2>",
+          "percentTraffic": 50.0,
+          "stageVariableOverrides": {
+            "testVar": "canary"
+          },
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
         "description": "dev stage",
         "lastUpdatedDate": "datetime",
         "methodSettings": {},
@@ -135,11 +200,11 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment": {
-    "recorded-date": "30-05-2025, 15:32:07",
+    "recorded-date": "30-05-2025, 16:54:51",
     "recorded-content": {
       "create-deployment": {
         "createdDate": "datetime",
-        "id": "vjnf3h",
+        "id": "<deployment-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -149,7 +214,7 @@
         "cacheClusterEnabled": false,
         "cacheClusterStatus": "NOT_AVAILABLE",
         "canarySettings": {
-          "deploymentId": "vjnf3h",
+          "deploymentId": "<deployment-id:1>",
           "percentTraffic": 40.0,
           "stageVariableOverrides": {
             "testVar": "canary1"
@@ -157,7 +222,7 @@
           "useStageCache": false
         },
         "createdDate": "datetime",
-        "deploymentId": "vjnf3h",
+        "deploymentId": "<deployment-id:1>",
         "description": "dev stage",
         "lastUpdatedDate": "datetime",
         "methodSettings": {},
@@ -173,7 +238,7 @@
       },
       "create-canary-deployment": {
         "createdDate": "datetime",
-        "id": "9g3p39",
+        "id": "<deployment-id:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -183,7 +248,7 @@
         "cacheClusterEnabled": false,
         "cacheClusterStatus": "NOT_AVAILABLE",
         "canarySettings": {
-          "deploymentId": "9g3p39",
+          "deploymentId": "<deployment-id:2>",
           "percentTraffic": 50.0,
           "stageVariableOverrides": {
             "testVar": "canary2"
@@ -191,7 +256,7 @@
           "useStageCache": false
         },
         "createdDate": "datetime",
-        "deploymentId": "vjnf3h",
+        "deploymentId": "<deployment-id:1>",
         "description": "dev stage",
         "lastUpdatedDate": "datetime",
         "methodSettings": {},
@@ -209,7 +274,7 @@
         "cacheClusterEnabled": false,
         "cacheClusterStatus": "NOT_AVAILABLE",
         "canarySettings": {
-          "deploymentId": "9g3p39",
+          "deploymentId": "<deployment-id:2>",
           "percentTraffic": 60.0,
           "stageVariableOverrides": {
             "testVar": "canary-overridden"
@@ -217,7 +282,7 @@
           "useStageCache": false
         },
         "createdDate": "datetime",
-        "deploymentId": "vjnf3h",
+        "deploymentId": "<deployment-id:1>",
         "description": "dev stage",
         "lastUpdatedDate": "datetime",
         "methodSettings": {},
@@ -230,6 +295,246 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
         }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_by_stage_update": {
+    "recorded-date": "30-05-2025, 16:52:40",
+    "recorded-content": {
+      "create-deployment": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-deployment-2": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update-stage-with-deployment": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "<deployment-id:2>",
+          "percentTraffic": 0.0,
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove-stage-canary": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-stage-with-percent": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "<deployment-id:1>",
+          "percentTraffic": 50.0,
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_validation": {
+    "recorded-date": "30-05-2025, 16:55:48",
+    "recorded-content": {
+      "create-canary-deployment-no-stage": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid deployment content specified.Non null and non empty stageName must be provided for canary deployment. Provided value is null"
+        },
+        "message": "Invalid deployment content specified.Non null and non empty stageName must be provided for canary deployment. Provided value is null",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-canary-deployment-non-existing-stage": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid deployment content specified.Stage non-existing must already be created before making a canary release deployment"
+        },
+        "message": "Invalid deployment content specified.Stage non-existing must already be created before making a canary release deployment",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_canary_deployment_validation": {
+    "recorded-date": "30-05-2025, 16:56:23",
+    "recorded-content": {
+      "update-stage-canary-settings-remove-overrides": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Cannot remove method setting canarySettings/stageVariableOverrides because there is no method setting for this method "
+        },
+        "message": "Cannot remove method setting canarySettings/stageVariableOverrides because there is no method setting for this method ",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-stage-canary-settings-bad-path": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Cannot remove method setting canarySettings/badPath because there is no method setting for this method "
+        },
+        "message": "Cannot remove method setting canarySettings/badPath because there is no method setting for this method ",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-stage-canary-settings-replace-bad-path": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid method setting path: /canarySettings/badPath. Must be one of: [/deploymentId, /description, /cacheClusterEnabled, /cacheClusterSize, /clientCertificateId, /accessLogSettings, /accessLogSettings/destinationArn, /accessLogSettings/format, /{resourcePath}/{httpMethod}/metrics/enabled, /{resourcePath}/{httpMethod}/logging/dataTrace, /{resourcePath}/{httpMethod}/logging/loglevel, /{resourcePath}/{httpMethod}/throttling/burstLimit/{resourcePath}/{httpMethod}/throttling/rateLimit/{resourcePath}/{httpMethod}/caching/ttlInSeconds, /{resourcePath}/{httpMethod}/caching/enabled, /{resourcePath}/{httpMethod}/caching/dataEncrypted, /{resourcePath}/{httpMethod}/caching/requireAuthorizationForCacheControl, /{resourcePath}/{httpMethod}/caching/unauthorizedCacheControlHeaderStrategy, /*/*/metrics/enabled, /*/*/logging/dataTrace, /*/*/logging/loglevel, /*/*/throttling/burstLimit /*/*/throttling/rateLimit /*/*/caching/ttlInSeconds, /*/*/caching/enabled, /*/*/caching/dataEncrypted, /*/*/caching/requireAuthorizationForCacheControl, /*/*/caching/unauthorizedCacheControlHeaderStrategy, /variables/{variable_name}, /tracingEnabled]"
+        },
+        "message": "Invalid method setting path: /canarySettings/badPath. Must be one of: [/deploymentId, /description, /cacheClusterEnabled, /cacheClusterSize, /clientCertificateId, /accessLogSettings, /accessLogSettings/destinationArn, /accessLogSettings/format, /{resourcePath}/{httpMethod}/metrics/enabled, /{resourcePath}/{httpMethod}/logging/dataTrace, /{resourcePath}/{httpMethod}/logging/loglevel, /{resourcePath}/{httpMethod}/throttling/burstLimit/{resourcePath}/{httpMethod}/throttling/rateLimit/{resourcePath}/{httpMethod}/caching/ttlInSeconds, /{resourcePath}/{httpMethod}/caching/enabled, /{resourcePath}/{httpMethod}/caching/dataEncrypted, /{resourcePath}/{httpMethod}/caching/requireAuthorizationForCacheControl, /{resourcePath}/{httpMethod}/caching/unauthorizedCacheControlHeaderStrategy, /*/*/metrics/enabled, /*/*/logging/dataTrace, /*/*/logging/loglevel, /*/*/throttling/burstLimit /*/*/throttling/rateLimit /*/*/caching/ttlInSeconds, /*/*/caching/enabled, /*/*/caching/dataEncrypted, /*/*/caching/requireAuthorizationForCacheControl, /*/*/caching/unauthorizedCacheControlHeaderStrategy, /variables/{variable_name}, /tracingEnabled]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-stage-add-deployment": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid add operation with path: /canarySettings/deploymentId"
+        },
+        "message": "Invalid add operation with path: /canarySettings/deploymentId",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestCanaryDeployments::test_invoking_canary_deployment": {
+    "recorded-date": "30-05-2025, 16:27:07",
+    "recorded-content": {
+      "create-deployment-1": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-deployment-2": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "response-deployment-1": {
+        "isCanary": "false",
+        "message": "default deployment",
+        "nonExistingDefault": "",
+        "statusCode": 200,
+        "variable": "default"
+      },
+      "update-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "<deployment-id:1>",
+          "percentTraffic": 100.0,
+          "stageVariableOverrides": {
+            "noStageVar": "canary",
+            "testVar": "canary"
+          },
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:2>",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "response-canary-deployment": {
+        "isCanary": "true",
+        "message": "canary deployment",
+        "nonExistingDefault": "canary",
+        "statusCode": 200,
+        "variable": "canary"
       }
     }
   }

--- a/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
@@ -478,7 +478,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestCanaryDeployments::test_invoking_canary_deployment": {
-    "recorded-date": "30-05-2025, 16:27:07",
+    "recorded-date": "30-05-2025, 17:06:30",
     "recorded-content": {
       "create-deployment-1": {
         "createdDate": "datetime",
@@ -500,6 +500,7 @@
         "isCanary": "false",
         "message": "default deployment",
         "nonExistingDefault": "",
+        "nonOverridden": "default",
         "statusCode": 200,
         "variable": "default"
       },
@@ -522,6 +523,7 @@
         "stageName": "dev",
         "tracingEnabled": false,
         "variables": {
+          "defaultVar": "default",
           "testVar": "default"
         },
         "ResponseMetadata": {
@@ -533,6 +535,7 @@
         "isCanary": "true",
         "message": "canary deployment",
         "nonExistingDefault": "canary",
+        "nonOverridden": "default",
         "statusCode": 200,
         "variable": "canary"
       }

--- a/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
@@ -200,7 +200,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment": {
-    "recorded-date": "30-05-2025, 16:54:51",
+    "recorded-date": "30-05-2025, 19:27:57",
     "recorded-content": {
       "create-deployment": {
         "createdDate": "datetime",
@@ -295,11 +295,22 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
         }
+      },
+      "bad-canary-deployment-id": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Deployment id does not exist"
+        },
+        "message": "Deployment id does not exist",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
       }
     }
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_by_stage_update": {
-    "recorded-date": "30-05-2025, 19:03:13",
+    "recorded-date": "30-05-2025, 19:26:29",
     "recorded-content": {
       "create-deployment": {
         "createdDate": "datetime",
@@ -398,17 +409,6 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      },
-      "wrong-deployment-id": {
-        "Error": {
-          "Code": "BadRequestException",
-          "Message": "Deployment id does not exist"
-        },
-        "message": "Deployment id does not exist",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
       }
     }
   },
@@ -451,7 +451,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_canary_deployment_validation": {
-    "recorded-date": "30-05-2025, 19:00:50",
+    "recorded-date": "30-05-2025, 20:02:51",
     "recorded-content": {
       "update-stage-canary-settings-remove-overrides": {
         "Error": {
@@ -470,6 +470,17 @@
           "Message": "Cannot remove method setting canarySettings/badPath because there is no method setting for this method "
         },
         "message": "Cannot remove method setting canarySettings/badPath because there is no method setting for this method ",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-stage-canary-settings-bad-path-2": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid method setting path: /canarySettings. Must be one of: [/deploymentId, /description, /cacheClusterEnabled, /cacheClusterSize, /clientCertificateId, /accessLogSettings, /accessLogSettings/destinationArn, /accessLogSettings/format, /{resourcePath}/{httpMethod}/metrics/enabled, /{resourcePath}/{httpMethod}/logging/dataTrace, /{resourcePath}/{httpMethod}/logging/loglevel, /{resourcePath}/{httpMethod}/throttling/burstLimit/{resourcePath}/{httpMethod}/throttling/rateLimit/{resourcePath}/{httpMethod}/caching/ttlInSeconds, /{resourcePath}/{httpMethod}/caching/enabled, /{resourcePath}/{httpMethod}/caching/dataEncrypted, /{resourcePath}/{httpMethod}/caching/requireAuthorizationForCacheControl, /{resourcePath}/{httpMethod}/caching/unauthorizedCacheControlHeaderStrategy, /*/*/metrics/enabled, /*/*/logging/dataTrace, /*/*/logging/loglevel, /*/*/throttling/burstLimit /*/*/throttling/rateLimit /*/*/caching/ttlInSeconds, /*/*/caching/enabled, /*/*/caching/dataEncrypted, /*/*/caching/requireAuthorizationForCacheControl, /*/*/caching/unauthorizedCacheControlHeaderStrategy, /variables/{variable_name}, /tracingEnabled]"
+        },
+        "message": "Invalid method setting path: /canarySettings. Must be one of: [/deploymentId, /description, /cacheClusterEnabled, /cacheClusterSize, /clientCertificateId, /accessLogSettings, /accessLogSettings/destinationArn, /accessLogSettings/format, /{resourcePath}/{httpMethod}/metrics/enabled, /{resourcePath}/{httpMethod}/logging/dataTrace, /{resourcePath}/{httpMethod}/logging/loglevel, /{resourcePath}/{httpMethod}/throttling/burstLimit/{resourcePath}/{httpMethod}/throttling/rateLimit/{resourcePath}/{httpMethod}/caching/ttlInSeconds, /{resourcePath}/{httpMethod}/caching/enabled, /{resourcePath}/{httpMethod}/caching/dataEncrypted, /{resourcePath}/{httpMethod}/caching/requireAuthorizationForCacheControl, /{resourcePath}/{httpMethod}/caching/unauthorizedCacheControlHeaderStrategy, /*/*/metrics/enabled, /*/*/logging/dataTrace, /*/*/logging/loglevel, /*/*/throttling/burstLimit /*/*/throttling/rateLimit /*/*/caching/ttlInSeconds, /*/*/caching/enabled, /*/*/caching/dataEncrypted, /*/*/caching/requireAuthorizationForCacheControl, /*/*/caching/unauthorizedCacheControlHeaderStrategy, /variables/{variable_name}, /tracingEnabled]",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
@@ -413,7 +413,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_validation": {
-    "recorded-date": "30-05-2025, 16:55:48",
+    "recorded-date": "30-05-2025, 19:06:19",
     "recorded-content": {
       "create-canary-deployment-no-stage": {
         "Error": {
@@ -421,6 +421,17 @@
           "Message": "Invalid deployment content specified.Non null and non empty stageName must be provided for canary deployment. Provided value is null"
         },
         "message": "Invalid deployment content specified.Non null and non empty stageName must be provided for canary deployment. Provided value is null",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-canary-deployment-empty-stage": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid deployment content specified.Non null and non empty stageName must be provided for canary deployment. Provided value is "
+        },
+        "message": "Invalid deployment content specified.Non null and non empty stageName must be provided for canary deployment. Provided value is ",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
@@ -474,8 +474,22 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_canary_deployment_validation": {
-    "recorded-date": "30-05-2025, 20:02:51",
+    "recorded-date": "30-05-2025, 22:27:14",
     "recorded-content": {
+      "get-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "update-stage-canary-settings-remove-overrides": {
         "Error": {
           "Code": "BadRequestException",

--- a/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.snapshot.json
@@ -310,7 +310,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_by_stage_update": {
-    "recorded-date": "30-05-2025, 19:26:29",
+    "recorded-date": "30-05-2025, 21:04:43",
     "recorded-content": {
       "create-deployment": {
         "createdDate": "datetime",
@@ -388,6 +388,29 @@
         }
       },
       "update-stage-with-percent": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "<deployment-id:1>",
+          "percentTraffic": 50.0,
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "dev stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "default"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stage": {
         "cacheClusterEnabled": false,
         "cacheClusterStatus": "NOT_AVAILABLE",
         "canarySettings": {
@@ -586,8 +609,27 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_with_copy_ops": {
-    "recorded-date": "30-05-2025, 18:06:48",
+    "recorded-date": "30-05-2025, 21:21:21",
     "recorded-content": {
+      "deployment-1": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "copy-with-bad-statement": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid copy operation with path: /canarySettings/stageVariableOverrides and from /variables. Valid copy:path are [/deploymentId, /variables] and valid copy:from are [/canarySettings/deploymentId, /canarySettings/stageVariableOverrides]"
+        },
+        "message": "Invalid copy operation with path: /canarySettings/stageVariableOverrides and from /variables. Valid copy:path are [/deploymentId, /variables] and valid copy:from are [/canarySettings/deploymentId, /canarySettings/stageVariableOverrides]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
       "copy-with-no-replace": {
         "Error": {
           "Code": "BadRequestException",
@@ -615,6 +657,66 @@
         "tracingEnabled": false,
         "variables": {
           "testVar": "test",
+          "testVar2": "test2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "deployment-canary": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "<deployment-id:2>",
+          "percentTraffic": 50.0,
+          "stageVariableOverrides": {
+            "testVar": "override"
+          },
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "test",
+          "testVar2": "test2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-stage-with-copy-2": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "canarySettings": {
+          "deploymentId": "<deployment-id:2>",
+          "percentTraffic": 0.0,
+          "stageVariableOverrides": {
+            "testVar": "override"
+          },
+          "useStageCache": false
+        },
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:2>",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "dev",
+        "tracingEnabled": false,
+        "variables": {
+          "testVar": "override",
           "testVar2": "test2"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/apigateway/test_apigateway_canary.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.validation.json
@@ -6,7 +6,7 @@
     "last_validated_date": "2025-05-30T16:54:51+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_by_stage_update": {
-    "last_validated_date": "2025-05-30T16:52:40+00:00"
+    "last_validated_date": "2025-05-30T19:03:13+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_validation": {
     "last_validated_date": "2025-05-30T16:55:48+00:00"
@@ -18,6 +18,9 @@
     "last_validated_date": "2025-05-30T16:53:20+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_canary_deployment_validation": {
-    "last_validated_date": "2025-05-30T16:56:23+00:00"
+    "last_validated_date": "2025-05-30T19:00:50+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_with_copy_ops": {
+    "last_validated_date": "2025-05-30T18:06:48+00:00"
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_canary.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.validation.json
@@ -9,7 +9,7 @@
     "last_validated_date": "2025-05-30T19:03:13+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_validation": {
-    "last_validated_date": "2025-05-30T16:55:48+00:00"
+    "last_validated_date": "2025-05-30T19:06:19+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_with_stage": {
     "last_validated_date": "2025-05-30T16:54:10+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_canary.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.validation.json
@@ -18,7 +18,7 @@
     "last_validated_date": "2025-05-30T16:53:20+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_canary_deployment_validation": {
-    "last_validated_date": "2025-05-30T20:02:51+00:00"
+    "last_validated_date": "2025-05-30T22:27:14+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_with_copy_ops": {
     "last_validated_date": "2025-05-30T21:21:21+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_canary.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.validation.json
@@ -1,0 +1,8 @@
+{
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment": {
+    "last_validated_date": "2025-05-30T15:32:07+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_update_stages": {
+    "last_validated_date": "2025-05-30T13:00:01+00:00"
+  }
+}

--- a/tests/aws/services/apigateway/test_apigateway_canary.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestCanaryDeployments::test_invoking_canary_deployment": {
-    "last_validated_date": "2025-05-30T16:27:07+00:00"
+    "last_validated_date": "2025-05-30T17:06:30+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment": {
     "last_validated_date": "2025-05-30T16:54:51+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_canary.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.validation.json
@@ -1,8 +1,23 @@
 {
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestCanaryDeployments::test_invoking_canary_deployment": {
+    "last_validated_date": "2025-05-30T16:27:07+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment": {
-    "last_validated_date": "2025-05-30T15:32:07+00:00"
+    "last_validated_date": "2025-05-30T16:54:51+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_by_stage_update": {
+    "last_validated_date": "2025-05-30T16:52:40+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_validation": {
+    "last_validated_date": "2025-05-30T16:55:48+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_with_stage": {
+    "last_validated_date": "2025-05-30T16:54:10+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_update_stages": {
-    "last_validated_date": "2025-05-30T13:00:01+00:00"
+    "last_validated_date": "2025-05-30T16:53:20+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_canary_deployment_validation": {
+    "last_validated_date": "2025-05-30T16:56:23+00:00"
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_canary.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.validation.json
@@ -3,10 +3,10 @@
     "last_validated_date": "2025-05-30T17:06:30+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment": {
-    "last_validated_date": "2025-05-30T16:54:51+00:00"
+    "last_validated_date": "2025-05-30T19:27:57+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_by_stage_update": {
-    "last_validated_date": "2025-05-30T19:03:13+00:00"
+    "last_validated_date": "2025-05-30T19:26:29+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_validation": {
     "last_validated_date": "2025-05-30T19:06:19+00:00"
@@ -18,7 +18,7 @@
     "last_validated_date": "2025-05-30T16:53:20+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_canary_deployment_validation": {
-    "last_validated_date": "2025-05-30T19:00:50+00:00"
+    "last_validated_date": "2025-05-30T20:02:51+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_with_copy_ops": {
     "last_validated_date": "2025-05-30T18:06:48+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_canary.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_canary.validation.json
@@ -6,7 +6,7 @@
     "last_validated_date": "2025-05-30T19:27:57+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_by_stage_update": {
-    "last_validated_date": "2025-05-30T19:26:29+00:00"
+    "last_validated_date": "2025-05-30T21:04:43+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_create_canary_deployment_validation": {
     "last_validated_date": "2025-05-30T19:06:19+00:00"
@@ -21,6 +21,6 @@
     "last_validated_date": "2025-05-30T20:02:51+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_canary.py::TestStageCrudCanary::test_update_stage_with_copy_ops": {
-    "last_validated_date": "2025-05-30T18:06:48+00:00"
+    "last_validated_date": "2025-05-30T21:21:21+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've got a request to support Canary Deployments CRUD logic as it is needed in some Terraform deployments. 

This was on a radar for a while, and there was no support for it in Moto. 
This PR only implements the CRUD support for it, a follow-up PR will implement the actually canary deployments logic during invocation, with the ability to direct requests to either deployment. The test for it is already in this PR just to verify how it worked in AWS (with `test_invoking_canary_deployment`). 

I'm conscious that this implementation is... not great. There are so many patches, the update logic is really complex. Those JSON Patches really don't make this easy. We should probably rework some kind of framework to easily handle validation + application of those. 

At first, I didn't want to duplicate the code, and I couldn't insert it from the child class inside `update_stage`. I had done in the legacy provider, but I don't want to break existing things and have partial things implemented so I moved it back to the next gen/current provider. This would have made the diff simpler, sorry!

The logic implemented is documented in AWS here: https://docs.aws.amazon.com/apigateway/latest/developerguide/canary-release.html

There was also a bug in Moto where it would update your stage deployment id to the one of the canary setting if you were to set one due to greedy check. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update operations related to canary settings: `CreateStage`, `UpdateStage`, `CreateDeployment`
- add a lot of tests around the behavior to make sure we're getting things somewhat right

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
