### PR TITLE
S3: implement ObjectParts in GetObjectAttributes

### DIFF
--- a/localstack-core/localstack/services/s3/models.py
+++ b/localstack-core/localstack/services/s3/models.py
@@ -50,6 +50,7 @@ from localstack.aws.api.s3 import (
     ObjectStorageClass,
     ObjectVersionId,
     Owner,
+    Part,
     PartNumber,
     Payer,
     Policy,
@@ -87,6 +88,10 @@ from localstack.utils.tagging import TaggingService
 LOG = logging.getLogger(__name__)
 
 _gmt_zone_info = ZoneInfo("GMT")
+
+
+class InternalObjectPart(Part):
+    _position: int
 
 
 # note: not really a need to use a dataclass here, as it has a lot of fields, but only a few are set at creation
@@ -271,7 +276,7 @@ class S3Object:
     website_redirect_location: Optional[WebsiteRedirectLocation]
     acl: Optional[AccessControlPolicy]
     is_current: bool
-    parts: Optional[dict[int, tuple[int, int]]]
+    parts: Optional[dict[int, InternalObjectPart]]
     restore: Optional[Restore]
     internal_last_modified: int
 
@@ -494,14 +499,16 @@ class S3Multipart:
         object_etag = hashlib.md5(usedforsecurity=False)
         has_checksum = self.checksum_algorithm is not None
         checksum_hash = None
+        checksum_key = None
         if has_checksum:
+            checksum_key = f"Checksum{self.checksum_algorithm.upper()}"
             if self.checksum_type == ChecksumType.COMPOSITE:
                 checksum_hash = get_s3_checksum(self.checksum_algorithm)
             else:
                 checksum_hash = CombinedCrcHash(self.checksum_algorithm)
 
         pos = 0
-        parts_map = {}
+        parts_map: dict[int, InternalObjectPart] = {}
         for index, part in enumerate(parts):
             part_number = part["PartNumber"]
             part_etag = part["ETag"].strip('"')
@@ -522,7 +529,6 @@ class S3Multipart:
                 )
 
             if has_checksum:
-                checksum_key = f"Checksum{self.checksum_algorithm.upper()}"
                 if not (part_checksum := part.get(checksum_key)):
                     if self.checksum_type == ChecksumType.COMPOSITE:
                         # weird case, they still try to validate a different checksum type than the multipart
@@ -571,7 +577,16 @@ class S3Multipart:
 
             object_etag.update(bytes.fromhex(s3_part.etag))
             # keep track of the parts size, as it can be queried afterward on the object as a Range
-            parts_map[part_number] = (pos, s3_part.size)
+            internal_part = InternalObjectPart(
+                _position=pos,
+                Size=s3_part.size,
+                ETag=s3_part.etag,
+                PartNumber=s3_part.part_number,
+            )
+            if has_checksum and self.checksum_type == ChecksumType.COMPOSITE:
+                internal_part[checksum_key] = s3_part.checksum_value
+
+            parts_map[part_number] = internal_part
             pos += s3_part.size
 
         if mpu_size and mpu_size != pos:

--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -163,6 +163,7 @@ from localstack.aws.api.s3 import (
     ObjectLockRetention,
     ObjectLockToken,
     ObjectOwnership,
+    ObjectPart,
     ObjectVersion,
     ObjectVersionId,
     ObjectVersionStorageClass,
@@ -312,6 +313,7 @@ from localstack.services.s3.validation import (
 from localstack.services.s3.website_hosting import register_website_hosting_routes
 from localstack.state import AssetDirectory, StateVisitor
 from localstack.utils.aws.arns import s3_bucket_name
+from localstack.utils.collections import select_from_typed_dict
 from localstack.utils.strings import short_uid, to_bytes, to_str
 
 LOG = logging.getLogger(__name__)
@@ -2027,6 +2029,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         object_attrs = request.get("ObjectAttributes", [])
         response = GetObjectAttributesOutput()
+        object_checksum_type = getattr(s3_object, "checksum_type", ChecksumType.FULL_OBJECT)
         if "ETag" in object_attrs:
             response["ETag"] = s3_object.etag
         if "StorageClass" in object_attrs:
@@ -2040,7 +2043,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 checksum_value = s3_object.checksum_value
             response["Checksum"] = {
                 f"Checksum{checksum_algorithm.upper()}": checksum_value,
-                "ChecksumType": getattr(s3_object, "checksum_type", ChecksumType.FULL_OBJECT),
+                "ChecksumType": object_checksum_type,
             }
 
         response["LastModified"] = s3_object.last_modified
@@ -2049,9 +2052,55 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             response["VersionId"] = s3_object.version_id
 
         if "ObjectParts" in object_attrs and s3_object.parts:
-            # TODO: implements ObjectParts, this is basically a simplified `ListParts` call on the object, we might
-            #  need to store more data about the Parts once we implement checksums for them
-            response["ObjectParts"] = GetObjectAttributesParts(TotalPartsCount=len(s3_object.parts))
+            if object_checksum_type == ChecksumType.FULL_OBJECT:
+                response["ObjectParts"] = GetObjectAttributesParts(
+                    TotalPartsCount=len(s3_object.parts)
+                )
+            else:
+                # this is basically a simplified `ListParts` call on the object, only returned when the checksum type is
+                # COMPOSITE
+                count = 0
+                is_truncated = False
+                part_number_marker = request.get("PartNumberMarker") or 0
+                max_parts = request.get("MaxParts") or 1000
+
+                parts = []
+                all_parts = sorted(s3_object.parts.items())
+                last_part_number, last_part = all_parts[-1]
+
+                # TODO: remove this backward compatibility hack needed for state created with <= 4.5
+                #  the parts would only be a tuple and would not store the proper state for 4.5 and earlier, so we need
+                #  to return early
+                if isinstance(last_part, tuple):
+                    response["ObjectParts"] = GetObjectAttributesParts(
+                        TotalPartsCount=len(s3_object.parts)
+                    )
+                    return response
+
+                for part_number, part in all_parts:
+                    if part_number <= part_number_marker:
+                        continue
+                    part_item = select_from_typed_dict(ObjectPart, part)
+
+                    parts.append(part_item)
+                    count += 1
+
+                    if count >= max_parts and part["PartNumber"] != last_part_number:
+                        is_truncated = True
+                        break
+
+                object_parts = GetObjectAttributesParts(
+                    TotalPartsCount=len(s3_object.parts),
+                    IsTruncated=is_truncated,
+                    MaxParts=max_parts,
+                    PartNumberMarker=part_number_marker,
+                    NextPartNumberMarker=0,
+                )
+                if parts:
+                    object_parts["Parts"] = parts
+                    object_parts["NextPartNumberMarker"] = parts[-1]["PartNumber"]
+
+                response["ObjectParts"] = object_parts
 
         return response
 
@@ -2724,8 +2773,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         sse_customer_key_md5: SSECustomerKeyMD5 = None,
         **kwargs,
     ) -> ListPartsOutput:
-        # TODO: implement MaxParts
-        # TODO: implements PartNumberMarker
         store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if (
@@ -2737,10 +2784,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 "The upload ID may be invalid, or the upload may have been aborted or completed.",
                 UploadId=upload_id,
             )
-
-        #     AbortDate: Optional[AbortDate] TODO: lifecycle
-        #     AbortRuleId: Optional[AbortRuleId] TODO: lifecycle
-        #     RequestCharged: Optional[RequestCharged]
 
         count = 0
         is_truncated = False
@@ -2791,6 +2834,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if s3_multipart.checksum_algorithm:
             response["ChecksumAlgorithm"] = s3_multipart.object.checksum_algorithm
             response["ChecksumType"] = getattr(s3_multipart, "checksum_type", None)
+
+        #     AbortDate: Optional[AbortDate] TODO: lifecycle
+        #     AbortRuleId: Optional[AbortRuleId] TODO: lifecycle
+        #     RequestCharged: Optional[RequestCharged]
 
         return response
 
@@ -4538,7 +4585,13 @@ def get_part_range(s3_object: S3Object, part_number: PartNumber) -> ObjectRange:
             ActualPartCount=len(s3_object.parts),
         )
 
