### PR TITLE
S3: add error for DeleteObject preconditions for regular buckets

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -1195,6 +1195,24 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 ArgumentName="x-amz-bypass-governance-retention",
             )
 
+        # TODO: this is only supported for Directory Buckets
+        non_supported_precondition = None
+        if if_match:
+            non_supported_precondition = "If-Match"
+        if if_match_size:
+            non_supported_precondition = "x-amz-if-match-size"
+        if if_match_last_modified_time:
+            non_supported_precondition = "x-amz-if-match-last-modified-time"
+        if non_supported_precondition:
+            LOG.warning(
+                "DeleteObject Preconditions is only supported for Directory Buckets. "
+                "LocalStack does not support Directory Buckets yet."
+            )
+            raise NotImplementedException(
+                "A header you provided implies functionality that is not implemented",
+                Header=non_supported_precondition,
+            )
+
         if s3_bucket.versioning_status is None:
             if version_id and version_id != "null":
                 raise InvalidArgument(

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -4601,5 +4601,69 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3DeletePrecondition::test_delete_object_if_match_non_express": {
+    "recorded-date": "23-06-2025, 08:53:20",
+    "recorded-content": {
+      "delete-obj-if-match": {
+        "Error": {
+          "Code": "NotImplemented",
+          "Header": "If-Match",
+          "Message": "A header you provided implies functionality that is not implemented"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 501
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3DeletePrecondition::test_delete_object_if_match_modified_non_express": {
+    "recorded-date": "23-06-2025, 09:05:52",
+    "recorded-content": {
+      "delete-obj-if-match-last-modified": {
+        "Error": {
+          "Code": "NotImplemented",
+          "Header": "x-amz-if-match-last-modified-time",
+          "Message": "A header you provided implies functionality that is not implemented"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 501
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3DeletePrecondition::test_delete_object_if_match_size_non_express": {
+    "recorded-date": "23-06-2025, 09:05:59",
+    "recorded-content": {
+      "delete-obj-if-match-size": {
+        "Error": {
+          "Code": "NotImplemented",
+          "Header": "x-amz-if-match-size",
+          "Message": "A header you provided implies functionality that is not implemented"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 501
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3DeletePrecondition::test_delete_object_if_match_all_non_express": {
+    "recorded-date": "23-06-2025, 09:06:41",
+    "recorded-content": {
+      "delete-obj-if-match-all": {
+        "Error": {
+          "Code": "NotImplemented",
+          "Header": "x-amz-if-match-last-modified-time",
+          "Message": "A header you provided implies functionality that is not implemented"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 501
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -68,6 +68,42 @@
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketVersioning::test_object_version_id_format": {
     "last_validated_date": "2025-01-21T18:10:31+00:00"
   },
+  "tests/aws/services/s3/test_s3_api.py::TestS3DeletePrecondition::test_delete_object_if_match_all_non_express": {
+    "last_validated_date": "2025-06-23T09:06:43+00:00",
+    "durations_in_seconds": {
+      "setup": 0.96,
+      "call": 0.24,
+      "teardown": 1.13,
+      "total": 2.33
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3DeletePrecondition::test_delete_object_if_match_modified_non_express": {
+    "last_validated_date": "2025-06-23T09:05:53+00:00",
+    "durations_in_seconds": {
+      "setup": 1.05,
+      "call": 0.23,
+      "teardown": 1.16,
+      "total": 2.44
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3DeletePrecondition::test_delete_object_if_match_non_express": {
+    "last_validated_date": "2025-06-23T08:53:21+00:00",
+    "durations_in_seconds": {
+      "setup": 1.05,
+      "call": 0.24,
+      "teardown": 1.1,
+      "total": 2.39
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3DeletePrecondition::test_delete_object_if_match_size_non_express": {
+    "last_validated_date": "2025-06-23T09:06:00+00:00",
+    "durations_in_seconds": {
+      "setup": 0.98,
+      "call": 0.22,
+      "teardown": 1.17,
+      "total": 2.37
+    }
+  },
   "tests/aws/services/s3/test_s3_api.py::TestS3MetricsConfiguration::test_delete_metrics_configuration": {
     "last_validated_date": "2025-06-13T08:33:19+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We got a report with #12783 that we did not support `IfMatch` header for `DeleteObject`. This is because this is only supported for Directory Bucket (S3 Express One Zone), which we don't support yet (requested at #12184). 

In the reported issue, the bucket was not created as a Directory Bucket, which would raise an exception in S3 when trying to use preconditions headers for `DeleteObject`. 

This PR adds that parity + a log message to indicate that directory buckets are not yet supported by LocalStack, to avoid users not understanding why such feature would just fail silently. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add test for DeleteObject preconditions when the bucket is not a directory bucket
- add the same validation in the provider

## Side note regarding Directory Buckets

It seems AWS is adding more feature again only to Directory Buckets, as seen by #12785 and https://aws.amazon.com/about-aws/whats-new/2025/06/amazon-s3-express-one-zone-atomic-renaming-objects-api/

