### PR TITLE
Update test durations automatically based on latest durations from master

### DIFF
--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -373,12 +373,18 @@ jobs:
           DOCKER_SDK_DEFAULT_TIMEOUT_SECONDS: 300
         run: make docker-run-tests
 
+      # Test durations are fetched and merged automatically by a separate workflow.
+      # Files must have unique names to prevent overwrites when multiple artifacts are downloaded
+      - name: Rename test durations file
+        run: |
+          mv .test_durations .test_durations-${{ env.PLATFORM }}-${{ matrix.group }}
+
       - name: Archive Test Durations
         uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: pytest-split-durations-${{ env.PLATFORM }}-${{ matrix.group }}
-          path: .test_durations
+          path: .test_durations-${{ env.PLATFORM }}-${{ matrix.group }}
           include-hidden-files: true
           retention-days: 5
 

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -31,7 +31,7 @@ jobs:
             latest_workflow_id=$(curl -s https://api.github.com/repos/localstack/localstack/actions/workflows \
               | jq '.workflows[] | select(.name=="AWS / Build, Test, Push").id')
             latest_run_id=$(curl -s \
-              https://api.github.com/repos/localstack/localstack/actions/workflows/159258776/runs?branch=master&status=success&per_page=30 \
+              "https://api.github.com/repos/localstack/localstack/actions/workflows/${latest_workflow_id}/runs?branch=master&status=success&per_page=30" \
                 | jq '[.workflow_runs[] | select(.event == "schedule")][0].id')
             echo "Latest run: https://github.com/localstack/localstack/actions/runs/${latest_run_id}"
             echo "AWS_MAIN_LATEST_SCHEDULED_RUN_ID=${latest_run_id}" >> $GITHUB_ENV
@@ -43,7 +43,7 @@ jobs:
             path: artifacts-test-durations
             merge-multiple: true
             run-id: ${{ env.AWS_MAIN_LATEST_SCHEDULED_RUN_ID }}
-            github-token: ${{ secrets.GH_UPDATE_TEST_DURATIONS_TOKEN }}  # PAT with access to artifacts from GH Actions
+            github-token: ${{ secrets.GITHUB_TOKEN }}  # PAT with access to artifacts from GH Actions
 
         - name: Merge test durations files
           shell: bash
@@ -72,4 +72,4 @@ jobs:
             path: localstack
             add-paths: .test_durations
             labels: "semver: patch, area: testing, area: ci"
-            token: ${{ secrets.GH_UPDATE_TEST_DURATIONS_TOKEN }}
+            token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -63,8 +63,8 @@ jobs:
           uses: peter-evans/create-pull-request@v7
           if: ${{ success() && inputs.publishMethod != 'UPLOAD_ARTIFACT' }}
           with:
-            title: "Update test durations"
-            body: "This PR includes an updated `.test_durations` file, generated using the latest test durations for the platform based on the master branch"
+            title: "[Testing] Update test durations"
+            body: "This PR includes an updated `.test_durations` file, generated based on latest test durations from master"
             branch: "test-durations-auto-updates"
             author: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
             committer: "LocalStack Bot <localstack-bot@users.noreply.github.com>"

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -1,0 +1,63 @@
+name: Update test durations
+
+on:
+  schedule:
+    - cron: 0 4 * 1-12 MON
+  workflow_dispatch:
+    inputs:
+      publishMethod:
+        description: 'Select how to publish the workflow result'
+        type: choice
+        options:
+          - UPLOAD_ARTIFACT
+          - CREATE_PR
+        default: UPLOAD_ARTIFACT
+
+env:
+  # Take test durations only for this platform
+  PLATFORM: "amd64"
+
+jobs:
+  report:
+    name: "Download, merge and create PR with test durations"
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            path: localstack
+
+        - name: Load test durations
+          uses: actions/download-artifact@v4
+          with:
+            pattern: pytest-split-durations-${{ env.PLATFORM }}-*
+            path: artifacts-test-durations
+            merge-multiple: true
+
+        - name: Merge test durations files
+          shell: bash
+          run: |
+            jq -s 'add | to_entries | sort_by(.key) | from_entries' artifacts-test-durations/.test_durations-${{ env.PLATFORM }}*  > localstack/.test_durations || echo "::warning::Test durations were not merged"
+
+        - name: Upload artifact with merged test durations
+          uses: actions/upload-artifact@v4
+          if: ${{ success() && inputs.publishMethod == 'UPLOAD_ARTIFACT' }}
+          with:
+            name: merged-test-durations
+            path: localstack/.test_durations
+            include-hidden-files: true
+            if-no-files-found: error
+
+        - name: Create PR
+          uses: peter-evans/create-pull-request@v7
+          if: ${{ success() && inputs.publishMethod != 'UPLOAD_ARTIFACT' }}
+          with:
+            title: "Update test durations"
+            body: "This PR includes an updated `.test_durations` file, generated using the latest test durations for the platform based on the master branch"
+            branch: "test-durations-auto-updates"
+            author: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
+            committer: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
+            commit-message: "CI: update .test_durations to latest version"
+            path: localstack
+            add-paths: .test_durations
+            labels: "semver: patch, area: testing, area: ci"
+            token: ${{ secrets.GH_UPDATE_TEST_DURATIONS_TOKEN }}

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -29,7 +29,7 @@ jobs:
         - name: Latest run-id from community repository
           run: |
             latest_workflow_id=$(curl -s https://api.github.com/repos/localstack/localstack/actions/workflows \
-              | jq '.workflows[] | select(.name=="AWS / Build, Test, Push").id')
+              | jq '.workflows[] | select(.path==".github/workflows/aws-main.yml").id')
             latest_run_id=$(curl -s \
               "https://api.github.com/repos/localstack/localstack/actions/workflows/${latest_workflow_id}/runs?branch=master&status=success&per_page=30" \
                 | jq '[.workflow_runs[] | select(.event == "schedule")][0].id')
