### PR TITLE
KMS: Add list-key-rotations flag

### DIFF
--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -2286,5 +2286,165 @@
         }
       }
     }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_list_key_rotations_after_on_demand_rotation": {
+    "recorded-date": "10-07-2025, 23:03:36",
+    "recorded-content": {
+      "initial-rotations": {
+        "Rotations": [],
+        "Truncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "after-on-demand-rotation": {
+        "Rotations": [
+          {
+            "KeyId": "<key-id:1>",
+            "KeyMaterialId": "6d631900e769898b2808d19755fdaa2fe6e6c19a61c33fbb7bc6d251475a6c03",
+            "KeyMaterialState": "CURRENT",
+            "RotationDate": "datetime",
+            "RotationType": "ON_DEMAND"
+          }
+        ],
+        "Truncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_list_key_rotations_different_key_states": {
+    "recorded-date": "10-07-2025, 23:23:30",
+    "recorded-content": {
+      "enabled-key-rotations": {
+        "Rotations": [
+          {
+            "KeyId": "<key-id:1>",
+            "KeyMaterialId": "da6fd345ea8e40601730aa8d2b92ceebb7c950f8e09b9802c57ac0f2045a8c35",
+            "KeyMaterialState": "CURRENT"
+          }
+        ],
+        "Truncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "disabled-key-rotations": {
+        "Rotations": [
+          {
+            "KeyId": "<key-id:1>",
+            "KeyMaterialId": "da6fd345ea8e40601730aa8d2b92ceebb7c950f8e09b9802c57ac0f2045a8c35",
+            "KeyMaterialState": "CURRENT"
+          }
+        ],
+        "Truncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "pending-deletion-key-rotations": {
+        "Rotations": [
+          {
+            "KeyId": "<key-id:1>",
+            "KeyMaterialId": "da6fd345ea8e40601730aa8d2b92ceebb7c950f8e09b9802c57ac0f2045a8c35",
+            "KeyMaterialState": "CURRENT"
+          }
+        ],
+        "Truncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_list_key_rotations_unsupported_key_types[RSA_2048-SIGN_VERIFY-UnsupportedOperationException]": {
+    "recorded-date": "10-07-2025, 23:04:26",
+    "recorded-content": {}
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_list_key_rotations_unsupported_key_types[RSA_4096-ENCRYPT_DECRYPT-UnsupportedOperationException]": {
+    "recorded-date": "10-07-2025, 23:04:27",
+    "recorded-content": {}
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_list_key_rotations_unsupported_key_types[ECC_NIST_P256-SIGN_VERIFY-UnsupportedOperationException]": {
+    "recorded-date": "10-07-2025, 23:04:27",
+    "recorded-content": {}
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_list_key_rotations_unsupported_key_types[HMAC_256-GENERATE_VERIFY_MAC-UnsupportedOperationException]": {
+    "recorded-date": "10-07-2025, 23:04:28",
+    "recorded-content": {}
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_list_key_rotations_include_key_material": {
+    "recorded-date": "10-07-2025, 23:04:47",
+    "recorded-content": {
+      "default-key-material": {
+        "Rotations": [
+          {
+            "KeyId": "<key-id:1>",
+            "KeyMaterialId": "60fe0d1221f11a75768cf445505fc100331e14a46eb948071fd1207a95dce6b8",
+            "KeyMaterialState": "CURRENT",
+            "RotationDate": "datetime",
+            "RotationType": "ON_DEMAND"
+          }
+        ],
+        "Truncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "all-key-material": {
+        "Rotations": [
+          {
+            "KeyId": "<key-id:1>",
+            "KeyMaterialId": "79d2a0ed3517f5e9e9c7a4c17d6f2ba4ac8702973755d9f8fb487b5bee3aba21",
+            "KeyMaterialState": "NON_CURRENT"
+          },
+          {
+            "KeyId": "<key-id:1>",
+            "KeyMaterialId": "60fe0d1221f11a75768cf445505fc100331e14a46eb948071fd1207a95dce6b8",
+            "KeyMaterialState": "CURRENT",
+            "RotationDate": "datetime",
+            "RotationType": "ON_DEMAND"
+          }
+        ],
+        "Truncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "rotations-only": {
+        "Rotations": [
+          {
+            "KeyId": "<key-id:1>",
+            "KeyMaterialId": "60fe0d1221f11a75768cf445505fc100331e14a46eb948071fd1207a95dce6b8",
+            "KeyMaterialState": "CURRENT",
+            "RotationDate": "datetime",
+            "RotationType": "ON_DEMAND"
+          }
+        ],
+        "Truncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invalid-key-material": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'INVALID_VALUE' at 'includeKeyMaterial' failed to satisfy constraint: Member must satisfy enum value set: [ALL_KEY_MATERIAL, ROTATIONS_ONLY]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -191,6 +191,33 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_list_grants_with_invalid_key": {
     "last_validated_date": "2024-04-11T15:52:39+00:00"
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_list_key_rotations_after_on_demand_rotation": {
+    "last_validated_date": "2025-07-10T23:03:36+00:00",
+    "durations_in_seconds": {
+      "setup": 0.55,
+      "call": 4.41,
+      "teardown": 0.13,
+      "total": 5.09
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_list_key_rotations_different_key_states": {
+    "last_validated_date": "2025-07-10T23:23:30+00:00",
+    "durations_in_seconds": {
+      "setup": 0.59,
+      "call": 1.17,
+      "teardown": 0.12,
+      "total": 1.88
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_list_key_rotations_include_key_material": {
+    "last_validated_date": "2025-07-10T23:04:47+00:00",
+    "durations_in_seconds": {
+      "setup": 0.53,
+      "call": 3.49,
+      "teardown": 0.13,
+      "total": 4.15
+    }
+  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_list_keys": {
     "last_validated_date": "2024-04-11T15:52:34+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Adding support for [ListKeyRotations](https://docs.aws.amazon.com/kms/latest/developerguide/list-rotations.html). Mentioned in #12342.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Implementation of [list-key-rotations](https://docs.aws.amazon.com/kms/latest/developerguide/list-rotations.html) feature for keys that may have multiple key materials associated with them.

As per AWS's, list-key-rotation is only allowed for:
- symmetric keys
- Imported keys from single-region-only

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
## TODO

What's left to do:

- [ ] Add support for imported EXTERNAL origin single-region keys
