### PR TITLE
test(esm/sqs): Skip flaky test_report_batch_item_failures test

### DIFF
--- a/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py
+++ b/tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py
@@ -415,6 +415,9 @@ def test_sqs_queue_as_lambda_dead_letter_queue(
 
 
 @markers.aws.validated
+@pytest.mark.skip(
+    reason="Flaky as an SQS queue will not always return messages in a ReceiveMessages call."
+)
 def test_report_batch_item_failures(
     create_lambda_function,
     sqs_create_queue,
@@ -538,6 +541,7 @@ def test_report_batch_item_failures(
     # now wait for the first invocation result which is expected to have processed message 1 we wait half the retry
     # interval to wait long enough for the message to appear, but short enough to check that the DLQ is empty after
     # the first attempt.
+    # FIXME: We cannot assume that the queue will always return a message in the given time-interval.
     first_invocation = aws_client.sqs.receive_message(
         QueueUrl=destination_url, WaitTimeSeconds=int(retry_timeout / 2), MaxNumberOfMessages=1
     )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This test makes a faulty assumption that a `ReceiveMessages` call will always return a value. Skip for now but re-visit this test after release.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Skips flaky `tests/aws/services/lambda_/event_source_mapping/test_lambda_integration_sqs.py/test_report_batch_item_failures`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
