### PR TITLE
Remove unneeded positional argument from cleanup lambda

### DIFF
--- a/tests/aws/services/iam/test_iam.py
+++ b/tests/aws/services/iam/test_iam.py
@@ -491,7 +491,7 @@ class TestIAMIntegrations:
         elif arn_type == "group":
             group_name = f"group-{short_uid()}"
             group = aws_client.iam.create_group(GroupName=group_name)["Group"]
-            cleanups.append(lambda _: aws_client.iam.delete_group(GroupName=group_name))
+            cleanups.append(lambda: aws_client.iam.delete_group(GroupName=group_name))
             aws_client.iam.attach_group_policy(GroupName=group_name, PolicyArn=policy_arn)
             arn = group["Arn"]
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Test fails on running community integration tests in ext workflow. Positional argument doesn't seem to be needed. Checking whether it works on a companion branch.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
