### PR TITLE
Step Functions: Mock feature for StartSyncExecution

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/backend/execution.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/execution.py
@@ -392,6 +392,7 @@ class SyncExecution(Execution):
             exec_comm=self._get_start_execution_worker_comm(),
             cloud_watch_logging_session=self._cloud_watch_logging_session,
             activity_store=self._activity_store,
+            mock_test_case=self.mock_test_case,
         )
 
     def _get_start_execution_worker_comm(self) -> BaseExecutionWorkerCommunication:

--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -773,8 +773,8 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         raise InvalidToken("Invalid token")
 
     @staticmethod
-    def _extract_base_arn(state_machine_arn: str) -> str:
-        """Extract the base ARN from a state machine ARN by removing any test case suffix."""
+    def _get_state_machine_arn(state_machine_arn: str) -> str:
+        """Extract the state machine ARN by removing the test case suffix."""
         return state_machine_arn.split("#")[0]
 
     @staticmethod
@@ -810,7 +810,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
     ) -> StartExecutionOutput:
         self._validate_state_machine_arn(state_machine_arn)
 
-        base_arn = self._extract_base_arn(state_machine_arn)
+        base_arn = self._get_state_machine_arn(state_machine_arn)
         store = self.get_store(context=context)
 
         alias: Optional[Alias] = store.aliases.get(base_arn)
@@ -900,7 +900,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
     ) -> StartSyncExecutionOutput:
         self._validate_state_machine_arn(state_machine_arn)
 
-        base_arn = self._extract_base_arn(state_machine_arn)
+        base_arn = self._get_state_machine_arn(state_machine_arn)
         unsafe_state_machine: Optional[StateMachineInstance] = self.get_store(
             context
         ).state_machines.get(base_arn)

--- a/localstack-core/localstack/testing/pytest/stepfunctions/utils.py
+++ b/localstack-core/localstack/testing/pytest/stepfunctions/utils.py
@@ -613,7 +613,7 @@ def create_and_record_mocked_execution(
         state_machine_name=state_machine_name,
         state_machine_type=state_machine_type,
     )
