### PR TITLE
S3: add validation around Retention Mode & consider COMPLIANCE when updating

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -4697,18 +4697,34 @@ def get_object_lock_parameters_from_bucket_and_request(
     request: PutObjectRequest | CopyObjectRequest | CreateMultipartUploadRequest,
     s3_bucket: S3Bucket,
 ):
-    # TODO: also validate here?
     lock_mode = request.get("ObjectLockMode")
     lock_legal_status = request.get("ObjectLockLegalHoldStatus")
     lock_until = request.get("ObjectLockRetainUntilDate")
 
-    if default_retention := s3_bucket.object_lock_default_retention:
-        lock_mode = lock_mode or default_retention.get("Mode")
-        if lock_mode and not lock_until:
-            lock_until = get_retention_from_now(
-                days=default_retention.get("Days"),
-                years=default_retention.get("Years"),
-            )
+    if lock_mode and not lock_until:
+        raise InvalidArgument(
+            "x-amz-object-lock-retain-until-date and x-amz-object-lock-mode must both be supplied",
+            ArgumentName="x-amz-object-lock-retain-until-date",
+        )
+    elif not lock_mode and lock_until:
+        raise InvalidArgument(
+            "x-amz-object-lock-retain-until-date and x-amz-object-lock-mode must both be supplied",
+            ArgumentName="x-amz-object-lock-mode",
+        )
+
+    if lock_mode and lock_mode not in OBJECT_LOCK_MODES:
+        raise InvalidArgument(
+            "Unknown wormMode directive.",
+            ArgumentName="x-amz-object-lock-mode",
+            ArgumentValue=lock_mode,
+        )
+
+    if (default_retention := s3_bucket.object_lock_default_retention) and not lock_mode:
+        lock_mode = default_retention["Mode"]
+        lock_until = get_retention_from_now(
+            days=default_retention.get("Days"),
+            years=default_retention.get("Years"),
+        )
 
     return ObjectLockParameters(lock_until, lock_legal_status, lock_mode)
 

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -9536,6 +9536,9 @@ class TestS3ObjectLockRetention:
             aws_client.s3.delete_object(Bucket=s3_bucket_lock, Key=object_key, VersionId=version_id)
         snapshot.match("delete-locked-1", e.value.response)
 
