### PR TITLE
Apigw canary logic

### DIFF
--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -622,7 +622,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                 param = param.replace("~1", "/")
                 if op == "remove":
                     integration_response.response_templates.pop(param)
-                elif op == "add":
+                elif op in ("add", "replace"):
                     integration_response.response_templates[param] = value
 
             elif "/contentHandling" in path and op == "replace":

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/context.py
@@ -5,7 +5,7 @@ from rolo import Request
 from rolo.gateway import RequestContext
 from werkzeug.datastructures import Headers
 
-from localstack.aws.api.apigateway import Integration, Method, Resource
+from localstack.aws.api.apigateway import Integration, Method, Resource, Stage
 from localstack.services.apigateway.models import RestApiDeployment
 
 from .variables import ContextVariableOverrides, ContextVariables, LoggingContextVariables
@@ -79,7 +79,7 @@ class RestApiInvocationContext(RequestContext):
     api_id: Optional[str]
     """The REST API identifier of the invoked API"""
     stage: Optional[str]
-    """The REST API stage linked to this invocation"""
+    """The REST API stage name linked to this invocation"""
     base_path: Optional[str]
     """The REST API base path mapped to the stage of this invocation"""
     deployment_id: Optional[str]
@@ -96,6 +96,10 @@ class RestApiInvocationContext(RequestContext):
     """The method of the resource the invocation matched"""
     stage_variables: Optional[dict[str, str]]
     """The Stage variables, also used in parameters mapping and mapping templates"""
+    stage_configuration: Optional[Stage]
+    """The Stage configuration, containing canary deployment settings"""
+    is_canary: bool = False
+    """If the current call was directed to a canary deployment"""
     context_variables: Optional[ContextVariables]
     """The $context used in data models, authorizers, mapping templates, and CloudWatch access logging"""
     context_variable_overrides: Optional[ContextVariableOverrides]
@@ -126,6 +130,7 @@ class RestApiInvocationContext(RequestContext):
         self.resource_method = None
         self.integration = None
         self.stage_variables = None
+        self.stage_configuration = None
         self.context_variables = None
         self.logging_context_variables = None
         self.integration_request = None

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/parse.py
@@ -17,7 +17,6 @@ from ..api import RestApiGatewayHandler, RestApiGatewayHandlerChain
 from ..context import InvocationRequest, RestApiInvocationContext
 from ..header_utils import should_drop_header_from_invocation
 from ..helpers import generate_trace_id, generate_trace_parent, parse_trace_id
-from ..moto_helpers import get_stage_variables
 from ..variables import (
     ContextVariableOverrides,
     ContextVariables,
@@ -53,7 +52,7 @@ class InvocationRequestParser(RestApiGatewayHandler):
         # TODO: maybe adjust the logging
         LOG.debug("Initializing $context='%s'", context.context_variables)
         # then populate the stage variables
-        context.stage_variables = self.fetch_stage_variables(context)
+        context.stage_variables = self.get_stage_variables(context)
         LOG.debug("Initializing $stageVariables='%s'", context.stage_variables)
 
         context.trace_id = self.populate_trace_id(context.request.headers)
@@ -172,19 +171,20 @@ class InvocationRequestParser(RestApiGatewayHandler):
             requestTime=timestamp(time=now, format=REQUEST_TIME_DATE_FORMAT),
             requestTimeEpoch=int(now.timestamp() * 1000),
             stage=context.stage,
+            isCanaryRequest=context.is_canary,
         )
         return context_variables
 
     @staticmethod
-    def fetch_stage_variables(context: RestApiInvocationContext) -> Optional[dict[str, str]]:
-        stage_variables = get_stage_variables(
-            account_id=context.account_id,
-            region=context.region,
-            api_id=context.api_id,
-            stage_name=context.stage,
-        )
+    def get_stage_variables(context: RestApiInvocationContext) -> Optional[dict[str, str]]:
+        stage_variables = context.stage_configuration.get("variables")
+        if context.is_canary:
+            overrides = (
+                context.stage_configuration["canarySettings"].get("stageVariableOverrides") or {}
+            )
+            stage_variables = (stage_variables or {}) | overrides
+
         if not stage_variables:
-            # we need to set the stage variables to None in the context if we don't have at least one
             return None
 
         return stage_variables

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/helpers.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import random
 import re
 import time
 from secrets import token_hex
