### PR TITLE
Implement Put, Get, Delete, List S3 MetricsConfiguration API

### DIFF
--- a/localstack-core/localstack/services/s3/exceptions.py
+++ b/localstack-core/localstack/services/s3/exceptions.py
@@ -46,3 +46,8 @@ class MalformedPolicy(CommonServiceException):
 class InvalidBucketOwnerAWSAccountID(CommonServiceException):
     def __init__(self, message=None) -> None:
         super().__init__("InvalidBucketOwnerAWSAccountID", status_code=400, message=message)
+
+
+class TooManyConfigurations(CommonServiceException):
+    def __init__(self, message=None) -> None:
+        super().__init__("TooManyConfigurations", status_code=400, message=message)

--- a/localstack-core/localstack/services/s3/models.py
+++ b/localstack-core/localstack/services/s3/models.py
@@ -37,6 +37,8 @@ from localstack.aws.api.s3 import (
     LoggingEnabled,
     Metadata,
     MethodNotAllowed,
+    MetricsConfiguration,
+    MetricsId,
     MultipartUploadId,
     NoSuchKey,
     NoSuchVersion,
@@ -115,6 +117,7 @@ class S3Bucket:
     intelligent_tiering_configurations: dict[IntelligentTieringId, IntelligentTieringConfiguration]
     analytics_configurations: dict[AnalyticsId, AnalyticsConfiguration]
     inventory_configurations: dict[InventoryId, InventoryConfiguration]
+    metric_configurations: dict[MetricsId, MetricsConfiguration]
     object_lock_default_retention: Optional[DefaultRetention]
     replication: ReplicationConfiguration
     owner: Owner
@@ -154,6 +157,7 @@ class S3Bucket:
         self.intelligent_tiering_configurations = {}
         self.analytics_configurations = {}
         self.inventory_configurations = {}
+        self.metric_configurations = {}
         self.object_lock_default_retention = {}
         self.replication = None
         self.acl = acl

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -2180,3 +2180,164 @@ class TestS3ObjectWritePrecondition:
             IfMatch=multipart_etag,
         )
         snapshot.match("complete-multipart-if-match-overwrite-multipart", complete_multipart_1)
