### PR TITLE
Docker: Add 'log_handler'-argument to pull()

### DIFF
--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -12,6 +12,7 @@ from abc import ABCMeta, abstractmethod
 from enum import Enum, unique
 from pathlib import Path
 from typing import (
+    Callable,
     Dict,
     List,
     Literal,
@@ -750,8 +751,17 @@ class ContainerClient(metaclass=ABCMeta):
         """Copy contents of the given container to the host"""
 
     @abstractmethod
-    def pull_image(self, docker_image: str, platform: Optional[DockerPlatform] = None) -> None:
-        """Pulls an image with a given name from a Docker registry"""
+    def pull_image(
+        self,
+        docker_image: str,
+        platform: Optional[DockerPlatform] = None,
+        log_handler: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        """
+        Pulls an image with a given name from a Docker registry
+
+        :log_handler: Optional parameter that can be used to process the logs. Logs will be streamed if possible, but this is not guaranteed.
+        """
 
     @abstractmethod
     def push_image(self, docker_image: str) -> None:

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1155,6 +1155,19 @@ class TestDockerClient:
         )
 
     @markers.skip_offline
+    def test_pull_docker_image_with_log_handler(self, docker_client: ContainerClient):
+        log_result: list[str] = []
+
+        def _process(line: str):
+            log_result.append(line)
+
+        docker_client.pull_image("alpine", log_handler=_process)
+
+        assert any("Pulling from library/alpine" in log for log in log_result), (
+            f"Should display useful logs in {log_result}"
+        )
+
+    @markers.skip_offline
     def test_run_container_automatic_pull(self, docker_client: ContainerClient):
         try:
             docker_client.remove_image("alpine")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Some of the images that we're downloading to support our emulation are quite large, so I've been considering a way to show more info to the user about what's happening in the background.

This PR adds an additional argument, `log_handler` to the `docker_client.pull(..)` method, allowing service developers to inspect (or log) the exact output of the `pull`-command.

### Example invocation
For example, to stream the logs to user (probably the most common usecase for this):
```python
def some_action():
    ...
    def _process(line: str):
        LOG.debug(line)

    docker_client.pull_image("alpine", log_handler=_process)
```
