### PR TITLE
S3: fix Access-Control-Allow-Headers handling in S3 CORS

### DIFF
--- a/localstack-core/localstack/services/s3/cors.py
+++ b/localstack-core/localstack/services/s3/cors.py
@@ -205,7 +205,12 @@ class S3CorsHandler(Handler):
 
         if requested_headers := request.headers.get("Access-Control-Request-Headers"):
             # if the rule matched, it means all Requested Headers are allowed
-            response.headers["Access-Control-Allow-Headers"] = requested_headers.lower()
+            requested_headers_formatted = [
+                header.strip().lower() for header in requested_headers.split(",")
+            ]
+            response.headers["Access-Control-Allow-Headers"] = ", ".join(
+                requested_headers_formatted
+            )
 
         if expose_headers := rule.get("ExposeHeaders"):
             response.headers["Access-Control-Expose-Headers"] = ", ".join(expose_headers)
@@ -266,8 +271,8 @@ class S3CorsHandler(Handler):
 
             lower_case_allowed_headers = {header.lower() for header in allowed_headers}
             if "*" not in allowed_headers and not all(
-                header in lower_case_allowed_headers
-                for header in request_headers.lower().split(", ")
+                header.strip() in lower_case_allowed_headers
+                for header in request_headers.lower().split(",")
             ):
                 return
 

--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -551,6 +551,18 @@ class TestS3Cors:
         match_headers("opt-get-allowed-diff-casing", opt_req)
         assert opt_req.ok
 
+        # test with specific headers and no space after the comma
+        opt_req = requests.options(
+            key_url,
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-amz-expected-bucket-owner,x-amz-server-side-encryption",
+            },
+        )
+        match_headers("opt-get-allowed-no-space", opt_req)
+        assert opt_req.ok
+
         # test GET with Access-Control-Request-Headers: should not happen in reality, AWS is considering it like an
         # OPTIONS request
         get_req = requests.get(

--- a/tests/aws/services/s3/test_s3_cors.snapshot.json
+++ b/tests/aws/services/s3/test_s3_cors.snapshot.json
@@ -340,7 +340,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_cors.py::TestS3Cors::test_cors_match_headers": {
-    "recorded-date": "02-01-2024, 16:08:41",
+    "recorded-date": "07-07-2025, 17:12:03",
     "recorded-content": {
       "opt-get": {
         "Body": "",
@@ -474,6 +474,23 @@
         },
         "StatusCode": 200
       },
+      "opt-get-allowed-no-space": {
+        "Body": "",
+        "Headers": {
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Headers": "x-amz-expected-bucket-owner, x-amz-server-side-encryption",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "https://localhost:4200",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "0",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:8>",
+          "x-amz-request-id": "<x-amz-request-id:8>"
+        },
+        "StatusCode": 200
+      },
       "get-non-allowed-with-acl": {
         "Body": "test-cors",
         "Headers": {
@@ -484,8 +501,8 @@
           "accept-ranges": "bytes",
           "date": "date",
           "server": "<server:1>",
-          "x-amz-id-2": "<x-amz-id-2:8>",
-          "x-amz-request-id": "<x-amz-request-id:8>",
+          "x-amz-id-2": "<x-amz-id-2:9>",
+          "x-amz-request-id": "<x-amz-request-id:9>",
           "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200
@@ -505,8 +522,8 @@
           "accept-ranges": "bytes",
           "date": "date",
           "server": "<server:1>",
-          "x-amz-id-2": "<x-amz-id-2:9>",
-          "x-amz-request-id": "<x-amz-request-id:9>",
+          "x-amz-id-2": "<x-amz-id-2:10>",
+          "x-amz-request-id": "<x-amz-request-id:10>",
           "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200

--- a/tests/aws/services/s3/test_s3_cors.validation.json
+++ b/tests/aws/services/s3/test_s3_cors.validation.json
@@ -12,7 +12,13 @@
     "last_validated_date": "2023-07-31T10:31:40+00:00"
   },
   "tests/aws/services/s3/test_s3_cors.py::TestS3Cors::test_cors_match_headers": {
-    "last_validated_date": "2024-01-02T16:08:41+00:00"
+    "last_validated_date": "2025-07-07T17:12:04+00:00",
+    "durations_in_seconds": {
+      "setup": 1.68,
+      "call": 4.08,
+      "teardown": 1.07,
+      "total": 6.83
+    }
   },
   "tests/aws/services/s3/test_s3_cors.py::TestS3Cors::test_cors_match_methods": {
     "last_validated_date": "2025-03-17T20:18:58+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #12835, we had bad handling of comma separated values in the `Access-Control-Allow-Headers` header when handling CORS. 

This PR adds a small fix for that, along with a test

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- properly parse the `Access-Control-Allow-Headers` before checking if it matches the S3 CORS Rule
- properly return the value in the same format as S3
- add a test for this case

_fixes #12835_

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
