### PR TITLE
CFn: correctly set physical resource id for VpnGatewayAttachment

### DIFF
--- a/localstack-core/localstack/services/ec2/resource_providers/aws_ec2_vpcgatewayattachment.py
+++ b/localstack-core/localstack/services/ec2/resource_providers/aws_ec2_vpcgatewayattachment.py
@@ -58,12 +58,13 @@ class EC2VPCGatewayAttachmentProvider(ResourceProvider[EC2VPCGatewayAttachmentPr
                 message="Either 'InternetGatewayId' or 'VpnGatewayId' is required but neither specified",
             )
 
+        vpc_id = model["VpcId"]
         if ig_id := model.get("InternetGatewayId"):
-            model["Id"] = ig_id
-            ec2.attach_internet_gateway(InternetGatewayId=ig_id, VpcId=model["VpcId"])
+            model["Id"] = f"IGW|{vpc_id}"
+            ec2.attach_internet_gateway(InternetGatewayId=ig_id, VpcId=vpc_id)
         elif vpn_id := model.get("VpnGatewayId"):
-            model["Id"] = vpn_id
-            ec2.attach_vpn_gateway(VpnGatewayId=vpn_id, VpcId=model["VpcId"])
+            model["Id"] = f"VGW|{vpc_id}"
+            ec2.attach_vpn_gateway(VpnGatewayId=vpn_id, VpcId=vpc_id)
         else:
             raise RuntimeError("Unreachable due to validations above")
 

--- a/localstack-core/localstack/services/ec2/resource_providers/aws_ec2_vpcgatewayattachment.py
+++ b/localstack-core/localstack/services/ec2/resource_providers/aws_ec2_vpcgatewayattachment.py
@@ -50,13 +50,22 @@ class EC2VPCGatewayAttachmentProvider(ResourceProvider[EC2VPCGatewayAttachmentPr
         """
         model = request.desired_state
         ec2 = request.aws_client_factory.ec2
-        # TODO: validations
-        if model.get("InternetGatewayId"):
-            ec2.attach_internet_gateway(
-                InternetGatewayId=model["InternetGatewayId"], VpcId=model["VpcId"]
+
+        if not model.get("InternetGatewayId") and not model.get("VpnGatewayId"):
+            return ProgressEvent(
+                status=OperationStatus.FAILED,
+                resource_model=model,
+                message="Either 'InternetGatewayId' or 'VpnGatewayId' is required but neither specified",
             )
+
+        if ig_id := model.get("InternetGatewayId"):
+            model["Id"] = ig_id
+            ec2.attach_internet_gateway(InternetGatewayId=ig_id, VpcId=model["VpcId"])
+        elif vpn_id := model.get("VpnGatewayId"):
+            model["Id"] = vpn_id
+            ec2.attach_vpn_gateway(VpnGatewayId=vpn_id, VpcId=model["VpcId"])
         else:
-            ec2.attach_vpn_gateway(VpnGatewayId=model["VpnGatewayId"], VpcId=model["VpcId"])
+            raise RuntimeError("Unreachable due to validations above")
 
         # TODO: idempotency
         return ProgressEvent(

--- a/tests/aws/services/cloudformation/resources/test_ec2.py
+++ b/tests/aws/services/cloudformation/resources/test_ec2.py
@@ -204,6 +204,24 @@ def test_transit_gateway_attachment(deploy_cfn_template, aws_client, snapshot):
 
 
 @markers.aws.validated
+def test_vpc_gateway_attachment(deploy_cfn_template, aws_client, snapshot):
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/vpc_gateway_attachment.yml"
+        )
+    )
+    vpc_id = stack.outputs["VpcId"]
+    # fetch the internet gateway id so we can transform the GW attachment id, as
+    # it's of the form "IGW|<vpc-id>" (for internet gateways) and "VGW|<vpc-id>" for
+    # VPN gateways
+    snapshot.add_transformer(snapshot.transform.regex(vpc_id, "<vpc-id>"))
+
+    snapshot.match("attachment-1-ref", stack.outputs["GatewayAttachment1Ref"])
+    # TODO: vpn gateway not supported by LocalStack yet
+    # snapshot.match("attachment-2-ref", stack.outputs["GatewayAttachment2Ref"])
+
+
+@markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(
     paths=["$..RouteTables..PropagatingVgws", "$..RouteTables..Tags"]
 )

--- a/tests/aws/services/cloudformation/resources/test_ec2.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.snapshot.json
@@ -299,5 +299,12 @@
         "ImportedKeyPairName": "<imported-key-name>"
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_ec2.py::test_vpc_gateway_attachment": {
+    "recorded-date": "18-07-2025, 20:52:38",
+    "recorded-content": {
+      "attachment-1-ref": "IGW|<vpc-id>",
+      "attachment-2-ref": "VGW|<vpc-id>"
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_ec2.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.validation.json
@@ -29,6 +29,15 @@
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_vpc_creates_default_sg": {
     "last_validated_date": "2024-04-01T11:21:54+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_ec2.py::test_vpc_gateway_attachment": {
+    "last_validated_date": "2025-07-18T20:50:13+00:00",
+    "durations_in_seconds": {
+      "setup": 1.21,
+      "call": 24.77,
+      "teardown": 6.47,
+      "total": 32.45
+    }
+  },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_vpc_with_route_table": {
     "last_validated_date": "2024-06-19T16:48:31+00:00"
   }

--- a/tests/aws/templates/vpc_gateway_attachment.yml
+++ b/tests/aws/templates/vpc_gateway_attachment.yml
@@ -1,0 +1,34 @@
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+
+#  TODO: not supported by LocalStack yet
+#  VpnGateway:
+#    Type: AWS::EC2::VPNGateway
+#    Properties:
+#      Type: ipsec.1
+
+  GatewayAttachment1:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref InternetGateway
+
+#  GatewayAttachment2:
+#    Type: AWS::EC2::VPCGatewayAttachment
+#    Properties:
+#      VpcId: !Ref Vpc
+#      VpnGatewayId: !Ref VpnGateway
+
+Outputs:
+  VpcId:
+    Value: !Ref Vpc
+  GatewayAttachment1Ref:
+    Value: !Ref GatewayAttachment1
+#  GatewayAttachment2Ref:
+#    Value: !Ref GatewayAttachment2


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We don't currently set the physical resource id when creating a VPC gateway attachment. This means the new CFn provider fails to deploy the resource.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Correctly set the physical resource id for either the vpn gateway id  or internet gateway id, whichever is provided
* Validate that the physical resource id is set


<!-- Optional section: How to test these changes? -->
<!--

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
