### PR TITLE
Add tag push trigger to main workflow

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -190,7 +190,7 @@ jobs:
     name: "Push images"
     runs-on: ubuntu-latest
     # push image on master, target branch not set, and the dependent steps were either successful or skipped
-    if: github.ref == 'refs/heads/master' && !failure() && !cancelled() && github.repository == 'localstack/localstack'
+    if: ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') ) && !failure() && !cancelled() && github.repository == 'localstack/localstack'
     needs:
       # all tests need to be successful for the image to be pushed
       - test
@@ -269,7 +269,7 @@ jobs:
 
   push-to-tinybird:
     name: Push Workflow Status to Tinybird
-    if: always() && github.ref == 'refs/heads/master' && github.repository == 'localstack/localstack'
+    if: always() && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') ) && github.repository == 'localstack/localstack'
     runs-on: ubuntu-latest
     needs:
       - test

--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -17,6 +17,8 @@ on:
       - '!docs/**'
     branches:
       - master
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     paths:
       - '**'

--- a/.github/workflows/aws-tests-mamr.yml
+++ b/.github/workflows/aws-tests-mamr.yml
@@ -67,7 +67,7 @@ jobs:
 
   push-to-tinybird:
     name: Push Workflow Status to Tinybird
-    if: always() && github.ref == 'refs/heads/master' && github.repository == 'localstack/localstack'
+    if: always() && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') ) && github.repository == 'localstack/localstack'
     runs-on: ubuntu-latest
     needs:
       - test-ma-mr

--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -132,7 +132,7 @@ env:
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
   # report to tinybird if executed on master
