### PR TITLE
Re-create venv for dev release publish

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -262,7 +262,7 @@ jobs:
           if git describe --exact-match --tags >/dev/null 2>&1; then
             echo "not publishing a dev release as this is a tagged commit"
           else
-            make publish || echo "dev release failed (maybe it is already published)"
+            make install-basic publish || echo "dev release failed (maybe it is already published)"
           fi
 
   push-to-tinybird:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In CircleCI we pass the workspace through and have an existing venv ready which we can activate. This is not the case in GitHub Actions so we need to re-create the venv with the `make publish` target.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- remove .venv activation in dev release
- install basic version of localstack for building the dist

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
