### PR TITLE
refactor: reduce max number of allowed labels in counters from 8 to 6 [DAT-146]

### DIFF
--- a/localstack-core/localstack/utils/analytics/metrics.py
+++ b/localstack-core/localstack/utils/analytics/metrics.py
@@ -259,8 +259,8 @@ class LabeledCounterMetric(Metric):
         if any(not label for label in labels):
             raise ValueError("Labels must be non-empty strings.")
 
-        if len(labels) > 8:
-            raise ValueError("A maximum of 8 labels are allowed.")
+        if len(labels) > 6:
+            raise ValueError("Too many labels: counters allow a maximum of 6.")
 
         self._type = "counter"
         self._labels = labels

--- a/tests/unit/utils/analytics/test_metrics.py
+++ b/tests/unit/utils/analytics/test_metrics.py
@@ -137,11 +137,11 @@ def test_thread_safety():
 
 
 def test_max_labels_limit():
-    with pytest.raises(ValueError, match="A maximum of 8 labels are allowed."):
+    with pytest.raises(ValueError, match="Too many labels: counters allow a maximum of 6."):
         Counter(
             namespace="test_namespace",
             name="test_counter",
-            labels=["l1", "l2", "l3", "l4", "l5", "l6", "l7", "l8", "l9"],
+            labels=["l1", "l2", "l3", "l4", "l5", "l6", "l7"],
         )
 
 


### PR DESCRIPTION
## Motivation
- After reviewing label usage over the past few months, we found that no existing metric uses more than 5 labels.
- Limiting counters to 6 labels help to avoid overly complex metrics that try to capture too many different aspects.
- Fewer labels simplify analytics query and makes dashboards easier to build/read.
- A limit of 6 is sufficiently high for current needs, but this threshold can be revisited in the future if necessary.

## Changes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