-    begin, part_length = part_data
+    # TODO: remove for next major version 5.0, compatibility for <= 4.5
+    if isinstance(part_data, tuple):
+        begin, part_length = part_data
+    else:
+        begin = part_data["_position"]
+        part_length = part_data["Size"]
+
     end = begin + part_length - 1
     return ObjectRange(
         begin=begin,

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -13023,7 +13023,10 @@ class TestS3MultipartUploadChecksum:
         snapshot.match("get-object-attrs", object_attrs)
 
     @markers.aws.validated
-    def test_multipart_upload_part_copy_checksum(self, s3_bucket, snapshot, aws_client):
+    @pytest.mark.parametrize("checksum_type", ("COMPOSITE", "FULL_OBJECT"))
+    def test_multipart_upload_part_copy_checksum(
+        self, s3_bucket, snapshot, aws_client, checksum_type
+    ):
         snapshot.add_transformer(
             [
                 snapshot.transform.key_value("Bucket", reference_replacement=False),
@@ -13044,7 +13047,7 @@ class TestS3MultipartUploadChecksum:
 
         key_name = "test-multipart-checksum"
         response = aws_client.s3.create_multipart_upload(
-            Bucket=s3_bucket, Key=key_name, ChecksumAlgorithm="SHA256"
+            Bucket=s3_bucket, Key=key_name, ChecksumAlgorithm="CRC32C", ChecksumType=checksum_type
         )
         snapshot.match("create-mpu-checksum-sha256", response)
         upload_id = response["UploadId"]
@@ -13075,7 +13078,7 @@ class TestS3MultipartUploadChecksum:
                     {
                         "ETag": upload_part_copy["CopyPartResult"]["ETag"],
                         "PartNumber": 1,
-                        "ChecksumSHA256": upload_part_copy["CopyPartResult"]["ChecksumSHA256"],
+                        "ChecksumCRC32C": upload_part_copy["CopyPartResult"]["ChecksumCRC32C"],
                     }
                 ]
             },
@@ -13096,7 +13099,7 @@ class TestS3MultipartUploadChecksum:
         object_attrs = aws_client.s3.get_object_attributes(
             Bucket=s3_bucket,
             Key=key_name,
-            ObjectAttributes=["Checksum", "ETag"],
+            ObjectAttributes=["Checksum", "ETag", "ObjectParts"],
         )
         snapshot.match("get-object-attrs", object_attrs)
 

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -12298,7 +12298,7 @@ class TestS3MultipartUploadChecksum:
         object_attrs = aws_client.s3.get_object_attributes(
             Bucket=s3_bucket,
             Key=key_name,
-            ObjectAttributes=["Checksum", "ETag"],
+            ObjectAttributes=["Checksum", "ETag", "ObjectParts"],
         )
         snapshot.match("get-object-attrs", object_attrs)
 
@@ -12311,7 +12311,7 @@ class TestS3MultipartUploadChecksum:
         object_attrs = aws_client.s3.get_object_attributes(
             Bucket=s3_bucket,
             Key=dest_key,
-            ObjectAttributes=["Checksum", "ETag"],
+            ObjectAttributes=["Checksum", "ETag", "ObjectParts"],
         )
         snapshot.match("get-copy-object-attrs", object_attrs)
 
@@ -12595,7 +12595,7 @@ class TestS3MultipartUploadChecksum:
         object_attrs = aws_client.s3.get_object_attributes(
             Bucket=s3_bucket,
             Key=key_name,
-            ObjectAttributes=["Checksum", "ETag"],
+            ObjectAttributes=["Checksum", "ETag", "ObjectParts"],
         )
         snapshot.match("get-object-attrs", object_attrs)
 
@@ -12608,7 +12608,7 @@ class TestS3MultipartUploadChecksum:
         object_attrs = aws_client.s3.get_object_attributes(
             Bucket=s3_bucket,
             Key=dest_key,
-            ObjectAttributes=["Checksum", "ETag"],
+            ObjectAttributes=["Checksum", "ETag", "ObjectParts"],
         )
         snapshot.match("get-copy-object-attrs", object_attrs)
 
@@ -12877,7 +12877,7 @@ class TestS3MultipartUploadChecksum:
         object_attrs = aws_client.s3.get_object_attributes(
             Bucket=s3_bucket,
             Key=key_name,
-            ObjectAttributes=["Checksum", "ETag"],
+            ObjectAttributes=["Checksum", "ETag", "ObjectParts"],
         )
         snapshot.match("get-object-attrs", object_attrs)
 
@@ -12890,7 +12890,7 @@ class TestS3MultipartUploadChecksum:
         object_attrs = aws_client.s3.get_object_attributes(
             Bucket=s3_bucket,
             Key=dest_key,
-            ObjectAttributes=["Checksum", "ETag"],
+            ObjectAttributes=["Checksum", "ETag", "ObjectParts"],
         )
         snapshot.match("get-copy-object-attrs", object_attrs)
 
@@ -12959,7 +12959,7 @@ class TestS3MultipartUploadChecksum:
         object_attrs = aws_client.s3.get_object_attributes(
             Bucket=s3_bucket,
             Key=key_name,
-            ObjectAttributes=["Checksum", "ETag"],
+            ObjectAttributes=["Checksum", "ETag", "ObjectParts"],
         )
         snapshot.match("get-object-attrs", object_attrs)
 

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -17523,8 +17523,8 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_copy_checksum": {
-    "recorded-date": "13-06-2025, 12:45:49",
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_copy_checksum[COMPOSITE]": {
+    "recorded-date": "16-06-2025, 10:53:39",
     "recorded-content": {
       "put-object": {
         "ChecksumCRC32": "nG7pIA==",
@@ -17538,7 +17538,7 @@
       },
       "create-mpu-checksum-sha256": {
         "Bucket": "bucket",
-        "ChecksumAlgorithm": "SHA256",
+        "ChecksumAlgorithm": "CRC32C",
         "ChecksumType": "COMPOSITE",
         "Key": "test-multipart-checksum",
         "ServerSideEncryption": "AES256",
@@ -17550,7 +17550,7 @@
       },
       "upload-part-copy": {
         "CopyPartResult": {
-          "ChecksumSHA256": "+j3Oc5P9QdoIdPJ4lFSyNlAAX0G7Am+wZsxu4FYN+wo=",
+          "ChecksumCRC32C": "iqJrOQ==",
           "ETag": "\"11df95d595559285eb2b042124e74f09\"",
           "LastModified": "datetime"
         },
@@ -17562,7 +17562,7 @@
       },
       "list-parts": {
         "Bucket": "bucket",
-        "ChecksumAlgorithm": "SHA256",
+        "ChecksumAlgorithm": "CRC32C",
         "ChecksumType": "COMPOSITE",
         "Initiator": {
           "DisplayName": "display-name",
@@ -17579,7 +17579,7 @@
         "PartNumberMarker": 0,
         "Parts": [
           {
-            "ChecksumSHA256": "+j3Oc5P9QdoIdPJ4lFSyNlAAX0G7Am+wZsxu4FYN+wo=",
+            "ChecksumCRC32C": "iqJrOQ==",
             "ETag": "\"11df95d595559285eb2b042124e74f09\"",
             "LastModified": "datetime",
             "PartNumber": 1,
@@ -17595,7 +17595,7 @@
       },
       "complete-multipart-checksum": {
         "Bucket": "bucket",
-        "ChecksumSHA256": "/4+xERoRlzE2Ryan+GX/sqNSrf6Qe30L2IM7APXadSE=-1",
+        "ChecksumCRC32C": "F9bAnw==-1",
         "ChecksumType": "COMPOSITE",
         "ETag": "\"395d97c07920de036bfa21e7568a2e9f-1\"",
         "Key": "test-multipart-checksum",
@@ -17609,7 +17609,7 @@
       "get-object-with-checksum": {
         "AcceptRanges": "bytes",
         "Body": "this is a part",
-        "ChecksumSHA256": "/4+xERoRlzE2Ryan+GX/sqNSrf6Qe30L2IM7APXadSE=-1",
+        "ChecksumCRC32C": "F9bAnw==-1",
         "ChecksumType": "COMPOSITE",
         "ContentLength": 14,
         "ContentType": "binary/octet-stream",
@@ -17624,7 +17624,7 @@
       },
       "head-object-with-checksum": {
         "AcceptRanges": "bytes",
-        "ChecksumSHA256": "/4+xERoRlzE2Ryan+GX/sqNSrf6Qe30L2IM7APXadSE=-1",
+        "ChecksumCRC32C": "F9bAnw==-1",
         "ChecksumType": "COMPOSITE",
         "ContentLength": 14,
         "ContentType": "binary/octet-stream",
@@ -17639,11 +17639,156 @@
       },
       "get-object-attrs": {
         "Checksum": {
-          "ChecksumSHA256": "/4+xERoRlzE2Ryan+GX/sqNSrf6Qe30L2IM7APXadSE=",
+          "ChecksumCRC32C": "F9bAnw==",
           "ChecksumType": "COMPOSITE"
         },
         "ETag": "395d97c07920de036bfa21e7568a2e9f-1",
         "LastModified": "datetime",
+        "ObjectParts": {
+          "IsTruncated": false,
+          "MaxParts": 1000,
+          "NextPartNumberMarker": 1,
+          "PartNumberMarker": 0,
+          "Parts": [
+            {
+              "ChecksumCRC32C": "iqJrOQ==",
+              "PartNumber": 1,
+              "Size": 14
+            }
+          ],
+          "TotalPartsCount": 1
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_copy_checksum[FULL_OBJECT]": {
+    "recorded-date": "16-06-2025, 10:53:42",
+    "recorded-content": {
+      "put-object": {
+        "ChecksumCRC32": "nG7pIA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"11df95d595559285eb2b042124e74f09\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-mpu-checksum-sha256": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32C",
+        "ChecksumType": "FULL_OBJECT",
+        "Key": "test-multipart-checksum",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy": {
+        "CopyPartResult": {
+          "ChecksumCRC32C": "iqJrOQ==",
+          "ETag": "\"11df95d595559285eb2b042124e74f09\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "CRC32C",
+        "ChecksumType": "FULL_OBJECT",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-multipart-checksum",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 1,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ChecksumCRC32C": "iqJrOQ==",
+            "ETag": "\"11df95d595559285eb2b042124e74f09\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 14
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-checksum": {
+        "Bucket": "bucket",
+        "ChecksumCRC32C": "iqJrOQ==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"395d97c07920de036bfa21e7568a2e9f-1\"",
+        "Key": "test-multipart-checksum",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "Body": "this is a part",
+        "ChecksumCRC32C": "iqJrOQ==",
+        "ChecksumType": "FULL_OBJECT",
+        "ContentLength": 14,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"395d97c07920de036bfa21e7568a2e9f-1\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "ChecksumCRC32C": "iqJrOQ==",
+        "ChecksumType": "FULL_OBJECT",
+        "ContentLength": 14,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"395d97c07920de036bfa21e7568a2e9f-1\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs": {
+        "Checksum": {
+          "ChecksumCRC32C": "iqJrOQ==",
+          "ChecksumType": "FULL_OBJECT"
+        },
+        "ETag": "395d97c07920de036bfa21e7568a2e9f-1",
+        "LastModified": "datetime",
+        "ObjectParts": {
+          "TotalPartsCount": 1
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -5238,7 +5238,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_composite": {
-    "recorded-date": "17-03-2025, 18:21:29",
+    "recorded-date": "15-06-2025, 17:11:24",
     "recorded-content": {
       "create-mpu-wrong-checksum-algo": {
         "Error": {
@@ -14676,7 +14676,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[CRC32]": {
-    "recorded-date": "17-03-2025, 22:35:34",
+    "recorded-date": "15-06-2025, 17:09:04",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -14769,7 +14769,7 @@
           "Code": "InvalidPart",
           "ETag": "c4c753e69bb853187f5854c46cf801c6",
           "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
-          "PartNumber": "1",
+          "PartNumber": "2",
           "UploadId": "<upload-id:1>"
         },
         "ResponseMetadata": {
@@ -14838,6 +14838,30 @@
         },
         "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
         "LastModified": "datetime",
+        "ObjectParts": {
+          "IsTruncated": false,
+          "MaxParts": 1000,
+          "NextPartNumberMarker": 3,
+          "PartNumberMarker": 0,
+          "Parts": [
+            {
+              "ChecksumCRC32": "NRU+Sw==",
+              "PartNumber": 1,
+              "Size": 5242881
+            },
+            {
+              "ChecksumCRC32": "NRU+Sw==",
+              "PartNumber": 2,
+              "Size": 5242881
+            },
+            {
+              "ChecksumCRC32": "TBHN8A==",
+              "PartNumber": 3,
+              "Size": 10
+            }
+          ],
+          "TotalPartsCount": 3
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -14870,7 +14894,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[CRC32C]": {
-    "recorded-date": "17-03-2025, 22:35:48",
+    "recorded-date": "15-06-2025, 17:09:18",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -14963,7 +14987,7 @@
           "Code": "InvalidPart",
           "ETag": "c4c753e69bb853187f5854c46cf801c6",
           "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
-          "PartNumber": "2",
+          "PartNumber": "1",
           "UploadId": "<upload-id:1>"
         },
         "ResponseMetadata": {
@@ -15032,6 +15056,30 @@
         },
         "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
         "LastModified": "datetime",
+        "ObjectParts": {
+          "IsTruncated": false,
+          "MaxParts": 1000,
+          "NextPartNumberMarker": 3,
+          "PartNumberMarker": 0,
+          "Parts": [
+            {
+              "ChecksumCRC32C": "2/Ckiw==",
+              "PartNumber": 1,
+              "Size": 5242881
+            },
+            {
+              "ChecksumCRC32C": "2/Ckiw==",
+              "PartNumber": 2,
+              "Size": 5242881
+            },
+            {
+              "ChecksumCRC32C": "5yZkMA==",
+              "PartNumber": 3,
+              "Size": 10
+            }
+          ],
+          "TotalPartsCount": 3
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -15064,7 +15112,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[SHA1]": {
-    "recorded-date": "17-03-2025, 22:36:04",
+    "recorded-date": "15-06-2025, 17:09:33",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -15226,6 +15274,30 @@
         },
         "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
         "LastModified": "datetime",
+        "ObjectParts": {
+          "IsTruncated": false,
+          "MaxParts": 1000,
+          "NextPartNumberMarker": 3,
+          "PartNumberMarker": 0,
+          "Parts": [
+            {
+              "ChecksumSHA1": "bH71WIZUKQtUwR2wKSSkFjCRBPM=",
+              "PartNumber": 1,
+              "Size": 5242881
+            },
+            {
+              "ChecksumSHA1": "bH71WIZUKQtUwR2wKSSkFjCRBPM=",
+              "PartNumber": 2,
+              "Size": 5242881
+            },
+            {
+              "ChecksumSHA1": "NJX/adNGcdHhWzOmPBN5/e3Toyo=",
+              "PartNumber": 3,
+              "Size": 10
+            }
+          ],
+          "TotalPartsCount": 3
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -15258,7 +15330,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[SHA256]": {
-    "recorded-date": "17-03-2025, 22:36:19",
+    "recorded-date": "15-06-2025, 17:09:48",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -15420,6 +15492,30 @@
         },
         "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
         "LastModified": "datetime",
+        "ObjectParts": {
+          "IsTruncated": false,
+          "MaxParts": 1000,
+          "NextPartNumberMarker": 3,
+          "PartNumberMarker": 0,
+          "Parts": [
+            {
+              "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+              "PartNumber": 1,
+              "Size": 5242881
+            },
+            {
+              "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+              "PartNumber": 2,
+              "Size": 5242881
+            },
+            {
+              "ChecksumSHA256": "vyy1imj2hNlaO3jvj2Ycmk5bCegsyPnMiMzpBSjK6yc=",
+              "PartNumber": 3,
+              "Size": 10
+            }
+          ],
+          "TotalPartsCount": 3
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -15452,7 +15548,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC32]": {
-    "recorded-date": "17-03-2025, 18:20:12",
+    "recorded-date": "15-06-2025, 17:09:49",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -15469,7 +15565,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC32C]": {
-    "recorded-date": "17-03-2025, 18:20:13",
+    "recorded-date": "15-06-2025, 17:09:50",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -15486,7 +15582,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-SHA1]": {
-    "recorded-date": "17-03-2025, 18:20:15",
+    "recorded-date": "15-06-2025, 17:09:52",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -15503,7 +15599,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-SHA256]": {
-    "recorded-date": "17-03-2025, 18:20:16",
+    "recorded-date": "15-06-2025, 17:09:53",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -15520,7 +15616,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC64NVME]": {
-    "recorded-date": "17-03-2025, 18:20:17",
+    "recorded-date": "15-06-2025, 17:09:54",
     "recorded-content": {
       "create-mpu-checksum-exc": {
         "Error": {
@@ -15535,7 +15631,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-CRC32]": {
-    "recorded-date": "17-03-2025, 18:20:19",
+    "recorded-date": "15-06-2025, 17:09:56",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -15552,7 +15648,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-CRC32C]": {
-    "recorded-date": "17-03-2025, 18:20:20",
+    "recorded-date": "15-06-2025, 17:09:57",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -15569,7 +15665,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-SHA1]": {
-    "recorded-date": "17-03-2025, 18:20:21",
+    "recorded-date": "15-06-2025, 17:09:58",
     "recorded-content": {
       "create-mpu-checksum-exc": {
         "Error": {
@@ -15584,7 +15680,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-SHA256]": {
-    "recorded-date": "17-03-2025, 18:20:23",
+    "recorded-date": "15-06-2025, 17:10:00",
     "recorded-content": {
       "create-mpu-checksum-exc": {
         "Error": {
@@ -15599,7 +15695,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-CRC64NVME]": {
-    "recorded-date": "17-03-2025, 18:20:24",
+    "recorded-date": "15-06-2025, 17:10:01",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -15616,7 +15712,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[CRC32]": {
-    "recorded-date": "17-03-2025, 18:20:25",
+    "recorded-date": "15-06-2025, 17:10:03",
     "recorded-content": {
       "create-mpu-default-checksum-type": {
         "Bucket": "bucket",
@@ -15633,7 +15729,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[CRC32C]": {
-    "recorded-date": "17-03-2025, 18:20:27",
+    "recorded-date": "15-06-2025, 17:10:04",
     "recorded-content": {
       "create-mpu-default-checksum-type": {
         "Bucket": "bucket",
@@ -15650,7 +15746,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[SHA1]": {
-    "recorded-date": "17-03-2025, 18:20:28",
+    "recorded-date": "15-06-2025, 17:10:05",
     "recorded-content": {
       "create-mpu-default-checksum-type": {
         "Bucket": "bucket",
@@ -15667,7 +15763,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[SHA256]": {
-    "recorded-date": "17-03-2025, 18:20:30",
+    "recorded-date": "15-06-2025, 17:10:07",
     "recorded-content": {
       "create-mpu-default-checksum-type": {
         "Bucket": "bucket",
@@ -15684,7 +15780,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[CRC64NVME]": {
-    "recorded-date": "17-03-2025, 18:20:31",
+    "recorded-date": "15-06-2025, 17:10:08",
     "recorded-content": {
       "create-mpu-default-checksum-type": {
         "Bucket": "bucket",
@@ -15701,7 +15797,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC32]": {
-    "recorded-date": "17-03-2025, 22:59:16",
+    "recorded-date": "15-06-2025, 17:11:37",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -15853,6 +15949,9 @@
         },
         "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
         "LastModified": "datetime",
+        "ObjectParts": {
+          "TotalPartsCount": 3
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -15885,7 +15984,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC32C]": {
-    "recorded-date": "17-03-2025, 22:59:31",
+    "recorded-date": "15-06-2025, 17:11:53",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -15978,7 +16077,7 @@
           "Code": "InvalidPart",
           "ETag": "c4c753e69bb853187f5854c46cf801c6",
           "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
-          "PartNumber": "1",
+          "PartNumber": "2",
           "UploadId": "<upload-id:1>"
         },
         "ResponseMetadata": {
@@ -16037,6 +16136,9 @@
         },
         "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
         "LastModified": "datetime",
+        "ObjectParts": {
+          "TotalPartsCount": 3
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -16069,7 +16171,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC64NVME]": {
-    "recorded-date": "17-03-2025, 22:59:46",
+    "recorded-date": "15-06-2025, 17:12:07",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -16221,6 +16323,9 @@
         },
         "ETag": "4d45984fc3feb2ac9b22683c49674b56-3",
         "LastModified": "datetime",
+        "ObjectParts": {
+          "TotalPartsCount": 3
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -16253,7 +16358,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_full_object": {
-    "recorded-date": "17-03-2025, 19:08:00",
+    "recorded-date": "15-06-2025, 17:12:51",
     "recorded-content": {
       "create-mpu-no-checksum-algo-with-type": {
         "Error": {
@@ -16415,7 +16520,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_default": {
-    "recorded-date": "17-03-2025, 22:36:46",
+    "recorded-date": "15-06-2025, 17:12:56",
     "recorded-content": {
       "create-mpu-no-checksum": {
         "Bucket": "bucket",
@@ -16592,6 +16697,9 @@
         },
         "ETag": "e2c3da976e66ec9e7dc128fbc782fc91-1",
         "LastModified": "datetime",
+        "ObjectParts": {
+          "TotalPartsCount": 1
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -16624,7 +16732,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_size_validation": {
-    "recorded-date": "17-03-2025, 19:05:35",
+    "recorded-date": "15-06-2025, 17:13:01",
     "recorded-content": {
       "create-mpu": {
         "Bucket": "bucket",
@@ -16683,7 +16791,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[CRC32]": {
-    "recorded-date": "17-03-2025, 18:20:42",
+    "recorded-date": "15-06-2025, 17:10:17",
     "recorded-content": {
       "put-wrong-checksum-no-b64": {
         "Error": {
@@ -16708,7 +16816,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[CRC32C]": {
-    "recorded-date": "17-03-2025, 18:20:50",
+    "recorded-date": "15-06-2025, 17:10:27",
     "recorded-content": {
       "put-wrong-checksum-no-b64": {
         "Error": {
@@ -16733,7 +16841,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[SHA1]": {
-    "recorded-date": "17-03-2025, 18:21:00",
+    "recorded-date": "15-06-2025, 17:10:44",
     "recorded-content": {
       "put-wrong-checksum-no-b64": {
         "Error": {
@@ -16758,7 +16866,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[SHA256]": {
-    "recorded-date": "17-03-2025, 18:21:07",
+    "recorded-date": "15-06-2025, 17:10:59",
     "recorded-content": {
       "put-wrong-checksum-no-b64": {
         "Error": {
@@ -16783,7 +16891,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[CRC64NVME]": {
-    "recorded-date": "17-03-2025, 18:21:23",
+    "recorded-date": "15-06-2025, 17:11:10",
     "recorded-content": {
       "put-wrong-checksum-no-b64": {
         "Error": {
@@ -16901,7 +17009,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object_default": {
-    "recorded-date": "17-03-2025, 18:22:27",
+    "recorded-date": "15-06-2025, 17:12:58",
     "recorded-content": {
       "create-mpu-checksum-crc64": {
         "Bucket": "bucket",
@@ -16975,6 +17083,9 @@
         },
         "ETag": "e2c3da976e66ec9e7dc128fbc782fc91-1",
         "LastModified": "datetime",
+        "ObjectParts": {
+          "TotalPartsCount": 1
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -576,100 +576,292 @@
     "last_validated_date": "2023-08-14T20:35:53+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[CRC32C]": {
-    "last_validated_date": "2025-03-17T22:35:48+00:00"
+    "last_validated_date": "2025-06-15T17:09:19+00:00",
+    "durations_in_seconds": {
+      "setup": 0.64,
+      "call": 13.05,
+      "teardown": 1.03,
+      "total": 14.72
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[CRC32]": {
-    "last_validated_date": "2025-03-17T22:35:34+00:00"
+    "last_validated_date": "2025-06-15T17:09:05+00:00",
+    "durations_in_seconds": {
+      "setup": 0.94,
+      "call": 13.68,
+      "teardown": 1.01,
+      "total": 15.63
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[SHA1]": {
-    "last_validated_date": "2025-03-17T22:36:04+00:00"
+    "last_validated_date": "2025-06-15T17:09:34+00:00",
+    "durations_in_seconds": {
+      "setup": 0.5,
+      "call": 13.37,
+      "teardown": 0.96,
+      "total": 14.83
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_composite[SHA256]": {
-    "last_validated_date": "2025-03-17T22:36:19+00:00"
+    "last_validated_date": "2025-06-15T17:09:49+00:00",
+    "durations_in_seconds": {
+      "setup": 0.69,
+      "call": 12.73,
+      "teardown": 1.01,
+      "total": 14.43
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_default": {
-    "last_validated_date": "2025-03-17T22:36:46+00:00"
+    "last_validated_date": "2025-06-15T17:12:57+00:00",
+    "durations_in_seconds": {
+      "setup": 0.59,
+      "call": 2.92,
+      "teardown": 0.99,
+      "total": 4.5
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC32C]": {
-    "last_validated_date": "2025-03-17T22:59:31+00:00"
+    "last_validated_date": "2025-06-15T17:11:54+00:00",
+    "durations_in_seconds": {
+      "setup": 0.49,
+      "call": 14.13,
+      "teardown": 0.96,
+      "total": 15.58
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC32]": {
-    "last_validated_date": "2025-03-17T22:59:16+00:00"
+    "last_validated_date": "2025-06-15T17:11:38+00:00",
+    "durations_in_seconds": {
+      "setup": 0.5,
+      "call": 11.77,
+      "teardown": 1.01,
+      "total": 13.28
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object[CRC64NVME]": {
-    "last_validated_date": "2025-03-17T22:59:46+00:00"
+    "last_validated_date": "2025-06-15T17:12:08+00:00",
+    "durations_in_seconds": {
+      "setup": 0.49,
+      "call": 12.83,
+      "teardown": 0.99,
+      "total": 14.31
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_complete_multipart_parts_checksum_full_object_default": {
-    "last_validated_date": "2025-03-17T18:22:27+00:00"
+    "last_validated_date": "2025-06-15T17:12:59+00:00",
+    "durations_in_seconds": {
+      "setup": 0.5,
+      "call": 0.92,
+      "teardown": 1.0,
+      "total": 2.42
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC32C]": {
-    "last_validated_date": "2025-03-17T18:20:13+00:00"
+    "last_validated_date": "2025-06-15T17:09:51+00:00",
+    "durations_in_seconds": {
+      "setup": 0.5,
+      "call": 0.12,
+      "teardown": 0.61,
+      "total": 1.23
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC32]": {
-    "last_validated_date": "2025-03-17T18:20:12+00:00"
+    "last_validated_date": "2025-06-15T17:09:50+00:00",
+    "durations_in_seconds": {
+      "setup": 0.48,
+      "call": 0.12,
+      "teardown": 0.56,
+      "total": 1.16
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-CRC64NVME]": {
-    "last_validated_date": "2025-03-17T18:20:17+00:00"
+    "last_validated_date": "2025-06-15T17:09:55+00:00",
+    "durations_in_seconds": {
+      "setup": 0.56,
+      "call": 0.11,
+      "teardown": 0.77,
+      "total": 1.44
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-SHA1]": {
-    "last_validated_date": "2025-03-17T18:20:15+00:00"
+    "last_validated_date": "2025-06-15T17:09:52+00:00",
+    "durations_in_seconds": {
+      "setup": 0.57,
+      "call": 0.14,
+      "teardown": 0.58,
+      "total": 1.29
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[COMPOSITE-SHA256]": {
-    "last_validated_date": "2025-03-17T18:20:16+00:00"
+    "last_validated_date": "2025-06-15T17:09:54+00:00",
+    "durations_in_seconds": {
+      "setup": 0.48,
+      "call": 0.14,
+      "teardown": 0.57,
+      "total": 1.19
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-CRC32C]": {
-    "last_validated_date": "2025-03-17T18:20:20+00:00"
+    "last_validated_date": "2025-06-15T17:09:58+00:00",
+    "durations_in_seconds": {
+      "setup": 0.64,
+      "call": 0.13,
+      "teardown": 0.64,
+      "total": 1.41
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-CRC32]": {
-    "last_validated_date": "2025-03-17T18:20:19+00:00"
+    "last_validated_date": "2025-06-15T17:09:56+00:00",
+    "durations_in_seconds": {
+      "setup": 0.51,
+      "call": 0.13,
+      "teardown": 0.64,
+      "total": 1.28
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-CRC64NVME]": {
-    "last_validated_date": "2025-03-17T18:20:24+00:00"
+    "last_validated_date": "2025-06-15T17:10:02+00:00",
+    "durations_in_seconds": {
+      "setup": 0.51,
+      "call": 0.15,
+      "teardown": 0.64,
+      "total": 1.3
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-SHA1]": {
-    "last_validated_date": "2025-03-17T18:20:21+00:00"
+    "last_validated_date": "2025-06-15T17:09:59+00:00",
+    "durations_in_seconds": {
+      "setup": 0.51,
+      "call": 0.11,
+      "teardown": 0.91,
+      "total": 1.53
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_compatibility[FULL_OBJECT-SHA256]": {
-    "last_validated_date": "2025-03-17T18:20:23+00:00"
+    "last_validated_date": "2025-06-15T17:10:01+00:00",
+    "durations_in_seconds": {
+      "setup": 0.51,
+      "call": 0.12,
+      "teardown": 0.83,
+      "total": 1.46
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[CRC32C]": {
-    "last_validated_date": "2025-03-17T18:20:27+00:00"
+    "last_validated_date": "2025-06-15T17:10:05+00:00",
+    "durations_in_seconds": {
+      "setup": 0.57,
+      "call": 0.13,
+      "teardown": 0.63,
+      "total": 1.33
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[CRC32]": {
-    "last_validated_date": "2025-03-17T18:20:25+00:00"
+    "last_validated_date": "2025-06-15T17:10:03+00:00",
+    "durations_in_seconds": {
+      "setup": 0.49,
+      "call": 0.12,
+      "teardown": 0.6,
+      "total": 1.21
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[CRC64NVME]": {
-    "last_validated_date": "2025-03-17T18:20:31+00:00"
+    "last_validated_date": "2025-06-15T17:10:08+00:00",
+    "durations_in_seconds": {
+      "setup": 0.47,
+      "call": 0.11,
+      "teardown": 0.57,
+      "total": 1.15
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[SHA1]": {
-    "last_validated_date": "2025-03-17T18:20:28+00:00"
+    "last_validated_date": "2025-06-15T17:10:06+00:00",
+    "durations_in_seconds": {
+      "setup": 0.59,
+      "call": 0.14,
+      "teardown": 0.6,
+      "total": 1.33
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_checksum_type_default_for_checksum[SHA256]": {
-    "last_validated_date": "2025-03-17T18:20:29+00:00"
+    "last_validated_date": "2025-06-15T17:10:07+00:00",
+    "durations_in_seconds": {
+      "setup": 0.5,
+      "call": 0.11,
+      "teardown": 0.57,
+      "total": 1.18
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_composite": {
-    "last_validated_date": "2025-03-17T18:21:29+00:00"
+    "last_validated_date": "2025-06-15T17:11:25+00:00",
+    "durations_in_seconds": {
+      "setup": 0.52,
+      "call": 12.45,
+      "teardown": 0.89,
+      "total": 13.86
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_parts_checksum_exceptions_full_object": {
-    "last_validated_date": "2025-03-17T19:08:00+00:00"
+    "last_validated_date": "2025-06-15T17:12:52+00:00",
+    "durations_in_seconds": {
+      "setup": 0.49,
+      "call": 42.48,
+      "teardown": 1.16,
+      "total": 44.13
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_size_validation": {
-    "last_validated_date": "2025-03-17T19:05:35+00:00"
+    "last_validated_date": "2025-06-15T17:13:02+00:00",
+    "durations_in_seconds": {
+      "setup": 0.53,
+      "call": 1.14,
+      "teardown": 1.03,
+      "total": 2.7
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[CRC32C]": {
-    "last_validated_date": "2025-03-17T18:20:50+00:00"
+    "last_validated_date": "2025-06-15T17:10:28+00:00",
+    "durations_in_seconds": {
+      "setup": 0.47,
+      "call": 9.47,
+      "teardown": 0.9,
+      "total": 10.84
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[CRC32]": {
-    "last_validated_date": "2025-03-17T18:20:42+00:00"
+    "last_validated_date": "2025-06-15T17:10:18+00:00",
+    "durations_in_seconds": {
+      "setup": 0.46,
+      "call": 8.02,
+      "teardown": 0.84,
+      "total": 9.32
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[CRC64NVME]": {
-    "last_validated_date": "2025-03-17T18:21:23+00:00"
+    "last_validated_date": "2025-06-15T17:11:11+00:00",
+    "durations_in_seconds": {
+      "setup": 0.52,
+      "call": 9.39,
+      "teardown": 0.81,
+      "total": 10.72
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[SHA1]": {
-    "last_validated_date": "2025-03-17T18:21:00+00:00"
+    "last_validated_date": "2025-06-15T17:10:44+00:00",
+    "durations_in_seconds": {
+      "setup": 0.52,
+      "call": 14.71,
+      "teardown": 0.86,
+      "total": 16.09
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_checksum_exception[SHA256]": {
-    "last_validated_date": "2025-03-17T18:21:07+00:00"
+    "last_validated_date": "2025-06-15T17:11:00+00:00",
+    "durations_in_seconds": {
+      "setup": 0.62,
+      "call": 14.22,
+      "teardown": 0.81,
+      "total": 15.65
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_copy_checksum": {
     "last_validated_date": "2025-06-13T12:45:50+00:00",

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -863,13 +863,22 @@
       "total": 15.65
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_copy_checksum": {
-    "last_validated_date": "2025-06-13T12:45:50+00:00",
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_copy_checksum[COMPOSITE]": {
+    "last_validated_date": "2025-06-16T10:53:40+00:00",
     "durations_in_seconds": {
-      "setup": 0.92,
-      "call": 1.39,
-      "teardown": 1.01,
-      "total": 3.32
+      "setup": 0.97,
+      "call": 1.5,
+      "teardown": 1.06,
+      "total": 3.53
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3MultipartUploadChecksum::test_multipart_upload_part_copy_checksum[FULL_OBJECT]": {
+    "last_validated_date": "2025-06-16T10:53:43+00:00",
+    "durations_in_seconds": {
+      "setup": 0.52,
+      "call": 1.4,
+      "teardown": 0.94,
+      "total": 2.86
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockLegalHold::test_delete_locked_object": {

--- a/tests/aws/services/s3/test_s3_list_operations.snapshot.json
+++ b/tests/aws/services/s3/test_s3_list_operations.snapshot.json
@@ -3223,5 +3223,150 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListParts::test_list_parts_via_object_attrs_pagination": {
+    "recorded-date": "16-06-2025, 13:47:27",
+    "recorded-content": {
+      "list-parts": {
+        "Bucket": "bucket",
+        "ChecksumAlgorithm": "SHA256",
+        "ChecksumType": "COMPOSITE",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-object-attrs-pagination",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 2,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 5242881
+          },
+          {
+            "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+            "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+            "LastModified": "datetime",
+            "PartNumber": 2,
+            "Size": 5242881
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-mpu": {
+        "Bucket": "bucket",
+        "ChecksumSHA256": "2Wjxbc3N6c1y3Eqve6x8X+xPy4qXhB1vAMgge0qeZJM=-2",
+        "ChecksumType": "COMPOSITE",
+        "ETag": "\"14cb3f95b2dfe6bd47fb59d47949e00e-2\"",
+        "Key": "test-object-attrs-pagination",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs-all": {
+        "LastModified": "datetime",
+        "ObjectParts": {
+          "IsTruncated": false,
+          "MaxParts": 1000,
+          "NextPartNumberMarker": 2,
+          "PartNumberMarker": 0,
+          "Parts": [
+            {
+              "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+              "PartNumber": 1,
+              "Size": 5242881
+            },
+            {
+              "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+              "PartNumber": 2,
+              "Size": 5242881
+            }
+          ],
+          "TotalPartsCount": 2
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs-1": {
+        "LastModified": "datetime",
+        "ObjectParts": {
+          "IsTruncated": false,
+          "MaxParts": 1000,
+          "NextPartNumberMarker": 2,
+          "PartNumberMarker": 0,
+          "Parts": [
+            {
+              "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+              "PartNumber": 1,
+              "Size": 5242881
+            },
+            {
+              "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+              "PartNumber": 2,
+              "Size": 5242881
+            }
+          ],
+          "TotalPartsCount": 2
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs-next": {
+        "LastModified": "datetime",
+        "ObjectParts": {
+          "IsTruncated": false,
+          "MaxParts": 1,
+          "NextPartNumberMarker": 2,
+          "PartNumberMarker": 1,
+          "Parts": [
+            {
+              "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
+              "PartNumber": 2,
+              "Size": 5242881
+            }
+          ],
+          "TotalPartsCount": 2
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-attrs-wrong-part": {
+        "LastModified": "datetime",
+        "ObjectParts": {
+          "IsTruncated": false,
+          "MaxParts": 1,
+          "NextPartNumberMarker": 0,
+          "PartNumberMarker": 10,
+          "TotalPartsCount": 2
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_list_operations.validation.json
+++ b/tests/aws/services/s3/test_s3_list_operations.validation.json
@@ -86,6 +86,15 @@
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListParts::test_list_parts_pagination": {
     "last_validated_date": "2025-01-21T18:15:18+00:00"
   },
+  "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListParts::test_list_parts_via_object_attrs_pagination": {
+    "last_validated_date": "2025-06-16T13:47:28+00:00",
+    "durations_in_seconds": {
+      "setup": 0.97,
+      "call": 10.45,
+      "teardown": 0.97,
+      "total": 12.39
+    }
+  },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListParts::test_s3_list_parts_timestamp_precision": {
     "last_validated_date": "2025-01-21T18:15:22+00:00"
   }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #12757, we dit not return the full `ObjectParts` response in S3. 

The behavior is different if the checksum specified when creating the Multipart Upload with `CreateMultipartUpload` is of type `COMPOSITE` or `FULL_OBJECT`. When it is `COMPOSITE`, any call to `GetObjectAttributes` with the `ObjectParts` attribute specified should act like a `ListParts` call. 

There was a TODO left about it, and this PR implements it. 

It needed a change in API as we were not saving the metadata related to the Parts used to create the end object (we only store the data necessary to support `PartNumber` in `GetObject`, via the `get_part_range` function). This minor change in API is properly covered defensively to avoid issues when using this functionality (`GetObject` with the `PartNumber` parameter, or the  `GetObjectAttributes` call) with a restored state from a previous version. 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- improve existing tests related to Checksum and Multipart Uploads to also verify the output of `GetObjectAttributes` with `ObjectParts` specified
- implement the listing behavior based on the new state that is stored when completing a multipart upload

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
