### PR TITLE
CFnv2: unskip more supported tests

### DIFF
--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_templates.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_templates.py
@@ -39,7 +39,7 @@ def test_get_template_summary(deploy_cfn_template, snapshot, aws_client):
     snapshot.match("template-summary", res)
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
+@pytest.mark.skip(reason="CFNV2: CreateStack")
 @markers.aws.validated
 @pytest.mark.parametrize("url_style", ["s3_url", "http_path", "http_host", "http_invalid"])
 def test_create_stack_from_s3_template_url(

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/engine/test_conditions.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/engine/test_conditions.py
@@ -17,7 +17,6 @@ pytestmark = pytest.mark.skipif(
 
 
 class TestCloudFormationConditions:
-    @pytest.mark.skip(reason="CFNV2:DescribeStackResources")
     @markers.aws.validated
     def test_simple_condition_evaluation_deploys_resource(
         self, aws_client, deploy_cfn_template, cleanups
@@ -44,7 +43,6 @@ class TestCloudFormationConditions:
             if topic_name in t["TopicArn"]
         ]
 
-    @pytest.mark.skip(reason="CFNV2:DescribeStackResources")
     @markers.aws.validated
     def test_simple_condition_evaluation_doesnt_deploy_resource(
         self, aws_client, deploy_cfn_template, cleanups
@@ -407,7 +405,6 @@ class TestCloudFormationConditions:
         aws_client.sns.get_topic_attributes(TopicArn=topic_arn_with_suffix)
         assert topic_arn_with_suffix.split(":")[-1] == f"{topic_prefix}-{region}-{suffix}"
 
-    @pytest.mark.skip(reason="CFNV2:ConditionInCondition")
     @markers.aws.validated
     @pytest.mark.parametrize("env,region", [("dev", "us-west-2"), ("production", "us-east-1")])
     def test_conditional_in_conditional(self, env, region, deploy_cfn_template, aws_client):

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/engine/test_mappings.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/engine/test_mappings.py
@@ -19,7 +19,6 @@ pytestmark = pytest.mark.skipif(
 
 @markers.snapshot.skip_snapshot_verify
 class TestCloudFormationMappings:
-    @pytest.mark.skip(reason="CFNV2:DescribeStackResources")
     @markers.aws.validated
     def test_simple_mapping_working(self, aws_client, deploy_cfn_template):
         """

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py
@@ -226,7 +226,6 @@ def test_cfn_with_apigateway_resources(deploy_cfn_template, aws_client, snapshot
     # assert not apis
 
 
-@pytest.mark.skip(reason="CFNV2:Other NotFoundException Invalid Method identifier specified")
 @markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(
     paths=[
@@ -415,9 +414,6 @@ def test_account(deploy_cfn_template, aws_client):
 
 
 @markers.aws.validated
-@pytest.mark.skip(
-    reason="CFNV2:Other ApiDeployment creation fails due to the REST API not having a method set"
-)
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         "$..tags.'aws:cloudformation:logical-id'",
@@ -468,9 +464,6 @@ def test_update_usage_plan(deploy_cfn_template, aws_client, snapshot):
     assert usage_plan["quota"]["limit"] == 7000
 
 
-@pytest.mark.skip(
-    reason="CFNV2:Other ApiDeployment creation fails due to the REST API not having a method set"
-)
 @markers.snapshot.skip_snapshot_verify(
     paths=["$..createdDate", "$..description", "$..lastUpdatedDate", "$..tags"]
 )

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_cdk.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_cdk.py
@@ -16,9 +16,6 @@ pytestmark = pytest.mark.skipif(
 
 
 class TestCdkInit:
-    @pytest.mark.skip(
-        reason="CFNV2:Destroy each test passes individually but because we don't delete resources, running all parameterized options fails"
-    )
     @pytest.mark.parametrize("bootstrap_version", ["10", "11", "12"])
     @markers.aws.validated
     def test_cdk_bootstrap(self, deploy_cfn_template, bootstrap_version, aws_client):

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_dynamodb.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_dynamodb.py
@@ -149,7 +149,6 @@ def test_global_table(deploy_cfn_template, snapshot, aws_client):
     assert "ResourceNotFoundException" == error_code
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.aws.validated
 def test_ttl_cdk(aws_client, snapshot, infrastructure_setup):
     infra = infrastructure_setup(namespace="DDBTableTTL")
@@ -195,7 +194,6 @@ def test_table_with_ttl_and_sse(deploy_cfn_template, snapshot, aws_client):
     snapshot.match("table_description", response)
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.aws.validated
 # We return the fields bellow, while AWS doesn't return them
 @markers.snapshot.skip_snapshot_verify(

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_firehose.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_firehose.py
@@ -14,7 +14,6 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(paths=["$..Destinations"])
 def test_firehose_stack_with_kinesis_as_source(deploy_cfn_template, snapshot, aws_client):

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_kinesis.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_kinesis.py
@@ -16,7 +16,6 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.skip(reason="CFNV2:DescribeStacks")
 @markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(paths=["$..StreamDescription.StreamModeDetails"])
 def test_stream_creation(deploy_cfn_template, snapshot, aws_client):

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_lambda.py
@@ -228,7 +228,6 @@ def test_cfn_function_url(deploy_cfn_template, snapshot, aws_client):
     snapshot.match("response_headers", lowered_headers)
 
 
-@pytest.mark.skip(reason="CFNV2:Other Function already exists error")
 @markers.aws.validated
 def test_lambda_alias(deploy_cfn_template, snapshot, aws_client):
     snapshot.add_transformer(snapshot.transform.cloudformation_api())
@@ -275,7 +274,6 @@ def test_lambda_alias(deploy_cfn_template, snapshot, aws_client):
     snapshot.match("provisioned_concurrency_config", provisioned_concurrency_config)
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.aws.validated
 def test_lambda_logging_config(deploy_cfn_template, snapshot, aws_client):
     function_name = f"function{short_uid()}"
@@ -308,7 +306,6 @@ def test_lambda_logging_config(deploy_cfn_template, snapshot, aws_client):
     snapshot.match("logging_config", logging_config)
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @pytest.mark.skipif(
     not in_default_partition(), reason="Test not applicable in non-default partitions"
 )
@@ -356,7 +353,6 @@ def test_event_invoke_config(deploy_cfn_template, snapshot, aws_client):
     snapshot.match("event_invoke_config", event_invoke_config)
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         # Lambda ZIP flaky in CI
@@ -401,7 +397,6 @@ def test_lambda_version(deploy_cfn_template, snapshot, aws_client):
     snapshot.match("get_function_version", get_function_version)
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         # Lambda ZIP flaky in CI
@@ -666,7 +661,6 @@ def test_lambda_function_tags(deploy_cfn_template, aws_client, snapshot):
 
 
 class TestCfnLambdaIntegrations:
-    @pytest.mark.skip(reason="CFNV2:Other")
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..Attributes.EffectiveDeliveryPolicy",  # broken in sns right now. needs to be wrapped within an http key
@@ -857,7 +851,6 @@ class TestCfnLambdaIntegrations:
         with pytest.raises(aws_client.lambda_.exceptions.ResourceNotFoundException):
             aws_client.lambda_.get_event_source_mapping(UUID=esm_id)
 
-    @pytest.mark.skip(reason="CFNV2:Other")
     # TODO: consider moving into the dedicated DynamoDB => Lambda tests because it tests the filtering functionality rather than CloudFormation (just using CF to deploy resources)
     #  tests.aws.services.lambda_.test_lambda_integration_dynamodbstreams.TestDynamoDBEventSourceMapping.test_dynamodb_event_filter
     @markers.aws.validated
@@ -1319,7 +1312,6 @@ def test_python_lambda_code_deployed_via_s3(deploy_cfn_template, aws_client, s3_
     assert invocation_result["StatusCode"] == 200
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.aws.validated
 def test_lambda_cfn_dead_letter_config_async_invocation(
     deploy_cfn_template, aws_client, s3_create_bucket, snapshot

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_s3.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_s3.py
@@ -130,7 +130,6 @@ def test_object_lock_configuration(deploy_cfn_template, snapshot, aws_client):
     snapshot.match("object-lock-info-only-enabled", cors_info)
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.aws.validated
 def test_cfn_handle_s3_notification_configuration(
     aws_client,

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_sam.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_sam.py
@@ -16,7 +16,6 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.aws.validated
 def test_sam_policies(deploy_cfn_template, snapshot, aws_client):
     snapshot.add_transformer(snapshot.transform.cloudformation_api())

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_sns.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_sns.py
@@ -141,7 +141,6 @@ def test_update_subscription(snapshot, deploy_cfn_template, aws_client, sqs_queu
     snapshot.add_transformer(snapshot.transform.cloudformation_api())
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.aws.validated
 def test_sns_topic_with_attributes(infrastructure_setup, aws_client, snapshot):
     infra = infrastructure_setup(namespace="SnsTests")

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_ssm.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_ssm.py
@@ -144,7 +144,6 @@ def test_deploy_patch_baseline(deploy_cfn_template, aws_client, snapshot):
     snapshot.match("patch_baseline", describe_resource)
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.aws.validated
 def test_maintenance_window(deploy_cfn_template, aws_client, snapshot):
     stack = deploy_cfn_template(

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/test_template_engine.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/test_template_engine.py
@@ -841,6 +841,7 @@ class TestMacros:
         )
         snapshot.match("processed_template", processed_template)
 
+    @pytest.mark.skip(reason="CFNV2: CreateStack")
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While implementing the new v2 provider we are leaving some passing tests behind, having marked them as skip and not revisiting them.

This PR only runs the tests marked as skipped with the reason prefix `CFNV2:` to work out what is currently _actually_ passing.

I use this `conftest.py` pytest plugin


```python
# in tests/aws/services/cloudformation/v2/conftest.py

import pytest


def pytest_collection_modifyitems(
    session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
):
    selected_items, deselected_items = [], []
    marker_name = "skip"
    for item in items:
        # only collect skipped tests
        mark = item.get_closest_marker("skip")
        if mark and (
            (mark.kwargs and "CFNV2:" in mark.kwargs.get("reason", ""))
            or (mark.args and "CFNV2:" in mark.args[0])
        ):
            filtered_markers = [item for item in item.own_markers if item.name != "skip"]
            item.own_markers[:] = filtered_markers

            # remove skip marker from parent nodes
            for parent in item.listchain():
                if not hasattr(parent, "own_markers"):
                    continue

                parent.own_markers[:] = [
                    item for item in parent.own_markers if item.name != marker_name
                ]

            selected_items.append(item)
        else:
            deselected_items.append(item)

    items[:] = selected_items
    config.hook.pytest_deselected(items=deselected_items)
```

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Unskip 23 more tests

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
