### PR TITLE
DynamoDB: skip failing test test_more_than_20_global_secondary_indexes

### DIFF
--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -474,6 +474,7 @@ class TestDynamoDB:
         transformed_dict = SortingTransformer("Items", lambda x: x).transform(result)
         snapshot.match("Items", transformed_dict)
 
+    @pytest.mark.skip(reason="Temporarily skipped")
     @markers.aws.only_localstack(reason="AWS has a 20 GSI limit")
     def test_more_than_20_global_secondary_indexes(
         self, dynamodb_create_table_with_parameters, aws_client


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Skip `test_more_than_20_global_secondary_indexes` test for now. Service owners have been informed about the issue

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Skip `test_more_than_20_global_secondary_indexes` integration test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
