### PR TITLE
APIGW: add negative tests for IntegrationResponse and improve error handling in PutIntegrationResponse and GetIntegrationResponse

### DIFF
--- a/localstack-core/localstack/aws/api/apigateway/__init__.py
+++ b/localstack-core/localstack/aws/api/apigateway/__init__.py
@@ -202,6 +202,12 @@ class LimitExceededException(ServiceException):
     retryAfterSeconds: Optional[String]
 
 
+class ValidationException(ServiceException):
+    code: str = "ValidationException"
+    sender_fault: bool = False
+    status_code: int = 400
+
+
 class NotFoundException(ServiceException):
     code: str = "NotFoundException"
     sender_fault: bool = False

--- a/localstack-core/localstack/aws/api/apigateway/__init__.py
+++ b/localstack-core/localstack/aws/api/apigateway/__init__.py
@@ -202,12 +202,6 @@ class LimitExceededException(ServiceException):
     retryAfterSeconds: Optional[String]
 
 
-class ValidationException(ServiceException):
-    code: str = "ValidationException"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
 class NotFoundException(ServiceException):
     code: str = "NotFoundException"
     sender_fault: bool = False

--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -2064,31 +2064,33 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             raise ValidationException(
                 "1 validation error detected: Value 'wrong' at 'statusCode' failed to satisfy constraint: Member must satisfy regular expression pattern: [1-5]\\d\\d"
             )
-
         try:
             moto_rest_api = get_moto_rest_api(context, rest_api_id)
         except NotFoundException:
             raise NotFoundException("Invalid Resource identifier specified")
+
         if not (moto_resource := moto_rest_api.resources.get(resource_id)):
             raise NotFoundException("Invalid Resource identifier specified")
 
         if not (moto_method := moto_resource.resource_methods.get(http_method)):
             raise NotFoundException("Invalid Method identifier specified")
+
         integration_response = None
-        try:
-            integration_response = moto_method.method_integration.integration_responses.get(status_code)
+        if integration_responses := moto_method.method_integration.integration_responses:
+            integration_response = integration_responses.get(status_code)
             if not integration_response:
                 raise NotFoundException("Invalid Integration Response identifier specified")
-        except NotFoundException:
-            pass
 
         response: IntegrationResponse = call_moto(context)
         remove_empty_attributes_from_integration_response(response)
         # moto does not return selectionPattern is set to an empty string
         # TODO: fix upstream
-        if "selectionPattern" not in response:
-            if integration_response is not None and integration_response.selection_pattern is not None:
-                response["selectionPattern"] = integration_response.selection_pattern
+        if (
+            "selectionPattern" not in response
+            and integration_response
+            and integration_response.selection_pattern is not None
+        ):
+            response["selectionPattern"] = integration_response.selection_pattern
         return response
 
     @handler("PutIntegrationResponse", expand=False)
@@ -2102,7 +2104,6 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             raise ValidationException(
                 "1 validation error detected: Value 'wrong' at 'statusCode' failed to satisfy constraint: Member must satisfy regular expression pattern: [1-5]\\d\\d"
             )
-
         try:
             # put integration response doesn't return the right exception compared to AWS
             moto_rest_api = get_moto_rest_api(context=context, rest_api_id=request.get("restApiId"))

--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -2784,7 +2784,7 @@ class TestApigatewayIntegration:
         snapshot.match("put-integration-response-invalid-responseTemplates-2", e.value.response)
 
     @markers.aws.validated
