### PR TITLE
Publish service provider mapping on startup

### DIFF
--- a/localstack-core/localstack/utils/analytics/service_providers.py
+++ b/localstack-core/localstack/utils/analytics/service_providers.py
@@ -6,25 +6,14 @@ def publish_provider_assignment():
     """
     Publishes the service provider assignment to the analytics service.
     """
-    from datetime import datetime
 
     from localstack.config import SERVICE_PROVIDER_CONFIG
     from localstack.services.plugins import SERVICE_PLUGINS
-    from localstack.utils.analytics import get_session_id
-    from localstack.utils.analytics.events import Event, EventMetadata
-    from localstack.utils.analytics.publisher import AnalyticsClientPublisher
+    from localstack.utils.analytics import log
 
     provider_assignment = {
         service: f"localstack.aws.provider/{service}:{SERVICE_PROVIDER_CONFIG[service]}"
         for service in SERVICE_PLUGINS.list_available()
     }
-    metadata = EventMetadata(
-        session_id=get_session_id(),
-        client_time=str(datetime.now()),
-    )
 
-    event = Event(
-        name="ls_service_provider_assignment", metadata=metadata, payload=provider_assignment
-    )
-
-    AnalyticsClientPublisher().publish([event])
+    log.event("ls_service_provider_assignment", provider_assignment)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We have the need to track which providers are used for different AWS services. We can do this by a startup hook which basically sends the service config on startup.

/cc @mmaureenliu 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- add a hook which takes the service config and creates a mapping from service to provider plugin name and publishes it to the analytics backend

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
