### PR TITLE
APIGW: fix VTL $input.path and $input.json

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/template_mapping.py
@@ -74,7 +74,8 @@ def extract_jsonpath(value: dict | list, path: str):
     jsonpath_expr = parse(path)
     result = [match.value for match in jsonpath_expr.find(value)]
     if not result:
-        return ""
+        # return ""
+        return None
     result = result[0] if len(result) == 1 else result
     return result
 
@@ -221,7 +222,7 @@ class VelocityInput:
 
     def _extract_json_path(self, path):
         if not self.value:
-            return ""
+            return None
         value = self.value if isinstance(self.value, dict) else json.loads(self.value)
         return extract_jsonpath(value, path)
 
@@ -231,7 +232,9 @@ class VelocityInput:
     def json(self, path):
         path = path or "$"
         matching = self._extract_json_path(path)
-        if isinstance(matching, (list, dict)):
+        if matching is None:
+            matching = ""
+        elif isinstance(matching, (list, dict)):
             matching = json_safe(matching)
         return json.dumps(matching)
 

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -837,6 +837,14 @@ class TestApiGatewayCommon:
         _create_route("nested", '#set($result = $input.path("$.json"))$result.nested')
         _create_route("list", '#set($result = $input.path("$.json"))$result[0]')
         _create_route("to-string", '#set($result = $input.path("$.json"))$result.toString()')
+        _create_route(
+            "invalid-path",
+            '#set($result = $input.path("$.nonExisting")){"body": $result, "nested": $result.nested}',
+        )
+        _create_route(
+            "nested-list",
+            '#set($result = $input.path("$.json.listValue")){"body": $result, "nested": $result.nested}',
+        )
 
         stage_name = "dev"
         aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
@@ -846,6 +854,8 @@ class TestApiGatewayCommon:
         nested_url = url + "nested"
         list_url = url + "list"
         to_string = url + "to-string"
+        invalid_path = url + "invalid-path"
+        nested_list = url + "nested-list"
 
         response = requests.post(path_url, json={"foo": "bar"})
         snapshot.match("dict-response", response.text)
@@ -878,6 +888,15 @@ class TestApiGatewayCommon:
 
         response = requests.post(to_string, json={"list": [{"foo": "bar"}]})
         snapshot.match("list-to-string", response.text)