@@ -72,4 +72,4 @@ jobs:
             path: localstack
             add-paths: .test_durations
             labels: "semver: patch, area: testing, area: ci"
-            token: ${{ secrets.GITHUB_TOKEN }}
+            token: ${{ secrets.PRO_ACCESS_TOKEN }}

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -26,12 +26,24 @@ jobs:
           with:
             path: localstack
 
+        - name: Latest run-id from community repository
+          run: |
+            latest_workflow_id=$(curl -s https://api.github.com/repos/localstack/localstack/actions/workflows \
+              | jq '.workflows[] | select(.name=="AWS / Build, Test, Push").id')
+            latest_run_id=$(curl -s \
+              https://api.github.com/repos/localstack/localstack/actions/workflows/159258776/runs?branch=master&status=success&per_page=30 \
+                | jq '[.workflow_runs[] | select(.event == "schedule")][0].id')
+            echo "Latest run: https://github.com/localstack/localstack/actions/runs/${latest_run_id}"
+            echo "AWS_MAIN_LATEST_SCHEDULED_RUN_ID=${latest_run_id}" >> $GITHUB_ENV
+
         - name: Load test durations
           uses: actions/download-artifact@v4
           with:
             pattern: pytest-split-durations-${{ env.PLATFORM }}-*
             path: artifacts-test-durations
             merge-multiple: true
+            run-id: ${{ env.AWS_MAIN_LATEST_SCHEDULED_RUN_ID }}
+            github-token: ${{ secrets.GH_PAT_TEST_DURATIONS_ARTS }}  # PAT with access to artifacts from GH Actions
 
         - name: Merge test durations files
           shell: bash

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -43,7 +43,7 @@ jobs:
             path: artifacts-test-durations
             merge-multiple: true
             run-id: ${{ env.AWS_MAIN_LATEST_SCHEDULED_RUN_ID }}
-            github-token: ${{ secrets.GH_PAT_TEST_DURATIONS_ARTS }}  # PAT with access to artifacts from GH Actions
+            github-token: ${{ secrets.GH_UPDATE_TEST_DURATIONS_TOKEN }}  # PAT with access to artifacts from GH Actions
 
         - name: Merge test durations files
           shell: bash


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While switching from CircleCI to GitHub Actions, I saw that the test durations file hadn’t been updated in about a year. Since then, we’ve added a lot of new tests. This pull request adds a workflow that downloads test durations from the latest scheduled run on the master branch, combines them, and creates a PR with the updated test durations file. New workflow is scheduled to run every month.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Added a workflow to download and merge the test durations file, and create a pull request with the updates

## Testing

Tested in a forked repostiory.
- PR created automatically: https://github.com/k-a-il/localstack/pull/5
- Merged test durations uploaded as [artifact](https://github.com/k-a-il/localstack/actions/runs/15628284152)

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
