### PR TITLE
CFNv2: Implement get_template

### DIFF
--- a/localstack-core/localstack/services/cloudformation/v2/entities.py
+++ b/localstack-core/localstack/services/cloudformation/v2/entities.py
@@ -46,6 +46,7 @@ class Stack:
     creation_time: datetime
     deletion_time: datetime | None
     events = list[StackEvent]
+    processed_template: dict | None
 
     # state after deploy
     resolved_parameters: dict[str, str]
@@ -72,6 +73,7 @@ class Stack:
         self.creation_time = datetime.now(tz=timezone.utc)
         self.deletion_time = None
         self.change_set_id = None
+        self.processed_template = None
 
         self.stack_name = request_payload["StackName"]
         self.parameters = request_payload.get("Parameters", [])

--- a/localstack-core/localstack/services/cloudformation/v2/entities.py
+++ b/localstack-core/localstack/services/cloudformation/v2/entities.py
@@ -1,3 +1,4 @@
+import copy
 from datetime import datetime, timezone
 from typing import NotRequired, Optional, TypedDict
 
@@ -63,6 +64,7 @@ class Stack:
         self.account_id = account_id
         self.region_name = region_name
         self.template = template
+        self.template_original = copy.deepcopy(self.template)
         self.template_body = template_body
         self.status = StackStatus.CREATE_IN_PROGRESS
         self.status_reason = None

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -850,8 +850,9 @@ class CloudformationProviderV2(CloudformationProvider):
         after_template = structured_template
 
         previous_update_model = None
-        if previous_change_set := find_change_set_v2(state, stack.change_set_id):
-            previous_update_model = previous_change_set.update_model
+        if stack.change_set_id:
+            if previous_change_set := find_change_set_v2(state, stack.change_set_id):
+                previous_update_model = previous_change_set.update_model
 
         change_set = ChangeSet(
             stack,
@@ -920,8 +921,9 @@ class CloudformationProviderV2(CloudformationProvider):
             return
 
         previous_update_model = None
-        if previous_change_set := find_change_set_v2(state, stack.change_set_id):
-            previous_update_model = previous_change_set.update_model
+        if stack.change_set_id:
+            if previous_change_set := find_change_set_v2(state, stack.change_set_id):
+                previous_update_model = previous_change_set.update_model
 
         # create a dummy change set
         change_set = ChangeSet(stack, {"ChangeSetName": f"delete-stack_{stack.stack_name}"})  # noqa

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -150,7 +150,7 @@ def find_stack_v2(state: CloudFormationStore, stack_name: str | None) -> Stack |
             else:
                 return stack_candidates[0]
     else:
-        raise NotImplementedError
+        raise ValueError("No stack name specified when finding stack")
 
 
 def find_change_set_v2(
@@ -169,7 +169,7 @@ def find_change_set_v2(
                 if change_set_candidate.change_set_name == change_set_name:
                     return change_set_candidate
         else:
-            raise NotImplementedError
+            raise ValueError("No stack name specified when finding change set")
 
 
 class CloudformationProviderV2(CloudformationProvider):

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -26,48 +26,11 @@ from localstack.aws.api.cloudformation import (
     DisableRollback,
     ExecuteChangeSetOutput,
     ExecutionStatus,
-    GetTemplateSummaryInput,
-    GetTemplateSummaryOutput,
-    IncludePropertyValues,
-    InsufficientCapabilitiesException,
-    InvalidChangeSetStatusException,
-    LogicalResourceId,
-    NextToken,
-    Parameter,
-    PhysicalResourceId,
-    RetainExceptOnCreate,
-    RetainResources,
-    RoleARN,
-    RollbackConfiguration,
-    StackName,
-    StackNameOrId,
-    StackStatus,
-    UpdateStackInput,
-    UpdateStackOutput,
-)
-from localstack.aws.api.cloudformation import (
-    Changes,
-    ChangeSetNameOrId,
-    ChangeSetNotFoundException,
-    ChangeSetStatus,
-    ChangeSetType,
-    ClientRequestToken,
-    CreateChangeSetInput,
-    CreateChangeSetOutput,
-    CreateStackInput,
-    CreateStackOutput,
-    DeletionMode,
-    DescribeChangeSetOutput,
-    DescribeStackEventsOutput,
-    DescribeStackResourcesOutput,
-    DescribeStacksOutput,
-    DisableRollback,
-    ExecuteChangeSetOutput,
-    ExecutionStatus,
     GetTemplateOutput,
     GetTemplateSummaryInput,
     GetTemplateSummaryOutput,
     IncludePropertyValues,
+    InsufficientCapabilitiesException,
     InvalidChangeSetStatusException,
     LogicalResourceId,
     NextToken,
@@ -687,7 +650,7 @@ class CloudformationProviderV2(CloudformationProvider):
         elif stack_name:
             stack = find_stack_v2(state, stack_name)
         else:
-            raise StackNotFoundError(stack_name)
+            raise StackWithIdNotFoundError(stack_name)
 
         if template_stage == TemplateStage.Processed and "Transform" in stack.template_body:
             template_body = json.dumps(stack.processed_template)

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.py
@@ -113,7 +113,6 @@ class TestStacksApi:
 
             snapshot.match("stack_response", e.value.response)
 
-    @pytest.mark.skip(reason="CFNV2:Other")
     @markers.aws.validated
     @pytest.mark.parametrize("fileformat", ["yaml", "json"])
     def test_get_template_using_create_stack(self, snapshot, fileformat, aws_client):
@@ -141,7 +140,6 @@ class TestStacksApi:
         )
         snapshot.match("template_processed", template_processed)
 
-    @pytest.mark.skip(reason="CFNV2:Other")
     @markers.aws.validated
     @pytest.mark.parametrize("fileformat", ["yaml", "json"])
     def test_get_template_using_changesets(

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_update_stack.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_update_stack.py
@@ -423,7 +423,6 @@ def test_update_with_rollback_configuration(deploy_cfn_template, aws_client):
     aws_client.cloudwatch.delete_alarms(AlarmNames=["HighResourceUsage"])
 
 
-@pytest.mark.skip(reason="CFNV2:UpdateStack")
 @markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(["$..Stacks..ChangeSetId"])
 def test_diff_after_update(deploy_cfn_template, aws_client, snapshot):

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/test_template_engine.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/test_template_engine.py
@@ -644,7 +644,7 @@ class TestMacros:
         snapshot.match("stack_outputs", stack_with_macro.outputs)
         snapshot.match("stack_resource_descriptions", description)
 
-    @pytest.mark.skip("CFNV2:GetTemplate")
+    # @pytest.mark.skip("CFNV2:GetTemplate")
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/test_template_engine.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/test_template_engine.py
@@ -644,7 +644,7 @@ class TestMacros:
         snapshot.match("stack_outputs", stack_with_macro.outputs)
         snapshot.match("stack_resource_descriptions", description)
 
-    # @pytest.mark.skip("CFNV2:GetTemplate")
+    @pytest.mark.skip("CFNV2:Macros")
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The new provider does not support the `GetTemplate` operation. This PR implements an initial version.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Store a copy of the original (parsed but not transformed) template on the stack
* Implement the provider method basically copying the v1 implementation
* Unskip 3 tests

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
