### PR TITLE
Bump moto-ext to 5.1.6.post2

### DIFF
--- a/localstack-core/localstack/services/iam/provider.py
+++ b/localstack-core/localstack/services/iam/provider.py
@@ -335,7 +335,7 @@ class IamProvider(IamApi):
         backend = get_iam_backend(context)
         profile = backend.get_instance_profile(instance_profile_name)
         response = ListInstanceProfileTagsResponse()
-        response["Tags"] = [Tag(Key=k, Value=v) for k, v in profile.tags.items()]
+        response["Tags"] = profile.tags
         return response
 
     def tag_instance_profile(
@@ -347,8 +347,7 @@ class IamProvider(IamApi):
     ) -> None:
         backend = get_iam_backend(context)
         profile = backend.get_instance_profile(instance_profile_name)
-        value_by_key = {tag["Key"]: tag["Value"] for tag in tags}
-        profile.tags.update(value_by_key)
+        profile.tags.extend(tags)
 
     def untag_instance_profile(
         self,
@@ -359,8 +358,7 @@ class IamProvider(IamApi):
     ) -> None:
         backend = get_iam_backend(context)
         profile = backend.get_instance_profile(instance_profile_name)
-        for tag in tag_keys:
-            profile.tags.pop(tag, None)
+        profile.tags = [tag for tag in profile.tags if tag["Key"] not in tag_keys]
 
     def create_service_linked_role(
         self,

--- a/localstack-core/localstack/services/iam/provider.py
+++ b/localstack-core/localstack/services/iam/provider.py
@@ -347,7 +347,10 @@ class IamProvider(IamApi):
     ) -> None:
         backend = get_iam_backend(context)
         profile = backend.get_instance_profile(instance_profile_name)
-        profile.tags.extend(tags)
+        new_keys = [tag["Key"] for tag in tags]
+        updated_tags = [tag for tag in profile.tags if tag["Key"] not in new_keys]
+        updated_tags.extend(tags)
+        profile.tags = updated_tags
 
     def untag_instance_profile(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.1.5.post1",
+    "moto-ext[all]==5.1.6.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.1.6.post1",
+    "moto-ext[all]==5.1.6.post2",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -38,11 +38,11 @@ psutil==7.0.0
     # via localstack-core (pyproject.toml)
 pycparser==2.22
     # via cffi
-pygments==2.19.1
+pygments==2.19.2
     # via rich
 pyproject-hooks==1.2.0
     # via build
-python-dotenv==1.1.0
+python-dotenv==1.1.1
     # via localstack-core (pyproject.toml)
 pyyaml==6.0.2
     # via localstack-core (pyproject.toml)
@@ -54,5 +54,5 @@ semver==3.0.4
     # via localstack-core (pyproject.toml)
 tailer==0.4.1
     # via localstack-core (pyproject.toml)
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -8,7 +8,7 @@ build==1.2.2.post1
     # via localstack-core (pyproject.toml)
 cachetools==6.0.0
     # via localstack-core (pyproject.toml)
-certifi==2025.4.26
+certifi==2025.6.15
     # via requests
 cffi==1.17.1
     # via cryptography

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -250,7 +250,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.5.post1
+moto-ext==5.1.6.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -250,7 +250,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.6.post1
+moto-ext==5.1.6.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.6.post1
+moto-ext==5.1.6.post2
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.5.post1
+moto-ext==5.1.6.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -234,7 +234,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.5.post1
+moto-ext==5.1.6.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -234,7 +234,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.6.post1
+moto-ext==5.1.6.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -254,7 +254,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.6.post1
+moto-ext==5.1.6.post2
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -254,7 +254,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.7.0
     # via openapi-core
-moto-ext==5.1.5.post1
+moto-ext==5.1.6.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.py
@@ -174,6 +174,7 @@ def test_lifecycle_nested_stack(deploy_cfn_template, s3_create_bucket, aws_clien
         "$..Role.Description",
         "$..Role.MaxSessionDuration",
         "$..Role.AssumeRolePolicyDocument..Action",
+        "$..Role.Tags",  # Moto returns a empty list for no tags
     ]
 )
 @markers.aws.validated

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.py
@@ -174,7 +174,7 @@ def test_lifecycle_nested_stack(deploy_cfn_template, s3_create_bucket, aws_clien
         "$..Role.Description",
         "$..Role.MaxSessionDuration",
         "$..Role.AssumeRolePolicyDocument..Action",
-        "$..Role.Tags",  # Moto returns a empty list for no tags
+        "$..Role.Tags",  # Moto returns an empty list for no tags
     ]
 )
 @markers.aws.validated

