### PR TITLE
migrate from depenadbot reviewers to codeowners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "silv-io"
-      - "alexrashed"
     ignore:
       - dependency-name: "python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -23,9 +20,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "silv-io"
-      - "alexrashed"
     labels:
       - "area: dependencies"
       - "semver: patch"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 # Docker
 /bin/docker-entrypoint.sh @thrau @alexrashed
 /.dockerignore @alexrashed
-/Dockerfile @alexrashed
+/Dockerfile* @alexrashed @silv-io
 
 # Git, Pipelines, GitHub config
 /.github @alexrashed @dfangl @dominikschubert @silv-io @k-a-il


### PR DESCRIPTION
## Motivation
It has been announced in a [blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) and via automated comments that the `reviewers` config in Dependabot is deprecated and that users should switch to a `CODEOWNERS` config instead.
This PR performs this migration.

## Changes
- Removes the deprecated `reviewers` section in the dependabot config.
- Explicitly sets me and @silv-io as reviewers for all Dockerfiles (i.e. the dependabot base image updates).