+
+        response = requests.post(invalid_path)
+        snapshot.match("empty-body", response.text)
+
+        response = requests.post(nested_list, json={"listValue": []})
+        snapshot.match("nested-empty-list", response.text)
+
+        response = requests.post(nested_list, json={"listValue": None})
+        snapshot.match("nested-null-list", response.text)
 
     @markers.aws.validated
     def test_input_body_formatting(

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -839,11 +839,11 @@ class TestApiGatewayCommon:
         _create_route("to-string", '#set($result = $input.path("$.json"))$result.toString()')
         _create_route(
             "invalid-path",
-            '#set($result = $input.path("$.nonExisting")){"body": $result, "nested": $result.nested}',
+            '#set($result = $input.path("$.nonExisting")){"body": $result, "nested": $result.nested, "isNull": #if( $result == $null )"true"#else"false"#end, "isEmptyString": #if( $result == "" )"true"#else"false"#end}',
         )
         _create_route(
             "nested-list",
-            '#set($result = $input.path("$.json.listValue")){"body": $result, "nested": $result.nested}',
+            '#set($result = $input.path("$.json.listValue")){"body": $result, "nested": $result.nested, "isNull": #if( $result == $null )"true"#else"false"#end, "isEmptyString": #if( $result == "" )"true"#else"false"#end}',
         )
 
         stage_name = "dev"

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -1378,7 +1378,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_path_template_formatting": {
-    "recorded-date": "18-06-2025, 16:41:18",
+    "recorded-date": "18-06-2025, 17:28:59",
     "recorded-content": {
       "dict-response": "{foo=bar}",
       "json-list": "[{\"foo\":\"bar\"}]",
@@ -1390,9 +1390,9 @@
       "bigger-dict": "{bigger=dict, to=test, with=separators}",
       "to-string": "{foo=bar}",
       "list-to-string": "{list=[{\"foo\":\"bar\"}]}",
-      "empty-body": "{\"body\": , \"nested\": }",
-      "nested-empty-list": "{\"body\": [], \"nested\": }",
-      "nested-null-list": "{\"body\": , \"nested\": }"
+      "empty-body": "{\"body\": , \"nested\": , \"isNull\": \"true\", \"isEmptyString\": \"true\"}",
+      "nested-empty-list": "{\"body\": [], \"nested\": , \"isNull\": \"false\", \"isEmptyString\": \"false\"}",
+      "nested-null-list": "{\"body\": , \"nested\": , \"isNull\": \"true\", \"isEmptyString\": \"true\"}"
     }
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_body_formatting": {

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -1378,7 +1378,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_path_template_formatting": {
-    "recorded-date": "12-03-2025, 21:18:25",
+    "recorded-date": "18-06-2025, 16:41:18",
     "recorded-content": {
       "dict-response": "{foo=bar}",
       "json-list": "[{\"foo\":\"bar\"}]",
@@ -1389,7 +1389,10 @@
       "dict-with-nested-list": "{foo=[{\"nested\":\"bar\"}]}",
       "bigger-dict": "{bigger=dict, to=test, with=separators}",
       "to-string": "{foo=bar}",
-      "list-to-string": "{list=[{\"foo\":\"bar\"}]}"
+      "list-to-string": "{list=[{\"foo\":\"bar\"}]}",
+      "empty-body": "{\"body\": , \"nested\": }",
+      "nested-empty-list": "{\"body\": [], \"nested\": }",
+      "nested-null-list": "{\"body\": , \"nested\": }"
     }
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_body_formatting": {

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -12,12 +12,12 @@
     "last_validated_date": "2025-03-19T17:03:40+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_path_template_formatting": {
-    "last_validated_date": "2025-06-18T16:41:18+00:00",
+    "last_validated_date": "2025-06-18T17:29:00+00:00",
     "durations_in_seconds": {
-      "setup": 0.46,
-      "call": 63.58,
-      "teardown": 0.56,
-      "total": 64.6
+      "setup": 0.48,
+      "call": 42.72,
+      "teardown": 0.86,
+      "total": 44.06
     }
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_integration_request_parameters_mapping": {

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -12,7 +12,13 @@
     "last_validated_date": "2025-03-19T17:03:40+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_input_path_template_formatting": {
-    "last_validated_date": "2025-03-12T21:18:25+00:00"
+    "last_validated_date": "2025-06-18T16:41:18+00:00",
+    "durations_in_seconds": {
+      "setup": 0.46,
+      "call": 63.58,
+      "teardown": 0.56,
+      "total": 64.6
+    }
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_integration_request_parameters_mapping": {
     "last_validated_date": "2024-02-05T19:37:03+00:00"

--- a/tests/unit/services/apigateway/test_template_mapping.py
+++ b/tests/unit/services/apigateway/test_template_mapping.py
@@ -94,12 +94,32 @@ class TestApiGatewayVtlTemplate:
     def test_apply_template_no_json_payload(self):
         variables = MappingTemplateVariables(input=MappingTemplateInput(body='"#foobar123"'))
 
+        template = "$input.json('$.message')"
+        rendered_request = ApiGatewayVtlTemplate().render_vtl(
+            template=template, variables=variables
+        )
+
+        assert rendered_request == '""'
+
+    def test_apply_template_no_json_payload_nested(self):
+        variables = MappingTemplateVariables(input=MappingTemplateInput(body='"#foobar123"'))
+
+        template = "$input.json('$.message').testAccess"
+        rendered_request = ApiGatewayVtlTemplate().render_vtl(
+            template=template, variables=variables
+        )
+
+        assert rendered_request == ""
+
+    def test_apply_template_no_json_payload_escaped(self):
+        variables = MappingTemplateVariables(input=MappingTemplateInput(body='"#foobar123"'))
+
         template = "$util.escapeJavaScript($input.json('$.message'))"
         rendered_request = ApiGatewayVtlTemplate().render_vtl(
             template=template, variables=variables
         )
 
-        assert "[]" == rendered_request
+        assert rendered_request == '\\"\\"'
 
     @pytest.mark.parametrize("format", [APPLICATION_JSON, APPLICATION_XML])
     def test_render_custom_template(self, format):
@@ -264,6 +284,16 @@ class TestApiGatewayVtlTemplate:
         )
 
         assert rendered_request == "%7B%7D"
+
+    def test_input_path_empty_body(self):
+        variables = MappingTemplateVariables(input=MappingTemplateInput(body=""))
+
+        template = '$input.path("$.myVar")'
+        rendered_request = ApiGatewayVtlTemplate().render_vtl(
+            template=template, variables=variables
+        )
+
+        assert rendered_request == ""
 
 
 TEMPLATE_JSON = """


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
I've noticed while working on other kind of VTL template that we were not handling `$input.path` and `$input.json` return values correctly when the body would be empty, or the JSONPath would not point to the correct value.

There were several reasons:
- the default `extract_jsonpath` helper method from LocalStack builds the result from a list, and return an empty list if there are no result. Because of this, we can't differentiate if we're actually fetching an empty list via the JSONPath, or we actually did not find a match. We now properly return `None` and verify behavior
- we would return an empty dict by default if there were no body, but this isn't the right behavior from AWS. We'd need new tests with request templates again to validate, I've checked it with the AWS console and multiple scenarios and external tests that this is the right behavior

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- use special `extract_jsonpath` for VTL rendering to stop returning empty list when no match
- stop returning an empty dict when there is no body when calling `input.path` or `input.body`
- add tests case
- update unit tests with finding from AWS console

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
