### PR TITLE
Add missing switch for forcing ARM tests on workflow dispatch

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: boolean
         default: false
+      forceARMTests:
+        description: 'Run the ARM tests'
+        required: false
+        type: boolean
+        default: false
       enableTestSelection:
         description: 'Enable Test Selection'
         required: false
@@ -78,6 +83,7 @@ jobs:
       # default "disableTestSelection" to `true` if it's a push or schedule event
       disableTestSelection: ${{ inputs.enableTestSelection != true }}
       PYTEST_LOGLEVEL: ${{ inputs.PYTEST_LOGLEVEL }}
+      forceARMTests: ${{ inputs.forceARMTests == true }}
     secrets:
       DOCKERHUB_PULL_USERNAME: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
       DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}

--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -492,7 +492,7 @@ jobs:
 
 
   test-acceptance:
-    name: "Acceptance Tests (${{ contains(matrix.runner, 'arm') && 'ARM64' || 'AMD64' }}"
+    name: "Acceptance Tests (${{ contains(matrix.runner, 'arm') && 'ARM64' || 'AMD64' }})"
     needs:
       - build
     strategy:

--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -24,12 +24,17 @@ on:
         type: boolean
         default: false
       randomize-aws-credentials:
-        description: "Randomize AWS credentials"
+        description: 'Randomize AWS credentials'
         default: false
         required: false
         type: boolean
       onlyAcceptanceTests:
-        description: "Run only acceptance tests"
+        description: 'Run only acceptance tests'
+        default: false
+        required: false
+        type: boolean
+      forceARMTests:
+        description: 'Run the ARM64 tests'
         default: false
         required: false
         type: boolean
@@ -72,6 +77,11 @@ on:
         type: boolean
       onlyAcceptanceTests:
         description: "Run only acceptance tests"
+        default: false
+        required: false
+        type: boolean
+      forceARMTests:
+        description: 'Run the ARM64 tests'
         default: false
         required: false
         type: boolean


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The GHA workflow only runs ARM tests on master and the dependency upgrade PRs, or when `input.forceARMTests` is set to true. However, we do not have that input. This PR adds that


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Add `forceARMTests` input to both the main pipeline as well as the test sub-pipeline
- Fix minor typo in Acceptance test job name


## Testing

Test run with force ARM tests:
https://github.com/localstack/localstack/actions/runs/15441275724

## TODO

What's left to do:

- [ ] Fix workflow summary reporting after merging this (#12707)
- [ ] ...

