### PR TITLE
fix dependencies installation for dev release publish

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -262,7 +262,7 @@ jobs:
           if git describe --exact-match --tags >/dev/null 2>&1; then
             echo "not publishing a dev release as this is a tagged commit"
           else
-            make install-basic publish || echo "dev release failed (maybe it is already published)"
+            make install-runtime publish || echo "dev release failed (maybe it is already published)"
           fi
 
   push-to-tinybird:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #12725, we were using `make install-basic` before building the entry points, which lead to issue while building, short snippet:

```bash
running plugins
error importing module localstack.aws.api.sts: No module named 'botocore'
error importing module localstack.services.opensearch.resource_providers.aws_elasticsearch_domain: No module named 'botocore'
error importing module localstack.aws.api.core: No module named 'botocore'
error importing module localstack.services.stepfunctions.asl.component.state.state_choice.comparison.comparison: No module named 'antlr4'
error importing module localstack.services.opensearch.cluster: No module named 'werkzeug'
error importing module localstack.services.sqs.exceptions: No module named 'botocore'
```

By using `install-runtime`, we'll make sure we have the right dependencies before building the entry points

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- switch the make target before publishing

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