-    def test_get_integration_response_invalid_integration(
+    def test_integration_response_invalid_integration(
         self, aws_client, apigw_create_rest_api, snapshot
     ):
         snapshot.add_transformer(snapshot.transform.key_value("cacheNamespace"))

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -3714,5 +3714,137 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_wrong_api": {
+    "recorded-date": "18-06-2025, 12:28:55",
+    "recorded-content": {
+      "put-integration-response-wrong-api": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "get-integration-response-wrong-api": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_wrong_resource": {
+    "recorded-date": "18-06-2025, 12:28:25",
+    "recorded-content": {
+      "put-integration-response-wrong-resource": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "get-integration-response-wrong-resource": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_wrong_method": {
+    "recorded-date": "18-06-2025, 11:47:00",
+    "recorded-content": {
+      "put-integration-response-wrong-method": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Method identifier specified"
+        },
+        "message": "Invalid Method identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "get-integration-response-wrong-method": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Method identifier specified"
+        },
+        "message": "Invalid Method identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_invalid_statuscode": {
+    "recorded-date": "18-06-2025, 11:51:51",
+    "recorded-content": {
+      "put-integration-response-invalid-statusCode": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'wrong' at 'statusCode' failed to satisfy constraint: Member must satisfy regular expression pattern: [1-5]\\d\\d"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-integration-response-invalid-statusCode": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'wrong' at 'statusCode' failed to satisfy constraint: Member must satisfy regular expression pattern: [1-5]\\d\\d"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_invalid_responsetemplates": {
+    "recorded-date": "18-06-2025, 13:03:29",
+    "recorded-content": {
+      "put-integration-response-invalid-responseTemplates-1": {
+        "Error": {
+          "Code": "SerializationException",
+          "Message": "class com.amazon.coral.value.json.numbers.TruncatingBigNumber can not be converted to an String"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-integration-response-invalid-responseTemplates-2": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Validation Result: warnings : [], errors : [Invalid content type specified: 123]"
+        },
+        "message": "Validation Result: warnings : [], errors : [Invalid content type specified: 123]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -3847,7 +3847,7 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_get_integration_response_invalid_integration": {
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_invalid_integration": {
     "recorded-date": "26-06-2025, 11:21:05",
     "recorded-content": {
       "get-integration-response-without-integration": {

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -3846,5 +3846,37 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_get_integration_response_invalid_integration": {
+    "recorded-date": "26-06-2025, 11:21:05",
+    "recorded-content": {
+      "get-integration-response-without-integration": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Integration identifier specified"
+        },
+        "message": "Invalid Integration identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_wrong_status_code": {
+    "recorded-date": "26-06-2025, 11:21:43",
+    "recorded-content": {
+      "get-integration-response-wrong-status-code": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Response status code specified"
+        },
+        "message": "Invalid Response status code specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -131,6 +131,51 @@
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_update_gateway_response": {
     "last_validated_date": "2024-04-15T20:47:11+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_invalid_responsetemplates": {
+    "last_validated_date": "2025-06-18T13:03:29+00:00",
+    "durations_in_seconds": {
+      "setup": 1.43,
+      "call": 2.04,
+      "teardown": 0.33,
+      "total": 3.8
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_invalid_statuscode": {
+    "last_validated_date": "2025-06-18T11:51:51+00:00",
+    "durations_in_seconds": {
+      "setup": 1.61,
+      "call": 1.31,
+      "teardown": 0.41,
+      "total": 3.33
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_wrong_api": {
+    "last_validated_date": "2025-06-18T12:28:55+00:00",
+    "durations_in_seconds": {
+      "setup": 1.08,
+      "call": 0.32,
+      "teardown": 0.0,
+      "total": 1.4
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_wrong_method": {
+    "last_validated_date": "2025-06-18T11:47:00+00:00",
+    "durations_in_seconds": {
+      "setup": 1.42,
+      "call": 1.17,
+      "teardown": 0.37,
+      "total": 2.96
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_wrong_resource": {
+    "last_validated_date": "2025-06-18T12:28:25+00:00",
+    "durations_in_seconds": {
+      "setup": 1.35,
+      "call": 1.22,
+      "teardown": 0.41,
+      "total": 2.98
+    }
+  },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_lifecycle_integration_response": {
     "last_validated_date": "2025-06-11T09:12:54+00:00",
     "durations_in_seconds": {

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -131,7 +131,7 @@
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_update_gateway_response": {
     "last_validated_date": "2024-04-15T20:47:11+00:00"
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_get_integration_response_invalid_integration": {
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_invalid_integration": {
     "last_validated_date": "2025-06-26T11:21:05+00:00",
     "durations_in_seconds": {
       "setup": 1.63,

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -131,6 +131,15 @@
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_update_gateway_response": {
     "last_validated_date": "2024-04-15T20:47:11+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_get_integration_response_invalid_integration": {
+    "last_validated_date": "2025-06-26T11:21:05+00:00",
+    "durations_in_seconds": {
+      "setup": 1.63,
+      "call": 1.17,
+      "teardown": 0.4,
+      "total": 3.2
+    }
+  },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_invalid_responsetemplates": {
     "last_validated_date": "2025-06-18T13:03:29+00:00",
     "durations_in_seconds": {
@@ -174,6 +183,15 @@
       "call": 1.22,
       "teardown": 0.41,
       "total": 2.98
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_wrong_status_code": {
+    "last_validated_date": "2025-06-26T11:21:43+00:00",
+    "durations_in_seconds": {
+      "setup": 1.58,
+      "call": 1.41,
+      "teardown": 0.41,
+      "total": 3.4
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_lifecycle_integration_response": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Add negative test coverage for the `IntegrationResponse` operation in API Gateway v1, to ensure LocalStack properly mimics AWS behavior when invalid inputs are provided. This improves parity and robustness of the emulated service.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added **negative test coverage** for `PutIntegrationResponse` and `GetIntegrationResponse` operations:
  - `test_integration_response_wrong_api`
  - `test_integration_response_wrong_resource`
  - `test_integration_response_wrong_method`
  - `test_integration_response_wrong_invalid_statuscode`
  - `test_integration_response_invalid_responsetemplates` (skipped for now due to LocalStack/AWS parity gap)
  - `test_integration_response_invalid_integration`
  - `test_integration_response_wrong_status_code`

- Updated `put_integration_response` and `get_integration_response` in `provider.py` to:
  - Validate `statusCode` using regex (`[1-5]\d\d`), raise `ValidationException` for invalid values
  - Raise appropriate `NotFoundException` messages for missing resources, methods, or integration responses

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
## TODO

What's left to do:

- [ ] Implement validation logic for `responseTemplates` in `put_integration_response` to ensure LocalStack raises appropriate exceptions (e.g., `SerializationException`, `BadRequestException`) when invalid values are provided
- [ ] Enable the currently skipped test `test_integration_response_invalid_responsetemplates` once LocalStack behavior matches AWS

<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
