### PR TITLE
S3: fix Checksum handling in UploadPartCopy

### DIFF
--- a/localstack-core/localstack/services/s3/storage/ephemeral.py
+++ b/localstack-core/localstack/services/s3/storage/ephemeral.py
@@ -340,10 +340,12 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         ):
             if not range_data:
                 stored_part.write(src_stored_object)
-                return
+            else:
+                object_slice = LimitedStream(src_stored_object, range_data=range_data)
+                stored_part.write(object_slice)
 
-            object_slice = LimitedStream(src_stored_object, range_data=range_data)
-            stored_part.write(object_slice)
+            if s3_part.checksum_algorithm:
+                s3_part.checksum_value = stored_part.checksum
 
 
 class BucketTemporaryFileSystem(TypedDict):

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -17411,5 +17411,133 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_copy_checksum": {
+    "recorded-date": "13-06-2025, 12:45:49",
+    "recorded-content": {
+      "put-object": {
+        "ChecksumCRC32": "nG7pIA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"11df95d595559285eb2b042124e74f09\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-mpu-checksum-sha256": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "SHA256",
+        "ChecksumType": "COMPOSITE",
+        "Key": "test-multipart-checksum",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy": {
+        "CopyPartResult": {
+          "ChecksumSHA256": "+j3Oc5P9QdoIdPJ4lFSyNlAAX0G7Am+wZsxu4FYN+wo=",
+          "ETag": "\"11df95d595559285eb2b042124e74f09\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "SHA256",
+        "ChecksumType": "COMPOSITE",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-multipart-checksum",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 1,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ChecksumSHA256": "+j3Oc5P9QdoIdPJ4lFSyNlAAX0G7Am+wZsxu4FYN+wo=",
+            "ETag": "\"11df95d595559285eb2b042124e74f09\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 14
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-checksum": {
+        "Bucket": "bucket",
+        "ChecksumSHA256": "/4+xERoRlzE2Ryan+GX/sqNSrf6Qe30L2IM7APXadSE=-1",
+        "ChecksumType": "COMPOSITE",
+        "ETag": "\"395d97c07920de036bfa21e7568a2e9f-1\"",
+        "Key": "test-multipart-checksum",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "Body": "this is a part",
+        "ChecksumSHA256": "/4+xERoRlzE2Ryan+GX/sqNSrf6Qe30L2IM7APXadSE=-1",
+        "ChecksumType": "COMPOSITE",
+        "ContentLength": 14,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"395d97c07920de036bfa21e7568a2e9f-1\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "ChecksumSHA256": "/4+xERoRlzE2Ryan+GX/sqNSrf6Qe30L2IM7APXadSE=-1",
+        "ChecksumType": "COMPOSITE",
+        "ContentLength": 14,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"395d97c07920de036bfa21e7568a2e9f-1\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs": {
+        "Checksum": {
+          "ChecksumSHA256": "/4+xERoRlzE2Ryan+GX/sqNSrf6Qe30L2IM7APXadSE=",
+          "ChecksumType": "COMPOSITE"
+        },
+        "ETag": "395d97c07920de036bfa21e7568a2e9f-1",
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -671,6 +671,15 @@
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[SHA256]": {
     "last_validated_date": "2025-03-17T18:21:07+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_copy_checksum": {
+    "last_validated_date": "2025-06-13T12:45:50+00:00",
+    "durations_in_seconds": {
+      "setup": 0.92,
+      "call": 1.39,
+      "teardown": 1.01,
+      "total": 3.32
+    }
+  },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockLegalHold::test_delete_locked_object": {
     "last_validated_date": "2025-01-21T18:17:15+00:00"
   },

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -3237,7 +3237,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_range": {
-    "recorded-date": "21-01-2025, 18:10:14",
+    "recorded-date": "13-06-2025, 12:42:54",
     "recorded-content": {
       "put-src-object": {
         "ChecksumCRC32": "poTHxg==",
@@ -3517,7 +3517,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_no_copy_source_range": {
-    "recorded-date": "21-01-2025, 18:10:16",
+    "recorded-date": "13-06-2025, 12:42:57",
     "recorded-content": {
       "put-src-object": {
         "ChecksumCRC32": "poTHxg==",

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -69,10 +69,22 @@
     "last_validated_date": "2025-01-21T18:10:31+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_no_copy_source_range": {
-    "last_validated_date": "2025-01-21T18:10:16+00:00"
+    "last_validated_date": "2025-06-13T12:42:58+00:00",
+    "durations_in_seconds": {
+      "setup": 0.55,
+      "call": 0.66,
+      "teardown": 1.07,
+      "total": 2.28
+    }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_range": {
-    "last_validated_date": "2025-01-21T18:10:14+00:00"
+    "last_validated_date": "2025-06-13T12:42:55+00:00",
+    "durations_in_seconds": {
+      "setup": 1.02,
+      "call": 5.28,
+      "teardown": 1.54,
+      "total": 7.84
+    }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectCRUD::test_delete_object": {
     "last_validated_date": "2025-01-21T18:09:31+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've got a report in our Community Slack with a small sample (as represented by the new test) where Checksum handling did not work well with the `UploadPartCopy` operation: https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html

This was due because we simply did not handle checksums as this was not implemented in our previous implementation. 

We now properly handle checksums when copying an object into a part, via our storage engine. 

This was the error when calling `ListParts`: 
```python
An error occurred (InternalError) when calling the ListParts operation (reached max retries: 4): exception while calling s3.ListParts: 'NoneType' object has no attribute 'upper'
```

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add new test covering the case of multipart uploads with checksum and UploadPartCopy
- fix the behavior to retrieve the new checksum from the stored object, calculated when being stored
- return the checksum field when the conditions are filled for `UploadPartCopy`
- add a better check in `ListParts` to avoid unhandled exceptions

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
