### PR TITLE
CFNv2: parameter resolution and presentation

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack-core/localstack/services/cloudformation/engine/transformers.py
@@ -217,7 +217,11 @@ def execute_macro(
     for key, value in stack_parameters.items():
         # TODO: we want to support other types of parameters
         if value.get("ParameterType") == "CommaDelimitedList":
-            formatted_stack_parameters[key] = value.get("ParameterValue").split(",")
+            parameter_value = value.get("ParameterValue", "")
+            # V2: we model parameters as classes so try to access the method that returns the resolved value
+            if resolve := getattr(parameter_value, "resolve", None):
+                parameter_value = resolve()
+            formatted_stack_parameters[key] = parameter_value.split(",")
         else:
             formatted_stack_parameters[key] = value.get("ParameterValue")
 

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
@@ -499,6 +499,18 @@ INTRINSIC_FUNCTIONS: Final[set[str]] = {
 }
 
 
+class ResolvedParameter:
+    value: str
+    resolved_value: str | None
+
+    def __init__(self, value: str, resolved_value: str | None = None):
+        self.value = value
+        self.resolved_value = resolved_value
+
+    def resolve(self) -> str:
+        return self.resolved_value or self.value
+
+
 class ChangeSetModel:
     # TODO: should this instead be generalised to work on "Stack" objects instead of just "Template"s?
 
@@ -1398,7 +1410,7 @@ class ChangeSetModel:
 
     @staticmethod
     def _is_terminal(value: Any) -> bool:
-        return type(value) in {int, float, bool, str, None, NothingType}
+        return type(value) in {int, float, bool, str, None, NothingType, ResolvedParameter}
 
     @staticmethod
     def _is_object(value: Any) -> bool:

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
@@ -81,11 +81,19 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                 "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
                 "AWS::SSM::Parameter::Value<CommaDelimitedList>",
             ]:
-                delta.after = resolve_ssm_parameter(
-                    account_id=self._change_set.account_id,
-                    region_name=self._change_set.region_name,
-                    stack_parameter_value=delta.after,
-                )
+                if is_nothing(delta.after):
+                    if is_nothing(delta.before):
+                        raise RuntimeError(
+                            "Invalid state: no resolved parameter found for SSM parameter {node_parameter.name}"
+                        )
+                    # we don't need to resolve the parameter here since it was done in the previous deployment
+                    delta.after = delta.before
+                else:
+                    delta.after = resolve_ssm_parameter(
+                        account_id=self._change_set.account_id,
+                        region_name=self._change_set.region_name,
+                        stack_parameter_value=delta.after,
+                    )
             else:
                 raise Exception(f"Unsupported stack parameter type: {parameter_type}")
 

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
@@ -17,7 +17,6 @@ from localstack.services.cloudformation.engine.parameters import resolve_ssm_par
 from localstack.services.cloudformation.engine.v2.change_set_model import (
     NodeDependsOn,
     NodeOutput,
-    NodeParameter,
     NodeResource,
     is_nothing,
 )
@@ -54,13 +53,11 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
     # TODO: add typing for resolved resources and parameters.
     resources: Final[dict]
     outputs: Final[dict]
-    resolved_parameters: Final[dict]
 
     def __init__(self, change_set: ChangeSet):
         super().__init__(change_set=change_set)
         self.resources = dict()
         self.outputs = dict()
-        self.resolved_parameters = dict()
 
     # TODO: use a structured type for the return value
     def execute(self) -> ChangeSetModelExecutorResult:
@@ -68,11 +65,6 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
         return ChangeSetModelExecutorResult(
             resources=self.resources, parameters=self.resolved_parameters, outputs=self.outputs
         )
-
-    def visit_node_parameter(self, node_parameter: NodeParameter) -> PreprocEntityDelta:
-        delta = super().visit_node_parameter(node_parameter)
-        self.resolved_parameters[node_parameter.name] = delta.after
-        return delta
 
     def _get_physical_id(self, logical_resource_id, strict: bool = True) -> str | None:
         physical_resource_id = None

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -9,6 +9,7 @@ from botocore.exceptions import ClientError
 
 from localstack.aws.api.ec2 import AvailabilityZoneList, DescribeAvailabilityZonesResult
 from localstack.aws.connect import connect_to
