### PR TITLE
DynamoDB: Bump DDB Local to v3

### DIFF
--- a/localstack-core/localstack/services/dynamodb/packages.py
+++ b/localstack-core/localstack/services/dynamodb/packages.py
@@ -15,8 +15,7 @@ from localstack.utils.functions import run_safe
 from localstack.utils.http import download
 from localstack.utils.run import run
 
-DDB_AGENT_JAR_URL = f"{ARTIFACTS_REPO}/raw/388cd73f45bfd3bcf7ad40aa35499093061c7962/dynamodb-local-patch/target/ddb-local-loader-0.1.jar"
-DDB_AGENT_JAR_URL = "https://github.com/localstack/localstack-artifacts/raw/refs/heads/ddbv3-patch/dynamodb-local-patch/target/ddb-local-loader-0.2.jar"
+DDB_AGENT_JAR_URL = f"{ARTIFACTS_REPO}/raw/e4e8c8e294b1fcda90c678ff6af5d5ebe1f091eb/dynamodb-local-patch/target/ddb-local-loader-0.2.jar"
 JAVASSIST_JAR_URL = f"{MAVEN_REPO_URL}/org/javassist/javassist/3.30.2-GA/javassist-3.30.2-GA.jar"
 
 DDBLOCAL_URL = "https://d1ni2b6xgvw0s0.cloudfront.net/v3.x/dynamodb_local_latest.zip"

--- a/localstack-core/localstack/services/dynamodb/packages.py
+++ b/localstack-core/localstack/services/dynamodb/packages.py
@@ -16,7 +16,7 @@ from localstack.utils.http import download
 from localstack.utils.run import run
 
 DDB_AGENT_JAR_URL = f"{ARTIFACTS_REPO}/raw/388cd73f45bfd3bcf7ad40aa35499093061c7962/dynamodb-local-patch/target/ddb-local-loader-0.1.jar"
-DDB_AGENT_JAR_URL = "https://github.com/localstack/localstack-artifacts/raw/refs/heads/ddbv3-patch/dynamodb-local-patch/target/ddb-local-loader-0.1.jar"
+DDB_AGENT_JAR_URL = "https://github.com/localstack/localstack-artifacts/raw/refs/heads/ddbv3-patch/dynamodb-local-patch/target/ddb-local-loader-0.2.jar"
 JAVASSIST_JAR_URL = f"{MAVEN_REPO_URL}/org/javassist/javassist/3.30.2-GA/javassist-3.30.2-GA.jar"
 
 DDBLOCAL_URL = "https://d1ni2b6xgvw0s0.cloudfront.net/v3.x/dynamodb_local_latest.zip"

--- a/localstack-core/localstack/services/dynamodb/packages.py
+++ b/localstack-core/localstack/services/dynamodb/packages.py
@@ -16,9 +16,10 @@ from localstack.utils.http import download
 from localstack.utils.run import run
 
 DDB_AGENT_JAR_URL = f"{ARTIFACTS_REPO}/raw/388cd73f45bfd3bcf7ad40aa35499093061c7962/dynamodb-local-patch/target/ddb-local-loader-0.1.jar"
+DDB_AGENT_JAR_URL = "https://github.com/localstack/localstack-artifacts/raw/refs/heads/ddbv3-patch/dynamodb-local-patch/target/ddb-local-loader-0.1.jar"
 JAVASSIST_JAR_URL = f"{MAVEN_REPO_URL}/org/javassist/javassist/3.30.2-GA/javassist-3.30.2-GA.jar"
 
-DDBLOCAL_URL = "https://d1ni2b6xgvw0s0.cloudfront.net/v2.x/dynamodb_local_latest.zip"
+DDBLOCAL_URL = "https://d1ni2b6xgvw0s0.cloudfront.net/v3.x/dynamodb_local_latest.zip"
 
 
 class DynamoDBLocalPackage(Package):

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -474,7 +474,6 @@ class TestDynamoDB:
         transformed_dict = SortingTransformer("Items", lambda x: x).transform(result)
         snapshot.match("Items", transformed_dict)
 
-    @pytest.mark.skip(reason="Temporarily skipped")
     @markers.aws.only_localstack(reason="AWS has a 20 GSI limit")
     def test_more_than_20_global_secondary_indexes(
         self, dynamodb_create_table_with_parameters, aws_client


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Last Friday, we had to skip a LocalStack only test (see https://github.com/localstack/localstack/pull/12874) that suddenly started to fail.
We realized that the last version of DynamoDB local (see [announcement](https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-dynamodb-major-version-release-version-3-0-0/)) now migrated to the SDK for Java 2.x.
Therefore, our custom transformation done in [here](https://github.com/localstack/localstack-artifacts/blob/21999d534d78ff740e8bcf1c4eab98b628f5187a/dynamodb-local-patch/src/main/java/cloud/localstack/ClassRewriter.java#L15) was not applicable anymore.

(see https://github.com/localstack/localstack-artifacts/pull/44 for more context)

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- This test re-enables the skipped test.
- All the fix is actually done in [this PR](https://github.com/localstack/localstack-artifacts/pull/44). ~This PR will be updated with the definitive URL once such a PR gets merged.~

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->

Closes PNX-32