+
+
+class TestS3MetricsConfiguration:
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            # PutBucketMetricsConfiguration should return 204, but we return 200
+            "$.put_bucket_metrics_configuration.ResponseMetadata.HTTPStatusCode",
+        ]
+    )
+    def test_put_bucket_metrics_configuration(self, s3_bucket, aws_client, snapshot):
+        snapshot.add_transformer([snapshot.transform.key_value("Id")])
+
+        metric_id = short_uid()
+        metrics_config = {"Id": metric_id, "Filter": {"Prefix": "logs/"}}
+
+        put_result = aws_client.s3.put_bucket_metrics_configuration(
+            Bucket=s3_bucket, Id=metric_id, MetricsConfiguration=metrics_config
+        )
+        snapshot.match("put_bucket_metrics_configuration", put_result)
+
+        get_result = aws_client.s3.get_bucket_metrics_configuration(Bucket=s3_bucket, Id=metric_id)
+        snapshot.match("get_bucket_metrics_configuration", get_result)
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            # PutBucketMetricsConfiguration should return 204, but we return 200
+            "$.overwrite_bucket_metrics_configuration.ResponseMetadata.HTTPStatusCode",
+        ]
+    )
+    def test_overwrite_bucket_metrics_configuration(self, s3_bucket, aws_client, snapshot):
+        snapshot.add_transformer([snapshot.transform.key_value("Id")])
+
+        metric_id = short_uid()
+        metrics_config = {"Id": metric_id, "Filter": {"Prefix": "logs/"}}
+
+        aws_client.s3.put_bucket_metrics_configuration(
+            Bucket=s3_bucket, Id=metric_id, MetricsConfiguration=metrics_config
+        )
+
+        metrics_config["Filter"]["Prefix"] = "logs/new-prefix"
+
+        overwrite_result = aws_client.s3.put_bucket_metrics_configuration(
+            Bucket=s3_bucket, Id=metric_id, MetricsConfiguration=metrics_config
+        )
+        snapshot.match("overwrite_bucket_metrics_configuration", overwrite_result)
+
+        get_result = aws_client.s3.get_bucket_metrics_configuration(Bucket=s3_bucket, Id=metric_id)
+        snapshot.match("get_bucket_metrics_configuration", get_result)
+
+    @markers.aws.validated
+    def test_list_bucket_metrics_configurations(self, s3_bucket, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("Id"))
+
+        metric_id_1 = f"1-{short_uid()}"
+        metric_id_2 = f"2-{short_uid()}"
+
+        metrics_configs = {
+            metric_id_1: {"Id": metric_id_1, "Filter": {"Prefix": "logs/prefix"}},
+            metric_id_2: {"Id": metric_id_2, "Filter": {"Prefix": "logs/prefix"}},
+        }
+
+        for metrics_config in metrics_configs.values():
+            aws_client.s3.put_bucket_metrics_configuration(
+                Bucket=s3_bucket, Id=metrics_config["Id"], MetricsConfiguration=metrics_config
+            )
+
+        result_configs = aws_client.s3.list_bucket_metrics_configurations(Bucket=s3_bucket)
+        snapshot.match("list_bucket_metrics_configurations", result_configs)
+
+    @markers.aws.validated
+    def test_list_bucket_metrics_configurations_paginated(self, s3_bucket, aws_client, snapshot):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("Id"),
+                snapshot.transform.key_value("NextContinuationToken"),
+                snapshot.transform.key_value("ContinuationToken"),
+            ]
+        )
+
+        metrics_configs = {}
+        for i in range(102):
+            metric_id = f"{100 + i}-{short_uid()}"
+            metrics_configs[metric_id] = {"Id": metric_id, "Filter": {"Prefix": "logs/prefix"}}
+
+        for metrics_config in metrics_configs.values():
+            aws_client.s3.put_bucket_metrics_configuration(
+                Bucket=s3_bucket, Id=metrics_config["Id"], MetricsConfiguration=metrics_config
+            )
+
+        result_configs_page_1 = aws_client.s3.list_bucket_metrics_configurations(Bucket=s3_bucket)
+        assert len(result_configs_page_1["MetricsConfigurationList"]) == 100
+        assert result_configs_page_1["NextContinuationToken"]
+
+        result_configs_page_2 = aws_client.s3.list_bucket_metrics_configurations(
+            Bucket=s3_bucket, ContinuationToken=result_configs_page_1["NextContinuationToken"]
+        )
+        snapshot.match("list_bucket_metrics_configurations_page_2", result_configs_page_2)
+
+    @markers.aws.validated
+    def test_get_bucket_metrics_configuration(self, s3_bucket, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("Id"))
+
+        metric_id = short_uid()
+        metrics_config = {"Id": metric_id, "Filter": {"Prefix": "logs/"}}
+
+        aws_client.s3.put_bucket_metrics_configuration(
+            Bucket=s3_bucket, Id=metric_id, MetricsConfiguration=metrics_config
+        )
+
+        result = aws_client.s3.get_bucket_metrics_configuration(Bucket=s3_bucket, Id=metric_id)
+        snapshot.match("get_bucket_metrics_configuration", result)
+
+    @markers.aws.validated
+    def test_get_bucket_metrics_configuration_not_exist(self, s3_bucket, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("Id"))
+
+        with pytest.raises(ClientError) as get_err:
+            aws_client.s3.get_bucket_metrics_configuration(Bucket=s3_bucket, Id="does-not-exist")
+        snapshot.match("get_bucket_metrics_configuration", get_err.value.response)
+
+    @markers.aws.validated
+    def test_delete_metrics_configuration(self, s3_bucket, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("Id"))
+
+        metric_id = short_uid()
+        metrics_config = {"Id": metric_id, "Filter": {"Prefix": "logs/"}}
+
+        aws_client.s3.put_bucket_metrics_configuration(
+            Bucket=s3_bucket, Id=metric_id, MetricsConfiguration=metrics_config
+        )
+
+        delete_result = aws_client.s3.delete_bucket_metrics_configuration(
+            Bucket=s3_bucket, Id=metric_id
+        )
+        snapshot.match("delete_bucket_metrics_configuration", delete_result)
+
+        with pytest.raises(ClientError) as get_err:
+            aws_client.s3.get_bucket_metrics_configuration(Bucket=s3_bucket, Id=metric_id)
+        snapshot.match("get_bucket_metrics_configuration", get_err.value.response)
+
+    @markers.aws.validated
+    def test_delete_metrics_configuration_twice(self, s3_bucket, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("Id"))
+
+        metric_id = short_uid()
+        metrics_config = {"Id": metric_id, "Filter": {"Prefix": "logs/"}}
+
+        aws_client.s3.put_bucket_metrics_configuration(
+            Bucket=s3_bucket, Id=metric_id, MetricsConfiguration=metrics_config
+        )
+
+        delete_result_1 = aws_client.s3.delete_bucket_metrics_configuration(
+            Bucket=s3_bucket, Id=metric_id
+        )
+        snapshot.match("delete_bucket_metrics_configuration_1", delete_result_1)
+
+        with pytest.raises(ClientError) as delete_err:
+            aws_client.s3.delete_bucket_metrics_configuration(Bucket=s3_bucket, Id=metric_id)
+        snapshot.match("delete_bucket_metrics_configuration_2", delete_err.value.response)

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -4428,5 +4428,178 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_put_bucket_metrics_configuration": {
+    "recorded-date": "13-06-2025, 08:33:02",
+    "recorded-content": {
+      "put_bucket_metrics_configuration": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get_bucket_metrics_configuration": {
+        "MetricsConfiguration": {
+          "Filter": {
+            "Prefix": "logs/"
+          },
+          "Id": "<id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_overwrite_bucket_metrics_configuration": {
+    "recorded-date": "13-06-2025, 08:33:03",
+    "recorded-content": {
+      "overwrite_bucket_metrics_configuration": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get_bucket_metrics_configuration": {
+        "MetricsConfiguration": {
+          "Filter": {
+            "Prefix": "logs/new-prefix"
+          },
+          "Id": "<id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_list_bucket_metrics_configurations": {
+    "recorded-date": "13-06-2025, 08:33:04",
+    "recorded-content": {
+      "list_bucket_metrics_configurations": {
+        "IsTruncated": false,
+        "MetricsConfigurationList": [
+          {
+            "Filter": {
+              "Prefix": "logs/prefix"
+            },
+            "Id": "<id:1>"
+          },
+          {
+            "Filter": {
+              "Prefix": "logs/prefix"
+            },
+            "Id": "<id:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_get_bucket_metrics_configuration": {
+    "recorded-date": "13-06-2025, 08:33:17",
+    "recorded-content": {
+      "get_bucket_metrics_configuration": {
+        "MetricsConfiguration": {
+          "Filter": {
+            "Prefix": "logs/"
+          },
+          "Id": "<id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_get_bucket_metrics_configuration_not_exist": {
+    "recorded-date": "13-06-2025, 08:33:18",
+    "recorded-content": {
+      "get_bucket_metrics_configuration": {
+        "Error": {
+          "Code": "NoSuchConfiguration",
+          "Message": "The specified configuration does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_delete_metrics_configuration": {
+    "recorded-date": "13-06-2025, 08:33:19",
+    "recorded-content": {
+      "delete_bucket_metrics_configuration": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get_bucket_metrics_configuration": {
+        "Error": {
+          "Code": "NoSuchConfiguration",
+          "Message": "The specified configuration does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_list_bucket_metrics_configurations_paginated": {
+    "recorded-date": "13-06-2025, 08:33:16",
+    "recorded-content": {
+      "list_bucket_metrics_configurations_page_2": {
+        "ContinuationToken": "<continuation-token:1>",
+        "IsTruncated": false,
+        "MetricsConfigurationList": [
+          {
+            "Filter": {
+              "Prefix": "logs/prefix"
+            },
+            "Id": "<id:1>"
+          },
+          {
+            "Filter": {
+              "Prefix": "logs/prefix"
+            },
+            "Id": "<id:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_delete_metrics_configuration_twice": {
+    "recorded-date": "13-06-2025, 08:33:20",
+    "recorded-content": {
+      "delete_bucket_metrics_configuration_1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "delete_bucket_metrics_configuration_2": {
+        "Error": {
+          "Code": "NoSuchConfiguration",
+          "Message": "The specified configuration does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -30,7 +30,7 @@
     "last_validated_date": "2025-01-21T18:11:06+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_bucket_tagging_exc": {
-    "last_validated_date": "2025-01-21T18:11:07+00:00"
+    "last_validated_date": "2025-06-12T23:32:16+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_crud": {
     "last_validated_date": "2025-01-21T18:11:10+00:00"
@@ -67,6 +67,30 @@
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketVersioning::test_object_version_id_format": {
     "last_validated_date": "2025-01-21T18:10:31+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_delete_metrics_configuration": {
+    "last_validated_date": "2025-06-13T08:33:19+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_delete_metrics_configuration_twice": {
+    "last_validated_date": "2025-06-13T08:33:20+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_get_bucket_metrics_configuration": {
+    "last_validated_date": "2025-06-13T08:33:17+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_get_bucket_metrics_configuration_not_exist": {
+    "last_validated_date": "2025-06-13T08:33:18+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_list_bucket_metrics_configurations": {
+    "last_validated_date": "2025-06-13T08:33:04+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_list_bucket_metrics_configurations_paginated": {
+    "last_validated_date": "2025-06-13T08:33:16+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_overwrite_bucket_metrics_configuration": {
+    "last_validated_date": "2025-06-13T08:33:03+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_put_bucket_metrics_configuration": {
+    "last_validated_date": "2025-06-13T08:33:02+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_no_copy_source_range": {
     "last_validated_date": "2025-06-13T12:42:58+00:00",
@@ -153,7 +177,7 @@
     "last_validated_date": "2025-03-17T20:15:50+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectWritePrecondition::test_put_object_if_match_and_if_none_match_validation": {
-    "last_validated_date": "2025-03-17T20:16:06+00:00"
+    "last_validated_date": "2025-06-12T23:32:49+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectWritePrecondition::test_put_object_if_match_validation": {
     "last_validated_date": "2025-03-17T20:15:52+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Feature request: Implement Put, Get, Delete, List S3 BucketMetricsConfiguration: https://github.com/localstack/localstack/issues/12739


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Implement Put, Get, Delete, List S3 BucketMetricsConfiguration APIs. These APIs will be available in LocalStack.

- **PutBucketMetricsConfiguration**: Add or update one BucketMetricsConfiguration. The limit to existing BucketMetricsConfiguration per bucket is 1000.
- **GetBucketMetricsConfiguration**: Get one BucketMetricsConfiguration. Return empty response if it does not exist.
- **DeleteBucketMetricsConfiguration**: Delete one BucketMetricsConfiguration.
- **ListBucketMetricsConfiguration**: Fetch all BucketMetricsConfigurations, paginated through 100-item pages.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
