### PR TITLE
Handle file not found case for chmod_r utility

### DIFF
--- a/localstack-core/localstack/utils/files.py
+++ b/localstack-core/localstack/utils/files.py
@@ -179,7 +179,11 @@ def idempotent_chmod(path: str, mode: int):
     try:
         os.chmod(path, mode)
     except Exception:
-        existing_mode = os.stat(path)
+        try:
+            existing_mode = os.stat(path)
+        except FileNotFoundError:
+            # file deleted in the meantime, or otherwise not accessible (socket)
+            return
         if mode in (existing_mode.st_mode, stat.S_IMODE(existing_mode.st_mode)):
             # file already has the desired permissions -> return
             return


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
It is possible, that during the execution of `chmod_r` on a directory, some files or directories are no longer available.

This can happen because:

1. The file or directory are deleted in the meantime
2. The file is a socket, which process is no longer running. It can happen that it is listed, but not actually "present" for `os.stat`. This happened especially in the case mysql data directories containing the mysql socket, after the process is no longer running.

Currently, we will error the entire operation, but we should ignore the file if it cannot be `chmod`ed since it is missing (there really is no point in doing anything).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Capture `FileNotFoundError`s when running `idempotent_chmod`.
* This change is tested by its accompanying ext PR. Testing the case in this repo would be quite complex and not really worth it.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
