### PR TITLE
CI: archive raw metrics

### DIFF
--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -427,6 +427,7 @@ jobs:
           path: |
             target/pytest-junit-integration-${{ env.PLATFORM }}-${{ matrix.group }}.xml
             target/.coverage.integration-${{ env.PLATFORM }}-${{ matrix.group }}
+            target/metric_reports
           retention-days: 30
 
   test-bootstrap:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR introduces archiving of CSV files with raw metrics generated during integration tests, which are required for parity docs updates

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- `target/metric_reports` path added to archive test results step

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
