### PR TITLE
Implement support for CDK Bootstrap stacks

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -715,6 +715,11 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             delimiter: str = str(args[0])
             values: list[Any] = args[1]
             if not isinstance(values, list):
+                # shortcut if values is the empty string, for example:
+                # {"Fn::Join": ["", {"Ref": <parameter>}]}
+                # CDK bootstrap does this
+                if values == "":
+                    return ""
                 raise RuntimeError(f"Invalid arguments list definition for Fn::Join: '{args}'")
             str_values: list[str] = list()
             for value in values:

--- a/localstack-core/localstack/services/cloudformation/v2/entities.py
+++ b/localstack-core/localstack/services/cloudformation/v2/entities.py
@@ -8,8 +8,10 @@ from localstack.aws.api.cloudformation import (
     ExecutionStatus,
     Output,
     Parameter,
+    ResourceStatus,
     StackDriftInformation,
     StackDriftStatus,
+    StackResource,
     StackStatus,
     StackStatusReason,
 )
@@ -46,6 +48,7 @@ class Stack:
     resolved_parameters: dict[str, str]
     resolved_resources: dict[str, ResolvedResource]
     resolved_outputs: dict[str, str]
+    resource_states: dict[str, StackResource]
 
     def __init__(
         self,
@@ -84,11 +87,32 @@ class Stack:
         self.resolved_parameters = {}
         self.resolved_resources = {}
         self.resolved_outputs = {}
+        self.resource_states = {}
 
     def set_stack_status(self, status: StackStatus, reason: StackStatusReason | None = None):
         self.status = status
         if reason:
             self.status_reason = reason
+
+    def set_resource_status(
+        self,
+        *,
+        logical_resource_id: str,
+        physical_resource_id: str | None,
+        resource_type: str,
+        status: ResourceStatus,
+        resource_status_reason: str | None = None,
+    ):
+        self.resource_states[logical_resource_id] = StackResource(
+            StackName=self.stack_name,
+            StackId=self.stack_id,
+            LogicalResourceId=logical_resource_id,
+            PhysicalResourceId=physical_resource_id,
+            ResourceType=resource_type,
+            Timestamp=datetime.now(tz=timezone.utc),
+            ResourceStatus=status,
+            ResourceStatusReason=resource_status_reason,
+        )
 
     def describe_details(self) -> ApiStack:
         result = {

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_cdk.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_cdk.py
@@ -16,7 +16,9 @@ pytestmark = pytest.mark.skipif(
 
 
 class TestCdkInit:
-    @pytest.mark.skip(reason="CFNV2:Fn::Join on empty string args")
+    @pytest.mark.skip(
+        reason="CFNV2:Destroy each test passes individually but because we don't delete resources, running all parameterized options fails"
+    )
     @pytest.mark.parametrize("bootstrap_version", ["10", "11", "12"])
     @markers.aws.validated
     def test_cdk_bootstrap(self, deploy_cfn_template, bootstrap_version, aws_client):


### PR DESCRIPTION
## Motivation

Currently CDK bootstrap fails for a variety of reasons. Without this,
users who use CDK cannot test their applications with our new engine.

## Changes

* Handle dynamic parameter lookup of SSM parameters
* Set resource status on success/failure of a deployment
* Handle the case where an Fn::Join is called without a list as a second argument, in the special case of an empty string, e.g. `Fn::Join: ["", ""] as the CDK does this
* Add helper `find_stack_v2` function for finding v2 stacks
* Implement `describe_stack_resources` to support our CDK bootstrap tests
* Update the cdk bootstrap test skip reason as our lack of deletion
  causes test failures

## Testing

I have not added any integration tests for this since its functionality is covered by our existing `TestCdkInit.test_cdk_bootstrap` (parametrized) tests. Unfortunately since we don't support deletions yet (see https://github.com/localstack/localstack/pull/12576), the tests fail when run together. Each test individually passes, so I've updated the skip reason to reflect the updated nature of the failure.

To test manually, unskip the tests, and run

```
pytest tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_cdk.py::TestCdkInit::test_cdk_bootstrap[10]
```
