### PR TITLE
CI: updated owners of .test_durations file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,7 +18,7 @@
 
 # Git, Pipelines, GitHub config
 /.github @alexrashed @dfangl @dominikschubert @silv-io @k-a-il
-/.test_durations @alexrashed
+/.test_durations @alexrashed @silv-io @k-a-il
 /.git-blame-ignore-revs @alexrashed @thrau
 /bin/release-dev.sh @thrau @alexrashed
 /bin/release-helper.sh @thrau @alexrashed


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Some time ago a [GitHub workflow](https://github.com/localstack/localstack/actions/workflows/update-test-durations.yml) to automatically fetch and update the `.test_durations` file has been created. @silv-io and I will be overseeing this workflow, so it makes sense to add us as code owners of the file. This way, whenever an automatic PR is created to update it, we’ll be assigned as reviewers.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Updated CODEOWNERS file

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
