### PR TITLE
Increase AWS CLI lower bound version to shorten resolution time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ base-runtime = [
 runtime = [
     "localstack-core[base-runtime]",
     # pinned / updated by ASF update action
-    "awscli>=1.37.0",
+    "awscli>=1.41.0",
     "airspeed-ext>=0.6.3",
     # version that has a built wheel
     "kclpy-ext>=3.0.0",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In some circumstances, when other packages with large dependencies install this package, they can have a large resolution tree because of the large amount of awscli versions we allow in the `pyproject.toml` in the runtime extras.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Up the lower bound for the `awscli` dependency in the `runtime` extra, to cut down the resolution tree for dependent projects. This is a safe upgrade because we know for both this project and the dependent one that a working resolution includes the latest version `1.41.3`.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