--- a/tests/aws/services/cloudformation/resource_providers/iam/aws_iam_user/test_parity.py
+++ b/tests/aws/services/cloudformation/resource_providers/iam/aws_iam_user/test_parity.py
@@ -22,6 +22,9 @@ class TestParity:
     """
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..IsTruncated"]
+    )  # Moto always returns this pagination-related field, AWS only when true
     def test_create_with_full_properties(self, aws_client, deploy_cfn_template, snapshot, cleanups):
         """A sort of smoke test that simply covers as many properties as possible"""
         # TODO: keep extending this test with more properties for higher parity with the official resource on AWS

--- a/tests/aws/services/iam/test_iam.py
+++ b/tests/aws/services/iam/test_iam.py
@@ -162,7 +162,7 @@ class TestIAMExtensions:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Role.Tags"]
-    )  # Moto returns a empty list for no tags
+    )  # Moto returns an empty list for no tags
     def test_role_with_path_lifecycle(self, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.iam_api())
         role_name = f"role-{short_uid()}"
@@ -591,7 +591,7 @@ class TestIAMIntegrations:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Role.Tags"]
-    )  # Moto returns a empty list for no tags
+    )  # Moto returns an empty list for no tags
     def test_update_assume_role_policy(self, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.iam_api())
 
@@ -624,7 +624,7 @@ class TestIAMIntegrations:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Role.Tags"]
-    )  # Moto returns a empty list for no tags
+    )  # Moto returns an empty list for no tags
     def test_create_describe_role(self, snapshot, aws_client, create_role, cleanups):
         snapshot.add_transformer(snapshot.transform.iam_api())
         path_prefix = f"/{short_uid()}/"
@@ -655,7 +655,7 @@ class TestIAMIntegrations:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Role.Tags"]
-    )  # Moto returns a empty list for no tags
+    )  # Moto returns an empty list for no tags
     def test_list_roles_with_permission_boundary(
         self, snapshot, aws_client, create_role, create_policy, cleanups
     ):
@@ -835,7 +835,7 @@ class TestIAMPolicyEncoding:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Role.Tags"]
-    )  # Moto returns a empty list for no tags
+    )  # Moto returns an empty list for no tags
     def test_put_role_policy_encoding(self, snapshot, aws_client, create_role, region_name):
         snapshot.add_transformer(snapshot.transform.iam_api())
 
@@ -1411,7 +1411,7 @@ class TestIAMServiceRoles:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Role.Tags"]
-    )  # Moto returns a empty list for no tags
+    )  # Moto returns an empty list for no tags
     @pytest.mark.parametrize("service_name", SERVICES_CUSTOM_SUFFIX)
     def test_service_role_lifecycle_custom_suffix(
         self, aws_client, snapshot, create_service_linked_role, service_name

--- a/tests/aws/services/iam/test_iam.py
+++ b/tests/aws/services/iam/test_iam.py
@@ -160,6 +160,9 @@ class TestIAMExtensions:
         snapshot.match("invalid-json", e.value.response)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Role.Tags"]
+    )  # Moto returns a empty list for tags
     def test_role_with_path_lifecycle(self, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.iam_api())
         role_name = f"role-{short_uid()}"

--- a/tests/aws/services/iam/test_iam.py
+++ b/tests/aws/services/iam/test_iam.py
@@ -162,7 +162,7 @@ class TestIAMExtensions:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Role.Tags"]
-    )  # Moto returns a empty list for tags
+    )  # Moto returns a empty list for no tags
     def test_role_with_path_lifecycle(self, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.iam_api())
         role_name = f"role-{short_uid()}"
@@ -589,6 +589,9 @@ class TestIAMIntegrations:
                 aws_client.iam.delete_service_linked_role(RoleName=role_name)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Role.Tags"]
+    )  # Moto returns a empty list for no tags
     def test_update_assume_role_policy(self, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.iam_api())
 
@@ -619,6 +622,9 @@ class TestIAMIntegrations:
             aws_client.iam.delete_role(RoleName=role_name)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Role.Tags"]
+    )  # Moto returns a empty list for no tags
     def test_create_describe_role(self, snapshot, aws_client, create_role, cleanups):
         snapshot.add_transformer(snapshot.transform.iam_api())
         path_prefix = f"/{short_uid()}/"
@@ -647,6 +653,9 @@ class TestIAMIntegrations:
         snapshot.match("list_roles_result", list_roles_result)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Role.Tags"]
+    )  # Moto returns a empty list for no tags
     def test_list_roles_with_permission_boundary(
         self, snapshot, aws_client, create_role, create_policy, cleanups
     ):
@@ -695,6 +704,7 @@ class TestIAMIntegrations:
             "$..Policy.IsAttachable",
             "$..Policy.PermissionsBoundaryUsageCount",
             "$..Policy.Tags",
+            "$..Policy.Description",
         ]
     )
     def test_role_attach_policy(self, snapshot, aws_client, create_role, create_policy):
@@ -751,6 +761,7 @@ class TestIAMIntegrations:
             "$..Policy.IsAttachable",
             "$..Policy.PermissionsBoundaryUsageCount",
             "$..Policy.Tags",
+            "$..Policy.Description",
         ]
     )
     def test_user_attach_policy(self, snapshot, aws_client, create_user, create_policy):
@@ -822,6 +833,9 @@ class TestIAMPolicyEncoding:
         snapshot.match("get-policy-response", get_policy_response)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Role.Tags"]
+    )  # Moto returns a empty list for no tags
     def test_put_role_policy_encoding(self, snapshot, aws_client, create_role, region_name):
         snapshot.add_transformer(snapshot.transform.iam_api())
 
@@ -1372,7 +1386,9 @@ class TestIAMServiceRoles:
 
     @markers.aws.validated
     # last used and the description depend on whether the role was created in the snapshot account by a service or manually
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Role.RoleLastUsed", "$..Role.Description"])
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Role.RoleLastUsed", "$..Role.Description", "$..Role.Tags"]
+    )
     @pytest.mark.parametrize(
         "service_name",
         [pytest.param(service, marks=marker) for service, marker in SERVICES.items()],

--- a/tests/aws/services/iam/test_iam.py
+++ b/tests/aws/services/iam/test_iam.py
@@ -1409,6 +1409,9 @@ class TestIAMServiceRoles:
         snapshot.match("attached-role-policies", response)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Role.Tags"]
+    )  # Moto returns a empty list for no tags
     @pytest.mark.parametrize("service_name", SERVICES_CUSTOM_SUFFIX)
     def test_service_role_lifecycle_custom_suffix(
         self, aws_client, snapshot, create_service_linked_role, service_name

--- a/tests/aws/services/iam/test_iam.snapshot.json
+++ b/tests/aws/services/iam/test_iam.snapshot.json
@@ -201,7 +201,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_role_attach_policy": {
-    "recorded-date": "06-03-2025, 12:25:04",
+    "recorded-date": "19-06-2025, 11:47:40",
     "recorded-content": {
       "create_policy_response": {
         "Policy": {

--- a/tests/aws/services/iam/test_iam.snapshot.json
+++ b/tests/aws/services/iam/test_iam.snapshot.json
@@ -325,7 +325,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMExtensions::test_role_with_path_lifecycle": {
-    "recorded-date": "06-03-2025, 12:24:45",
+    "recorded-date": "19-06-2025, 11:39:59",
     "recorded-content": {
       "create-role-response": {
         "Role": {

--- a/tests/aws/services/iam/test_iam.validation.json
+++ b/tests/aws/services/iam/test_iam.validation.json
@@ -15,7 +15,13 @@
     "last_validated_date": "2025-03-06T12:24:26+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMExtensions::test_role_with_path_lifecycle": {
-    "last_validated_date": "2025-03-06T12:24:45+00:00"
+    "last_validated_date": "2025-06-19T11:39:59+00:00",
+    "durations_in_seconds": {
+      "setup": 1.34,
+      "call": 2.25,
+      "teardown": 0.01,
+      "total": 3.6
+    }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_attach_detach_role_policy": {
     "last_validated_date": "2025-03-06T12:24:54+00:00"

--- a/tests/aws/services/iam/test_iam.validation.json
+++ b/tests/aws/services/iam/test_iam.validation.json
@@ -51,7 +51,13 @@
     "last_validated_date": "2025-03-06T12:24:48+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_role_attach_policy": {
-    "last_validated_date": "2025-03-06T12:25:03+00:00"
+    "last_validated_date": "2025-06-19T11:47:40+00:00",
+    "durations_in_seconds": {
+      "setup": 1.46,
+      "call": 5.22,
+      "teardown": 2.05,
+      "total": 8.73
+    }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_simulate_principle_policy[group]": {
     "last_validated_date": "2025-04-21T20:07:37+00:00"

--- a/tests/aws/services/sts/test_sts.py
+++ b/tests/aws/services/sts/test_sts.py
@@ -96,7 +96,10 @@ TEST_SAML_ASSERTION = """
 class TestSTSIntegrations:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        paths=["$..PackedPolicySize"],