-    execution_arn = launch_and_record_mocked_sync_execution(
+    execution_arn = launch_and_record_mocked_execution(
         target_aws_client, sfn_snapshot, state_machine_arn, execution_input, test_name
     )
     return execution_arn

--- a/localstack-core/localstack/testing/pytest/stepfunctions/utils.py
+++ b/localstack-core/localstack/testing/pytest/stepfunctions/utils.py
@@ -613,16 +613,34 @@ def create_and_record_mocked_execution(
         state_machine_name=state_machine_name,
         state_machine_type=state_machine_type,
     )
-    if state_machine_type == StateMachineType.EXPRESS:
-        execution_arn = launch_and_record_mocked_sync_execution(
-            target_aws_client, sfn_snapshot, state_machine_arn, execution_input, test_name
-        )
-        return execution_arn
-    else:
-        execution_arn = launch_and_record_mocked_execution(
-            target_aws_client, sfn_snapshot, state_machine_arn, execution_input, test_name
-        )
-        return execution_arn
+    execution_arn = launch_and_record_mocked_sync_execution(
+        target_aws_client, sfn_snapshot, state_machine_arn, execution_input, test_name
+    )
+    return execution_arn
+
+
+def create_and_record_mocked_sync_execution(
+    target_aws_client,
+    create_state_machine_iam_role,
+    create_state_machine,
+    sfn_snapshot,
+    definition,
+    execution_input,
+    state_machine_name,
+    test_name,
+) -> LongArn:
+    state_machine_arn = create_state_machine_with_iam_role(
+        target_aws_client,
+        create_state_machine_iam_role,
+        create_state_machine,
+        sfn_snapshot,
+        definition,
+        state_machine_name=state_machine_name,
+        state_machine_type=StateMachineType.EXPRESS,
+    )
+    execution_arn = launch_and_record_mocked_sync_execution(
+        target_aws_client, sfn_snapshot, state_machine_arn, execution_input, test_name
+    )
     return execution_arn
 
 

--- a/tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.py
+++ b/tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.py
@@ -5,7 +5,7 @@ from localstack_snapshot.snapshots.transformer import JsonpathTransformer, Regex
 import localstack.testing.config
 from localstack import config
 from localstack.aws.api.lambda_ import Runtime
-from localstack.aws.api.stepfunctions import HistoryEventType, StateMachineType
+from localstack.aws.api.stepfunctions import HistoryEventType
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.stepfunctions.utils import (
@@ -14,6 +14,7 @@ from localstack.testing.pytest.stepfunctions.utils import (
     create_and_record_execution,
     create_and_record_express_sync_execution,
     create_and_record_mocked_execution,
+    create_and_record_mocked_sync_execution,
 )
 from localstack.utils.strings import short_uid
 from tests.aws.services.stepfunctions.mocked_service_integrations.mocked_service_integrations import (
@@ -289,7 +290,7 @@ class TestBaseScenarios:
             mock_config_file_path = mock_config_file(mock_config)
             monkeypatch.setattr(config, "SFN_MOCK_CONFIG", mock_config_file_path)
 
-            create_and_record_mocked_execution(
+            create_and_record_mocked_sync_execution(
                 target_aws_client=aws_client_no_sync_prefix,
                 create_state_machine_iam_role=create_state_machine_iam_role,
                 create_state_machine=create_state_machine,
@@ -298,7 +299,6 @@ class TestBaseScenarios:
                 execution_input=exec_input,
                 state_machine_name=state_machine_name,
                 test_name=test_name,
-                state_machine_type=StateMachineType.EXPRESS,
             )
 
     @markers.aws.validated

--- a/tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.snapshot.json
@@ -2475,5 +2475,132 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.py::TestBaseScenarios::test_lambda_service_invoke_sync_execution": {
+    "recorded-date": "03-06-2025, 18:47:04",
+    "recorded-content": {
+      "creation_response": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_execution_sync_response": {
+        "billingDetails": {
+          "billedDurationInMilliseconds": 300,
+          "billedMemoryUsedInMB": 64
+        },
+        "executionArn": "arn:<partition>:states:<region>:111111111111:express:<ArnPart_0idx>:<SyncExecArn_Part1_0idx>:<SyncExecArn_Part2_0idx>",
+        "input": {
+          "FunctionName": "lambda_function_name",
+          "Payload": {
+            "body": "string body"
+          }
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<SyncExecArn_Part1_0idx>",
+        "output": {
+          "ExecutedVersion": "$LATEST",
+          "Payload": {
+            "body": "string body"
+          },
+          "SdkHttpMetadata": {
+            "AllHttpHeaders": {
+              "X-Amz-Executed-Version": [
+                "$LATEST"
+              ],
+              "x-amzn-Remapped-Content-Length": [
+                "0"
+              ],
+              "Connection": [
+                "keep-alive"
+              ],
+              "x-amzn-RequestId": "x-amzn-RequestId",
+              "Content-Length": [
+                "23"
+              ],
+              "Date": "date",
+              "X-Amzn-Trace-Id": "X-Amzn-Trace-Id",
+              "Content-Type": [
+                "application/json"
+              ]
+            },
+            "HttpHeaders": {
+              "Connection": "keep-alive",
+              "Content-Length": "23",
+              "Content-Type": "application/json",
+              "Date": "date",
+              "X-Amz-Executed-Version": "$LATEST",
+              "x-amzn-Remapped-Content-Length": "0",
+              "x-amzn-RequestId": "x-amzn-RequestId",
+              "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
+            },
+            "HttpStatusCode": 200
+          },
+          "SdkResponseMetadata": {
+            "RequestId": "RequestId"
+          },
+          "StatusCode": 200,
+          "final": {
+            "ExecutedVersion": "$LATEST",
+            "Payload": {
+              "body": "string body"
+            },
+            "SdkHttpMetadata": {
+              "AllHttpHeaders": {
+                "X-Amz-Executed-Version": [
+                  "$LATEST"
+                ],
+                "x-amzn-Remapped-Content-Length": [
+                  "0"
+                ],
+                "Connection": [
+                  "keep-alive"
+                ],
+                "x-amzn-RequestId": "x-amzn-RequestId",
+                "Content-Length": [
+                  "23"
+                ],
+                "Date": "date",
+                "X-Amzn-Trace-Id": "X-Amzn-Trace-Id",
+                "Content-Type": [
+                  "application/json"
+                ]
+              },
+              "HttpHeaders": {
+                "Connection": "keep-alive",
+                "Content-Length": "23",
+                "Content-Type": "application/json",
+                "Date": "date",
+                "X-Amz-Executed-Version": "$LATEST",
+                "x-amzn-Remapped-Content-Length": "0",
+                "x-amzn-RequestId": "x-amzn-RequestId",
+                "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
+              },
+              "HttpStatusCode": 200
+            },
+            "SdkResponseMetadata": {
+              "RequestId": "RequestId"
+            },
+            "StatusCode": 200
+          }
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.validation.json
+++ b/tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.validation.json
@@ -11,6 +11,9 @@
   "tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.py::TestBaseScenarios::test_lambda_service_invoke": {
     "last_validated_date": "2025-04-14T18:51:50+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.py::TestBaseScenarios::test_lambda_service_invoke_sync_execution": {
+    "last_validated_date": "2025-06-03T18:47:04+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.py::TestBaseScenarios::test_map_state_lambda": {
     "last_validated_date": "2025-04-24T11:11:05+00:00"
   },


### PR DESCRIPTION
## Motivation
Extend the Step Functions mocking capability to support `StartSyncExecution`, enabling consistent testing across both Standard and Express state machines https://github.com/localstack/localstack/issues/12711

## Changes
- Apply mock config (`LOCALSTACK_SFN_MOCK_CONFIG`) when starting a state machine via `StartSyncExecution`
- New parity test `tests/aws/services/stepfunctions/v2/mocking/test_base_scenarios.py::TestBaseScenarios::test_lambda_service_invoke` to verify that the mocked service integration mechanism also works when using `StartSyncExecution`


## Testing
1. Create an express state machine
2. Create a mock config to mock the state machine response
3. Start localstack with the mock configuration
4. Start the state machine synchronously with `start-execution`
5. Verify that the execution response is the expected one

## TODO
- Add a parity test `tests/aws/services/stepfunctions/v2/mocking/test_base_callbacks.py::TestBaseScenarios::test_sqs_wait_for_task_token`  to verify that the callback mechanism (sync2) returns correctly when executed via `StartSyncExecution`
