### PR TITLE
Update STS session storage model to be more flexible

### DIFF
--- a/localstack-core/localstack/services/sts/models.py
+++ b/localstack-core/localstack/services/sts/models.py
@@ -4,16 +4,18 @@ from localstack.aws.api.sts import Tag
 from localstack.services.stores import AccountRegionBundle, BaseStore, CrossRegionAttribute
 
 
-class SessionTaggingConfig(TypedDict):
+class SessionConfig(TypedDict):
     # <lower-case-tag-key> => {"Key": <case-preserved-tag-key>, "Value": <tag-value>}
     tags: dict[str, Tag]
     # list of lowercase transitive tag keys
     transitive_tags: list[str]
+    # other stored context variables
+    iam_context: dict[str, str | list[str]]
 
 
 class STSStore(BaseStore):
     # maps access key ids to tagging config for the session they belong to
-    session_tags: dict[str, SessionTaggingConfig] = CrossRegionAttribute(default=dict)
+    sessions: dict[str, SessionConfig] = CrossRegionAttribute(default=dict)
 
 
 sts_stores = AccountRegionBundle("sts", STSStore)

--- a/localstack-core/localstack/services/sts/provider.py
+++ b/localstack-core/localstack/services/sts/provider.py
@@ -21,7 +21,7 @@ from localstack.aws.api.sts import (
 from localstack.services.iam.iam_patches import apply_iam_patches
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
-from localstack.services.sts.models import SessionTaggingConfig, sts_stores
+from localstack.services.sts.models import SessionConfig, sts_stores
 from localstack.utils.aws.arns import extract_account_id_from_arn
 from localstack.utils.aws.request_context import extract_access_key_id_from_auth_header
 
@@ -64,7 +64,7 @@ class StsProvider(StsApi, ServiceLifecycleHook):
         target_account_id = extract_account_id_from_arn(role_arn)
         access_key_id = extract_access_key_id_from_auth_header(context.request.headers)
         store = sts_stores[target_account_id]["us-east-1"]
-        existing_tagging_config = store.session_tags.get(access_key_id, {})
+        existing_session_config = store.sessions.get(access_key_id, {})
 
         if tags:
             tag_keys = {tag["Key"].lower() for tag in tags}
@@ -75,8 +75,8 @@ class StsProvider(StsApi, ServiceLifecycleHook):
                 )
 
             # prevent transitive tags from being overridden
-            if existing_tagging_config:
-                if set(existing_tagging_config["transitive_tags"]).intersection(tag_keys):
+            if existing_session_config:
+                if set(existing_session_config["transitive_tags"]).intersection(tag_keys):
                     raise InvalidParameterValueError(
                         "One of the specified transitive tag keys can't be set because it conflicts with a transitive tag key from the calling session."
                     )
@@ -93,15 +93,16 @@ class StsProvider(StsApi, ServiceLifecycleHook):
         tags = tags or []
         transformed_tags = {tag["Key"].lower(): tag for tag in tags}
         # propagate transitive tags
-        if existing_tagging_config:
-            for tag in existing_tagging_config["transitive_tags"]:
-                transformed_tags[tag] = existing_tagging_config["tags"][tag]
-            transitive_tag_keys += existing_tagging_config["transitive_tags"]
+        if existing_session_config:
+            for tag in existing_session_config["transitive_tags"]:
+                transformed_tags[tag] = existing_session_config["tags"][tag]
+            transitive_tag_keys += existing_session_config["transitive_tags"]
         if transformed_tags:
             # store session tagging config
             access_key_id = response["Credentials"]["AccessKeyId"]
-            store.session_tags[access_key_id] = SessionTaggingConfig(
+            store.sessions[access_key_id] = SessionConfig(
                 tags=transformed_tags,
                 transitive_tags=[key.lower() for key in transitive_tag_keys],
+                iam_context={},
             )
         return response


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR contains no behavioral changes, just some refactoring of the STS session storage.
Instead of storing tags exclusively, I adapted naming and added additional properties to the session storage.

This will allow us to store more information per session, which is needed for advanced IAM functionality downstream.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Rename SessionTagConfig to SessionConfig to reflect storage of other attributes of a session
* Some renames in local variables
* Add `iam_context` field to allow storage of iam context variables

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
