### PR TITLE
Stop pushing empty release commit for community

### DIFF
--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -175,8 +175,7 @@ function cmd-git-commit-release() {
     echo $1 || verify_valid_version
 
     git add "${DEPENDENCY_FILE}"
-    # allow empty commit here as the community version might not have any changes, but we still need a commit for a tag
-    git commit --allow-empty -m "release version ${1}"
+    git commit -m "release version ${1}"
     git tag -a "v${1}" -m "Release version ${1}"
 }
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

With the removal of CircleCI and #12829 we removed the need of having an empty commit to trigger the CI on releases of `localstack-core` and `localstack/localstack`. 

We can now proceed to trigger the pipeline purely via the tag on the latest commit in the `main` branch.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- remove `--allow-empty` in the release commit



## Testing

- running `git commit -m "test"` on a clean working tree just skips the creation of a commit. Subsequently running `git tag` will then put it on the latest commit in the branch. 


## TODO

What's left to do:

- [ ] Decide whether we should remove `--allow-empty` for the development iteration branch as well or not. In theory this commit is also unnecessary
- [ ] ...

