### PR TITLE
KMS #12530: Error handling for invalid blob  issue

### DIFF
--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -1565,7 +1565,7 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_encrypt_decrypt_encryption_context": {
-    "recorded-date": "11-05-2023, 22:46:49",
+    "recorded-date": "08-07-2025, 05:53:27",
     "recorded-content": {
       "encrypt_response": {
         "CiphertextBlob": "ciphertext-blob",
@@ -1579,6 +1579,7 @@
       "decrypt_response_with_encryption_context": {
         "EncryptionAlgorithm": "SYMMETRIC_DEFAULT",
         "KeyId": "<key-id:1>",
+        "KeyMaterialId": "e2333676b9bf055cb0caa2bec3957d7f3e60b7545a3706314e397746cd26122e",
         "Plaintext": "plaintext",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1586,6 +1587,16 @@
         }
       },
       "decrypt_response_without_encryption_context": {
+        "Error": {
+          "Code": "InvalidCiphertextException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "decrypt_response_with_invalid_ciphertext": {
         "Error": {
           "Code": "InvalidCiphertextException",
           "Message": ""

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -60,7 +60,13 @@
     "last_validated_date": "2024-04-11T15:53:18+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_encrypt_decrypt_encryption_context": {
-    "last_validated_date": "2024-04-11T15:54:22+00:00"
+    "last_validated_date": "2025-07-08T05:53:27+00:00",
+    "durations_in_seconds": {
+      "setup": 0.74,
+      "call": 1.08,
+      "teardown": 0.15,
+      "total": 1.97
+    }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_2048-RSAES_OAEP_SHA_1]": {
     "last_validated_date": "2024-04-11T15:53:20+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
User reported a issue https://github.com/localstack/localstack/issues/12530 that causes a attribute error in Localstack. The error doesn't guide or provide clue to user on the problem. User is trying to decrypt the ciphertext blob by providing KeyId using Lambda function.
This PR fixes how LocalStack handles corrupted blobs during decryption when KeyId is provided by user. The fix ensures LocalStack's response matches AWS behavior.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Localstack will mimic AWS behavior i.e. it will generate same response that AWS would generate. It will help user to validate the blob text that need to be decrypted using Localstack.

<!-- Optional section: How to test these changes? -->

## Testing
Add a snaphshot test case in existing test method test_encrypt_decrypt_encryption_context() because AWS response is same. Newl response from AWS is added to test_kms.snapshot.json.

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