+        paths=[
+            "$..PackedPolicySize",
+            "$..Role.Tags",  # Moto returns a empty list for no tags
+        ],
     )
     def test_assume_role(self, aws_client, create_role, account_id, snapshot):
         snapshot.add_transformers_list(
@@ -326,6 +329,9 @@ class TestSTSIntegrations:
 
 class TestSTSAssumeRoleTagging:
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Role.Tags"]
+    )  # Moto returns a empty list for no tags
     def test_iam_role_chaining_override_transitive_tags(
         self,
         aws_client,
@@ -408,6 +414,9 @@ class TestSTSAssumeRoleTagging:
         snapshot.match("override-transitive-tag-case-ignore-error", e.value.response)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Role.Tags"]
+    )  # Moto returns a empty list for no tags
     def test_assume_role_tag_validation(
         self,
         aws_client,

--- a/tests/aws/services/sts/test_sts.py
+++ b/tests/aws/services/sts/test_sts.py
@@ -98,7 +98,7 @@ class TestSTSIntegrations:
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..PackedPolicySize",
-            "$..Role.Tags",  # Moto returns a empty list for no tags
+            "$..Role.Tags",  # Moto returns an empty list for no tags
         ],
     )
     def test_assume_role(self, aws_client, create_role, account_id, snapshot):
@@ -331,7 +331,7 @@ class TestSTSAssumeRoleTagging:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Role.Tags"]
-    )  # Moto returns a empty list for no tags
+    )  # Moto returns an empty list for no tags
     def test_iam_role_chaining_override_transitive_tags(
         self,
         aws_client,
@@ -416,7 +416,7 @@ class TestSTSAssumeRoleTagging:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Role.Tags"]
-    )  # Moto returns a empty list for no tags
+    )  # Moto returns an empty list for no tags
     def test_assume_role_tag_validation(
         self,
         aws_client,


### PR DESCRIPTION
## Summary

This PR bumps moto-ext to 5.1.6.post2

Contains:

- https://github.com/getmoto/moto/pull/8960

Moto response serialiser is being reworked upstream where now the tags field in IAM resources is always returned. AWS does not return this field if no tags are set. This is causing snapshot tests to fail, because of which this PR marks the tags attribute to be skipped. This is expected to be resolved in future Moto releases. See https://github.com/getmoto/moto/pull/8997.

## To do

- [x] Ext compatibility https://github.com/localstack/localstack-ext/actions/runs/15845021789
- [x] Multi-account/region compatibility https://github.com/localstack/localstack/actions/runs/15843314419