### PR TITLE
fix delete method of AWS::SNS::TopicPolicy CFn resource

### DIFF
--- a/localstack-core/localstack/services/sns/models.py
+++ b/localstack-core/localstack/services/sns/models.py
@@ -11,6 +11,7 @@ from localstack.aws.api.sns import (
     topicARN,
 )
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
+from localstack.utils.aws.arns import parse_arn
 from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import long_uid
 
@@ -23,6 +24,38 @@ SnsApplicationPlatforms = Literal[
 ]
 
 SnsMessageProtocols = Literal[SnsProtocols, SnsApplicationPlatforms]
+
+
+def create_default_sns_topic_policy(topic_arn: str) -> dict:
+    """
+    Creates the default SNS topic policy for the given topic ARN.
+
+    :param topic_arn: The topic arn
+    :return: A policy document
+    """
+    return {
+        "Version": "2008-10-17",
+        "Id": "__default_policy_ID",
+        "Statement": [
+            {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": [
+                    "SNS:GetTopicAttributes",
+                    "SNS:SetTopicAttributes",
+                    "SNS:AddPermission",
+                    "SNS:RemovePermission",
+                    "SNS:DeleteTopic",
+                    "SNS:Subscribe",
+                    "SNS:ListSubscriptionsByTopic",
+                    "SNS:Publish",
+                ],
+                "Resource": topic_arn,
+                "Condition": {"StringEquals": {"AWS:SourceOwner": parse_arn(topic_arn)["account"]}},
+            }
+        ],
+    }
 
 
 @singleton_factory

--- a/localstack-core/localstack/services/sns/resource_providers/aws_sns_topicpolicy.py
+++ b/localstack-core/localstack/services/sns/resource_providers/aws_sns_topicpolicy.py
@@ -14,6 +14,7 @@ from localstack.services.cloudformation.resource_provider import (
     ResourceProvider,
     ResourceRequest,
 )
+from localstack.services.sns.models import create_default_sns_topic_policy
 
 
 class SNSTopicPolicyProperties(TypedDict):
@@ -96,14 +97,17 @@ class SNSTopicPolicyProvider(ResourceProvider[SNSTopicPolicyProperties]):
         for topic_arn in model["Topics"]:
             try:
                 sns.set_topic_attributes(
-                    TopicArn=topic_arn, AttributeName="Policy", AttributeValue=""
+                    TopicArn=topic_arn,
+                    AttributeName="Policy",
+                    AttributeValue=json.dumps(create_default_sns_topic_policy(topic_arn)),
                 )
+
             except ClientError as err:
                 if "NotFound" not in err.response["Error"]["Code"]:
                     raise
 
         return ProgressEvent(
-            status=OperationStatus.IN_PROGRESS,
+            status=OperationStatus.SUCCESS,
             resource_model=model,
             custom_context=request.custom_context,
         )

--- a/tests/aws/services/cloudformation/resources/test_sns.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_sns.snapshot.json
@@ -134,5 +134,87 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_policy_resets_to_default": {
+    "recorded-date": "04-07-2025, 00:04:32",
+    "recorded-content": {
+      "default-topic-attributes": {
+        "Version": "2008-10-17",
+        "Id": "__default_policy_ID",
+        "Statement": [
+          {
+            "Sid": "__default_statement_ID",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "*"
+            },
+            "Action": [
+              "SNS:GetTopicAttributes",
+              "SNS:SetTopicAttributes",
+              "SNS:AddPermission",
+              "SNS:RemovePermission",
+              "SNS:DeleteTopic",
+              "SNS:Subscribe",
+              "SNS:ListSubscriptionsByTopic",
+              "SNS:Publish"
+            ],
+            "Resource": "arn:<partition>:sns:<region>:111111111111:<topic-name>",
+            "Condition": {
+              "StringEquals": {
+                "AWS:SourceOwner": "111111111111"
+              }
+            }
+          }
+        ]
+      },
+      "modified-topic-attributes": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "0",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "*"
+            },
+            "Action": "sns:Publish",
+            "Resource": "arn:<partition>:sns:<region>:111111111111:<topic-name>",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceAccount": "111111111111"
+              }
+            }
+          }
+        ]
+      },
+      "reverted-topic-attributes": {
+        "Version": "2008-10-17",
+        "Id": "__default_policy_ID",
+        "Statement": [
+          {
+            "Sid": "__default_statement_ID",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "*"
+            },
+            "Action": [
+              "SNS:GetTopicAttributes",
+              "SNS:SetTopicAttributes",
+              "SNS:AddPermission",
+              "SNS:RemovePermission",
+              "SNS:DeleteTopic",
+              "SNS:Subscribe",
+              "SNS:ListSubscriptionsByTopic",
+              "SNS:Publish"
+            ],
+            "Resource": "arn:<partition>:sns:<region>:111111111111:<topic-name>",
+            "Condition": {
+              "StringEquals": {
+                "AWS:SourceOwner": "111111111111"
+              }
+            }
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_sns.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_sns.validation.json
@@ -5,8 +5,23 @@
   "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_fifo_with_deduplication": {
     "last_validated_date": "2023-11-27T20:27:29+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_policy_resets_to_default": {
+    "last_validated_date": "2025-07-04T00:04:32+00:00",
+    "durations_in_seconds": {
+      "setup": 1.08,
+      "call": 22.27,
+      "teardown": 0.09,
+      "total": 23.44
+    }
+  },
   "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_with_attributes": {
-    "last_validated_date": "2024-08-16T15:44:50+00:00"
+    "last_validated_date": "2025-07-03T23:32:29+00:00",
+    "durations_in_seconds": {
+      "setup": 0.8,
+      "call": 21.33,
+      "teardown": 0.0,
+      "total": 22.13
+    }
   },
   "tests/aws/services/cloudformation/resources/test_sns.py::test_update_subscription": {
     "last_validated_date": "2024-03-29T21:16:21+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This was a short detour on my main quest to get the CloudTrail scenario test working. The test uses a CDK construct to configure CloudTrail delivery events to SNS, which also creates a topic policy for SNS. I noticed the stacks weren’t deleting properly because the TopicPolicy resource was stuck in a retry loop.

I also raised https://github.com/getmoto/moto/pull/9041 to get rid of the `SNS:Receive` action in the default policy that moto creates incorrectly.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Deleting a topic policy via cloudformation now correctly resets the topic's policy to the default policy

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
