### PR TITLE
chore(utils): Fix typo when forwarding envars to container

### DIFF
--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -523,7 +523,7 @@ class ContainerConfigurators:
                 # Show a deprecation warning for each individual env var collected above
                 LOG.warning(
                     "Non-prefixed environment variable %(env_var)s is forwarded to the LocalStack container! "
-                    "Please use `LOCALSTACK_%(env_var)s` instead of %(env_var)s to explicitly mark this environment variable to be forwarded form the CLI to the LocalStack Runtime.",
+                    "Please use `LOCALSTACK_%(env_var)s` instead of %(env_var)s to explicitly mark this environment variable to be forwarded from the CLI to the LocalStack Runtime.",
                     {"env_var": non_prefixed_env_var},
                 )
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Fixes a small typo when warning a user about non-prefixed envars being forwarded to LocalStack container.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Changes `... to be forwarded form ...` => `... to be forwarded from ...`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