+        put_delete_marker = aws_client.s3.delete_object(Bucket=s3_bucket_lock, Key=object_key)
+        snapshot.match("put-delete-marker", put_delete_marker)
+
         # delete object with retention lock with bypass before 5 seconds
         with pytest.raises(ClientError) as e:
             aws_client.s3.delete_object(

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -9831,7 +9831,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_bucket_config_default_retention": {
-    "recorded-date": "21-01-2025, 18:18:03",
+    "recorded-date": "20-06-2025, 17:35:52",
     "recorded-content": {
       "put-lock-config": {
         "ResponseMetadata": {
@@ -9891,6 +9891,17 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "put-object-with-lock-no-date": {
+        "Error": {
+          "ArgumentName": "x-amz-object-lock-retain-until-date",
+          "Code": "InvalidArgument",
+          "Message": "x-amz-object-lock-retain-until-date and x-amz-object-lock-mode must both be supplied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }
@@ -17879,6 +17890,57 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_lock_mode_validation": {
+    "recorded-date": "20-06-2025, 17:33:40",
+    "recorded-content": {
+      "put-obj-locked-error-no-retain-date": {
+        "Error": {
+          "ArgumentName": "x-amz-object-lock-retain-until-date",
+          "Code": "InvalidArgument",
+          "Message": "x-amz-object-lock-retain-until-date and x-amz-object-lock-mode must both be supplied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-locked-error-no-mode": {
+        "Error": {
+          "ArgumentName": "x-amz-object-lock-mode",
+          "Code": "InvalidArgument",
+          "Message": "x-amz-object-lock-retain-until-date and x-amz-object-lock-mode must both be supplied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-locked-bad-value": {
+        "Error": {
+          "ArgumentName": "x-amz-object-lock-mode",
+          "ArgumentValue": "BAD-VALUE",
+          "Code": "InvalidArgument",
+          "Message": "Unknown wormMode directive."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-mpu-locked-bad-value": {
+        "Error": {
+          "ArgumentName": "x-amz-object-lock-mode",
+          "ArgumentValue": "BAD-VALUE",
+          "Code": "InvalidArgument",
+          "Message": "Unknown wormMode directive."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -9574,7 +9574,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_exc": {
-    "recorded-date": "23-01-2025, 11:12:34",
+    "recorded-date": "20-06-2025, 16:29:06",
     "recorded-content": {
       "put-object-retention-no-bucket": {
         "Error": {
@@ -9634,6 +9634,16 @@
           "ArgumentValue": "Tue Dec 31 16:00:00 PST 2019",
           "Code": "InvalidArgument",
           "Message": "The retain until date must be in the future!"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-retention-bad-value": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -9723,7 +9733,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention": {
-    "recorded-date": "21-01-2025, 18:17:58",
+    "recorded-date": "20-06-2025, 17:02:01",
     "recorded-content": {
       "put-obj-locked-1": {
         "ChecksumCRC32": "2H9+DA==",
@@ -17792,6 +17802,75 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_compliance_mode": {
+    "recorded-date": "20-06-2025, 16:56:13",
+    "recorded-content": {
+      "put-obj-locked-1": {
+        "ChecksumCRC32": "2H9+DA==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "add-compliance-retention": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-locked-1": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied because object protected by object lock."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "delete-locked-2": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied because object protected by object lock."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "update-retention-shortened": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied because object protected by object lock."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "update-retention-less-restrictive": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied because object protected by object lock."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "delete-obj-after-lock-expiration": {
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -17807,7 +17807,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_compliance_mode": {
-    "recorded-date": "20-06-2025, 16:56:13",
+    "recorded-date": "20-06-2025, 17:19:56",
     "recorded-content": {
       "put-obj-locked-1": {
         "ChecksumCRC32": "2H9+DA==",
@@ -17834,6 +17834,14 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 403
+        }
+      },
+      "put-delete-marker": {
+        "DeleteMarker": true,
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
         }
       },
       "delete-locked-2": {

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -921,12 +921,12 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_compliance_mode": {
-    "last_validated_date": "2025-06-20T16:56:13+00:00",
+    "last_validated_date": "2025-06-20T17:19:57+00:00",
     "durations_in_seconds": {
-      "setup": 0.47,
-      "call": 11.63,
-      "teardown": 0.74,
-      "total": 12.84
+      "setup": 0.44,
+      "call": 11.7,
+      "teardown": 1.29,
+      "total": 13.43
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_exc": {

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -912,10 +912,31 @@
     "last_validated_date": "2025-01-21T18:18:00+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention": {
-    "last_validated_date": "2025-01-21T18:17:58+00:00"
+    "last_validated_date": "2025-06-20T17:02:02+00:00",
+    "durations_in_seconds": {
+      "setup": 0.47,
+      "call": 12.42,
+      "teardown": 0.62,
+      "total": 13.51
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_compliance_mode": {
+    "last_validated_date": "2025-06-20T16:56:13+00:00",
+    "durations_in_seconds": {
+      "setup": 0.47,
+      "call": 11.63,
+      "teardown": 0.74,
+      "total": 12.84
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_exc": {
-    "last_validated_date": "2025-01-23T11:12:34+00:00"
+    "last_validated_date": "2025-06-20T16:29:08+00:00",
+    "durations_in_seconds": {
+      "setup": 0.5,
+      "call": 3.38,
+      "teardown": 2.69,
+      "total": 6.57
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_default_checksum": {
     "last_validated_date": "2025-03-17T21:46:24+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -900,7 +900,13 @@
     "last_validated_date": "2025-01-21T18:17:18+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_bucket_config_default_retention": {
-    "last_validated_date": "2025-01-21T18:18:03+00:00"
+    "last_validated_date": "2025-06-20T17:35:53+00:00",
+    "durations_in_seconds": {
+      "setup": 0.48,
+      "call": 1.55,
+      "teardown": 1.78,
+      "total": 3.81
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_object_lock_delete_markers": {
     "last_validated_date": "2025-01-21T18:18:05+00:00"
@@ -910,6 +916,15 @@
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_copy_object_retention_lock": {
     "last_validated_date": "2025-01-21T18:18:00+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_lock_mode_validation": {
+    "last_validated_date": "2025-06-20T17:33:41+00:00",
+    "durations_in_seconds": {
+      "setup": 0.43,
+      "call": 1.68,
+      "teardown": 0.86,
+      "total": 2.97
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention": {
     "last_validated_date": "2025-06-20T17:02:02+00:00",

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -1438,6 +1438,21 @@ class TestS3ObjectLock:
                     "ObjectLockEnabled": "Enabled",
                     "Rule": {
                         "DefaultRetention": {
+                            "Mode": "BAD-VALUE",
+                            "Days": 1,
+                        }
+                    },
+                },
+            )
+        snapshot.match("put-lock-config-bad-mode", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_lock_configuration(
+                Bucket=s3_bucket,
+                ObjectLockConfiguration={
+                    "ObjectLockEnabled": "Enabled",
+                    "Rule": {
+                        "DefaultRetention": {
                             "Mode": "GOVERNANCE",
                             "Days": 1,
                             "Years": 1,

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -2489,7 +2489,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectLock::test_put_object_lock_configuration_exc": {
-    "recorded-date": "21-01-2025, 18:11:40",
+    "recorded-date": "20-06-2025, 17:03:24",
     "recorded-content": {
       "put-lock-config-no-enabled": {
         "Error": {
@@ -2532,6 +2532,16 @@
         }
       },
       "put-lock-config-no-days": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-lock-config-bad-mode": {
         "Error": {
           "Code": "MalformedXML",
           "Message": "The XML you provided was not well-formed or did not validate against our published schema"

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -150,7 +150,13 @@
     "last_validated_date": "2025-01-21T18:11:37+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectLock::test_put_object_lock_configuration_exc": {
-    "last_validated_date": "2025-01-21T18:11:40+00:00"
+    "last_validated_date": "2025-06-20T17:03:25+00:00",
+    "durations_in_seconds": {
+      "setup": 0.55,
+      "call": 2.64,
+      "teardown": 0.83,
+      "total": 4.02
+    }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectLock::test_put_object_lock_configuration_on_existing_bucket": {
     "last_validated_date": "2025-01-21T18:11:36+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We got a report from a user that setting the Object Lock Mode to `COMPLIANCE` did not work. This ended up being a user misunderstanding about the behavior of Versioned buckets adding delete markers on top of versions, same as this post: https://repost.aws/questions/QUyamFMI7QQy2zmIkF_0IxwQ/s3-object-lock-in-compliance-mode-file-uploaded-thru-cli-file-properties-shows-compliance-mode-i-can-still-delete-it

However, while looking at the issue, I realized we didn't consider the `COMPLIANCE` value when trying to reduce or remove the effective locking on the object via `PutObjectRetention`, which this PR fixes.
I've also added validation around the `Mode` value

I've also added validation for the Lock Mode in operation where it is possible to pass it, like `PutObject` and `CreateMultipartUpload`. 

Also added validation around behavior with missing values around object lock, which was wrong.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add tests for `Mode` validation and add that validation in the provider
- add test for the `COMPLIANCE` value when trying to override existing object retention configuration
- fix the behavior in `PutObjectRetention`
- add test for direct passing of Object Lock values in operation that are creating objects (PutObject, etc)
- fix behavior in util function to validate the Object lock values and update default value behavior when retention is configured on the bucket


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
