### PR TITLE
SQS: add automatic propagation of AWSTraceHeader attribute when sending message

### DIFF
--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -1679,6 +1679,13 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             MessageSystemAttributeName.SenderId: context.account_id,  # not the account ID in AWS
             MessageSystemAttributeName.SentTimestamp: str(now(millis=True)),
         }
+        # we are not using the `context.trace_context` here as it is automatically populated
+        # AWS only adds the `AWSTraceHeader` attribute if the header is explicitly present
+        # TODO: check maybe with X-Ray Active mode?
+        if "X-Amzn-Trace-Id" in context.request.headers:
+            result[MessageSystemAttributeName.AWSTraceHeader] = str(
+                context.request.headers["X-Amzn-Trace-Id"]
+            )
 
         if message_system_attributes is not None:
             for attr in message_system_attributes:

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3974,5 +3974,43 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_aws_trace_header_propagation[sqs]": {
+    "recorded-date": "27-06-2025, 10:55:55",
+    "recorded-content": {
+      "xray-msg": {
+        "Attributes": {
+          "AWSTraceHeader": "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1",
+          "SentTimestamp": "timestamp"
+        },
+        "Body": "test",
+        "MD5OfBody": "098f6bcd4621d373cade4e832627b4f6",
+        "MD5OfMessageAttributes": "235c5c510d26fb653d073faed50ae77c",
+        "MessageAttributes": {
+          "timestamp": "timestamp"
+        },
+        "MessageId": "<uuid:1>",
+        "ReceiptHandle": "<receipt-handle:1>"
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_aws_trace_header_propagation[sqs_query]": {
+    "recorded-date": "27-06-2025, 10:55:56",
+    "recorded-content": {
+      "xray-msg": {
+        "Attributes": {
+          "AWSTraceHeader": "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1",
+          "SentTimestamp": "timestamp"
+        },
+        "Body": "test",
+        "MD5OfBody": "098f6bcd4621d373cade4e832627b4f6",
+        "MD5OfMessageAttributes": "235c5c510d26fb653d073faed50ae77c",
+        "MessageAttributes": {
+          "timestamp": "timestamp"
+        },
+        "MessageId": "<uuid:1>",
+        "ReceiptHandle": "<receipt-handle:1>"
+      }
+    }
   }
 }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -1,4 +1,22 @@
 {
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_aws_trace_header_propagation[sqs]": {
+    "last_validated_date": "2025-06-27T10:55:55+00:00",
+    "durations_in_seconds": {
+      "setup": 0.47,
+      "call": 0.71,
+      "teardown": 0.15,
+      "total": 1.33
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_aws_trace_header_propagation[sqs_query]": {
+    "last_validated_date": "2025-06-27T10:55:56+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.68,
+      "teardown": 0.15,
+      "total": 0.83
+    }
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_change_message_visibility_after_visibility_timeout_expiration[sqs]": {
     "last_validated_date": "2024-04-30T13:33:26+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While reading about SQS and X-Ray, I had a hunch we didn't implement the automatic passing of X-Ray headers to the Attributes. 
See https://docs.aws.amazon.com/xray/latest/devguide/xray-services-sqs.html

It might have been the case in the past, due to this following function:
https://github.com/localstack/localstack/blob/5b0180cbf277936f83334c7a61e1f63f18e9c01e/localstack-core/localstack/utils/aws/aws_responses.py#L189-L196

But this was lacking now.
I've added a test to verify the behavior in AWS. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add automatic propagation from incoming request headers to `AWSTraceHeader` Attribute

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
