### PR TITLE
SES: add snapshot test for describe_configuration_set with SNS destinations

### DIFF
--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -6,6 +6,7 @@ from datetime import date, datetime
 import pytest
 import requests
 from botocore.exceptions import ClientError
+from localstack_snapshot.snapshots.transformer import SortingTransformer
 
 import localstack.config as config
 from localstack.services.ses.provider import EMAILS, EMAILS_ENDPOINT
@@ -286,6 +287,39 @@ class TestSES:
 
         _ = retry(_assert_sent_quota, expected_counter=counter + 1, retries=retries, sleep=1)
         # snapshot.match('get-quota-3', _)
+
+    @markers.aws.validated
+    def test_describe_config_set_event_destinations(
+        self,
+        aws_client,
+        sns_topic,
+        ses_configuration_set,
+        ses_configuration_set_sns_event_destination,
+        snapshot,
+    ):
+        config_set_name = f"config-set-{short_uid()}"
+        snapshot.add_transformer(snapshot.transform.regex(config_set_name, "<config-set-name>"))
+
+        topic_arn = sns_topic["Attributes"]["TopicArn"]
+        snapshot.add_transformer(snapshot.transform.regex(topic_arn, "<arn>"))
+
+        ses_configuration_set(config_set_name)
+        event_destination_name = f"config-set-event-destination-{short_uid()}"
+        snapshot.add_transformer(
+            snapshot.transform.regex(event_destination_name, "<event-destination-name>")
+        )
+
+        snapshot.add_transformer(SortingTransformer("MatchingEventTypes"))
+
+        ses_configuration_set_sns_event_destination(
+            config_set_name, event_destination_name, topic_arn
+        )
+
+        response = aws_client.ses.describe_configuration_set(
+            ConfigurationSetName=config_set_name,
+            ConfigurationSetAttributeNames=["eventDestinations"],
+        )
+        snapshot.match("event_destinations", response)
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(

--- a/tests/aws/services/ses/test_ses.snapshot.json
+++ b/tests/aws/services/ses/test_ses.snapshot.json
@@ -1081,5 +1081,35 @@
         }
       }
     }
+  },
+  "tests/aws/services/ses/test_ses.py::TestSES::test_describe_config_set_event_destinations": {
+    "recorded-date": "20-08-2025, 12:00:48",
+    "recorded-content": {
+      "event_destinations": {
+        "ConfigurationSet": {
+          "Name": "<config-set-name>"
+        },
+        "EventDestinations": [
+          {
+            "Enabled": true,
+            "MatchingEventTypes": [
+              "bounce",
+              "click",
+              "delivery",
+              "open",
+              "send"
+            ],
+            "Name": "<event-destination-name>",
+            "SNSDestination": {
+              "TopicARN": "<arn>"
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/ses/test_ses.validation.json
+++ b/tests/aws/services/ses/test_ses.validation.json
@@ -23,6 +23,15 @@
   "tests/aws/services/ses/test_ses.py::TestSES::test_deleting_non_existent_configuration_set_event_destination": {
     "last_validated_date": "2023-08-25T22:04:53+00:00"
   },
+  "tests/aws/services/ses/test_ses.py::TestSES::test_describe_config_set_event_destinations": {
+    "last_validated_date": "2025-08-20T12:00:48+00:00",
+    "durations_in_seconds": {
+      "setup": 2.09,
+      "call": 1.15,
+      "teardown": 0.58,
+      "total": 3.82
+    }
+  },
   "tests/aws/services/ses/test_ses.py::TestSES::test_invalid_tags_send_email[-]": {
     "last_validated_date": "2024-07-30T10:18:09+00:00"
   },


### PR DESCRIPTION
## Motivation

As reported in #12722, `describe_configuration_set` is missing SNS event destinations.

This is addressed in https://github.com/getmoto/moto/pull/9023 and this PR complements the parity enhancement with a snapshot test.

## Changes

Only tests.

## Testing

- Snapshot test to validate the destinations are there when setting them for a configuration set.

## TODO

- Wait until https://github.com/getmoto/moto/pull/9023 is merged and cascaded to Localstack. Otherwise this test fails.
