### PR TITLE
S3: fix CORS handler + GZIP handling

### DIFF
--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -1,3 +1,6 @@
+import gzip
+from io import BytesIO
+
 import pytest
 import requests
 import xmltodict
@@ -14,7 +17,7 @@ from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.config import TEST_AWS_ACCESS_KEY_ID
 from localstack.testing.pytest import markers
 from localstack.utils.aws.request_context import mock_aws_request_headers
-from localstack.utils.strings import short_uid
+from localstack.utils.strings import checksum_crc32, short_uid
 
 
 def _bucket_url_vhost(bucket_name: str, region: str = "", localstack_host: str = None) -> str:
@@ -791,3 +794,34 @@ class TestS3Cors:
             aws_client.s3.get_bucket_cors(Bucket=s3_bucket)
 
         snapshot.match("get-cors-deleted", e.value.response)
+
+    @markers.aws.only_localstack
+    def test_s3_cors_disabled(self, s3_bucket, aws_client, monkeypatch):
+        monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_S3", True)
+        # the ContentDecoder handler depends on the S3 CORS/pre-process handler to determine the service name
+
+        data = "1234567890"
+        # Write contents to memory rather than a file.
+        upload_file_object = BytesIO()
+        mtime = 1676569620  # hardcode the GZIP timestamp
+        with gzip.GzipFile(fileobj=upload_file_object, mode="w", mtime=mtime) as filestream:
+            filestream.write(data.encode("utf-8"))
+
+        raw_gzip_value = upload_file_object.getvalue()
+        checksum = checksum_crc32(raw_gzip_value)
+
+        # Upload gzip
+        put_obj = aws_client.s3.put_object(
+            Bucket=s3_bucket,
+            Key="test.gz",
+            ContentEncoding="gzip",
+            Body=raw_gzip_value,
+        )
+        assert put_obj["ChecksumCRC32"] == checksum
+
+        get_obj = aws_client.s3.get_object(
+            Bucket=s3_bucket,
+            Key="test.gz",
+        )
+        assert get_obj["ContentEncoding"] == "gzip"
+        assert get_obj["Body"].read() == raw_gzip_value


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #12854, we had an issue in S3 with GZIP handling when disabling S3 CORS. 

This is because the GZIP handler depends on the service name being set in the context. However, we were only attaching the S3 service name if S3 CORS was not disabled.
This is a consequence of the ServiceNameParser being moved further down the chain with #11800

As a quick fix and bandaid, I've moved the logic around to *always* try to determine if it's an S3 request, even if S3 CORS is disabled.

However, we're muddling a bit the responsibility of the "CORS" handler with a mini service name parser. I'd suggest to get this first PR as a quick fix for the issue, because the first part will always need to be executed anyway.

As a follow-up, we could either split this in 2 handlers: one "S3 Detection" and one "S3 CORS", however the order will need to be respected closely, and the ordering of handlers inside a `CompositeHandler` is not something that is defined. It is rather implicit depending on the order you are appending your handlers, but it could be modified somewhere else. 

My problem is the naming of the "S3CORSHandler", which has more responsibilities than just CORS

So for now I'm proposing to do it this way to quickly solve the issue, which does not really have a cost anyway, but we'll need to address the naming + responsibility issue soon 👀 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- always execute the S3 detection in the S3 CORS handler
- add a small test validating the fix

_fixes #12854_

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
