### PR TITLE
CI: put parity metrics to separate artifact

### DIFF
--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -427,7 +427,14 @@ jobs:
           path: |
             target/pytest-junit-integration-${{ env.PLATFORM }}-${{ matrix.group }}.xml
             target/.coverage.integration-${{ env.PLATFORM }}-${{ matrix.group }}
-            target/metric_reports
+          retention-days: 30
+
+      - name: Archive Parity Metric Results
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: parity-metric-raw-${{ env.PLATFORM }}-${{ matrix.group }}
+          path: target/metric_reports
           retention-days: 30
 
   test-bootstrap:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR adds a new step to archive the parity metrics. The previous changes were insufficient, as the script used to fetch artifacts supports only a single level of folder nesting.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
