### PR TITLE
Visualization docs for the localstack's codebase

### DIFF
--- a/.codeboarding/AWS_Service_Emulation_Specs.md
+++ b/.codeboarding/AWS_Service_Emulation_Specs.md
@@ -1,0 +1,191 @@
+```mermaid
+
+graph LR
+
+    Service_Providers["Service Providers"]
+
+    AWS_API_Specifications["AWS API Specifications"]
+
+    Request_Validation_Handler["Request Validation Handler"]
+
+    Protocol_Parsers["Protocol Parsers"]
+
+    Protocol_Serializers["Protocol Serializers"]
+
+    API_Routing_Operation_Router_["API Routing (Operation Router)"]
+
+    API_Routing_Service_Router_["API Routing (Service Router)"]
+
+    API_Routing_Service_Router_ -- "dispatches requests to" --> API_Routing_Operation_Router_
+
+    API_Routing_Operation_Router_ -- "routes requests to" --> Service_Providers
+
+    Protocol_Parsers -- "provides parsed requests to" --> API_Routing_Operation_Router_
+
+    Service_Providers -- "generates responses for" --> Protocol_Serializers
+
+    AWS_API_Specifications -- "provides schema for" --> Request_Validation_Handler
+
+    AWS_API_Specifications -- "informs parsing logic of" --> Protocol_Parsers
+
+    AWS_API_Specifications -- "guides serialization of" --> Protocol_Serializers
+
+    Service_Providers -- "consults" --> AWS_API_Specifications
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `AWS Service Emulation & Specs` component is a cornerstone of LocalStack, providing the foundational logic for emulating various AWS APIs and ensuring strict adherence to official AWS API specifications. This comprehensive layer of emulated AWS services offers the core business logic for specific AWS APIs (e.g., S3, Lambda, API Gateway, CloudFormation). It also incorporates and utilizes official AWS API specifications for request validation, contract adherence, and mock response generation.
+
+
+
+### Service Providers
+
+These are the central classes responsible for implementing the emulation logic for individual AWS services. Each `provider.py` file within a service's directory (e.g., `localstack.services.s3.provider`, `localstack.services.lambda_.provider`) acts as the entry point for handling API requests for that specific service. They contain the business logic, state management, and interactions with other internal LocalStack components to simulate AWS API behavior.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/apigateway/next_gen/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.apigateway.next_gen.provider` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/lambda_/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.lambda_.provider` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/s3/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.s3.provider` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/cloudformation/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.cloudformation.provider` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/sns/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.sns.provider` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/sqs/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.sqs.provider` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/stepfunctions/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.stepfunctions.provider` (1:1)</a>
+
+
+
+
+
+### AWS API Specifications
+
+This module is responsible for loading, parsing, and providing access to the official AWS API specifications (e.g., OpenAPI/Swagger definitions). These specifications are crucial for ensuring that LocalStack's emulated services adhere to the correct request/response contracts, data types, and validation rules defined by AWS. It acts as a central source of truth for AWS API definitions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/aws/spec.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.aws.spec` (1:1)</a>
+
+
+
+
+
+### Request Validation Handler
+
+This handler intercepts incoming AWS API requests and validates them against the loaded AWS API specifications. It ensures that the request payload, headers, and parameters conform to the expected format and constraints defined by AWS. This is a critical component for maintaining API contract adherence.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/aws/handlers/validation.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.aws.handlers.validation` (1:1)</a>
+
+
+
+
+
+### Protocol Parsers
+
+These modules are responsible for parsing incoming AWS API requests from their raw HTTP format into structured data (Python dictionaries) that the service providers can understand. They interpret various AWS protocols (e.g., JSON, Query, REST-XML) and leverage AWS API specifications for correct data type handling.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/aws/protocol/parser.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.aws.protocol.parser` (1:1)</a>
+
+
+
+
+
+### Protocol Serializers
+
+These modules are responsible for serializing outgoing responses from structured data (Python dictionaries) generated by service providers back into the appropriate AWS protocol format (e.g., JSON, Query, REST-XML) for HTTP responses. They ensure responses adhere to AWS API specifications.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/aws/protocol/serializer.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.aws.protocol.serializer` (1:1)</a>
+
+
+
+
+
+### API Routing (Operation Router)
+
+This component is responsible for routing incoming AWS API requests to the correct specific API operation within a service. It uses information from the request (e.g., path, method, headers, query parameters) and the service specifications to dispatch the request to the appropriate handler function.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/aws/protocol/op_router.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.aws.protocol.op_router` (1:1)</a>
+
+
+
+
+
+### API Routing (Service Router)
+
+This component is responsible for identifying which AWS service an incoming HTTP request is targeting. It uses various indicators like host, path, and authentication headers to determine the correct service model, acting as the first layer of routing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/aws/protocol/service_router.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.aws.protocol.service_router` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,197 @@
+```mermaid
+
+graph LR
+
+    LocalStack_Core_Orchestration["LocalStack Core Orchestration"]
+
+    AWS_Request_Processing["AWS Request Processing"]
+
+    AWS_Service_Emulation_Specs["AWS Service Emulation & Specs"]
+
+    Core_Infrastructure_Services["Core Infrastructure Services"]
+
+    Observability_State_Management["Observability & State Management"]
+
+    LocalStack_Core_Orchestration -- "Manages" --> AWS_Request_Processing
+
+    LocalStack_Core_Orchestration -- "Manages" --> AWS_Service_Emulation_Specs
+
+    LocalStack_Core_Orchestration -- "Manages" --> Core_Infrastructure_Services
+
+    LocalStack_Core_Orchestration -- "Configures" --> Observability_State_Management
+
+    AWS_Request_Processing -- "Routes requests to" --> AWS_Service_Emulation_Specs
+
+    AWS_Request_Processing -- "Generates data for" --> Observability_State_Management
+
+    AWS_Service_Emulation_Specs -- "Processes requests from" --> AWS_Request_Processing
+
+    AWS_Service_Emulation_Specs -- "Persists state via" --> Observability_State_Management
+
+    AWS_Service_Emulation_Specs -- "Relies on" --> Core_Infrastructure_Services
+
+    Core_Infrastructure_Services -- "Supports" --> AWS_Service_Emulation_Specs
+
+    Core_Infrastructure_Services -- "Generates data for" --> Observability_State_Management
+
+    Observability_State_Management -- "Stores state for" --> AWS_Service_Emulation_Specs
+
+    Observability_State_Management -- "Receives operational data from" --> AWS_Request_Processing
+
+    Observability_State_Management -- "Receives operational data from" --> Core_Infrastructure_Services
+
+    Observability_State_Management -- "Configured by" --> LocalStack_Core_Orchestration
+
+    click AWS_Service_Emulation_Specs href "https://github.com/localstack/localstack/blob/main/.codeboarding//AWS_Service_Emulation_Specs.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Final Architecture Analysis for `localstack`
+
+
+
+### LocalStack Core Orchestration
+
+The central control plane for LocalStack, responsible for application lifecycle management, initialization of core services, and overall orchestration. It includes the command-line interface for user interaction and the runtime engine that manages the entire LocalStack environment.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/cli/localstack.py#L168-L182" target="_blank" rel="noopener noreferrer">`localstack.cli.localstack` (168:182)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/runtime/main.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.runtime.main` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/runtime/runtime.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.runtime.runtime` (1:1)</a>
+
+
+
+
+
+### AWS Request Processing
+
+Handles all incoming AWS API requests, including receiving HTTP requests, parsing them according to AWS protocols (JSON, XML, Query), routing them to the appropriate emulated service, and serializing responses back to clients.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/aws/app.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.aws.app` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/aws/gateway.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.aws.gateway` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/aws/protocol/parser.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.aws.protocol.parser` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/aws/protocol/serializer.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.aws.protocol.serializer` (1:1)</a>
+
+
+
+
+
+### AWS Service Emulation & Specs
+
+A comprehensive layer of emulated AWS services, providing the core business logic for specific AWS APIs (e.g., S3, Lambda, API Gateway, CloudFormation). This component also incorporates and utilizes official AWS API specifications for request validation, contract adherence, and mock response generation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `localstack.services.apigateway.provider` (1:1)
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/lambda_/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.lambda_.provider` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/s3/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.s3.provider` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/cloudformation/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.cloudformation.provider` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/sns/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.sns.provider` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/sqs/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.sqs.provider` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/stepfunctions/provider.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.services.stepfunctions.provider` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/aws/spec.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.aws.spec` (1:1)</a>
+
+
+
+
+
+### Core Infrastructure Services
+
+Provides foundational utilities and integrations necessary for LocalStack's operation. This includes managing internal and external service connections (e.g., DNS resolution, client factories), interacting with container runtimes like Docker, and handling the download and lifecycle of external software dependencies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/aws/connect.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.aws.connect` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/dns/server.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.dns.server` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/utils/docker_utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.utils.docker_utils` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/utils/container_utils/container_client.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.utils.container_utils.container_client` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/packages/api.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.packages.api` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/packages/core.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.packages.core` (1:1)</a>
+
+
+
+
+
+### Observability & State Management
+
+Manages the persistence and retrieval of LocalStack's internal state for all emulated services, enabling features like state snapshots and consistent behavior. It also provides a centralized logging infrastructure and collects usage/performance metrics for monitoring and debugging across the entire system.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/state/core.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.state.core` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/state/pickle.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.state.pickle` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/logging/setup.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.logging.setup` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/logging/format.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.logging.format` (1:1)</a>
+
+- <a href="https://github.com/localstack/localstack/blob/master/localstack-core/localstack/runtime/analytics.py#L1-L1" target="_blank" rel="noopener noreferrer">`localstack.runtime.analytics` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->
semver: patch

Hi! This PR adds high-level diagrams of the localstack codebase to help new contributors quickly get oriented.
You can see how it all renders here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/localstack/on_boarding.md

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The idea is to make onboarding easier—especially for open-source contributors who typically want to work on a specific module. Visualizing the codebase helps people understand how things fit together without needing to read everything up front.

I’d love to hear how you currently onboard new contributors—do you think something like this could help?
Feedback is very welcome.

(Discussions aren't enabled on this repo, so I’m opening a PR instead.)

We’ve also released a free GitHub Action that keeps the diagrams automatically updated as the code changes, so there's no ongoing maintenance burden.

Full transparency: we’re exploring this idea as a potential startup, but we’re still early and figuring out what’s actually useful to developers.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
All the added files are rendered in markdown as you can see here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/localstack/on_boarding.md