+from localstack.services.cloudformation.engine.parameters import resolve_ssm_parameter
 from localstack.services.cloudformation.engine.transformers import (
     Transformer,
     execute_macro,
@@ -932,6 +933,31 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
 
         before = dynamic_delta.before or default_delta.before
         after = dynamic_delta.after or default_delta.after
+
+        # handle dynamic references, e.g. references to SSM parameters
+        # TODO: support more parameter types
+        parameter_type: str = node_parameter.type_.value
+        if parameter_type.startswith("AWS::SSM"):
+            if parameter_type in [
+                "AWS::SSM::Parameter::Value<String>",
+                "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+                "AWS::SSM::Parameter::Value<CommaDelimitedList>",
+            ]:
+                if is_nothing(after):
+                    if is_nothing(before):
+                        raise RuntimeError(
+                            "Invalid state: no resolved parameter found for SSM parameter {node_parameter.name}"
+                        )
+                    # we don't need to resolve the parameter here since it was done in the previous deployment
+                    after = before
+                else:
+                    after = resolve_ssm_parameter(
+                        account_id=self._change_set.account_id,
+                        region_name=self._change_set.region_name,
+                        stack_parameter_value=after,
+                    )
+            else:
+                raise Exception(f"Unsupported stack parameter type: {parameter_type}")
 
         return PreprocEntityDelta(before=before, after=after)
 

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -409,6 +409,17 @@ class CloudformationProviderV2(CloudformationProvider):
         )
         changes: Changes = change_set_describer.get_changes()
 
+        # TODO: add masking support.
+        parameters = []
+        for key, resolved_parameter in change_set_describer.resolved_parameters.items():
+            parameters.append(
+                Parameter(
+                    ParameterKey=key,
+                    ParameterValue=resolved_parameter.value,
+                    ResolvedValue=resolved_parameter.resolved_value,
+                )
+            )
+
         result = DescribeChangeSetOutput(
             Status=change_set.status,
             ChangeSetId=change_set.change_set_id,
@@ -418,11 +429,7 @@ class CloudformationProviderV2(CloudformationProvider):
             StackId=change_set.stack.stack_id,
             StackName=change_set.stack.stack_name,
             CreationTime=change_set.creation_time,
-            Parameters=[
-                # TODO: add masking support.
-                Parameter(ParameterKey=key, ParameterValue=value)
-                for (key, value) in change_set.stack.resolved_parameters.items()
-            ],
+            Parameters=parameters,
             Changes=changes,
         )
         return result

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_changesets.py
@@ -394,7 +394,7 @@ def test_create_change_set_missing_stackname(aws_client):
         )
 
 