@@ -174,3 +175,9 @@ def mime_type_matches_binary_media_types(mime_type: str | None, binary_media_typ
             return True
 
     return False
+
+
+def should_divert_to_canary(percent_traffic: float) -> bool:
+    if int(percent_traffic) == 100:
+        return True
+    return percent_traffic > random.random() * 100

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/moto_helpers.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/moto_helpers.py
@@ -1,7 +1,13 @@
 from moto.apigateway.models import APIGatewayBackend, apigateway_backends
 from moto.apigateway.models import RestAPI as MotoRestAPI
 
-from localstack.aws.api.apigateway import ApiKey, ListOfUsagePlan, ListOfUsagePlanKey, Resource
+from localstack.aws.api.apigateway import (
+    ApiKey,
+    ListOfUsagePlan,
+    ListOfUsagePlanKey,
+    Resource,
+    Stage,
+)
 
 
 def get_resources_from_moto_rest_api(moto_rest_api: MotoRestAPI) -> dict[str, Resource]:
@@ -38,6 +44,13 @@ def get_stage_variables(
     moto_rest_api = apigateway_backend.get_rest_api(api_id)
     stage = moto_rest_api.stages[stage_name]
     return stage.variables
+
+
+def get_stage_configuration(account_id: str, region: str, api_id: str, stage_name: str) -> Stage:
+    apigateway_backend: APIGatewayBackend = apigateway_backends[account_id][region]
+    moto_rest_api = apigateway_backend.get_rest_api(api_id)
+    stage = moto_rest_api.stages[stage_name]
+    return stage.to_json()
 
 
 def get_usage_plans(account_id: str, region_name: str) -> ListOfUsagePlan:

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/variables.py
@@ -112,7 +112,7 @@ class ContextVariables(TypedDict, total=False):
     httpMethod: str
     """The HTTP method used"""
     identity: Optional[ContextVarsIdentity]
-    isCanaryRequest: Optional[bool | str]  # TODO: verify type
+    isCanaryRequest: Optional[bool]
     """Indicates if the request was directed to the canary"""
     path: str
     """The request path."""

--- a/localstack-core/localstack/services/apigateway/next_gen/provider.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/provider.py
@@ -216,6 +216,9 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
                     "useStageCache": False,
                 }
                 default_canary_settings.update(canary_settings)
+                default_canary_settings["percentTraffic"] = float(
+                    default_canary_settings["percentTraffic"]
+                )
                 moto_stage_copy.canary_settings = default_canary_settings
 
         moto_rest_api.stages[stage_name] = moto_stage_copy
@@ -291,7 +294,6 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
 
         if stage_name:
             moto_stage = moto_rest_api.stages[stage_name]
-            store.active_deployments.setdefault(router_api_id, {})[stage_name] = deployment_id
             if canary_settings:
                 moto_stage = current_stage
                 moto_rest_api.stages[stage_name] = current_stage
@@ -304,6 +306,7 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
                 default_settings.update(canary_settings)
                 moto_stage.canary_settings = default_settings
             else:
+                store.active_deployments.setdefault(router_api_id, {})[stage_name] = deployment_id
                 moto_stage.canary_settings = None
 
             if variables:

--- a/tests/aws/services/apigateway/test_apigateway_canary.py
+++ b/tests/aws/services/apigateway/test_apigateway_canary.py
@@ -589,7 +589,6 @@ class TestStageCrudCanary:
         snapshot.match("update-stage-with-copy-2", update_stage_2)
 
 
-@pytest.mark.skip(reason="Not yet implemented")
 class TestCanaryDeployments:
     @markers.aws.validated
     def test_invoking_canary_deployment(self, aws_client, create_api_for_deployment, snapshot):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Based on #12694 

This is the actual implementation of canary dispatching between deployments. 

Not a lot to add, the code is pretty descriptive. I wasn't sure where to add the dispatching logic, but I think getting this in the router somewhat makes sense, as it is where we are deciding which deployment to use. One of the limitation is that we only know the account id and region from the active deployment itself. 

We could also add a handler first in the chain to fetch the stage config and update the deployment.

Also added a small fix in `UpdateIntegrationResponse`, this will be a good revamp at some point 😅 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- enable the test
- implement the logic in the invocation layer, adding some fields in the context to support the use case

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
