### PR TITLE
Update Extension API

### DIFF
--- a/localstack-core/localstack/extensions/api/aws.py
+++ b/localstack-core/localstack/extensions/api/aws.py
@@ -7,6 +7,7 @@ from localstack.aws.api import (
 )
 from localstack.aws.chain import (
     CompositeExceptionHandler,
+    CompositeFinalizer,
     CompositeHandler,
     CompositeResponseHandler,
     ExceptionHandler,
@@ -28,4 +29,5 @@ __all__ = [
     "ExceptionHandler",
     "CompositeResponseHandler",
     "CompositeExceptionHandler",
+    "CompositeFinalizer",
 ]

--- a/localstack-core/localstack/extensions/api/extension.py
+++ b/localstack-core/localstack/extensions/api/extension.py
@@ -1,6 +1,11 @@
 from plux import Plugin
 
-from .aws import CompositeExceptionHandler, CompositeHandler, CompositeResponseHandler
+from .aws import (
+    CompositeExceptionHandler,
+    CompositeFinalizer,
+    CompositeHandler,
+    CompositeResponseHandler,
+)
 from .http import RouteHandler, Router
 
 
@@ -83,6 +88,14 @@ class Extension(BaseExtension):
         Called with the custom exception handlers of the LocalStack gateway. Overwrite this to add or update handlers.
 
         :param handlers: custom exception handlers of the gateway
+        """
+        pass
+
+    def update_finalizers(self, handlers: CompositeFinalizer):
+        """
+        Called with the custom finalizer handlers of the LocalStack gateway. Overwrite this to add or update handlers.
+
+        :param handlers: custom finalizer handlers of the gateway
         """
         pass
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With #9194, we introduced the concept of Finalizers. 
Those are not yet available in Extensions.
This PR adds that 😄 

note: naming can be updated, but all the methods ending with `_handlers` were accessing a `Composite*Handler`, but the finalizers are defined as `CompositeFinalizer` with no handler in the name, so I followed the same convention. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update the signature of the Extension base class

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
