### PR TITLE
fix issue with CloudWatch after state reset

### DIFF
--- a/localstack-core/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack-core/localstack/services/cloudwatch/provider_v2.py
@@ -175,6 +175,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         self.cloudwatch_database.clear_tables()
 
     def on_after_state_reset(self):
+        self.cloudwatch_database = CloudwatchDatabase()
         self.start_alarm_scheduler()
 
     def on_before_state_load(self):


### PR DESCRIPTION
## Motivation
This PR fixes an issue that occurs when the CW Provider is restared and the user tries to write some metrics into the service with the "clean" state. 

The cause of this issue is that the reset operation removes the directory `/tmp/localstack/state/cloudwatch` and the DB files inside it. After the reset operation, the provider doesn't start a new DB file. So any operation that comes after failes.

## Changes
- Make sure that a Database is started after a reset operation

## Testing (Not)
- the persistence feature is not available in this repository so a test cannot be added. 