### PR TITLE
Update lambda runtime init, fix legacy ENV format in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && test ! $(which python3.9)
 
 SHELL [ "/bin/bash", "-c" ]
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # set workdir
 RUN mkdir -p /opt/code/localstack

--- a/localstack-core/localstack/services/lambda_/packages.py
+++ b/localstack-core/localstack/services/lambda_/packages.py
@@ -13,7 +13,7 @@ from localstack.utils.platform import get_arch
 """Customized LocalStack version of the AWS Lambda Runtime Interface Emulator (RIE).
 https://github.com/localstack/lambda-runtime-init/blob/localstack/README-LOCALSTACK.md
 """
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.33-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.34-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Our current go lambda init binary contains several vulnerabilities reported by scanners, including one designated as HIGH.
Even though they are not exploitable in LocalStack, we need to fix it.

This PR contains no behavioral changes:
- The lambda init is just a rebuild using a newer go version
- The ENV variable change is changing the deprecated syntax(https://github.com/docker/cli/pull/2743) to the proper one to avoid warnings with newer docker versions.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Update lambda init (rebuild without changes)
- Correct syntax of ENV instruction in dockerfile

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
