### PR TITLE
APIGW: update CFN related snapshots

### DIFF
--- a/tests/aws/scenario/note_taking/test_note_taking.py
+++ b/tests/aws/scenario/note_taking/test_note_taking.py
@@ -162,11 +162,11 @@ class TestNoteTakingScenario:
         paths=[
             "$..Tags",
             "$..get_resources.items",  # TODO apigateway.get-resources
-            "$..rootResourceId",
             "$..Table.DeletionProtectionEnabled",
             "$..Table.ProvisionedThroughput.LastDecreaseDateTime",
             "$..Table.ProvisionedThroughput.LastIncreaseDateTime",
             "$..Table.Replicas",
+            "$..Table.WarmThroughput",
         ]
     )
     def test_validate_infra_setup(self, aws_client, infrastructure, snapshot):

--- a/tests/aws/scenario/note_taking/test_note_taking.snapshot.json
+++ b/tests/aws/scenario/note_taking/test_note_taking.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/scenario/note_taking/test_note_taking.py::TestNoteTakingScenario::test_validate_infra_setup": {
-    "recorded-date": "16-04-2024, 08:42:29",
+    "recorded-date": "15-07-2025, 19:26:03",
     "recorded-content": {
       "describe_stack_resources": {
         "StackResources": [
@@ -504,7 +504,12 @@
           "TableId": "<uuid:1>",
           "TableName": "<resource:2>",
           "TableSizeBytes": 0,
-          "TableStatus": "ACTIVE"
+          "TableStatus": "ACTIVE",
+          "WarmThroughput": {
+            "ReadUnitsPerSecond": 5,
+            "Status": "ACTIVE",
+            "WriteUnitsPerSecond": 5
+          }
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -806,6 +811,7 @@
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]

--- a/tests/aws/scenario/note_taking/test_note_taking.validation.json
+++ b/tests/aws/scenario/note_taking/test_note_taking.validation.json
@@ -1,5 +1,20 @@
 {
+  "tests/aws/scenario/note_taking/test_note_taking.py::TestNoteTakingScenario::test_notes_rest_api": {
+    "last_validated_date": "2025-07-15T19:26:45+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 12.05,
+      "teardown": 30.29,
+      "total": 42.34
+    }
+  },
   "tests/aws/scenario/note_taking/test_note_taking.py::TestNoteTakingScenario::test_validate_infra_setup": {
-    "last_validated_date": "2024-04-16T08:42:29+00:00"
+    "last_validated_date": "2025-07-15T19:26:03+00:00",
+    "durations_in_seconds": {
+      "setup": 72.68,
+      "call": 2.59,
+      "teardown": 0.0,
+      "total": 75.27
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_transformers.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_transformers.snapshot.json
@@ -1,12 +1,13 @@
 {
   "tests/aws/services/cloudformation/api/test_transformers.py::test_duplicate_resources": {
-    "recorded-date": "15-04-2024, 22:51:13",
+    "recorded-date": "15-07-2025, 19:27:40",
     "recorded-content": {
       "api-details": {
         "apiKeySource": "HEADER",
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]

--- a/tests/aws/services/cloudformation/api/test_transformers.validation.json
+++ b/tests/aws/services/cloudformation/api/test_transformers.validation.json
@@ -45,7 +45,13 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_transformers.py::test_duplicate_resources": {
-    "last_validated_date": "2024-04-15T22:51:13+00:00"
+    "last_validated_date": "2025-07-15T19:27:45+00:00",
+    "durations_in_seconds": {
+      "setup": 1.03,
+      "call": 13.37,
+      "teardown": 5.79,
+      "total": 20.19
+    }
   },
   "tests/aws/services/cloudformation/api/test_transformers.py::test_language_extensions": {
     "last_validated_date": "2025-06-27T16:00:28+00:00",

--- a/tests/aws/services/cloudformation/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.py
@@ -329,11 +329,8 @@ def test_cfn_deploy_apigateway_integration(deploy_cfn_template, snapshot, aws_cl
     paths=[
         "$.resources.items..resourceMethods.GET",  # TODO: after importing, AWS returns them empty?
         # TODO: missing from LS response
-        "$.get-stage.createdDate",
-        "$.get-stage.lastUpdatedDate",
         "$.get-stage.methodSettings",
         "$.get-stage.tags",
-        "$..endpointConfiguration.ipAddressType",
     ]
 )
 def test_cfn_deploy_apigateway_from_s3_swagger(

--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -1,12 +1,13 @@
 {
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_integration": {
-    "recorded-date": "21-02-2024, 12:50:57",
+    "recorded-date": "15-07-2025, 19:28:45",
     "recorded-content": {
       "rest_api": {
         "apiKeySource": "HEADER",
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]
@@ -66,13 +67,14 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_api_gateway_with_policy_as_dict": {
-    "recorded-date": "15-04-2024, 22:59:53",
+    "recorded-date": "15-07-2025, 19:30:54",
     "recorded-content": {
       "rest-api": {
         "apiKeySource": "HEADER",
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]

--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -109,7 +109,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "recorded-date": "06-05-2025, 18:31:54",
+    "recorded-date": "15-07-2025, 20:30:26",
     "recorded-content": {
       "rest-api": {
         "apiKeySource": "HEADER",

--- a/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
@@ -18,7 +18,13 @@
     "last_validated_date": "2025-05-05T14:23:13+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "last_validated_date": "2025-05-06T18:31:53+00:00"
+    "last_validated_date": "2025-07-15T20:30:33+00:00",
+    "durations_in_seconds": {
+      "setup": 1.02,
+      "call": 18.79,
+      "teardown": 8.1,
+      "total": 27.91
+    }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_integration": {
     "last_validated_date": "2025-07-15T19:28:58+00:00",

--- a/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
@@ -3,7 +3,13 @@
     "last_validated_date": "2024-02-19T08:55:12+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_api_gateway_with_policy_as_dict": {
-    "last_validated_date": "2024-04-15T22:59:53+00:00"
+    "last_validated_date": "2025-07-15T19:30:59+00:00",
+    "durations_in_seconds": {
+      "setup": 0.47,
+      "call": 11.81,
+      "teardown": 4.71,
+      "total": 16.99
+    }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_apigateway_rest_api": {
     "last_validated_date": "2025-05-05T14:50:14+00:00"
@@ -15,7 +21,13 @@
     "last_validated_date": "2025-05-06T18:31:53+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_integration": {
-    "last_validated_date": "2024-02-21T12:54:34+00:00"
+    "last_validated_date": "2025-07-15T19:28:58+00:00",
+    "durations_in_seconds": {
+      "setup": 0.46,
+      "call": 26.77,
+      "teardown": 13.21,
+      "total": 40.44
+    }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_models": {
     "last_validated_date": "2024-06-21T00:09:05+00:00"

--- a/tests/aws/services/cloudformation/resources/test_sam.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_sam.snapshot.json
@@ -22,13 +22,14 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_sam.py::test_cfn_handle_serverless_api_resource": {
-    "recorded-date": "20-06-2024, 20:16:01",
+    "recorded-date": "15-07-2025, 19:31:46",
     "recorded-content": {
       "get_rest_api": {
         "apiKeySource": "HEADER",
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]
@@ -56,7 +57,7 @@
           "Architectures": [
             "x86_64"
           ],
-          "CodeSha256": "+xvKfGS3ENINs/yK7dLJgId2fDM+vv9OP03rJ9mLflU=",
+          "CodeSha256": "EvPuzuBz5Tmw0kKjgaQva4dsYcd10oxkSwFlAElJESw=",
           "CodeSize": "<code-size>",
           "Description": "",
           "EphemeralStorage": {

--- a/tests/aws/services/cloudformation/resources/test_sam.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_sam.validation.json
@@ -1,6 +1,12 @@
 {
   "tests/aws/services/cloudformation/resources/test_sam.py::test_cfn_handle_serverless_api_resource": {
-    "last_validated_date": "2024-06-20T20:16:01+00:00"
+    "last_validated_date": "2025-07-15T19:32:08+00:00",
+    "durations_in_seconds": {
+      "setup": 0.46,
+      "call": 41.1,
+      "teardown": 21.72,
+      "total": 63.28
+    }
   },
   "tests/aws/services/cloudformation/resources/test_sam.py::test_sam_policies": {
     "last_validated_date": "2023-07-11T16:08:53+00:00"

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_transformers.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_transformers.snapshot.json
@@ -1,12 +1,13 @@
 {
   "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_transformers.py::test_duplicate_resources": {
-    "recorded-date": "15-04-2024, 22:51:13",
+    "recorded-date": "15-07-2025, 19:28:05",
     "recorded-content": {
       "api-details": {
         "apiKeySource": "HEADER",
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_transformers.validation.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_transformers.validation.json
@@ -1,6 +1,12 @@
 {
   "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_transformers.py::test_duplicate_resources": {
-    "last_validated_date": "2024-04-15T22:51:13+00:00"
+    "last_validated_date": "2025-07-15T19:28:15+00:00",
+    "durations_in_seconds": {
+      "setup": 1.05,
+      "call": 13.13,
+      "teardown": 10.12,
+      "total": 24.3
+    }
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_transformers.py::test_transformer_individual_resource_level": {
     "last_validated_date": "2024-06-13T06:43:21+00:00"

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py
@@ -4,7 +4,6 @@ from operator import itemgetter
 
 import pytest
 import requests
-from localstack_snapshot.snapshots.transformer import SortingTransformer
 from tests.aws.services.apigateway.apigateway_fixtures import api_invoke_url
 
 from localstack import constants
@@ -316,15 +315,13 @@ def test_cfn_deploy_apigateway_integration(deploy_cfn_template, snapshot, aws_cl
         # TODO: missing from LS response
         "$.get-stage.methodSettings",
         "$.get-stage.tags",
+        "$..binaryMediaTypes",
     ]
 )
 def test_cfn_deploy_apigateway_from_s3_swagger(
     deploy_cfn_template, snapshot, aws_client, s3_bucket
 ):
     snapshot.add_transformer(snapshot.transform.key_value("deploymentId"))
-    # FIXME: we need to sort the binaryMediaTypes as we don't return it in the same order as AWS, but this does not have
-    # behavior incidence
-    snapshot.add_transformer(SortingTransformer("binaryMediaTypes"))
     # put the swagger file in S3
     swagger_template = load_file(
         os.path.join(os.path.dirname(__file__), "../../../../../files/pets.json")

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py
@@ -313,11 +313,8 @@ def test_cfn_deploy_apigateway_integration(deploy_cfn_template, snapshot, aws_cl
     paths=[
         "$.resources.items..resourceMethods.GET",  # TODO: after importing, AWS returns them empty?
         # TODO: missing from LS response
-        "$.get-stage.createdDate",
-        "$.get-stage.lastUpdatedDate",
         "$.get-stage.methodSettings",
         "$.get-stage.tags",
-        "$..binaryMediaTypes",
     ]
 )
 def test_cfn_deploy_apigateway_from_s3_swagger(

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py
@@ -4,6 +4,7 @@ from operator import itemgetter
 
 import pytest
 import requests
+from localstack_snapshot.snapshots.transformer import SortingTransformer
 from tests.aws.services.apigateway.apigateway_fixtures import api_invoke_url
 
 from localstack import constants
@@ -321,6 +322,9 @@ def test_cfn_deploy_apigateway_from_s3_swagger(
     deploy_cfn_template, snapshot, aws_client, s3_bucket
 ):
     snapshot.add_transformer(snapshot.transform.key_value("deploymentId"))
+    # FIXME: we need to sort the binaryMediaTypes as we don't return it in the same order as AWS, but this does not have
+    # behavior incidence
+    snapshot.add_transformer(SortingTransformer("binaryMediaTypes"))
     # put the swagger file in S3
     swagger_template = load_file(
         os.path.join(os.path.dirname(__file__), "../../../../../files/pets.json")

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.snapshot.json
@@ -1,12 +1,13 @@
 {
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py::test_cfn_deploy_apigateway_integration": {
-    "recorded-date": "21-02-2024, 12:50:57",
+    "recorded-date": "15-07-2025, 19:29:28",
     "recorded-content": {
       "rest_api": {
         "apiKeySource": "HEADER",
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]
@@ -66,13 +67,14 @@
     }
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py::test_api_gateway_with_policy_as_dict": {
-    "recorded-date": "15-04-2024, 22:59:53",
+    "recorded-date": "15-07-2025, 19:29:58",
     "recorded-content": {
       "rest-api": {
         "apiKeySource": "HEADER",
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.snapshot.json
@@ -109,13 +109,20 @@
     }
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "recorded-date": "24-09-2024, 20:22:38",
+    "recorded-date": "15-07-2025, 20:32:03",
     "recorded-content": {
       "rest-api": {
         "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/png",
+          "image/jpg",
+          "image/gif",
+          "application/pdf"
+        ],
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "REGIONAL"
           ]

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.validation.json
@@ -15,7 +15,13 @@
     "last_validated_date": "2024-06-25T18:12:55+00:00"
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "last_validated_date": "2024-09-24T20:22:37+00:00"
+    "last_validated_date": "2025-07-15T20:32:10+00:00",
+    "durations_in_seconds": {
+      "setup": 1.04,
+      "call": 18.98,
+      "teardown": 8.13,
+      "total": 28.15
+    }
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py::test_cfn_deploy_apigateway_integration": {
     "last_validated_date": "2025-07-15T19:29:44+00:00",

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.validation.json
@@ -3,7 +3,13 @@
     "last_validated_date": "2024-02-19T08:55:12+00:00"
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py::test_api_gateway_with_policy_as_dict": {
-    "last_validated_date": "2024-04-15T22:59:53+00:00"
+    "last_validated_date": "2025-07-15T19:30:16+00:00",
+    "durations_in_seconds": {
+      "setup": 0.5,
+      "call": 11.81,
+      "teardown": 17.53,
+      "total": 29.84
+    }
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py::test_cfn_apigateway_rest_api": {
     "last_validated_date": "2024-06-25T18:12:55+00:00"
@@ -12,7 +18,13 @@
     "last_validated_date": "2024-09-24T20:22:37+00:00"
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py::test_cfn_deploy_apigateway_integration": {
-    "last_validated_date": "2024-02-21T12:54:34+00:00"
+    "last_validated_date": "2025-07-15T19:29:44+00:00",
+    "durations_in_seconds": {
+      "setup": 0.57,
+      "call": 26.97,
+      "teardown": 15.37,
+      "total": 42.91
+    }
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py::test_cfn_deploy_apigateway_models": {
     "last_validated_date": "2024-06-21T00:09:05+00:00"

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.validation.json
@@ -15,12 +15,12 @@
     "last_validated_date": "2024-06-25T18:12:55+00:00"
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "last_validated_date": "2025-07-15T20:32:10+00:00",
+    "last_validated_date": "2025-07-16T00:25:05+00:00",
     "durations_in_seconds": {
-      "setup": 1.04,
-      "call": 18.98,
-      "teardown": 8.13,
-      "total": 28.15
+      "setup": 1.15,
+      "call": 18.86,
+      "teardown": 8.08,
+      "total": 28.09
     }
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_apigateway.py::test_cfn_deploy_apigateway_integration": {

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_sam.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_sam.snapshot.json
@@ -22,13 +22,14 @@
     }
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_sam.py::test_cfn_handle_serverless_api_resource": {
-    "recorded-date": "20-06-2024, 20:16:01",
+    "recorded-date": "15-07-2025, 19:33:25",
     "recorded-content": {
       "get_rest_api": {
         "apiKeySource": "HEADER",
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "ipv4",
           "types": [
             "EDGE"
           ]
@@ -56,7 +57,7 @@
           "Architectures": [
             "x86_64"
           ],
-          "CodeSha256": "+xvKfGS3ENINs/yK7dLJgId2fDM+vv9OP03rJ9mLflU=",
+          "CodeSha256": "W479VjWcFpBg+yx255glPq1ZLEq5WjlmjJi7CmxLFio=",
           "CodeSize": "<code-size>",
           "Description": "",
           "EphemeralStorage": {

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_sam.validation.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_sam.validation.json
@@ -1,6 +1,12 @@
 {
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_sam.py::test_cfn_handle_serverless_api_resource": {
-    "last_validated_date": "2024-06-20T20:16:01+00:00"
+    "last_validated_date": "2025-07-15T19:33:44+00:00",
+    "durations_in_seconds": {
+      "setup": 0.46,
+      "call": 40.88,
+      "teardown": 19.65,
+      "total": 60.99
+    }
   },
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_sam.py::test_sam_policies": {
     "last_validated_date": "2023-07-11T16:08:53+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #12826, we took extra care with @ArthurAkh to make sure we would not break upstream pipelines, but the test selection did not trigger on CloudFormation and Scenario tests, making us miss some outdated snapshots (https://github.com/localstack/localstack/runs/46031151305)

This PR regenerated those outdated snapshots

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- regenerate CFN / Scenario tests related to APIGW
- update snapshot skip related to DynamoDB 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
