### PR TITLE
Fix Workflow summaries for ARM workflows

### DIFF
--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -447,12 +447,12 @@ jobs:
     name: Publish Test Results
     strategy:
       matrix:
-        runner:
-          - ubuntu-latest
-          - ubuntu-24.04-arm
+        arch:
+          - amd64
+          - arm64
         exclude:
           # skip the ARM integration tests in case we are not on the master and not on the upgrade-dependencies branch and forceARMTests is not set to true
-          - runner: ${{ (github.ref != 'refs/heads/master' && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false) && 'ubuntu-24.04-arm' || ''}}
+          - arch: ${{ (github.ref != 'refs/heads/master' && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false) && 'arm64' || ''}}
     needs:
       - test-integration
       - test-bootstrap
@@ -465,20 +465,16 @@ jobs:
     # execute on success or failure, but not if the workflow is cancelled or any of the dependencies has been skipped
     if: always() && !cancelled() && !contains(needs.*.result, 'skipped')
     steps:
-      - name: Determine Runner Architecture
-        shell: bash
-        run: echo "PLATFORM=${{ (runner.arch == 'X64' && 'amd64') || (runner.arch == 'ARM64' && 'arm64') || '' }}" >> $GITHUB_ENV
-
       - name: Download Bootstrap Artifacts
         uses: actions/download-artifact@v4
-        if: ${{ env.PLATFORM == 'amd64' }}
+        if: ${{ matrix.arch == 'amd64' }}
         with:
           pattern: test-results-bootstrap
 
       - name: Download Integration Artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: test-results-integration-${{ env.PLATFORM }}-*
+          pattern: test-results-integration-${{ matrix.arch }}-*
 
       - name: Publish Bootstrap and Integration Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -486,7 +482,7 @@ jobs:
         with:
           files: |
             **/pytest-junit-*.xml
-          check_name: "Test Results (${{ env.PLATFORM }}${{ inputs.testAWSAccountId != '000000000000' && ', MA/MR' || ''}}) - Integration${{ env.PLATFORM == 'amd64' && ', Bootstrap' || ''}}"
+          check_name: "Test Results (${{ matrix.arch }}${{ inputs.testAWSAccountId != '000000000000' && ', MA/MR' || ''}}) - Integration${{ matrix.arch == 'amd64' && ', Bootstrap' || ''}}"
           test_file_prefix: "-/opt/code/localstack/"
           action_fail_on_inconclusive: true
 
@@ -571,12 +567,12 @@ jobs:
     name: Publish Acceptance Test Results
     strategy:
       matrix:
-        runner:
-          - ubuntu-latest
-          - ubuntu-24.04-arm
+        arch:
+          - amd64
+          - arm64
         exclude:
           # skip the ARM integration tests in case we are not on the master and not on the upgrade-dependencies branch and forceARMTests is not set to true
-          - runner: ${{ (github.ref != 'refs/heads/master' && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false) && 'ubuntu-24.04-arm' || ''}}
+          - arch: ${{ (github.ref != 'refs/heads/master' && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false) && 'arm64' || ''}}
     needs:
       - test-acceptance
     runs-on: ubuntu-latest
@@ -588,14 +584,10 @@ jobs:
     # execute on success or failure, but not if the workflow is cancelled or any of the dependencies has been skipped
     if: always() && !cancelled() && !contains(needs.*.result, 'skipped')
     steps:
-      - name: Determine Runner Architecture
-        shell: bash
-        run: echo "PLATFORM=${{ (runner.arch == 'X64' && 'amd64') || (runner.arch == 'ARM64' && 'arm64') || '' }}" >> $GITHUB_ENV
-
       - name: Download Acceptance Artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: test-results-acceptance-${{ env.PLATFORM }}
+          pattern: test-results-acceptance-${{ matrix.arch }}
 
       - name: Publish Acceptance Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -603,7 +595,7 @@ jobs:
         with:
           files: |
             **/pytest-junit-*.xml
-          check_name: "Test Results (${{ env.PLATFORM }}${{ inputs.testAWSAccountId != '000000000000' && ', MA/MR' || ''}}) - Acceptance"
+          check_name: "Test Results (${{ matrix.arch }}${{ inputs.testAWSAccountId != '000000000000' && ', MA/MR' || ''}}) - Acceptance"
           test_file_prefix: "-/opt/code/localstack/"
           action_fail_on_inconclusive: true
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While looking at a failed ARM workflow run, I've noticed that arm64 workflow summaries don't work. The reason is a wrong determination of the architecture that is to be reported.
For simplicity, the matrix for determining the architecture remained the same between workflow run and publishing. The error happened in choosing only AMD to actually run the publishing job. To determine the architecture that should be published, however, we checked the architecture of the runner - which would only be AMD. 

Because amd64 and arm64 look so similar we didn't spot this in the initial PR.

To fix this, we can simplify the matrix a bit and just iterate over the actual values `amd64` and `arm64`. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- change matrix to iterate over `amd64` and `arm64` and use the matrix value directly for downloading and publishing the summary.


## Testing

- Run the ARM tests manually and look in the PR summaries for the ARM test results
  - https://github.com/localstack/localstack/actions/runs/15466016690
  - See below, arm results are showing ✅ 

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] The manual test mentioned above
- [ ] ...

