### PR TITLE
Fix logging placeholder for apigateway openapi import

### DIFF
--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -739,7 +739,7 @@ def import_api_from_openapi_spec(
                             model_ref = media_type.get("schema", {}).get("$ref")
                             continue
                         LOG.warning(
-                            "Found '%s' content-type for the MethodResponse model for path '%s' and method '', not adding the model as currently not supported",
+                            "Found '%s' content-type for the MethodResponse model for path '%s' and method '%s', not adding the model as currently not supported",
                             content_type,
                             rel_path,
                             method_name,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We got alerted that there is a missing placeholder for our apigateway logging for importing openapi specs.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Fix log format string

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
