### PR TITLE
Events: fix PutEvents triggering Scheduled rules

### DIFF
--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -1896,6 +1896,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
 
         if configured_rules := list(event_bus.rules.values()):
             for rule in configured_rules:
+                if rule.schedule_expression:
+                    # we do not want to execute Scheduled Rules on PutEvents
+                    continue
+
                 self._process_rules(rule, region, account_id, event_formatted, trace_header)
         else:
             LOG.info(

--- a/tests/aws/services/events/test_events_schedule.validation.json
+++ b/tests/aws/services/events/test_events_schedule.validation.json
@@ -68,6 +68,15 @@
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_put_rule_with_schedule_cron[cron(5,35 14 * * ? *)]": {
     "last_validated_date": "2025-01-22T13:22:43+00:00"
   },
+  "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_scheduled_rule_does_not_trigger_on_put_events": {
+    "last_validated_date": "2025-06-04T19:23:59+00:00",
+    "durations_in_seconds": {
+      "setup": 0.56,
+      "call": 11.78,
+      "teardown": 1.18,
+      "total": 13.52
+    }
+  },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleRate::test_put_rule_with_invalid_schedule_rate[ rate(10 minutes)]": {
     "last_validated_date": "2024-05-14T11:27:18+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #12714, we would trigger scheduled rules when a call to `PutEvents` would be done (in this issue, the call would be internal from `SSM.PutParameter`. 

We need to skip triggering scheduled rules when processing entries. 

I validated that the user shared sample now works with this fix. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a skip when processing rules
- add a test validating that AWS does not trigger the scheduled rules when calling `PutEvents`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
