### PR TITLE
KMS: RotateKeyOnDemand api update

### DIFF
--- a/localstack-core/localstack/aws/api/kms/__init__.py
+++ b/localstack-core/localstack/aws/api/kms/__init__.py
@@ -10,6 +10,7 @@ ArnType = str
 BackingKeyIdResponseType = str
 BackingKeyIdType = str
 BooleanType = bool
+CurrentKeyMaterialIdType = str
 CloudHsmClusterIdType = str
 CustomKeyStoreIdType = str
 CustomKeyStoreNameType = str
@@ -717,6 +718,7 @@ class KeyMetadata(TypedDict, total=False):
     DeletionDate: Optional[DateType]
     ValidTo: Optional[DateType]
     Origin: Optional[OriginType]
+    CurrentKeyMaterialId: Optional[CurrentKeyMaterialIdType]
     CustomKeyStoreId: Optional[CustomKeyStoreIdType]
     CloudHsmClusterId: Optional[CloudHsmClusterIdType]
     ExpirationModel: Optional[ExpirationModelType]

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -1371,14 +1371,13 @@ class TestKMS:
         snapshot.match("error-response", e.value.response)
 
     @markers.aws.validated
-    def test_rotate_key_on_demand_raises_error_given_key_with_imported_key_material(
-        self, kms_create_key, aws_client, snapshot
+    def test_rotate_key_on_demand_succeeds_for_key_with_imported_key_material(
+            self, kms_create_key, aws_client, snapshot
     ):
         key_id = kms_create_key(Origin="EXTERNAL")["KeyId"]
 
-        with pytest.raises(ClientError) as e:
-            aws_client.kms.rotate_key_on_demand(KeyId=key_id)
-        snapshot.match("error-response", e.value.response)
+        response = aws_client.kms.rotate_key_on_demand(KeyId=key_id)
+        snapshot.match("rotate-on-demand-response", response)
 
     @markers.aws.validated
     @pytest.mark.parametrize("rotation_period_in_days", [90, 180])
@@ -2093,3 +2092,9 @@ class TestKMSGenerateKeys:
 
         err = exc.value.response
         snapshot.match("dryrun_exception", err)
+
+
+
+
+
+

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -2090,6 +2090,18 @@
       }
     }
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_rotate_key_on_demand_succeeds_for_key_with_imported_key_material": {
+    "recorded-date": "24-06-2025, 18:13:33",
+    "recorded-content": {
+      "rotate-on-demand-response": {
+        "KeyId": "<key-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_rotate_key_on_demand_raises_error_given_key_is_disabled": {
     "recorded-date": "08-03-2025, 09:26:50",
     "recorded-content": {
@@ -2130,22 +2142,6 @@
           "Code": "UnsupportedOperationException",
           "Message": ""
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/kms/test_kms.py::TestKMS::test_rotate_key_on_demand_raises_error_given_key_with_imported_key_material": {
-    "recorded-date": "08-03-2025, 09:28:13",
-    "recorded-content": {
-      "error-response": {
-        "Error": {
-          "Code": "UnsupportedOperationException",
-          "Message": "<key-arn> origin is EXTERNAL which is not valid for this operation."
-        },
-        "message": "<key-arn> origin is EXTERNAL which is not valid for this operation.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -218,9 +218,6 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_rotate_key_on_demand_raises_error_given_key_that_does_not_exist": {
     "last_validated_date": "2025-03-08T09:27:10+00:00"
   },
-  "tests/aws/services/kms/test_kms.py::TestKMS::test_rotate_key_on_demand_raises_error_given_key_with_imported_key_material": {
-    "last_validated_date": "2025-03-08T09:28:13+00:00"
-  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_rotate_key_on_demand_raises_error_given_non_symmetric_key": {
     "last_validated_date": "2025-03-08T09:27:44+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
In response to the latest changes to KMS that AWS have made it is now possible to rotate keys on demand if they are and external key,
https://aws.amazon.com/blogs/security/how-to-use-on-demand-rotation-for-aws-kms-imported-keys/


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Add `CurrentKeyMaterialId` to key Metadata
- Allow `RotateKeyOnDemand` to accept `EXTERNAL` Type keys
- Updated test for `RotateKeyOnDemand`

Relates to issue #12803 
