### PR TITLE
Do not login to DockerHub if there is no pull secret

### DIFF
--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -133,6 +133,7 @@ env:
   CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
   # report to tinybird if executed on master
   TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+  DOCKER_PULL_SECRET_AVAILABLE: ${{ secrets.DOCKERHUB_PULL_USERNAME != '' && secrets.DOCKERHUB_PULL_TOKEN != '' && 'true' || 'false' }}
 
 
 
@@ -322,7 +323,7 @@ jobs:
 
       - name: Login to Docker Hub
         # login to DockerHub to avoid rate limiting issues on custom runners
-        if: github.repository_owner == 'localstack' && secrets.DOCKERHUB_PULL_USERNAME != '' && secrets.DOCKERHUB_PULL_TOKEN != ''
+        if: github.repository_owner == 'localstack' && env.DOCKER_PULL_SECRET_AVAILABLE == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
@@ -514,7 +515,7 @@ jobs:
 
       - name: Login to Docker Hub
         # login to DockerHub to avoid rate limiting issues on custom runners
-        if: github.repository_owner == 'localstack' && secrets.DOCKERHUB_PULL_USERNAME != '' && secrets.DOCKERHUB_PULL_TOKEN != ''
+        if: github.repository_owner == 'localstack' && env.DOCKER_PULL_SECRET_AVAILABLE == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
@@ -845,7 +846,7 @@ jobs:
     steps:
       - name: Login to Docker Hub
         # login to DockerHub to avoid rate limiting issues on custom runners
-        if: github.repository_owner == 'localstack' && secrets.DOCKERHUB_PULL_USERNAME != '' && secrets.DOCKERHUB_PULL_TOKEN != ''
+        if: github.repository_owner == 'localstack' && env.DOCKER_PULL_SECRET_AVAILABLE == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When receiving community contributions on this repository, the trigger `pull_request` won't add repository secrets. 

This means we have to not only ignore Docker Logins in forks which don't have that secret set but also in this repo for cases where they don't exist

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Add an additional condition to usages of Docker Login that both secrets need to be available

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
