### PR TITLE
CFNv2: support validation of CAPABILITY_AUTO_EXPAND

### DIFF
--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -477,9 +477,8 @@ class CloudformationProviderV2(CloudformationProvider):
         template_body = api_utils.extract_template_body(request)
         structured_template = template_preparer.parse_template(template_body)
 
-        if (
-            "CAPABILITY_AUTO_EXPAND" not in request.get("Capabilities", [])
-            and "Transform" in structured_template.keys()
+        if "CAPABILITY_AUTO_EXPAND" not in request.get("Capabilities", []) and (
+            "Transform" in structured_template.keys() or "Fn::Transform" in template_body
         ):
             raise InsufficientCapabilitiesException(
                 "Requires capabilities : [CAPABILITY_AUTO_EXPAND]"
@@ -689,9 +688,8 @@ class CloudformationProviderV2(CloudformationProvider):
         template_body = api_utils.extract_template_body(request)
         structured_template = template_preparer.parse_template(template_body)
 
-        if (
-            "CAPABILITY_AUTO_EXPAND" not in request.get("Capabilities", [])
-            and "Transform" in structured_template.keys()
+        if "CAPABILITY_AUTO_EXPAND" not in request.get("Capabilities", []) and (
+            "Transform" in structured_template.keys() or "Fn::Transform" in template_body
         ):
             raise InsufficientCapabilitiesException(
                 "Requires capabilities : [CAPABILITY_AUTO_EXPAND]"

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -27,6 +27,7 @@ from localstack.aws.api.cloudformation import (
     GetTemplateSummaryInput,
     GetTemplateSummaryOutput,
     IncludePropertyValues,
+    InsufficientCapabilitiesException,
     InvalidChangeSetStatusException,
     LogicalResourceId,
     NextToken,
@@ -476,6 +477,14 @@ class CloudformationProviderV2(CloudformationProvider):
         template_body = api_utils.extract_template_body(request)
         structured_template = template_preparer.parse_template(template_body)
 
+        if (
+            "CAPABILITY_AUTO_EXPAND" not in request.get("Capabilities", [])
+            and "Transform" in structured_template.keys()
+        ):
+            raise InsufficientCapabilitiesException(
+                "Requires capabilities : [CAPABILITY_AUTO_EXPAND]"
+            )
+
         stack = Stack(
             account_id=context.account_id,
             region_name=context.region,
@@ -679,6 +688,14 @@ class CloudformationProviderV2(CloudformationProvider):
 
         template_body = api_utils.extract_template_body(request)
         structured_template = template_preparer.parse_template(template_body)
+
+        if (
+            "CAPABILITY_AUTO_EXPAND" not in request.get("Capabilities", [])
+            and "Transform" in structured_template.keys()
+        ):
+            raise InsufficientCapabilitiesException(
+                "Requires capabilities : [CAPABILITY_AUTO_EXPAND]"
+            )
 
         # this is intentionally not in a util yet. Let's first see how the different operations deal with these before generalizing
         # handle ARN stack_name here (not valid for initial CREATE, since stack doesn't exist yet)

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_changesets.py
@@ -905,7 +905,6 @@ def test_deleted_changeset(snapshot, cleanups, aws_client):
     snapshot.match("postdelete_changeset_notfound", e.value)
 
 
-@pytest.mark.skip("CFNV2:Capabilities")
 @markers.aws.validated
 def test_autoexpand_capability_requirement(cleanups, aws_client):
     stack_name = f"test-stack-{short_uid()}"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When creating a stack with transforms, the `CAPABILITY_AUTO_EXPAND` capability is required. This is not currently validated with the new engine


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Validate auto expand capability on create and update stacks

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
