### PR TITLE
add resource events to CFn v2

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
@@ -88,7 +88,7 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
         self.resolved_parameters[node_parameter.name] = delta.after
         return delta
 
-    def _get_physical_id(self, logical_resource_id, strict: bool = True) -> str:
+    def _get_physical_id(self, logical_resource_id, strict: bool = True) -> str | None:
         physical_resource_id = None
         try:
             physical_resource_id = self._after_resource_physical_id(logical_resource_id)
@@ -416,7 +416,6 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                     "Resource provider operation failed: '%s'",
                     reason,
                 )
-                # TODO: duplication
             case other:
                 raise NotImplementedError(f"Event status '{other}' not handled")
         return event

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
@@ -116,7 +116,7 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
         resource_type=None,
     ):
         status_from_action = special_action or EventOperationFromAction[action.value]
-        if event_status.value == OperationStatus.SUCCESS.value:
+        if event_status == OperationStatus.SUCCESS:
             status = f"{status_from_action}_COMPLETE"
         else:
             status = f"{status_from_action}_{event_status.name}"
@@ -129,7 +129,7 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
             resource_status_reason=reason,
         )
 
-        if event_status.value == OperationStatus.FAILED.value:
+        if event_status == OperationStatus.FAILED:
             self._change_set.stack.set_stack_status(StackStatus(status))
 
     def _after_deployed_property_value_of(

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
@@ -36,6 +36,8 @@ from localstack.services.cloudformation.v2.entities import ChangeSet
 
 LOG = logging.getLogger(__name__)
 
+EventOperationFromAction = {"Add": "CREATE", "Modify": "UPDATE", "Remove": "DELETE"}
+
 
 @dataclass
 class ChangeSetModelExecutorResult:
@@ -85,6 +87,47 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
 
         self.resolved_parameters[node_parameter.name] = delta.after
         return delta
+
+    def _get_physical_id(self, logical_resource_id, strict: bool = True) -> str:
+        physical_resource_id = None
+        try:
+            physical_resource_id = self._after_resource_physical_id(logical_resource_id)
+        except RuntimeError:
+            # The physical id is missing or is set to None, which is invalid.
+            pass
+        if physical_resource_id is None:
+            # The physical resource id is None after an update that didn't rewrite the resource, the previous
+            # resource id is therefore the current physical id of this resource.
+
+            try:
+                physical_resource_id = self._before_resource_physical_id(logical_resource_id)
+            except RuntimeError as e:
+                if strict:
+                    raise e
+        return physical_resource_id
+
+    def _add_resource_event(
+        self,
+        action: ChangeAction,
+        logical_resource_id,
+        event_status: OperationStatus,
+        special_action: str = None,
+        reason: str = None,
+    ):
+        status_from_action = special_action or EventOperationFromAction[action.value]
+        if event_status.value == OperationStatus.SUCCESS.value:
+            status = StackStatus(f"{status_from_action}_COMPLETE")
+        else:
+            status = StackStatus(f"{status_from_action}_{event_status.name}")
+        self._change_set.stack.add_resource_event(
+            logical_resource_id,
+            self._get_physical_id(logical_resource_id, False),
+            status=status,
+            status_reason=reason,
+        )
+
+        if event_status.value == OperationStatus.FAILED.value:
+            self._change_set.stack.set_stack_status(StackStatus(status))
 
     def _after_deployed_property_value_of(
         self, resource_logical_id: str, property_name: str
@@ -173,12 +216,16 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                 # XXX hacky, stick the previous resources' properties into the payload
                 before_properties = self._merge_before_properties(name, before)
 
-                self._execute_resource_action(
+                self._add_resource_event(ChangeAction.Modify, name, OperationStatus.IN_PROGRESS)
+                event = self._execute_resource_action(
                     action=ChangeAction.Modify,
                     logical_resource_id=name,
                     resource_type=before.resource_type,
                     before_properties=before_properties,
                     after_properties=after.properties,
+                )
+                self._add_resource_event(
+                    ChangeAction.Modify, name, event.status, reason=event.message
                 )
             # Case: type migration.
             # TODO: Add test to assert that on type change the resources are replaced.
@@ -186,7 +233,8 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                 # XXX hacky, stick the previous resources' properties into the payload
                 before_properties = self._merge_before_properties(name, before)
                 # Register a Removed for the previous type.
-                self._execute_resource_action(
+
+                event = self._execute_resource_action(
                     action=ChangeAction.Remove,
                     logical_resource_id=name,
                     resource_type=before.resource_type,
@@ -194,35 +242,44 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                     after_properties=None,
                 )
                 # Register a Create for the next type.
-                self._execute_resource_action(
+                self._add_resource_event(
+                    ChangeAction.Modify, name, event.status, reason=event.message
+                )
+                event = self._execute_resource_action(
                     action=ChangeAction.Add,
                     logical_resource_id=name,
                     resource_type=after.resource_type,
                     before_properties=None,
                     after_properties=after.properties,
                 )
+                self._add_resource_event(
+                    ChangeAction.Modify, name, event.status, reason=event.message
+                )
         elif not is_nothing(before):
             # Case: removal
             # XXX hacky, stick the previous resources' properties into the payload
             # XXX hacky, stick the previous resources' properties into the payload
             before_properties = self._merge_before_properties(name, before)
-
-            self._execute_resource_action(
+            self._add_resource_event(ChangeAction.Remove, name, OperationStatus.IN_PROGRESS)
+            event = self._execute_resource_action(
                 action=ChangeAction.Remove,
                 logical_resource_id=name,
                 resource_type=before.resource_type,
                 before_properties=before_properties,
                 after_properties=None,
             )
+            self._add_resource_event(ChangeAction.Remove, name, event.status, reason=event.message)
         elif not is_nothing(after):
             # Case: addition
-            self._execute_resource_action(
+            self._add_resource_event(ChangeAction.Add, name, OperationStatus.IN_PROGRESS)
+            event = self._execute_resource_action(
                 action=ChangeAction.Add,
                 logical_resource_id=name,
                 resource_type=after.resource_type,
                 before_properties=None,
                 after_properties=after.properties,
             )
+            self._add_resource_event(ChangeAction.Add, name, event.status, reason=event.message)
 
     def _merge_before_properties(
         self, name: str, preproc_resource: PreprocResource
@@ -242,7 +299,7 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
         resource_type: str,
         before_properties: Optional[PreprocProperties],
         after_properties: Optional[PreprocProperties],
-    ) -> None:
+    ) -> ProgressEvent:
         LOG.debug("Executing resource action: %s for resource '%s'", action, logical_resource_id)
         resource_provider_executor = ResourceProviderExecutor(
             stack_name=self._change_set.stack.stack_name, stack_id=self._change_set.stack.stack_id
@@ -272,16 +329,6 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                     exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
                 stack = self._change_set.stack
-                match stack.status:
-                    case StackStatus.CREATE_IN_PROGRESS:
-                        stack.set_stack_status(StackStatus.CREATE_FAILED, reason=reason)
-                    case StackStatus.UPDATE_IN_PROGRESS:
-                        stack.set_stack_status(StackStatus.UPDATE_FAILED, reason=reason)
-                    case StackStatus.DELETE_IN_PROGRESS:
-                        stack.set_stack_status(StackStatus.DELETE_FAILED, reason=reason)
-                    case _:
-                        raise NotImplementedError(f"Unexpected stack status: {stack.status}")
-                # update resource status
                 stack.set_resource_status(
                     logical_resource_id=logical_resource_id,
                     # TODO,
@@ -292,7 +339,11 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                     else ResourceStatus.UPDATE_FAILED,
                     resource_status_reason=reason,
                 )
-                return
+                event = ProgressEvent(
+                    OperationStatus.FAILED,
+                    resource_model={},
+                    message=f"Resource provider operation failed: {reason}",
+                )
 
         self.resources.setdefault(logical_resource_id, {"Properties": {}})
         match event.status:
@@ -313,19 +364,8 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                 self.resources[logical_resource_id]["LogicalResourceId"] = logical_resource_id
                 self.resources[logical_resource_id]["Type"] = resource_type
 
-                # TODO: review why the physical id is returned as None during updates
-                # TODO: abstract this in member function of resource classes instead
-                physical_resource_id = None
-                try:
-                    physical_resource_id = self._after_resource_physical_id(logical_resource_id)
-                except RuntimeError:
-                    # The physical id is missing or is set to None, which is invalid.
-                    pass
-                if physical_resource_id is None:
-                    # The physical resource id is None after an update that didn't rewrite the resource, the previous
-                    # resource id is therefore the current physical id of this resource.
-                    physical_resource_id = self._before_resource_physical_id(logical_resource_id)
-                    self.resources[logical_resource_id]["PhysicalResourceId"] = physical_resource_id
+                physical_resource_id = self._get_physical_id(logical_resource_id)
+                self.resources[logical_resource_id]["PhysicalResourceId"] = physical_resource_id
 
                 self._change_set.stack.set_resource_status(
                     logical_resource_id=logical_resource_id,
@@ -343,16 +383,6 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                     reason,
                 )
                 # TODO: duplication
-                stack = self._change_set.stack
-                match stack.status:
-                    case StackStatus.CREATE_IN_PROGRESS:
-                        stack.set_stack_status(StackStatus.CREATE_FAILED, reason=reason)
-                    case StackStatus.UPDATE_IN_PROGRESS:
-                        stack.set_stack_status(StackStatus.UPDATE_FAILED, reason=reason)
-                    case StackStatus.DELETE_IN_PROGRESS:
-                        stack.set_stack_status(StackStatus.DELETE_FAILED, reason=reason)
-                    case _:
-                        raise NotImplementedError(f"Unhandled stack status: '{stack.status}'")
                 stack.set_resource_status(
                     logical_resource_id=logical_resource_id,
                     # TODO
@@ -365,6 +395,7 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                 )
             case other:
                 raise NotImplementedError(f"Event status '{other}' not handled")
+        return event
 
     def create_resource_provider_payload(
         self,

--- a/localstack-core/localstack/services/cloudformation/v2/entities.py
+++ b/localstack-core/localstack/services/cloudformation/v2/entities.py
@@ -28,7 +28,6 @@ from localstack.services.cloudformation.engine.v2.change_set_model import (
 )
 from localstack.utils.aws import arns
 from localstack.utils.strings import long_uid, short_uid
-from localstack.utils.time import timestamp_millis
 
 
 class ResolvedResource(TypedDict):
@@ -120,7 +119,7 @@ class Stack:
 
         event: StackEvent = {
             "EventId": long_uid(),
-            "Timestamp": timestamp_millis(),
+            "Timestamp": datetime.now(tz=timezone.utc),
             "StackId": self.stack_id,
             "StackName": self.stack_name,
             "LogicalResourceId": resource_id,

--- a/localstack-core/localstack/services/cloudformation/v2/entities.py
+++ b/localstack-core/localstack/services/cloudformation/v2/entities.py
@@ -109,8 +109,8 @@ class Stack:
         status: str = "",
         status_reason: str = "",
     ):
-        resource_id = resource_id or self.stack_name
-        physical_res_id = physical_res_id or self.stack_id
+        resource_id = resource_id
+        physical_res_id = physical_res_id
         resource_type = (
             self.template.get("Resources", {})
             .get(resource_id, {})

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -476,30 +476,7 @@ class CloudformationProviderV2(CloudformationProvider):
         **kwargs,
     ) -> DescribeStackEventsOutput:
         state = get_cloudformation_store(context.account_id, context.region)
-        if stack_name:
-            if is_stack_arn(stack_name):
-                stack = state.stacks_v2[stack_name]
-            else:
-                stack_candidates = []
-                for stack in state.stacks_v2.values():
-                    if (
-                        stack.stack_name == stack_name
-                        and stack.status != StackStatus.DELETE_COMPLETE
-                    ):
-                        stack_candidates.append(stack)
-                if len(stack_candidates) == 0:
-                    raise ValidationError(f"No stack with name {stack_name} found")
-                elif len(stack_candidates) > 1:
-                    raise RuntimeError("Programing error, duplicate stacks found")
-                else:
-                    stack = stack_candidates[0]
-        else:
-            raise NotImplementedError
-
-        if not stack:
-            # aws will silently ignore invalid stack names - we should do the same
-            return
-
+        stack = find_stack_v2(state, stack_name)
         return DescribeStackEventsOutput(StackEvents=stack.events)
 
     @handler("DeleteStack")

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -236,7 +236,10 @@ class CloudformationProviderV2(CloudformationProvider):
                     raise ValidationError(f"Stack '{stack_name}' does not exist.")
                 stack = active_stack_candidates[0]
 
-        stack.set_stack_status(StackStatus.REVIEW_IN_PROGRESS)
+        if stack.status in [StackStatus.CREATE_COMPLETE, StackStatus.UPDATE_COMPLETE]:
+            stack.set_stack_status(StackStatus.UPDATE_IN_PROGRESS)
+        else:
+            stack.set_stack_status(StackStatus.REVIEW_IN_PROGRESS)
 
         # TODO: test if rollback status is allowed as well
         if (

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -472,7 +472,32 @@ class CloudformationProviderV2(CloudformationProvider):
         next_token: NextToken = None,
         **kwargs,
     ) -> DescribeStackEventsOutput:
-        return DescribeStackEventsOutput(StackEvents=[])
+        state = get_cloudformation_store(context.account_id, context.region)
+        if stack_name:
+            if is_stack_arn(stack_name):
+                stack = state.stacks_v2[stack_name]
+            else:
+                stack_candidates = []
+                for stack in state.stacks_v2.values():
+                    if (
+                        stack.stack_name == stack_name
+                        and stack.status != StackStatus.DELETE_COMPLETE
+                    ):
+                        stack_candidates.append(stack)
+                if len(stack_candidates) == 0:
+                    raise ValidationError(f"No stack with name {stack_name} found")
+                elif len(stack_candidates) > 1:
+                    raise RuntimeError("Programing error, duplicate stacks found")
+                else:
+                    stack = stack_candidates[0]
+        else:
+            raise NotImplementedError
+
+        if not stack:
+            # aws will silently ignore invalid stack names - we should do the same
+            return
+
+        return DescribeStackEventsOutput(StackEvents=stack.events)
 
     @handler("DeleteStack")
     def delete_stack(

--- a/localstack-core/localstack/testing/pytest/cloudformation/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/cloudformation/fixtures.py
@@ -11,14 +11,11 @@ from localstack.utils.strings import short_uid
 
 
 def normalize_event(event: StackEvent):
-    """Simplify the event and skip DELETE_* events."""
-    status = event.get("ResourceStatus")
-
     return {
-        # TODO "PhysicalResourceId": event.get("PhysicalResourceId"),
+        "PhysicalResourceId": event.get("PhysicalResourceId"),
         "LogicalResourceId": event.get("LogicalResourceId"),
         "ResourceType": event.get("ResourceType"),
-        "ResourceStatus": status,
+        "ResourceStatus": event.get("ResourceStatus"),
         "Timestamp": event.get("Timestamp"),
     }
 
@@ -43,7 +40,9 @@ def capture_per_resource_events(
 
             if logical_resource_id := event.get("LogicalResourceId"):
                 resource_name = (
-                    logical_resource_id if logical_resource_id != stack_name else "Stack"
+                    logical_resource_id
+                    if logical_resource_id != event.get("StackName")
+                    else "Stack"
                 )
                 normalized_event = normalize_event(event)
                 per_resource_events[resource_name].append(normalized_event)

--- a/tests/aws/services/cloudformation/v2/test_change_sets.py
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.py
@@ -21,7 +21,6 @@ pytestmark = pytest.mark.skipif(
 )
 @markers.snapshot.skip_snapshot_verify(
     paths=[
-        "per-resource-events..*",
         "delete-describe..*",
         #
         # Before/After Context
@@ -34,6 +33,10 @@ pytestmark = pytest.mark.skipif(
         "$..Replacement",
         "$..PolicyAction",
         "$..PhysicalResourceId",
+        # Unsupported events
+        "$..DELETE_COMPLETE",
+        "$..DELETE_IN_PROGRESS",
+        "$..UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
     ]
 )
 class TestCaptureUpdateProcess:

--- a/tests/aws/services/cloudformation/v2/test_change_sets.py
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.py
@@ -33,10 +33,6 @@ pytestmark = pytest.mark.skipif(
         "$..Replacement",
         "$..PolicyAction",
         "$..PhysicalResourceId",
-        # Unsupported events
-        "$..DELETE_COMPLETE",
-        "$..DELETE_IN_PROGRESS",
-        "$..UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
     ]
 )
 class TestCaptureUpdateProcess:

--- a/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
@@ -95,7 +95,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_direct_update": {
-    "recorded-date": "24-04-2025, 17:00:59",
+    "recorded-date": "16-06-2025, 22:25:10",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -323,174 +323,82 @@
         "Tags": []
       },
       "per-resource-events": {
-        "Foo": [
-          {
-            "EventId": "Foo-8fa001c0-096c-4f9e-9aed-0c31f45ded09",
+        "Foo": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          "DELETE_COMPLETE": {
+            "LogicalResourceId": "Foo",
             "ResourceStatus": "DELETE_COMPLETE",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-57ec24a9-92bd-4f31-8d36-972323072283",
+          "DELETE_IN_PROGRESS": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
             "ResourceStatus": "DELETE_IN_PROGRESS",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-UPDATE_COMPLETE-date",
+          "UPDATE_COMPLETE": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-2",
-            "ResourceProperties": {
-              "TopicName": "topic-2"
-            },
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-UPDATE_IN_PROGRESS-date",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-2",
-            "ResourceProperties": {
-              "TopicName": "topic-2"
-            },
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
-            "ResourceProperties": {
-              "TopicName": "topic-2"
-            },
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "Requested update requires the creation of a new physical resource; hence creating one.",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
-            "ResourceProperties": {
-              "TopicName": "topic-1"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
-            "ResourceProperties": {
-              "TopicName": "topic-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "TopicName": "topic-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "<stack-name:1>": [
-          {
-            "EventId": "<uuid:1>",
+        },
+        "Stack": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:2>",
+          "CREATE_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "REVIEW_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
             "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:3>",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:4>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:5>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:6>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ]
+        }
       },
       "delete-describe": {
         "CreationTime": "datetime",

--- a/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
@@ -95,7 +95,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_direct_update": {
-    "recorded-date": "16-06-2025, 22:25:10",
+    "recorded-date": "17-06-2025, 15:48:17",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -418,7 +418,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_dynamic_update": {
-    "recorded-date": "24-04-2025, 17:02:59",
+    "recorded-date": "17-06-2025, 15:50:21",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -608,6 +608,19 @@
               },
               "Details": [
                 {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
+                  "Target": {
+                    "AfterValue": "{{changeSet:KNOWN_AFTER_APPLY}}",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "topic-1",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                },
+                {
                   "CausingEntity": "Foo.TopicName",
                   "ChangeSource": "ResourceAttribute",
                   "Evaluation": "Static",
@@ -620,23 +633,10 @@
                     "Path": "/Properties/Value",
                     "RequiresRecreation": "Never"
                   }
-                },
-                {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Dynamic",
-                  "Target": {
-                    "AfterValue": "{{changeSet:KNOWN_AFTER_APPLY}}",
-                    "Attribute": "Properties",
-                    "AttributeChangeType": "Modify",
-                    "BeforeValue": "topic-1",
-                    "Name": "Value",
-                    "Path": "/Properties/Value",
-                    "RequiresRecreation": "Never"
-                  }
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-b4xwNWwXL1pX",
+              "PhysicalResourceId": "CFN-Parameter-MV9j0kT1pZVw",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -705,7 +705,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-b4xwNWwXL1pX",
+              "PhysicalResourceId": "CFN-Parameter-MV9j0kT1pZVw",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -751,247 +751,108 @@
         "Tags": []
       },
       "per-resource-events": {
-        "Foo": [
-          {
-            "EventId": "Foo-33c3e9d2-d059-45a8-a51e-33eaf1f08abc",
+        "Foo": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          "DELETE_COMPLETE": {
+            "LogicalResourceId": "Foo",
             "ResourceStatus": "DELETE_COMPLETE",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-5160f677-0c84-41ba-ab19-45a474a4b7bf",
+          "DELETE_IN_PROGRESS": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
             "ResourceStatus": "DELETE_IN_PROGRESS",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-UPDATE_COMPLETE-date",
+          "UPDATE_COMPLETE": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-2",
-            "ResourceProperties": {
-              "TopicName": "topic-2"
-            },
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-UPDATE_IN_PROGRESS-date",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-2",
-            "ResourceProperties": {
-              "TopicName": "topic-2"
-            },
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
-            "ResourceProperties": {
-              "TopicName": "topic-2"
-            },
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "Requested update requires the creation of a new physical resource; hence creating one.",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
-            "ResourceProperties": {
-              "TopicName": "topic-1"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
-            "ResourceProperties": {
-              "TopicName": "topic-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "TopicName": "topic-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "Parameter": [
-          {
-            "EventId": "Parameter-UPDATE_COMPLETE-date",
+        },
+        "Parameter": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-b4xwNWwXL1pX",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-2"
-            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "Parameter",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "Parameter",
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Parameter-UPDATE_IN_PROGRESS-date",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-b4xwNWwXL1pX",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-2"
-            },
             "ResourceStatus": "UPDATE_IN_PROGRESS",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-b4xwNWwXL1pX",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-1"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-b4xwNWwXL1pX",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "<stack-name:1>": [
-          {
-            "EventId": "<uuid:1>",
+        },
+        "Stack": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "REVIEW_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "<stack-name:1>",
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:2>",
+          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:3>",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:4>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:5>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:6>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ]
+        }
       },
       "delete-describe": {
         "CreationTime": "datetime",
@@ -1011,7 +872,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_parameter_changes": {
-    "recorded-date": "24-04-2025, 17:38:55",
+    "recorded-date": "17-06-2025, 15:52:26",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -1178,8 +1039,9 @@
               },
               "Details": [
                 {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Dynamic",
+                  "CausingEntity": "TopicName",
+                  "ChangeSource": "ParameterReference",
+                  "Evaluation": "Static",
                   "Target": {
                     "AfterValue": "topic-2",
                     "Attribute": "Properties",
@@ -1191,9 +1053,8 @@
                   }
                 },
                 {
-                  "CausingEntity": "TopicName",
-                  "ChangeSource": "ParameterReference",
-                  "Evaluation": "Static",
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
                   "Target": {
                     "AfterValue": "topic-2",
                     "Attribute": "Properties",
@@ -1233,19 +1094,6 @@
               },
               "Details": [
                 {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Dynamic",
-                  "Target": {
-                    "AfterValue": "{{changeSet:KNOWN_AFTER_APPLY}}",
-                    "Attribute": "Properties",
-                    "AttributeChangeType": "Modify",
-                    "BeforeValue": "topic-1",
-                    "Name": "Value",
-                    "Path": "/Properties/Value",
-                    "RequiresRecreation": "Never"
-                  }
-                },
-                {
                   "CausingEntity": "Foo.TopicName",
                   "ChangeSource": "ResourceAttribute",
                   "Evaluation": "Static",
@@ -1258,10 +1106,23 @@
                     "Path": "/Properties/Value",
                     "RequiresRecreation": "Never"
                   }
+                },
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
+                  "Target": {
+                    "AfterValue": "{{changeSet:KNOWN_AFTER_APPLY}}",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "topic-1",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-59wvoXl3mFfy",
+              "PhysicalResourceId": "CFN-Parameter-aauza4UeZvlW",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -1346,7 +1207,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-59wvoXl3mFfy",
+              "PhysicalResourceId": "CFN-Parameter-aauza4UeZvlW",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -1404,247 +1265,108 @@
         "Tags": []
       },
       "per-resource-events": {
-        "Foo": [
-          {
-            "EventId": "Foo-da242d34-1619-4128-b9a1-24ae25f05899",
+        "Foo": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          "DELETE_COMPLETE": {
+            "LogicalResourceId": "Foo",
             "ResourceStatus": "DELETE_COMPLETE",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-8aa7df32-a61d-4794-9f57-c33004142e46",
+          "DELETE_IN_PROGRESS": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
             "ResourceStatus": "DELETE_IN_PROGRESS",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-UPDATE_COMPLETE-date",
+          "UPDATE_COMPLETE": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-2",
-            "ResourceProperties": {
-              "TopicName": "topic-2"
-            },
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-UPDATE_IN_PROGRESS-date",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-2",
-            "ResourceProperties": {
-              "TopicName": "topic-2"
-            },
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
-            "ResourceProperties": {
-              "TopicName": "topic-2"
-            },
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "Requested update requires the creation of a new physical resource; hence creating one.",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
-            "ResourceProperties": {
-              "TopicName": "topic-1"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
-            "ResourceProperties": {
-              "TopicName": "topic-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "TopicName": "topic-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "Parameter": [
-          {
-            "EventId": "Parameter-UPDATE_COMPLETE-date",
+        },
+        "Parameter": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-59wvoXl3mFfy",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-2"
-            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "Parameter",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "Parameter",
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Parameter-UPDATE_IN_PROGRESS-date",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-59wvoXl3mFfy",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-2"
-            },
             "ResourceStatus": "UPDATE_IN_PROGRESS",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-59wvoXl3mFfy",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-1"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-59wvoXl3mFfy",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "<stack-name:1>": [
-          {
-            "EventId": "<uuid:1>",
+        },
+        "Stack": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "REVIEW_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "<stack-name:1>",
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:2>",
+          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:3>",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:4>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:5>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:6>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ]
+        }
       },
       "delete-describe": {
         "CreationTime": "datetime",
@@ -1670,7 +1392,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_mappings_with_static_fields": {
-    "recorded-date": "24-04-2025, 17:40:57",
+    "recorded-date": "17-06-2025, 15:54:31",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -1888,7 +1610,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-U4lqVSH21TIK",
+              "PhysicalResourceId": "CFN-Parameter-Bg9tRBFfL6b9",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -1957,7 +1679,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-U4lqVSH21TIK",
+              "PhysicalResourceId": "CFN-Parameter-Bg9tRBFfL6b9",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -2003,247 +1725,108 @@
         "Tags": []
       },
       "per-resource-events": {
-        "Foo": [
-          {
-            "EventId": "Foo-19d3838e-f734-4c47-bbc3-ed5ce898ae7f",
+        "Foo": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          "DELETE_COMPLETE": {
+            "LogicalResourceId": "Foo",
             "ResourceStatus": "DELETE_COMPLETE",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-1d67606c-91cd-478e-aa7f-bb5f79834fe4",
+          "DELETE_IN_PROGRESS": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
             "ResourceStatus": "DELETE_IN_PROGRESS",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-UPDATE_COMPLETE-date",
+          "UPDATE_COMPLETE": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
-            "ResourceProperties": {
-              "TopicName": "topic-name-2"
-            },
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-UPDATE_IN_PROGRESS-date",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
-            "ResourceProperties": {
-              "TopicName": "topic-name-2"
-            },
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "TopicName": "topic-name-2"
-            },
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "Requested update requires the creation of a new physical resource; hence creating one.",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "Parameter": [
-          {
-            "EventId": "Parameter-UPDATE_COMPLETE-date",
+        },
+        "Parameter": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-U4lqVSH21TIK",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-name-2"
-            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "Parameter",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "Parameter",
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Parameter-UPDATE_IN_PROGRESS-date",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-U4lqVSH21TIK",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-name-2"
-            },
             "ResourceStatus": "UPDATE_IN_PROGRESS",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-U4lqVSH21TIK",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-U4lqVSH21TIK",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "<stack-name:1>": [
-          {
-            "EventId": "<uuid:1>",
+        },
+        "Stack": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "REVIEW_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "<stack-name:1>",
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:2>",
+          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:3>",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:4>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:5>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:6>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ]
+        }
       },
       "delete-describe": {
         "CreationTime": "datetime",
@@ -2263,7 +1846,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_mappings_with_parameter_lookup": {
-    "recorded-date": "24-04-2025, 17:42:57",
+    "recorded-date": "17-06-2025, 15:56:35",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -2430,8 +2013,9 @@
               },
               "Details": [
                 {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Dynamic",
+                  "CausingEntity": "TopicName",
+                  "ChangeSource": "ParameterReference",
+                  "Evaluation": "Static",
                   "Target": {
                     "AfterValue": "topic-name-2",
                     "Attribute": "Properties",
@@ -2443,9 +2027,8 @@
                   }
                 },
                 {
-                  "CausingEntity": "TopicName",
-                  "ChangeSource": "ParameterReference",
-                  "Evaluation": "Static",
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
                   "Target": {
                     "AfterValue": "topic-name-2",
                     "Attribute": "Properties",
@@ -2485,19 +2068,6 @@
               },
               "Details": [
                 {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Dynamic",
-                  "Target": {
-                    "AfterValue": "{{changeSet:KNOWN_AFTER_APPLY}}",
-                    "Attribute": "Properties",
-                    "AttributeChangeType": "Modify",
-                    "BeforeValue": "topic-name-1",
-                    "Name": "Value",
-                    "Path": "/Properties/Value",
-                    "RequiresRecreation": "Never"
-                  }
-                },
-                {
                   "CausingEntity": "Foo.TopicName",
                   "ChangeSource": "ResourceAttribute",
                   "Evaluation": "Static",
@@ -2510,10 +2080,23 @@
                     "Path": "/Properties/Value",
                     "RequiresRecreation": "Never"
                   }
+                },
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
+                  "Target": {
+                    "AfterValue": "{{changeSet:KNOWN_AFTER_APPLY}}",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "topic-name-1",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-ir98heGTa0zR",
+              "PhysicalResourceId": "CFN-Parameter-dzDuhAbUJEPp",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -2598,7 +2181,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-ir98heGTa0zR",
+              "PhysicalResourceId": "CFN-Parameter-dzDuhAbUJEPp",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -2656,247 +2239,108 @@
         "Tags": []
       },
       "per-resource-events": {
-        "Foo": [
-          {
-            "EventId": "Foo-4f6c54a4-1549-4bd7-97c4-dd0ecca23860",
+        "Foo": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          "DELETE_COMPLETE": {
+            "LogicalResourceId": "Foo",
             "ResourceStatus": "DELETE_COMPLETE",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-53ede9ba-f993-45dd-9b68-e31f406d95c2",
+          "DELETE_IN_PROGRESS": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
             "ResourceStatus": "DELETE_IN_PROGRESS",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-UPDATE_COMPLETE-date",
+          "UPDATE_COMPLETE": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
-            "ResourceProperties": {
-              "TopicName": "topic-name-2"
-            },
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Foo-UPDATE_IN_PROGRESS-date",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
-            "ResourceProperties": {
-              "TopicName": "topic-name-2"
-            },
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
             "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "TopicName": "topic-name-2"
-            },
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "Requested update requires the creation of a new physical resource; hence creating one.",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
-            "ResourceProperties": {
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Foo-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Foo",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "TopicName": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "Parameter": [
-          {
-            "EventId": "Parameter-UPDATE_COMPLETE-date",
+        },
+        "Parameter": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-ir98heGTa0zR",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-name-2"
-            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "Parameter",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "Parameter",
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Parameter-UPDATE_IN_PROGRESS-date",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-ir98heGTa0zR",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-name-2"
-            },
             "ResourceStatus": "UPDATE_IN_PROGRESS",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-ir98heGTa0zR",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-ir98heGTa0zR",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "topic-name-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "<stack-name:1>": [
-          {
-            "EventId": "<uuid:1>",
+        },
+        "Stack": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "REVIEW_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "<stack-name:1>",
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:2>",
+          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:3>",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:4>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:5>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:6>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ]
+        }
       },
       "delete-describe": {
         "CreationTime": "datetime",
@@ -2922,7 +2366,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_conditions": {
-    "recorded-date": "24-04-2025, 17:54:44",
+    "recorded-date": "17-06-2025, 15:57:14",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -3146,152 +2590,72 @@
         "Tags": []
       },
       "per-resource-events": {
-        "Bucket": [
-          {
-            "EventId": "Bucket-CREATE_COMPLETE-date",
+        "Bucket": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "Bucket",
-            "PhysicalResourceId": "<stack-name:1>-bucket-lrfokvsfgf0f",
-            "ResourceProperties": {},
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::S3::Bucket",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Bucket-CREATE_IN_PROGRESS-date",
+          "CREATE_IN_PROGRESS": {
             "LogicalResourceId": "Bucket",
-            "PhysicalResourceId": "<stack-name:1>-bucket-lrfokvsfgf0f",
-            "ResourceProperties": {},
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::S3::Bucket",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Bucket-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Bucket",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {},
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceType": "AWS::S3::Bucket",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "Parameter": [
-          {
-            "EventId": "Parameter-CREATE_COMPLETE-date",
+        },
+        "Parameter": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-XN7hqAZ0p5We",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "test"
-            },
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+          "CREATE_IN_PROGRESS": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-XN7hqAZ0p5We",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "test"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "test"
-            },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "<stack-name:1>": [
-          {
-            "EventId": "<uuid:1>",
+        },
+        "Stack": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "REVIEW_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "<stack-name:1>",
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:2>",
+          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:3>",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:4>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:5>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:6>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ]
+        }
       },
       "delete-describe": {
         "CreationTime": "datetime",
@@ -3317,7 +2681,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_dynamic]": {
-    "recorded-date": "24-04-2025, 17:55:06",
+    "recorded-date": "17-06-2025, 15:57:39",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -3489,7 +2853,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-UlYVEyGMt3Hh",
+              "PhysicalResourceId": "CFN-Parameter-B3JQENmH8XiB",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -3548,7 +2912,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-UlYVEyGMt3Hh",
+              "PhysicalResourceId": "CFN-Parameter-B3JQENmH8XiB",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -3606,144 +2970,70 @@
         "Tags": []
       },
       "per-resource-events": {
-        "Parameter": [
-          {
-            "EventId": "Parameter-UPDATE_COMPLETE-date",
+        "Parameter": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-UlYVEyGMt3Hh",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "value-2"
-            },
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-UlYVEyGMt3Hh",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "value-2"
-            },
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-UlYVEyGMt3Hh",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "value-1"
-            },
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+          "CREATE_IN_PROGRESS": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "CFN-Parameter-UlYVEyGMt3Hh",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "value-1"
-            },
             "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
+          "UPDATE_COMPLETE": {
             "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "value-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_IN_PROGRESS": {
+            "LogicalResourceId": "Parameter",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
             "Timestamp": "timestamp"
           }
-        ],
-        "<stack-name:1>": [
-          {
-            "EventId": "<uuid:1>",
+        },
+        "Stack": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:2>",
+          "CREATE_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "REVIEW_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
             "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:3>",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:4>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:5>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:6>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ]
+        }
       },
       "delete-describe": {
         "CreationTime": "datetime",
@@ -3769,15 +3059,15 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_unrelated_property]": {
-    "recorded-date": "24-04-2025, 17:55:06",
+    "recorded-date": "17-06-2025, 15:57:39",
     "recorded-content": {}
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_unrelated_property_not_create_only]": {
-    "recorded-date": "24-04-2025, 17:55:06",
+    "recorded-date": "17-06-2025, 15:57:39",
     "recorded-content": {}
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_parameter_for_condition_create_resource]": {
-    "recorded-date": "24-04-2025, 17:55:28",
+    "recorded-date": "17-06-2025, 15:58:04",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -4004,161 +3294,72 @@
         "Tags": []
       },
       "per-resource-events": {
-        "SSMParameter1": [
-          {
-            "EventId": "SSMParameter1-CREATE_COMPLETE-date",
+        "SSMParameter1": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "SSMParameter1",
-            "PhysicalResourceId": "CFN-SSMParameter1-qGQrGgGvuC42",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "first"
-            },
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "SSMParameter1-CREATE_IN_PROGRESS-date",
+          "CREATE_IN_PROGRESS": {
             "LogicalResourceId": "SSMParameter1",
-            "PhysicalResourceId": "CFN-SSMParameter1-qGQrGgGvuC42",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "first"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "SSMParameter1-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "SSMParameter1",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "first"
-            },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "SSMParameter2": [
-          {
-            "EventId": "SSMParameter2-CREATE_COMPLETE-date",
+        },
+        "SSMParameter2": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "SSMParameter2",
-            "PhysicalResourceId": "CFN-SSMParameter2-9KvTVovmiPsN",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "first"
-            },
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "SSMParameter2-CREATE_IN_PROGRESS-date",
+          "CREATE_IN_PROGRESS": {
             "LogicalResourceId": "SSMParameter2",
-            "PhysicalResourceId": "CFN-SSMParameter2-9KvTVovmiPsN",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "first"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "SSMParameter2-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "SSMParameter2",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "first"
-            },
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "<stack-name:1>": [
-          {
-            "EventId": "<uuid:1>",
+        },
+        "Stack": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "CREATE_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "REVIEW_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "<stack-name:1>",
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:2>",
+          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:3>",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:4>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:5>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:6>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ]
+        }
       },
       "delete-describe": {
         "CreationTime": "datetime",
@@ -4184,14 +3385,14 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_execute_with_ref": {
-    "recorded-date": "24-04-2025, 17:55:57",
+    "recorded-date": "17-06-2025, 15:58:38",
     "recorded-content": {
       "before-value": "<name-1>",
       "after-value": "<name-2>"
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_mapping_scenarios[update_string_referencing_resource]": {
-    "recorded-date": "24-04-2025, 17:56:19",
+    "recorded-date": "17-06-2025, 15:59:04",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -4331,7 +3532,7 @@
                 }
               ],
               "LogicalResourceId": "MySSMParameter",
-              "PhysicalResourceId": "CFN-MySSMParameter-sK4jajBbVCXk",
+              "PhysicalResourceId": "CFN-MySSMParameter-cI5TOEuueEDD",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -4374,7 +3575,7 @@
                 }
               ],
               "LogicalResourceId": "MySSMParameter",
-              "PhysicalResourceId": "CFN-MySSMParameter-sK4jajBbVCXk",
+              "PhysicalResourceId": "CFN-MySSMParameter-cI5TOEuueEDD",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -4420,144 +3621,70 @@
         "Tags": []
       },
       "per-resource-events": {
-        "MySSMParameter": [
-          {
-            "EventId": "MySSMParameter-UPDATE_COMPLETE-date",
+        "MySSMParameter": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "MySSMParameter",
-            "PhysicalResourceId": "CFN-MySSMParameter-sK4jajBbVCXk",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "value-2"
-            },
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "MySSMParameter-UPDATE_IN_PROGRESS-date",
-            "LogicalResourceId": "MySSMParameter",
-            "PhysicalResourceId": "CFN-MySSMParameter-sK4jajBbVCXk",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "value-2"
-            },
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "MySSMParameter-CREATE_COMPLETE-date",
-            "LogicalResourceId": "MySSMParameter",
-            "PhysicalResourceId": "CFN-MySSMParameter-sK4jajBbVCXk",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "value-1"
-            },
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "MySSMParameter-CREATE_IN_PROGRESS-date",
+          "CREATE_IN_PROGRESS": {
             "LogicalResourceId": "MySSMParameter",
-            "PhysicalResourceId": "CFN-MySSMParameter-sK4jajBbVCXk",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "value-1"
-            },
             "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "MySSMParameter-CREATE_IN_PROGRESS-date",
+          "UPDATE_COMPLETE": {
             "LogicalResourceId": "MySSMParameter",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "value-1"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_IN_PROGRESS": {
+            "LogicalResourceId": "MySSMParameter",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
             "Timestamp": "timestamp"
           }
-        ],
-        "<stack-name:1>": [
-          {
-            "EventId": "<uuid:1>",
+        },
+        "Stack": {
+          "CREATE_COMPLETE": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:2>",
+          "CREATE_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "REVIEW_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE": {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
+            "LogicalResourceId": "<stack-name:1>",
             "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           },
-          {
-            "EventId": "<uuid:3>",
+          "UPDATE_IN_PROGRESS": {
             "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:4>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:5>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:6>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ]
+        }
       },
       "delete-describe": {
         "CreationTime": "datetime",

--- a/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
@@ -95,7 +95,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_direct_update": {
-    "recorded-date": "17-06-2025, 15:48:17",
+    "recorded-date": "18-06-2025, 16:17:02",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -322,84 +322,6 @@
         "StackStatus": "UPDATE_COMPLETE",
         "Tags": []
       },
-      "per-resource-events": {
-        "Foo": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "DELETE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "DELETE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Stack": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "REVIEW_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          }
-        }
-      },
       "delete-describe": {
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
@@ -414,6 +336,108 @@
         "StackName": "<stack-name:1>",
         "StackStatus": "DELETE_COMPLETE",
         "Tags": []
+      },
+      "per-resource-events": {
+        "Foo": [
+          {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
       }
     }
   },

--- a/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
@@ -95,7 +95,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_direct_update": {
-    "recorded-date": "18-06-2025, 16:17:02",
+    "recorded-date": "18-06-2025, 19:04:55",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -341,99 +341,66 @@
         "Foo": [
           {
             "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "",
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceType": "AWS::SNS::Topic",
             "Timestamp": "timestamp"
           },
           {
             "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::SNS::Topic",
             "Timestamp": "timestamp"
           },
           {
             "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
             "ResourceType": "AWS::SNS::Topic",
             "Timestamp": "timestamp"
           },
           {
             "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-2",
             "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_COMPLETE",
             "ResourceType": "AWS::SNS::Topic",
             "Timestamp": "timestamp"
           }
         ],
-        "<stack-name:1>": [
+        "Stack": [
           {
             "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "REVIEW_IN_PROGRESS",
             "ResourceType": "AWS::CloudFormation::Stack",
             "Timestamp": "timestamp"
           },
           {
             "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceType": "AWS::CloudFormation::Stack",
             "Timestamp": "timestamp"
           },
           {
             "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::CloudFormation::Stack",
             "Timestamp": "timestamp"
           },
           {
             "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
             "ResourceType": "AWS::CloudFormation::Stack",
             "Timestamp": "timestamp"
           },
           {
             "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          {
-            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "DELETE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "DELETE_COMPLETE",
             "ResourceType": "AWS::CloudFormation::Stack",
             "Timestamp": "timestamp"
           }
@@ -442,7 +409,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_dynamic_update": {
-    "recorded-date": "17-06-2025, 15:50:21",
+    "recorded-date": "18-06-2025, 19:06:59",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -632,19 +599,6 @@
               },
               "Details": [
                 {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Dynamic",
-                  "Target": {
-                    "AfterValue": "{{changeSet:KNOWN_AFTER_APPLY}}",
-                    "Attribute": "Properties",
-                    "AttributeChangeType": "Modify",
-                    "BeforeValue": "topic-1",
-                    "Name": "Value",
-                    "Path": "/Properties/Value",
-                    "RequiresRecreation": "Never"
-                  }
-                },
-                {
                   "CausingEntity": "Foo.TopicName",
                   "ChangeSource": "ResourceAttribute",
                   "Evaluation": "Static",
@@ -657,10 +611,23 @@
                     "Path": "/Properties/Value",
                     "RequiresRecreation": "Never"
                   }
+                },
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
+                  "Target": {
+                    "AfterValue": "{{changeSet:KNOWN_AFTER_APPLY}}",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "topic-1",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-MV9j0kT1pZVw",
+              "PhysicalResourceId": "CFN-Parameter-OkuGHMW4ltfZ",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -729,7 +696,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-MV9j0kT1pZVw",
+              "PhysicalResourceId": "CFN-Parameter-OkuGHMW4ltfZ",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -774,110 +741,6 @@
         "StackStatus": "UPDATE_COMPLETE",
         "Tags": []
       },
-      "per-resource-events": {
-        "Foo": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "DELETE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "DELETE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Parameter": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Stack": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "REVIEW_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          }
-        }
-      },
       "delete-describe": {
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
@@ -892,11 +755,110 @@
         "StackName": "<stack-name:1>",
         "StackStatus": "DELETE_COMPLETE",
         "Tags": []
+      },
+      "per-resource-events": {
+        "Foo": [
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-2",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-OkuGHMW4ltfZ",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-OkuGHMW4ltfZ",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-OkuGHMW4ltfZ",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
       }
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_parameter_changes": {
-    "recorded-date": "17-06-2025, 15:52:26",
+    "recorded-date": "18-06-2025, 19:09:04",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -1063,9 +1025,8 @@
               },
               "Details": [
                 {
-                  "CausingEntity": "TopicName",
-                  "ChangeSource": "ParameterReference",
-                  "Evaluation": "Static",
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
                   "Target": {
                     "AfterValue": "topic-2",
                     "Attribute": "Properties",
@@ -1077,8 +1038,9 @@
                   }
                 },
                 {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Dynamic",
+                  "CausingEntity": "TopicName",
+                  "ChangeSource": "ParameterReference",
+                  "Evaluation": "Static",
                   "Target": {
                     "AfterValue": "topic-2",
                     "Attribute": "Properties",
@@ -1146,7 +1108,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-aauza4UeZvlW",
+              "PhysicalResourceId": "CFN-Parameter-lZ25tyPMdFIo",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -1231,7 +1193,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-aauza4UeZvlW",
+              "PhysicalResourceId": "CFN-Parameter-lZ25tyPMdFIo",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -1288,110 +1250,6 @@
         "StackStatus": "UPDATE_COMPLETE",
         "Tags": []
       },
-      "per-resource-events": {
-        "Foo": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "DELETE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "DELETE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Parameter": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Stack": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "REVIEW_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          }
-        }
-      },
       "delete-describe": {
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
@@ -1412,11 +1270,110 @@
         "StackName": "<stack-name:1>",
         "StackStatus": "DELETE_COMPLETE",
         "Tags": []
+      },
+      "per-resource-events": {
+        "Foo": [
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-1",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-2",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-lZ25tyPMdFIo",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-lZ25tyPMdFIo",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-lZ25tyPMdFIo",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
       }
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_mappings_with_static_fields": {
-    "recorded-date": "17-06-2025, 15:54:31",
+    "recorded-date": "18-06-2025, 19:11:09",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -1606,6 +1563,19 @@
               },
               "Details": [
                 {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
+                  "Target": {
+                    "AfterValue": "{{changeSet:KNOWN_AFTER_APPLY}}",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "topic-name-1",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                },
+                {
                   "CausingEntity": "Foo.TopicName",
                   "ChangeSource": "ResourceAttribute",
                   "Evaluation": "Static",
@@ -1618,23 +1588,10 @@
                     "Path": "/Properties/Value",
                     "RequiresRecreation": "Never"
                   }
-                },
-                {
-                  "ChangeSource": "DirectModification",
-                  "Evaluation": "Dynamic",
-                  "Target": {
-                    "AfterValue": "{{changeSet:KNOWN_AFTER_APPLY}}",
-                    "Attribute": "Properties",
-                    "AttributeChangeType": "Modify",
-                    "BeforeValue": "topic-name-1",
-                    "Name": "Value",
-                    "Path": "/Properties/Value",
-                    "RequiresRecreation": "Never"
-                  }
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-Bg9tRBFfL6b9",
+              "PhysicalResourceId": "CFN-Parameter-QY7XaFoB4kQc",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -1703,7 +1660,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-Bg9tRBFfL6b9",
+              "PhysicalResourceId": "CFN-Parameter-QY7XaFoB4kQc",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -1748,110 +1705,6 @@
         "StackStatus": "UPDATE_COMPLETE",
         "Tags": []
       },
-      "per-resource-events": {
-        "Foo": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "DELETE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "DELETE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Parameter": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Stack": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "REVIEW_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          }
-        }
-      },
       "delete-describe": {
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
@@ -1866,11 +1719,110 @@
         "StackName": "<stack-name:1>",
         "StackStatus": "DELETE_COMPLETE",
         "Tags": []
+      },
+      "per-resource-events": {
+        "Foo": [
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-QY7XaFoB4kQc",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-QY7XaFoB4kQc",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-QY7XaFoB4kQc",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
       }
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_mappings_with_parameter_lookup": {
-    "recorded-date": "17-06-2025, 15:56:35",
+    "recorded-date": "18-06-2025, 19:13:17",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -2120,7 +2072,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-dzDuhAbUJEPp",
+              "PhysicalResourceId": "CFN-Parameter-tGkdmdoGLN1m",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -2205,7 +2157,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-dzDuhAbUJEPp",
+              "PhysicalResourceId": "CFN-Parameter-tGkdmdoGLN1m",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -2262,110 +2214,6 @@
         "StackStatus": "UPDATE_COMPLETE",
         "Tags": []
       },
-      "per-resource-events": {
-        "Foo": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "DELETE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "DELETE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "DELETE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "Foo",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Parameter": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Stack": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "REVIEW_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          }
-        }
-      },
       "delete-describe": {
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
@@ -2386,11 +2234,110 @@
         "StackName": "<stack-name:1>",
         "StackStatus": "DELETE_COMPLETE",
         "Tags": []
+      },
+      "per-resource-events": {
+        "Foo": [
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Foo",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-tGkdmdoGLN1m",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-tGkdmdoGLN1m",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-tGkdmdoGLN1m",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
       }
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_conditions": {
-    "recorded-date": "17-06-2025, 15:57:14",
+    "recorded-date": "18-06-2025, 19:13:55",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -2613,74 +2560,6 @@
         "StackStatus": "UPDATE_COMPLETE",
         "Tags": []
       },
-      "per-resource-events": {
-        "Bucket": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "Bucket",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::S3::Bucket",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "Bucket",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::S3::Bucket",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Parameter": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Stack": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "REVIEW_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          }
-        }
-      },
       "delete-describe": {
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
@@ -2701,11 +2580,82 @@
         "StackName": "<stack-name:1>",
         "StackStatus": "DELETE_COMPLETE",
         "Tags": []
+      },
+      "per-resource-events": {
+        "Bucket": [
+          {
+            "LogicalResourceId": "Bucket",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::S3::Bucket",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Bucket",
+            "PhysicalResourceId": "<stack-name:1>-bucket-rvkyycxytnfz",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::S3::Bucket",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-ytEGT7JWBrkx",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
       }
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_dynamic]": {
-    "recorded-date": "17-06-2025, 15:57:39",
+    "recorded-date": "18-06-2025, 19:14:21",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -2877,7 +2827,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-B3JQENmH8XiB",
+              "PhysicalResourceId": "CFN-Parameter-BNuHBis1ysn1",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -2936,7 +2886,7 @@
                 }
               ],
               "LogicalResourceId": "Parameter",
-              "PhysicalResourceId": "CFN-Parameter-B3JQENmH8XiB",
+              "PhysicalResourceId": "CFN-Parameter-BNuHBis1ysn1",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -2993,72 +2943,6 @@
         "StackStatus": "UPDATE_COMPLETE",
         "Tags": []
       },
-      "per-resource-events": {
-        "Parameter": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "Parameter",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Stack": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "REVIEW_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          }
-        }
-      },
       "delete-describe": {
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
@@ -3079,19 +2963,88 @@
         "StackName": "<stack-name:1>",
         "StackStatus": "DELETE_COMPLETE",
         "Tags": []
+      },
+      "per-resource-events": {
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-BNuHBis1ysn1",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-BNuHBis1ysn1",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "CFN-Parameter-BNuHBis1ysn1",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
       }
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_unrelated_property]": {
-    "recorded-date": "17-06-2025, 15:57:39",
+    "recorded-date": "18-06-2025, 19:14:21",
     "recorded-content": {}
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_unrelated_property_not_create_only]": {
-    "recorded-date": "17-06-2025, 15:57:39",
+    "recorded-date": "18-06-2025, 19:14:21",
     "recorded-content": {}
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_parameter_for_condition_create_resource]": {
-    "recorded-date": "17-06-2025, 15:58:04",
+    "recorded-date": "18-06-2025, 19:14:47",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -3317,74 +3270,6 @@
         "StackStatus": "UPDATE_COMPLETE",
         "Tags": []
       },
-      "per-resource-events": {
-        "SSMParameter1": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "SSMParameter1",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "SSMParameter1",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          }
-        },
-        "SSMParameter2": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "SSMParameter2",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "SSMParameter2",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Stack": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "REVIEW_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          }
-        }
-      },
       "delete-describe": {
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
@@ -3405,18 +3290,89 @@
         "StackName": "<stack-name:1>",
         "StackStatus": "DELETE_COMPLETE",
         "Tags": []
+      },
+      "per-resource-events": {
+        "SSMParameter1": [
+          {
+            "LogicalResourceId": "SSMParameter1",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "SSMParameter1",
+            "PhysicalResourceId": "CFN-SSMParameter1-YEPpTp1eTqmV",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "SSMParameter2": [
+          {
+            "LogicalResourceId": "SSMParameter2",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "SSMParameter2",
+            "PhysicalResourceId": "CFN-SSMParameter2-Cy9JferYSQvx",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
       }
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_execute_with_ref": {
-    "recorded-date": "17-06-2025, 15:58:38",
+    "recorded-date": "18-06-2025, 19:15:20",
     "recorded-content": {
       "before-value": "<name-1>",
       "after-value": "<name-2>"
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_mapping_scenarios[update_string_referencing_resource]": {
-    "recorded-date": "17-06-2025, 15:59:04",
+    "recorded-date": "18-06-2025, 19:15:45",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -3556,7 +3512,7 @@
                 }
               ],
               "LogicalResourceId": "MySSMParameter",
-              "PhysicalResourceId": "CFN-MySSMParameter-cI5TOEuueEDD",
+              "PhysicalResourceId": "CFN-MySSMParameter-yMAYpjhjWvEz",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -3599,7 +3555,7 @@
                 }
               ],
               "LogicalResourceId": "MySSMParameter",
-              "PhysicalResourceId": "CFN-MySSMParameter-cI5TOEuueEDD",
+              "PhysicalResourceId": "CFN-MySSMParameter-yMAYpjhjWvEz",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -3644,72 +3600,6 @@
         "StackStatus": "UPDATE_COMPLETE",
         "Tags": []
       },
-      "per-resource-events": {
-        "MySSMParameter": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "MySSMParameter",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "MySSMParameter",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "MySSMParameter",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "MySSMParameter",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "Timestamp": "timestamp"
-          }
-        },
-        "Stack": {
-          "CREATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "CREATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "REVIEW_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          },
-          "UPDATE_IN_PROGRESS": {
-            "LogicalResourceId": "<stack-name:1>",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "Timestamp": "timestamp"
-          }
-        }
-      },
       "delete-describe": {
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
@@ -3724,6 +3614,75 @@
         "StackName": "<stack-name:1>",
         "StackStatus": "DELETE_COMPLETE",
         "Tags": []
+      },
+      "per-resource-events": {
+        "MySSMParameter": [
+          {
+            "LogicalResourceId": "MySSMParameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "MySSMParameter",
+            "PhysicalResourceId": "CFN-MySSMParameter-yMAYpjhjWvEz",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "MySSMParameter",
+            "PhysicalResourceId": "CFN-MySSMParameter-yMAYpjhjWvEz",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "MySSMParameter",
+            "PhysicalResourceId": "CFN-MySSMParameter-yMAYpjhjWvEz",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
       }
     }
   }

--- a/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
@@ -36,12 +36,12 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_direct_update": {
-    "last_validated_date": "2025-06-17T15:48:17+00:00",
+    "last_validated_date": "2025-06-18T16:17:02+00:00",
     "durations_in_seconds": {
-      "setup": 0.22,
-      "call": 116.43,
-      "teardown": 0.15,
-      "total": 116.8
+      "setup": 1.3,
+      "call": 115.52,
+      "teardown": 0.16,
+      "total": 116.98
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_dynamic_update": {

--- a/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
@@ -1,6 +1,24 @@
 {
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_dynamic]": {
-    "last_validated_date": "2025-06-17T15:57:39+00:00",
+    "last_validated_date": "2025-06-18T19:14:21+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 25.11,
+      "teardown": 0.14,
+      "total": 25.25
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_parameter_for_condition_create_resource]": {
+    "last_validated_date": "2025-06-18T19:14:47+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 26.23,
+      "teardown": 0.14,
+      "total": 26.37
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_mapping_scenarios[update_string_referencing_resource]": {
+    "last_validated_date": "2025-06-18T19:15:45+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
       "call": 25.01,
@@ -8,85 +26,67 @@
       "total": 25.16
     }
   },
-  "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_parameter_for_condition_create_resource]": {
-    "last_validated_date": "2025-06-17T15:58:04+00:00",
-    "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 24.98,
-      "teardown": 0.14,
-      "total": 25.12
-    }
-  },
-  "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_mapping_scenarios[update_string_referencing_resource]": {
-    "last_validated_date": "2025-06-17T15:59:04+00:00",
-    "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 26.25,
-      "teardown": 0.14,
-      "total": 26.39
-    }
-  },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_conditions": {
-    "last_validated_date": "2025-06-17T15:57:14+00:00",
+    "last_validated_date": "2025-06-18T19:13:55+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 38.17,
-      "teardown": 0.15,
-      "total": 38.32
+      "call": 37.82,
+      "teardown": 0.16,
+      "total": 37.98
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_direct_update": {
-    "last_validated_date": "2025-06-18T16:17:02+00:00",
+    "last_validated_date": "2025-06-18T19:04:55+00:00",
     "durations_in_seconds": {
-      "setup": 1.3,
-      "call": 115.52,
-      "teardown": 0.16,
-      "total": 116.98
+      "setup": 0.26,
+      "call": 116.94,
+      "teardown": 0.15,
+      "total": 117.35
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_dynamic_update": {
-    "last_validated_date": "2025-06-17T15:50:21+00:00",
+    "last_validated_date": "2025-06-18T19:06:59+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 123.39,
-      "teardown": 0.14,
-      "total": 123.53
+      "call": 124.05,
+      "teardown": 0.16,
+      "total": 124.21
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_execute_with_ref": {
-    "last_validated_date": "2025-06-17T15:58:38+00:00",
+    "last_validated_date": "2025-06-18T19:15:20+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 27.0,
-      "teardown": 6.57,
-      "total": 33.57
+      "call": 26.07,
+      "teardown": 6.64,
+      "total": 32.71
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_mappings_with_parameter_lookup": {
-    "last_validated_date": "2025-06-17T15:56:35+00:00",
+    "last_validated_date": "2025-06-18T19:13:18+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 124.37,
-      "teardown": 0.15,
-      "total": 124.52
+      "call": 128.68,
+      "teardown": 0.14,
+      "total": 128.82
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_mappings_with_static_fields": {
-    "last_validated_date": "2025-06-17T15:54:31+00:00",
+    "last_validated_date": "2025-06-18T19:11:09+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 124.47,
+      "call": 124.56,
       "teardown": 0.14,
-      "total": 124.61
+      "total": 124.7
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_parameter_changes": {
-    "last_validated_date": "2025-06-17T15:52:26+00:00",
+    "last_validated_date": "2025-06-18T19:09:04+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 125.38,
+      "call": 124.46,
       "teardown": 0.14,
-      "total": 125.52
+      "total": 124.6
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::test_single_resource_static_update": {

--- a/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
@@ -12,7 +12,13 @@
     "last_validated_date": "2025-04-24T17:54:44+00:00"
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_direct_update": {
-    "last_validated_date": "2025-04-24T17:00:59+00:00"
+    "last_validated_date": "2025-06-16T22:25:10+00:00",
+    "durations_in_seconds": {
+      "setup": 0.24,
+      "call": 116.21,
+      "teardown": 0.14,
+      "total": 116.59
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_dynamic_update": {
     "last_validated_date": "2025-04-24T17:02:59+00:00"

--- a/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
@@ -1,39 +1,93 @@
 {
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_dynamic]": {
-    "last_validated_date": "2025-04-24T17:55:06+00:00"
+    "last_validated_date": "2025-06-17T15:57:39+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 25.01,
+      "teardown": 0.15,
+      "total": 25.16
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_dynamic_parameter_scenarios[change_parameter_for_condition_create_resource]": {
-    "last_validated_date": "2025-04-24T17:55:28+00:00"
+    "last_validated_date": "2025-06-17T15:58:04+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 24.98,
+      "teardown": 0.14,
+      "total": 25.12
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_base_mapping_scenarios[update_string_referencing_resource]": {
-    "last_validated_date": "2025-04-24T17:56:19+00:00"
+    "last_validated_date": "2025-06-17T15:59:04+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 26.25,
+      "teardown": 0.14,
+      "total": 26.39
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_conditions": {
-    "last_validated_date": "2025-04-24T17:54:44+00:00"
+    "last_validated_date": "2025-06-17T15:57:14+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 38.17,
+      "teardown": 0.15,
+      "total": 38.32
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_direct_update": {
-    "last_validated_date": "2025-06-16T22:25:10+00:00",
+    "last_validated_date": "2025-06-17T15:48:17+00:00",
     "durations_in_seconds": {
-      "setup": 0.24,
-      "call": 116.21,
-      "teardown": 0.14,
-      "total": 116.59
+      "setup": 0.22,
+      "call": 116.43,
+      "teardown": 0.15,
+      "total": 116.8
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_dynamic_update": {
-    "last_validated_date": "2025-04-24T17:02:59+00:00"
+    "last_validated_date": "2025-06-17T15:50:21+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 123.39,
+      "teardown": 0.14,
+      "total": 123.53
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_execute_with_ref": {
-    "last_validated_date": "2025-04-24T17:55:52+00:00"
+    "last_validated_date": "2025-06-17T15:58:38+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 27.0,
+      "teardown": 6.57,
+      "total": 33.57
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_mappings_with_parameter_lookup": {
-    "last_validated_date": "2025-04-24T17:42:57+00:00"
+    "last_validated_date": "2025-06-17T15:56:35+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 124.37,
+      "teardown": 0.15,
+      "total": 124.52
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_mappings_with_static_fields": {
-    "last_validated_date": "2025-04-24T17:40:56+00:00"
+    "last_validated_date": "2025-06-17T15:54:31+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 124.47,
+      "teardown": 0.14,
+      "total": 124.61
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::TestCaptureUpdateProcess::test_parameter_changes": {
-    "last_validated_date": "2025-04-24T17:38:55+00:00"
+    "last_validated_date": "2025-06-17T15:52:26+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 125.38,
+      "teardown": 0.14,
+      "total": 125.52
+    }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::test_single_resource_static_update": {
     "last_validated_date": "2025-03-18T16:52:35+00:00"


### PR DESCRIPTION
## Motivation
This PR enables the new CloudFormation engine to emit and store stack resource events, aligning its behavior more closely with AWS for parity testing and improving visibility into stack changes.

## Changes

- The new engine now emits CloudFormation resource-level events.
- These events are stored and exposed via describe_stack_events.
- Updated the logic to include intermediate states (e.g., *_IN_PROGRESS) and filter out unsupported ones (e.g., DELETE_*) for now.

## Testing

- Unskipped snapshot tests that were previously skipped due to missing event support.
- Normalized event output to avoid duplicates in test comparisons. 
- Verified event ordering by timestamp to ensure consistent results across runs.