### PR TITLE
Fix publishing credentials

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -256,8 +256,8 @@ jobs:
 
       - name: Publish dev release
         env:
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
           if git describe --exact-match --tags >/dev/null 2>&1; then
             echo "not publishing a dev release as this is a tagged commit"

--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -219,8 +219,8 @@ jobs:
 
       - name: Push ${{ env.PLATFORM_NAME_AMD64 }} Docker Image
         env:
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_PUSH_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           PLATFORM: ${{ env.PLATFORM_NAME_AMD64 }}
         run: |
           # Push to Docker Hub
@@ -235,8 +235,8 @@ jobs:
 
       - name: Push ${{ env.PLATFORM_NAME_ARM64 }} Docker Image
         env:
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_PUSH_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           PLATFORM: ${{ env.PLATFORM_NAME_ARM64 }}
         run: |
           # Push to Docker Hub
@@ -246,8 +246,8 @@ jobs:
 
       - name: Push Multi-Arch Manifest
         env:
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_PUSH_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
           # Push to Docker Hub
           ./bin/docker-helper.sh push-manifests
@@ -256,8 +256,8 @@ jobs:
 
       - name: Publish dev release
         env:
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_PUSH_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
           if git describe --exact-match --tags >/dev/null 2>&1; then
             echo "not publishing a dev release as this is a tagged commit"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The DockerHub user secrets were wrongly assumed to contain `PUSH` in them, compared to the `PULL` tokens. However, a look at the s3 image pipeline shows that this is not the case.

Also, the twine credentials are missing in the dev release publishing step.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Adapt to use correct secret names
- Adapt to use twine username and password for dev release publish

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