-  TINYBIRD_PYTEST_ARGS: "${{ github.repository == 'localstack/localstack' && github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+  TINYBIRD_PYTEST_ARGS: "${{ github.repository == 'localstack/localstack' && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') ) && '--report-to-tinybird ' || '' }}"
   DOCKER_PULL_SECRET_AVAILABLE: ${{ secrets.DOCKERHUB_PULL_USERNAME != '' && secrets.DOCKERHUB_PULL_TOKEN != '' && 'true' || 'false' }}
 
 
@@ -150,7 +150,7 @@ jobs:
         exclude:
           # skip the ARM integration tests in forks, and also if not on master/upgrade-dependencies and forceARMTests is not set to true
           # TODO ARM runners are not yet available for private repositories; skip them for potential private forks
-          - runner: ${{ ((github.repository != 'localstack/localstack') || (github.ref != 'refs/heads/master' && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false)) && 'ubuntu-24.04-arm' || ''}}
+          - runner: ${{ ((github.repository != 'localstack/localstack') || (github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v') && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false)) && 'ubuntu-24.04-arm' || ''}}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
@@ -338,7 +338,7 @@ jobs:
         exclude:
           # skip the ARM integration tests in forks, and also if not on master/upgrade-dependencies and forceARMTests is not set to true
           # TODO ARM runners are not yet available for private repositories; skip them for potential private forks
-          - runner: ${{ ((github.repository != 'localstack/localstack') || (github.ref != 'refs/heads/master' && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false)) && 'ubuntu-24.04-arm' || ''}}
+          - runner: ${{ ((github.repository != 'localstack/localstack') || (github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v') && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false)) && 'ubuntu-24.04-arm' || ''}}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     env:
@@ -489,7 +489,7 @@ jobs:
         exclude:
           # skip the ARM integration tests in forks, and also if not on master/upgrade-dependencies and forceARMTests is not set to true
           # TODO ARM runners are not yet available for private repositories; skip them for potential private forks
-          - arch: ${{ ((github.repository != 'localstack/localstack') || (github.ref != 'refs/heads/master' && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false)) && 'arm64' || ''}}
+          - arch: ${{ ((github.repository != 'localstack/localstack') || (github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v') && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false)) && 'arm64' || ''}}
     needs:
       - test-integration
       - test-bootstrap
@@ -535,7 +535,7 @@ jobs:
         exclude:
           # skip the ARM integration tests in forks, and also if not on master/upgrade-dependencies and forceARMTests is not set to true
           # TODO ARM runners are not yet available for private repositories; skip them for potential private forks
-          - runner: ${{ ((github.repository != 'localstack/localstack') || (github.ref != 'refs/heads/master' && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false)) && 'ubuntu-24.04-arm' || ''}}
+          - runner: ${{ ((github.repository != 'localstack/localstack') || (github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v') && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false)) && 'ubuntu-24.04-arm' || ''}}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     env:
@@ -610,7 +610,7 @@ jobs:
         exclude:
           # skip the ARM integration tests in forks, and also if not on master/upgrade-dependencies and forceARMTests is not set to true
           # TODO ARM runners are not yet available for private repositories; skip them for potential private forks
-          - arch: ${{ ((github.repository != 'localstack/localstack') || (github.ref != 'refs/heads/master' && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false)) && 'arm64' || ''}}
+          - arch: ${{ ((github.repository != 'localstack/localstack') || (github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v') && github.ref != 'upgrade-dependencies' && inputs.forceARMTests == false)) && 'arm64' || ''}}
     needs:
       - test-acceptance
     runs-on: ubuntu-latest
@@ -639,7 +639,7 @@ jobs:
 
   test-cloudwatch-v1:
     name: Test CloudWatch V1
-    if: ${{ !inputs.onlyAcceptanceTests && (github.ref == 'refs/heads/master' || needs.test-preflight.outputs.cloudwatch-v1 == 'true') }}
+    if: ${{ !inputs.onlyAcceptanceTests && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || needs.test-preflight.outputs.cloudwatch-v1 == 'true') }}
     runs-on: ubuntu-latest
     needs:
       - test-preflight
@@ -689,7 +689,7 @@ jobs:
 
   test-ddb-v2:
     name: Test DynamoDB(Streams) v2
-    if: ${{ !inputs.onlyAcceptanceTests && (github.ref == 'refs/heads/master' || needs.test-preflight.outputs.dynamodb-v2 == 'true') }}
+    if: ${{ !inputs.onlyAcceptanceTests && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || needs.test-preflight.outputs.dynamodb-v2 == 'true') }}
     runs-on: ubuntu-latest
     needs:
       - test-preflight
@@ -738,7 +738,7 @@ jobs:
 
   test-events-v1:
     name: Test EventBridge v1
-    if: ${{ !inputs.onlyAcceptanceTests && (github.ref == 'refs/heads/master' || needs.test-preflight.outputs.events-v1 == 'true') }}
+    if: ${{ !inputs.onlyAcceptanceTests && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || needs.test-preflight.outputs.events-v1 == 'true') }}
     runs-on: ubuntu-latest
     needs:
       - test-preflight
@@ -787,7 +787,7 @@ jobs:
 
   test-cfn-v2-engine:
     name: Test CloudFormation Engine v2
-    if: ${{ !inputs.onlyAcceptanceTests && ( github.ref == 'refs/heads/master' || needs.test-preflight.outputs.cloudformation-v2 == 'true' )}}
+    if: ${{ !inputs.onlyAcceptanceTests && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || needs.test-preflight.outputs.cloudformation-v2 == 'true' )}}
     runs-on: ubuntu-latest
     needs:
       - test-preflight
@@ -882,7 +882,7 @@ jobs:
 
   capture-not-implemented:
     name: "Capture Not Implemented"
-    if: ${{ !inputs.onlyAcceptanceTests && github.ref == 'refs/heads/master' }}
+    if: ${{ !inputs.onlyAcceptanceTests && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') ) }}
     runs-on: ubuntu-latest
     needs: build
     env:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We use an empty commit + a version tag to mark the release of new versions in PyPI and DockerHub. The empty commit triggered the run in CircleCI
Since switching to GitHub Actions for our CI, the empty commit does not do that anymore because of the path specifiers. However, we can use tag pushes instead to trigger the CI + push jobs.

[In a separate repo](https://github.com/silv-io/gha-trigger-testing/actions/runs/16269110767/job/45931870915), I've checked how this would behave:

Having both `tags` and `paths` patterns in a workflow does not interfere with each other. That means that pushed tags will trigger the CI regardless of which files were changed in the commit that the tag points to. 

Furthermore, a tag push event still has the same name of `push` in `github.event_name`, so we don't need to change that part in the pipeline.

The `github.ref` however changes to `refs/tags/v...` which is why we need to check for `startsWith( github.ref, refs/tags/v' )` to determine if a triggered action is on a tagged release.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- add a tag push trigger on all version tags (so `v<major>.<minor>.<patch>` where major, minor and hotfix can be arbitrary integers)
- Adapt all workflows that are called by the main workflow or are the main workflow to include checks for tag refs in addition to master branch checks. 

<!--
## Testing

I've tested the triggering behavior in the separate repository. 

- An empty commit will still not trigger the action
- A tag push will trigger the action with the appropriate tag name

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