-@pytest.mark.skip("CFNV2:Other")
+# @pytest.mark.skip("CFNV2:Other")
 @markers.aws.validated
 def test_create_change_set_with_ssm_parameter(
     cleanup_changesets,

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_changesets.validation.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_changesets.validation.json
@@ -56,6 +56,15 @@
   "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_changesets.py::test_create_change_set_update_without_parameters": {
     "last_validated_date": "2022-05-31T07:32:02+00:00"
   },
+  "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_changesets.py::test_create_change_set_with_ssm_parameter": {
+    "last_validated_date": "2025-06-24T14:17:37+00:00",
+    "durations_in_seconds": {
+      "setup": 0.08,
+      "call": 64.46,
+      "teardown": 0.0,
+      "total": 64.54
+    }
+  },
   "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_changesets.py::test_create_changeset_with_stack_id": {
     "last_validated_date": "2023-11-28T06:48:23+00:00"
   },

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_cdk.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_cdk.py
@@ -16,9 +16,6 @@ pytestmark = pytest.mark.skipif(
 
 
 class TestCdkInit:
-    @pytest.mark.skip(
-        reason="CFNV2:Destroy each test passes individually but because we don't delete resources, running all parameterized options fails"
-    )
     @pytest.mark.parametrize("bootstrap_version", ["10", "11", "12"])
     @markers.aws.validated
     def test_cdk_bootstrap(self, deploy_cfn_template, bootstrap_version, aws_client):

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/test_template_engine.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/test_template_engine.py
@@ -316,9 +316,9 @@ class TestImports:
         assert stack2.outputs["MessageQueueArn2"] == queue_arn2
 
 
-# @pytest.mark.skip(reason="CFNV2:resolve")
 class TestSsmParameters:
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Capabilities", "$..NotificationARNs"])
     def test_create_stack_with_ssm_parameters(
         self, create_parameter, deploy_cfn_template, snapshot, aws_client
     ):
@@ -351,6 +351,7 @@ class TestSsmParameters:
         snapshot.match("topic-tags", tags)
 
     @markers.aws.validated
+    @pytest.mark.skip("CFNV2:resolve")
     def test_resolve_ssm(self, create_parameter, deploy_cfn_template):
         parameter_key = f"param-key-{short_uid()}"
         parameter_value = f"param-value-{short_uid()}"
@@ -366,6 +367,7 @@ class TestSsmParameters:
         topic_name = result.outputs["TopicName"]
         assert topic_name == parameter_value
 
+    @pytest.mark.skip("CFNV2:resolve")
     @markers.aws.validated
     def test_resolve_ssm_with_version(self, create_parameter, deploy_cfn_template, aws_client):
         parameter_key = f"param-key-{short_uid()}"
@@ -393,6 +395,7 @@ class TestSsmParameters:
         assert topic_name == parameter_value_v1
 
     @markers.aws.needs_fixing
+    @pytest.mark.skip("CFNV2:resolve")
     def test_resolve_ssm_secure(self, create_parameter, deploy_cfn_template):
         parameter_key = f"param-key-{short_uid()}"
         parameter_value = f"param-value-{short_uid()}"
@@ -410,6 +413,7 @@ class TestSsmParameters:
         assert topic_name == parameter_value
 
     @markers.aws.validated
+    @pytest.mark.skip("CFNV2:nested attribute lookup")
     def test_ssm_nested_with_nested_stack(self, s3_create_bucket, deploy_cfn_template, aws_client):
         """
         When resolving the references in the cloudformation template for 'Fn::GetAtt' we need to consider the attribute subname.
@@ -445,6 +449,7 @@ class TestSsmParameters:
         assert ssm_parameter == key_value
 
     @markers.aws.validated
+    @pytest.mark.skip("CFNV2:resolve")
     def test_create_change_set_with_ssm_parameter_list(
         self, deploy_cfn_template, aws_client, region_name, account_id, snapshot
     ):

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/test_template_engine.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/test_template_engine.py
@@ -316,7 +316,7 @@ class TestImports:
         assert stack2.outputs["MessageQueueArn2"] == queue_arn2
 
 
-@pytest.mark.skip(reason="CFNV2:resolve")
+# @pytest.mark.skip(reason="CFNV2:resolve")
 class TestSsmParameters:
     @markers.aws.validated
     def test_create_stack_with_ssm_parameters(

--- a/tests/aws/services/cloudformation/v2/test_change_sets.py
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.py
@@ -801,6 +801,23 @@ def test_single_resource_static_update(aws_client: ServiceLevelClientFactory, sn
 
 
 @markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        "delete-describe..*",
+        "$..Outputs..OutputValue",
+        #
+        # Before/After Context
+        "$..Capabilities",
+        "$..NotificationARNs",
+        "$..IncludeNestedStacks",
+        "$..Scope",
+        "$..Details",
+        "$..Parameters",
+        "$..Replacement",
+        "$..PolicyAction",
+        "$..PhysicalResourceId",
+    ]
+)
 def test_dynamic_ssm_parameter_lookup(
     snapshot,
     aws_client: ServiceLevelClientFactory,
@@ -818,6 +835,15 @@ def test_dynamic_ssm_parameter_lookup(
     parameter_name = f"param-{short_uid()}"
     value1 = f"1-{short_uid()}"
     value2 = f"2-{short_uid()}"
+
+    snapshot.add_transformers_list(
+        [
+            snapshot.transform.regex(parameter_name, "<parameter-name>"),
+            snapshot.transform.regex(value1, "<value-1>"),
+            snapshot.transform.regex(value2, "<value-2>"),
+        ]
+    )
+
     create_parameter(Name=parameter_name, Value=value1, Type="String")
 
     template = {

--- a/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
@@ -3685,5 +3685,387 @@
         ]
       }
     }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_sets.py::test_dynamic_ssm_parameter_lookup": {
+    "recorded-date": "24-06-2025, 12:51:24",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "1-d0d04e54",
+                  "Type": "String"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "DerivedParameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "InputValue",
+            "ParameterValue": "param-e8903479",
+            "ResolvedValue": "1-d0d04e54"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "DerivedParameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "InputValue",
+            "ParameterValue": "param-e8903479",
+            "ResolvedValue": "1-d0d04e54"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Outputs": [
+          {
+            "OutputKey": "DerivedParameterName",
+            "OutputValue": "CFN-DerivedParameter-swzfj5uOI0xp"
+          }
+        ],
+        "Parameters": [
+          {
+            "ParameterKey": "InputValue",
+            "ParameterValue": "param-e8903479",
+            "ResolvedValue": "1-d0d04e54"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "2-90be8ed8",
+                  "Type": "String"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "Value": "1-d0d04e54",
+                  "Type": "String"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "2-90be8ed8",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "1-d0d04e54",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "DerivedParameter",
+              "PhysicalResourceId": "CFN-DerivedParameter-swzfj5uOI0xp",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "InputValue",
+            "ParameterValue": "param-e8903479",
+            "ResolvedValue": "2-90be8ed8"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "DerivedParameter",
+              "PhysicalResourceId": "CFN-DerivedParameter-swzfj5uOI0xp",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "InputValue",
+            "ParameterValue": "param-e8903479",
+            "ResolvedValue": "2-90be8ed8"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Outputs": [
+          {
+            "OutputKey": "DerivedParameterName",
+            "OutputValue": "CFN-DerivedParameter-swzfj5uOI0xp"
+          }
+        ],
+        "Parameters": [
+          {
+            "ParameterKey": "InputValue",
+            "ParameterValue": "param-e8903479",
+            "ResolvedValue": "2-90be8ed8"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Outputs": [
+          {
+            "OutputKey": "DerivedParameterName",
+            "OutputValue": "CFN-DerivedParameter-swzfj5uOI0xp"
+          }
+        ],
+        "Parameters": [
+          {
+            "ParameterKey": "InputValue",
+            "ParameterValue": "param-e8903479",
+            "ResolvedValue": "2-90be8ed8"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "DerivedParameter": [
+          {
+            "LogicalResourceId": "DerivedParameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "DerivedParameter",
+            "PhysicalResourceId": "CFN-DerivedParameter-swzfj5uOI0xp",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "DerivedParameter",
+            "PhysicalResourceId": "CFN-DerivedParameter-swzfj5uOI0xp",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "DerivedParameter",
+            "PhysicalResourceId": "CFN-DerivedParameter-swzfj5uOI0xp",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
@@ -3687,7 +3687,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::test_dynamic_ssm_parameter_lookup": {
-    "recorded-date": "24-06-2025, 12:51:24",
+    "recorded-date": "24-06-2025, 13:57:09",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -3707,7 +3707,7 @@
               "Action": "Add",
               "AfterContext": {
                 "Properties": {
-                  "Value": "1-d0d04e54",
+                  "Value": "<value-1>",
                   "Type": "String"
                 }
               },
@@ -3726,8 +3726,8 @@
         "Parameters": [
           {
             "ParameterKey": "InputValue",
-            "ParameterValue": "param-e8903479",
-            "ResolvedValue": "1-d0d04e54"
+            "ParameterValue": "<parameter-name>",
+            "ResolvedValue": "<value-1>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3762,8 +3762,8 @@
         "Parameters": [
           {
             "ParameterKey": "InputValue",
-            "ParameterValue": "param-e8903479",
-            "ResolvedValue": "1-d0d04e54"
+            "ParameterValue": "<parameter-name>",
+            "ResolvedValue": "<value-1>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3794,14 +3794,14 @@
         "Outputs": [
           {
             "OutputKey": "DerivedParameterName",
-            "OutputValue": "CFN-DerivedParameter-swzfj5uOI0xp"
+            "OutputValue": "CFN-DerivedParameter-YIO8ynD1Sgjp"
           }
         ],
         "Parameters": [
           {
             "ParameterKey": "InputValue",
-            "ParameterValue": "param-e8903479",
-            "ResolvedValue": "1-d0d04e54"
+            "ParameterValue": "<parameter-name>",
+            "ResolvedValue": "<value-1>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3828,13 +3828,13 @@
               "Action": "Modify",
               "AfterContext": {
                 "Properties": {
-                  "Value": "2-90be8ed8",
+                  "Value": "<value-2>",
                   "Type": "String"
                 }
               },
               "BeforeContext": {
                 "Properties": {
-                  "Value": "1-d0d04e54",
+                  "Value": "<value-1>",
                   "Type": "String"
                 }
               },
@@ -3843,10 +3843,10 @@
                   "ChangeSource": "DirectModification",
                   "Evaluation": "Static",
                   "Target": {
-                    "AfterValue": "2-90be8ed8",
+                    "AfterValue": "<value-2>",
                     "Attribute": "Properties",
                     "AttributeChangeType": "Modify",
-                    "BeforeValue": "1-d0d04e54",
+                    "BeforeValue": "<value-1>",
                     "Name": "Value",
                     "Path": "/Properties/Value",
                     "RequiresRecreation": "Never"
@@ -3854,7 +3854,7 @@
                 }
               ],
               "LogicalResourceId": "DerivedParameter",
-              "PhysicalResourceId": "CFN-DerivedParameter-swzfj5uOI0xp",
+              "PhysicalResourceId": "CFN-DerivedParameter-YIO8ynD1Sgjp",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -3871,8 +3871,8 @@
         "Parameters": [
           {
             "ParameterKey": "InputValue",
-            "ParameterValue": "param-e8903479",
-            "ResolvedValue": "2-90be8ed8"
+            "ParameterValue": "<parameter-name>",
+            "ResolvedValue": "<value-2>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3904,7 +3904,7 @@
                 }
               ],
               "LogicalResourceId": "DerivedParameter",
-              "PhysicalResourceId": "CFN-DerivedParameter-swzfj5uOI0xp",
+              "PhysicalResourceId": "CFN-DerivedParameter-YIO8ynD1Sgjp",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -3921,8 +3921,8 @@
         "Parameters": [
           {
             "ParameterKey": "InputValue",
-            "ParameterValue": "param-e8903479",
-            "ResolvedValue": "2-90be8ed8"
+            "ParameterValue": "<parameter-name>",
+            "ResolvedValue": "<value-2>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3953,14 +3953,14 @@
         "Outputs": [
           {
             "OutputKey": "DerivedParameterName",
-            "OutputValue": "CFN-DerivedParameter-swzfj5uOI0xp"
+            "OutputValue": "CFN-DerivedParameter-YIO8ynD1Sgjp"
           }
         ],
         "Parameters": [
           {
             "ParameterKey": "InputValue",
-            "ParameterValue": "param-e8903479",
-            "ResolvedValue": "2-90be8ed8"
+            "ParameterValue": "<parameter-name>",
+            "ResolvedValue": "<value-2>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3981,14 +3981,14 @@
         "Outputs": [
           {
             "OutputKey": "DerivedParameterName",
-            "OutputValue": "CFN-DerivedParameter-swzfj5uOI0xp"
+            "OutputValue": "CFN-DerivedParameter-YIO8ynD1Sgjp"
           }
         ],
         "Parameters": [
           {
             "ParameterKey": "InputValue",
-            "ParameterValue": "param-e8903479",
-            "ResolvedValue": "2-90be8ed8"
+            "ParameterValue": "<parameter-name>",
+            "ResolvedValue": "<value-2>"
           }
         ],
         "RollbackConfiguration": {},
@@ -4008,21 +4008,21 @@
           },
           {
             "LogicalResourceId": "DerivedParameter",
-            "PhysicalResourceId": "CFN-DerivedParameter-swzfj5uOI0xp",
+            "PhysicalResourceId": "CFN-DerivedParameter-YIO8ynD1Sgjp",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
             "Timestamp": "timestamp"
           },
           {
             "LogicalResourceId": "DerivedParameter",
-            "PhysicalResourceId": "CFN-DerivedParameter-swzfj5uOI0xp",
+            "PhysicalResourceId": "CFN-DerivedParameter-YIO8ynD1Sgjp",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
             "ResourceType": "AWS::SSM::Parameter",
             "Timestamp": "timestamp"
           },
           {
             "LogicalResourceId": "DerivedParameter",
-            "PhysicalResourceId": "CFN-DerivedParameter-swzfj5uOI0xp",
+            "PhysicalResourceId": "CFN-DerivedParameter-YIO8ynD1Sgjp",
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
             "Timestamp": "timestamp"

--- a/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.snapshot.json
@@ -3687,7 +3687,7 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::test_dynamic_ssm_parameter_lookup": {
-    "recorded-date": "24-06-2025, 13:57:09",
+    "recorded-date": "24-06-2025, 14:41:11",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -3707,12 +3707,44 @@
               "Action": "Add",
               "AfterContext": {
                 "Properties": {
-                  "Value": "<value-1>",
+                  "Value": "<default-value-2>",
                   "Type": "String"
                 }
               },
               "Details": [],
-              "LogicalResourceId": "DerivedParameter",
+              "LogicalResourceId": "DefaultParameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<external-value-1>",
+                  "Type": "String"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "ExternalParameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<provided-value-1>",
+                  "Type": "String"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "ProvidedParameter",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
@@ -3725,9 +3757,17 @@
         "NotificationARNs": [],
         "Parameters": [
           {
-            "ParameterKey": "InputValue",
+            "ParameterKey": "DefaultInputValue",
+            "ParameterValue": "<default-value-2>"
+          },
+          {
+            "ParameterKey": "ExternalInputValue",
             "ParameterValue": "<parameter-name>",
-            "ResolvedValue": "<value-1>"
+            "ResolvedValue": "<external-value-1>"
+          },
+          {
+            "ParameterKey": "ProvidedInputValue",
+            "ParameterValue": "<provided-value-1>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3748,7 +3788,27 @@
             "ResourceChange": {
               "Action": "Add",
               "Details": [],
-              "LogicalResourceId": "DerivedParameter",
+              "LogicalResourceId": "DefaultParameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "ExternalParameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "ProvidedParameter",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": []
             },
@@ -3761,9 +3821,17 @@
         "NotificationARNs": [],
         "Parameters": [
           {
-            "ParameterKey": "InputValue",
+            "ParameterKey": "DefaultInputValue",
+            "ParameterValue": "<default-value-2>"
+          },
+          {
+            "ParameterKey": "ExternalInputValue",
             "ParameterValue": "<parameter-name>",
-            "ResolvedValue": "<value-1>"
+            "ResolvedValue": "<external-value-1>"
+          },
+          {
+            "ParameterKey": "ProvidedInputValue",
+            "ParameterValue": "<provided-value-1>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3793,15 +3861,31 @@
         "NotificationARNs": [],
         "Outputs": [
           {
-            "OutputKey": "DerivedParameterName",
-            "OutputValue": "CFN-DerivedParameter-YIO8ynD1Sgjp"
+            "OutputKey": "DefaultParameterName",
+            "OutputValue": "CFN-DefaultParameter-XZTowJJO5ayT"
+          },
+          {
+            "OutputKey": "ExternalParameterName",
+            "OutputValue": "CFN-ExternalParameter-tKIiDHqu6jnn"
+          },
+          {
+            "OutputKey": "ProvidedParameterName",
+            "OutputValue": "CFN-ProvidedParameter-48Iab30cQ0nx"
           }
         ],
         "Parameters": [
           {
-            "ParameterKey": "InputValue",
+            "ParameterKey": "DefaultInputValue",
+            "ParameterValue": "<default-value-2>"
+          },
+          {
+            "ParameterKey": "ExternalInputValue",
             "ParameterValue": "<parameter-name>",
-            "ResolvedValue": "<value-1>"
+            "ResolvedValue": "<external-value-1>"
+          },
+          {
+            "ParameterKey": "ProvidedInputValue",
+            "ParameterValue": "<provided-value-1>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3828,13 +3912,13 @@
               "Action": "Modify",
               "AfterContext": {
                 "Properties": {
-                  "Value": "<value-2>",
+                  "Value": "<external-value-2>",
                   "Type": "String"
                 }
               },
               "BeforeContext": {
                 "Properties": {
-                  "Value": "<value-1>",
+                  "Value": "<external-value-1>",
                   "Type": "String"
                 }
               },
@@ -3843,18 +3927,72 @@
                   "ChangeSource": "DirectModification",
                   "Evaluation": "Static",
                   "Target": {
-                    "AfterValue": "<value-2>",
+                    "AfterValue": "<external-value-2>",
                     "Attribute": "Properties",
                     "AttributeChangeType": "Modify",
-                    "BeforeValue": "<value-1>",
+                    "BeforeValue": "<external-value-1>",
                     "Name": "Value",
                     "Path": "/Properties/Value",
                     "RequiresRecreation": "Never"
                   }
                 }
               ],
-              "LogicalResourceId": "DerivedParameter",
-              "PhysicalResourceId": "CFN-DerivedParameter-YIO8ynD1Sgjp",
+              "LogicalResourceId": "ExternalParameter",
+              "PhysicalResourceId": "CFN-ExternalParameter-tKIiDHqu6jnn",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "<provided-value-2>",
+                  "Type": "String"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "Value": "<provided-value-1>",
+                  "Type": "String"
+                }
+              },
+              "Details": [
+                {
+                  "CausingEntity": "ProvidedInputValue",
+                  "ChangeSource": "ParameterReference",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "<provided-value-2>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "<provided-value-1>",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                },
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
+                  "Target": {
+                    "AfterValue": "<provided-value-2>",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "<provided-value-1>",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "ProvidedParameter",
+              "PhysicalResourceId": "CFN-ProvidedParameter-48Iab30cQ0nx",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -3870,9 +4008,17 @@
         "NotificationARNs": [],
         "Parameters": [
           {
-            "ParameterKey": "InputValue",
+            "ParameterKey": "DefaultInputValue",
+            "ParameterValue": "<default-value-2>"
+          },
+          {
+            "ParameterKey": "ExternalInputValue",
             "ParameterValue": "<parameter-name>",
-            "ResolvedValue": "<value-2>"
+            "ResolvedValue": "<external-value-2>"
+          },
+          {
+            "ParameterKey": "ProvidedInputValue",
+            "ParameterValue": "<provided-value-2>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3903,8 +4049,42 @@
                   }
                 }
               ],
-              "LogicalResourceId": "DerivedParameter",
-              "PhysicalResourceId": "CFN-DerivedParameter-YIO8ynD1Sgjp",
+              "LogicalResourceId": "ExternalParameter",
+              "PhysicalResourceId": "CFN-ExternalParameter-tKIiDHqu6jnn",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                },
+                {
+                  "CausingEntity": "ProvidedInputValue",
+                  "ChangeSource": "ParameterReference",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "ProvidedParameter",
+              "PhysicalResourceId": "CFN-ProvidedParameter-48Iab30cQ0nx",
               "Replacement": "False",
               "ResourceType": "AWS::SSM::Parameter",
               "Scope": [
@@ -3920,9 +4100,17 @@
         "NotificationARNs": [],
         "Parameters": [
           {
-            "ParameterKey": "InputValue",
+            "ParameterKey": "DefaultInputValue",
+            "ParameterValue": "<default-value-2>"
+          },
+          {
+            "ParameterKey": "ExternalInputValue",
             "ParameterValue": "<parameter-name>",
-            "ResolvedValue": "<value-2>"
+            "ResolvedValue": "<external-value-2>"
+          },
+          {
+            "ParameterKey": "ProvidedInputValue",
+            "ParameterValue": "<provided-value-2>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3952,15 +4140,31 @@
         "NotificationARNs": [],
         "Outputs": [
           {
-            "OutputKey": "DerivedParameterName",
-            "OutputValue": "CFN-DerivedParameter-YIO8ynD1Sgjp"
+            "OutputKey": "DefaultParameterName",
+            "OutputValue": "CFN-DefaultParameter-XZTowJJO5ayT"
+          },
+          {
+            "OutputKey": "ExternalParameterName",
+            "OutputValue": "CFN-ExternalParameter-tKIiDHqu6jnn"
+          },
+          {
+            "OutputKey": "ProvidedParameterName",
+            "OutputValue": "CFN-ProvidedParameter-48Iab30cQ0nx"
           }
         ],
         "Parameters": [
           {
-            "ParameterKey": "InputValue",
+            "ParameterKey": "DefaultInputValue",
+            "ParameterValue": "<default-value-2>"
+          },
+          {
+            "ParameterKey": "ExternalInputValue",
             "ParameterValue": "<parameter-name>",
-            "ResolvedValue": "<value-2>"
+            "ResolvedValue": "<external-value-2>"
+          },
+          {
+            "ParameterKey": "ProvidedInputValue",
+            "ParameterValue": "<provided-value-2>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3980,15 +4184,31 @@
         "NotificationARNs": [],
         "Outputs": [
           {
-            "OutputKey": "DerivedParameterName",
-            "OutputValue": "CFN-DerivedParameter-YIO8ynD1Sgjp"
+            "OutputKey": "DefaultParameterName",
+            "OutputValue": "CFN-DefaultParameter-XZTowJJO5ayT"
+          },
+          {
+            "OutputKey": "ExternalParameterName",
+            "OutputValue": "CFN-ExternalParameter-tKIiDHqu6jnn"
+          },
+          {
+            "OutputKey": "ProvidedParameterName",
+            "OutputValue": "CFN-ProvidedParameter-48Iab30cQ0nx"
           }
         ],
         "Parameters": [
           {
-            "ParameterKey": "InputValue",
+            "ParameterKey": "DefaultInputValue",
+            "ParameterValue": "<default-value-2>"
+          },
+          {
+            "ParameterKey": "ExternalInputValue",
             "ParameterValue": "<parameter-name>",
-            "ResolvedValue": "<value-2>"
+            "ResolvedValue": "<external-value-2>"
+          },
+          {
+            "ParameterKey": "ProvidedInputValue",
+            "ParameterValue": "<provided-value-2>"
           }
         ],
         "RollbackConfiguration": {},
@@ -3998,31 +4218,77 @@
         "Tags": []
       },
       "per-resource-events": {
-        "DerivedParameter": [
+        "DefaultParameter": [
           {
-            "LogicalResourceId": "DerivedParameter",
+            "LogicalResourceId": "DefaultParameter",
             "PhysicalResourceId": "",
             "ResourceStatus": "CREATE_IN_PROGRESS",
             "ResourceType": "AWS::SSM::Parameter",
             "Timestamp": "timestamp"
           },
           {
-            "LogicalResourceId": "DerivedParameter",
-            "PhysicalResourceId": "CFN-DerivedParameter-YIO8ynD1Sgjp",
+            "LogicalResourceId": "DefaultParameter",
+            "PhysicalResourceId": "CFN-DefaultParameter-XZTowJJO5ayT",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ExternalParameter": [
+          {
+            "LogicalResourceId": "ExternalParameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "ExternalParameter",
+            "PhysicalResourceId": "CFN-ExternalParameter-tKIiDHqu6jnn",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
             "Timestamp": "timestamp"
           },
           {
-            "LogicalResourceId": "DerivedParameter",
-            "PhysicalResourceId": "CFN-DerivedParameter-YIO8ynD1Sgjp",
+            "LogicalResourceId": "ExternalParameter",
+            "PhysicalResourceId": "CFN-ExternalParameter-tKIiDHqu6jnn",
             "ResourceStatus": "UPDATE_IN_PROGRESS",
             "ResourceType": "AWS::SSM::Parameter",
             "Timestamp": "timestamp"
           },
           {
-            "LogicalResourceId": "DerivedParameter",
-            "PhysicalResourceId": "CFN-DerivedParameter-YIO8ynD1Sgjp",
+            "LogicalResourceId": "ExternalParameter",
+            "PhysicalResourceId": "CFN-ExternalParameter-tKIiDHqu6jnn",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ProvidedParameter": [
+          {
+            "LogicalResourceId": "ProvidedParameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "ProvidedParameter",
+            "PhysicalResourceId": "CFN-ProvidedParameter-48Iab30cQ0nx",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "ProvidedParameter",
+            "PhysicalResourceId": "CFN-ProvidedParameter-48Iab30cQ0nx",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "ProvidedParameter",
+            "PhysicalResourceId": "CFN-ProvidedParameter-48Iab30cQ0nx",
             "ResourceStatus": "UPDATE_COMPLETE",
             "ResourceType": "AWS::SSM::Parameter",
             "Timestamp": "timestamp"

--- a/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
@@ -90,12 +90,12 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::test_dynamic_ssm_parameter_lookup": {
-    "last_validated_date": "2025-06-24T13:57:09+00:00",
+    "last_validated_date": "2025-06-24T14:41:11+00:00",
     "durations_in_seconds": {
-      "setup": 2.08,
-      "call": 25.0,
-      "teardown": 0.36,
-      "total": 27.44
+      "setup": 1.19,
+      "call": 24.36,
+      "teardown": 0.5,
+      "total": 26.05
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::test_single_resource_static_update": {

--- a/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
@@ -89,6 +89,15 @@
       "total": 124.6
     }
   },
+  "tests/aws/services/cloudformation/v2/test_change_sets.py::test_dynamic_ssm_parameter_lookup": {
+    "last_validated_date": "2025-06-24T12:51:24+00:00",
+    "durations_in_seconds": {
+      "setup": 2.03,
+      "call": 63.12,
+      "teardown": 1.14,
+      "total": 66.29
+    }
+  },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::test_single_resource_static_update": {
     "last_validated_date": "2025-03-18T16:52:35+00:00"
   }

--- a/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
+++ b/tests/aws/services/cloudformation/v2/test_change_sets.validation.json
@@ -90,12 +90,12 @@
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::test_dynamic_ssm_parameter_lookup": {
-    "last_validated_date": "2025-06-24T12:51:24+00:00",
+    "last_validated_date": "2025-06-24T13:57:09+00:00",
     "durations_in_seconds": {
-      "setup": 2.03,
-      "call": 63.12,
-      "teardown": 1.14,
-      "total": 66.29
+      "setup": 2.08,
+      "call": 25.0,
+      "teardown": 0.36,
+      "total": 27.44
     }
   },
   "tests/aws/services/cloudformation/v2/test_change_sets.py::test_single_resource_static_update": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We currently don't support the resolution of SSM parameters in the template `Parameters` when performing template describing, only executing. This does not match AWS behaviour, which represents the resolved values as well as the given parameters.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Move SSM parameter resolution to the preprocessing step as it's performed during `create_change_set`, so we should do it before describing and executing
* Add significant test for resolving SSM parameters
* Remove skip from cdk bootstrap since it's no longer failing
* Add structured type to parameters when describing so we can represent the original value (e.g. SSM parameter name) and resolved value (the SSM parameter value)

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->