### PR TITLE
CloudFormation v2 Engine: Runtime Caching Support

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
@@ -159,7 +159,8 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
             depends_on_resource_logical_ids.update(array_identifiers_delta.after)
         for depends_on_resource_logical_id in depends_on_resource_logical_ids:
             node_resource = self._get_node_resource_for(
-                resource_name=depends_on_resource_logical_id, node_template=self._node_template
+                resource_name=depends_on_resource_logical_id,
+                node_template=self._change_set.update_model.node_template,
             )
             self.visit(node_resource)
 

--- a/localstack-core/localstack/services/cloudformation/v2/entities.py
+++ b/localstack-core/localstack/services/cloudformation/v2/entities.py
@@ -24,7 +24,7 @@ from localstack.services.cloudformation.engine.entities import (
     StackTemplate,
 )
 from localstack.services.cloudformation.engine.v2.change_set_model import (
-    NodeTemplate,
+    UpdateModel,
 )
 from localstack.utils.aws import arns
 from localstack.utils.strings import long_uid, short_uid
@@ -195,7 +195,7 @@ class ChangeSet:
     change_set_name: str
     change_set_id: str
     change_set_type: ChangeSetType
-    update_model: Optional[NodeTemplate]
+    update_model: Optional[UpdateModel]
     status: ChangeSetStatus
     execution_status: ExecutionStatus
     creation_time: datetime
@@ -222,7 +222,7 @@ class ChangeSet:
             region_name=self.stack.region_name,
         )
 
-    def set_update_model(self, update_model: NodeTemplate) -> None:
+    def set_update_model(self, update_model: UpdateModel) -> None:
         self.update_model = update_model
 
     def set_change_set_status(self, status: ChangeSetStatus):

--- a/tests/aws/services/cloudformation/v2/test_change_set_global_macros.py
+++ b/tests/aws/services/cloudformation/v2/test_change_set_global_macros.py
@@ -31,9 +31,6 @@ from localstack.utils.strings import short_uid
 )
 class TestChangeSetGlobalMacros:
     @markers.aws.validated
-    @pytest.mark.skip(
-        reason="CFNV2:Other deletion of CFN macro is received before the template update event"
-    )
     def test_base_global_macro(
         self,
         aws_client,
@@ -94,7 +91,6 @@ class TestChangeSetGlobalMacros:
                 },
             },
             "Outputs": {
-                "ParameterName": {"Value": {"Ref": "Parameter"}},
                 "Parameter2Name": {"Value": {"Ref": "Parameter2"}},
             },
         }

--- a/tests/aws/services/cloudformation/v2/test_change_set_global_macros.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/test_change_set_global_macros.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/v2/test_change_set_global_macros.py::TestChangeSetGlobalMacros::test_base_global_macro": {
-    "recorded-date": "16-06-2025, 09:52:28",
+    "recorded-date": "24-06-2025, 15:16:22",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -222,10 +222,6 @@
         "NotificationARNs": [],
         "Outputs": [
           {
-            "OutputKey": "ParameterName",
-            "OutputValue": "<output-value:1>"
-          },
-          {
             "OutputKey": "Parameter2Name",
             "OutputValue": "<output-value:2>"
           }
@@ -242,163 +238,6 @@
         "StackStatus": "UPDATE_COMPLETE",
         "Tags": []
       },
-      "per-resource-events": {
-        "Parameter": [
-          {
-            "EventId": "Parameter-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "<output-value:1>",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "SubstitutionDefault"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "<output-value:1>",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "SubstitutionDefault"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "SubstitutionDefault"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          }
-        ],
-        "Parameter2": [
-          {
-            "EventId": "Parameter2-CREATE_COMPLETE-date",
-            "LogicalResourceId": "Parameter2",
-            "PhysicalResourceId": "<output-value:2>",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "SubstitutionDefault"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter2-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter2",
-            "PhysicalResourceId": "<output-value:2>",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "SubstitutionDefault"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "Parameter2-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "Parameter2",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "Type": "String",
-              "Value": "SubstitutionDefault"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SSM::Parameter",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          }
-        ],
-        "<stack-name:1>": [
-          {
-            "EventId": "<uuid:1>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "UPDATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:2>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:3>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "UPDATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:4>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:5>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:6>",
-            "LogicalResourceId": "<stack-name:1>",
-            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
-            "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          }
-        ]
-      },
       "delete-describe": {
         "CreationTime": "datetime",
         "DeletionTime": "datetime",
@@ -409,10 +248,6 @@
         "LastUpdatedTime": "datetime",
         "NotificationARNs": [],
         "Outputs": [
-          {
-            "OutputKey": "ParameterName",
-            "OutputValue": "<output-value:1>"
-          },
           {
             "OutputKey": "Parameter2Name",
             "OutputValue": "<output-value:2>"
@@ -429,6 +264,77 @@
         "StackName": "<stack-name:1>",
         "StackStatus": "DELETE_COMPLETE",
         "Tags": []
+      },
+      "per-resource-events": {
+        "Parameter": [
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter",
+            "PhysicalResourceId": "<output-value:1>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Parameter2": [
+          {
+            "LogicalResourceId": "Parameter2",
+            "PhysicalResourceId": "",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "Parameter2",
+            "PhysicalResourceId": "<output-value:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
       }
     }
   }

--- a/tests/aws/services/cloudformation/v2/test_change_set_global_macros.validation.json
+++ b/tests/aws/services/cloudformation/v2/test_change_set_global_macros.validation.json
@@ -1,11 +1,11 @@
 {
   "tests/aws/services/cloudformation/v2/test_change_set_global_macros.py::TestChangeSetGlobalMacros::test_base_global_macro": {
-    "last_validated_date": "2025-06-16T09:52:29+00:00",
+    "last_validated_date": "2025-06-24T15:16:22+00:00",
     "durations_in_seconds": {
-      "setup": 12.19,
-      "call": 37.41,
-      "teardown": 5.9,
-      "total": 55.5
+      "setup": 11.62,
+      "call": 34.97,
+      "teardown": 5.44,
+      "total": 52.03
     }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The introduction of the CloudFormation v2 engine laid the foundation for a redesigned engine capable of accurately determining update requirements between CloudFormation deployments, while also enabling parallel execution during updates. However, the new engine does not store or cache the evaluation of previous change set operations. This leads to  issues, such as the need to reevaluate global macros from earlier template versions. This process fails if the macro is no longer available, or it can result in corrupted states if the macro has been modified.
The absence of caching also forces full reevaluation of both template versions during a chain of change set updates, even when this information could simply be read from cache.
This PR introduces support for caching, resolving issues related to global transformations. It also adds utility functions for downstream processors to take advantage of the cache, applies these utilities in several scenarios within the preprocessor, and includes a negative test case for the global transformation scenario.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added UpdateModel encapsulation for change set model visitors to handle runtime caching values
- Added logics to load and save the runtime caches
- Added utility function to utilize the cache within change set model visitors
- Ported a number of preprocessing visitors to using the cache
- Added related negative test for global transforms (see description above)
- Other related/minors

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
