### PR TITLE
Lambda: Proper error handling for code in S3

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack-core/localstack/services/lambda_/invocation/lambda_service.py
@@ -645,9 +645,15 @@ def store_s3_bucket_archive(
         return create_hot_reloading_code(path=archive_key)
     s3_client: "S3Client" = connect_to().s3
     kwargs = {"VersionId": archive_version} if archive_version else {}
-    archive_file = s3_client.get_object(Bucket=archive_bucket, Key=archive_key, **kwargs)[
-        "Body"
-    ].read()
+    try:
+        archive_file = s3_client.get_object(Bucket=archive_bucket, Key=archive_key, **kwargs)[
+            "Body"
+        ].read()
+    except s3_client.exceptions.ClientError as e:
+        raise InvalidParameterValueException(
+            f"Error occurred while GetObject. S3 Error Code: {e.response['Error']['Code']}. S3 Error Message: {e.response['Error']['Message']}",
+            Type="User",
+        )
     return store_lambda_archive(
         archive_file, function_name=function_name, region_name=region_name, account_id=account_id
     )

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -653,6 +653,66 @@ class TestLambdaFunction:
             == get_function_response_updated["Configuration"]["CodeSize"]
         )
 
+    @markers.aws.validated
+    def test_lambda_code_location_s3_errors(
+        self, s3_bucket, snapshot, lambda_su_role, aws_client, create_lambda_function_aws
+    ):
+        function_name = f"code-function-{short_uid()}"
+        bucket_key = "code/code-function.zip"
+        zip_file_bytes = create_lambda_archive(load_file(TEST_LAMBDA_PYTHON_ECHO), get_content=True)
+        aws_client.s3.upload_fileobj(
+            Fileobj=io.BytesIO(zip_file_bytes), Bucket=s3_bucket, Key=bucket_key
+        )
+
+        # try to create the function with invalid bucket path
+        with pytest.raises(ClientError) as e:
+            aws_client.lambda_.create_function(
+                FunctionName=function_name,
+                Handler="index.handler",
+                Code={
+                    "S3Bucket": f"some-random-non-existent-bucket-{short_uid()}",
+                    "S3Key": bucket_key,
+                },
+                PackageType="Zip",
+                Role=lambda_su_role,
+                Runtime=Runtime.python3_12,
+            )
+        snapshot.match("create-error-wrong-bucket", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.lambda_.create_function(
+                FunctionName=function_name,
+                Handler="index.handler",
+                Code={"S3Bucket": s3_bucket, "S3Key": "non/existent.zip"},
+                PackageType="Zip",
+                Role=lambda_su_role,
+                Runtime=Runtime.python3_12,
+            )
+        snapshot.match("create-error-wrong-key", e.value.response)
+
+        create_lambda_function_aws(
+            FunctionName=function_name,
+            Handler="index.handler",
+            Code={"S3Bucket": s3_bucket, "S3Key": bucket_key},
+            PackageType="Zip",
+            Role=lambda_su_role,
+            Runtime=Runtime.python3_12,
+        )
+
+        with pytest.raises(ClientError) as e:
+            aws_client.lambda_.update_function_code(
+                FunctionName=function_name,
+                S3Bucket=f"some-random-non-existent-bucket-{short_uid()}",
+                S3Key=bucket_key,
+            )
+        snapshot.match("update-error-wrong-bucket", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.lambda_.update_function_code(
+                FunctionName=function_name, S3Bucket=s3_bucket, S3Key="non/existent.zip"
+            )
+        snapshot.match("update-error-wrong-key", e.value.response)
+
     # TODO: fix type of AccessDeniedException yielding null
     @markers.snapshot.skip_snapshot_verify(
         paths=[

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -19000,5 +19000,58 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_s3_errors": {
+    "recorded-date": "21-07-2025, 17:45:01",
+    "recorded-content": {
+      "create-error-wrong-bucket": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Error occurred while GetObject. S3 Error Code: NoSuchBucket. S3 Error Message: The specified bucket does not exist"
+        },
+        "Type": "User",
+        "message": "Error occurred while GetObject. S3 Error Code: NoSuchBucket. S3 Error Message: The specified bucket does not exist",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-error-wrong-key": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Error occurred while GetObject. S3 Error Code: NoSuchKey. S3 Error Message: The specified key does not exist."
+        },
+        "Type": "User",
+        "message": "Error occurred while GetObject. S3 Error Code: NoSuchKey. S3 Error Message: The specified key does not exist.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-error-wrong-bucket": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Error occurred while GetObject. S3 Error Code: NoSuchBucket. S3 Error Message: The specified bucket does not exist"
+        },
+        "Type": "User",
+        "message": "Error occurred while GetObject. S3 Error Code: NoSuchBucket. S3 Error Message: The specified bucket does not exist",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-error-wrong-key": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Error occurred while GetObject. S3 Error Code: NoSuchKey. S3 Error Message: The specified key does not exist."
+        },
+        "Type": "User",
+        "message": "Error occurred while GetObject. S3 Error Code: NoSuchKey. S3 Error Message: The specified key does not exist.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -371,6 +371,15 @@
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_s3": {
     "last_validated_date": "2024-09-12T11:29:56+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_s3_errors": {
+    "last_validated_date": "2025-07-21T17:45:02+00:00",
+    "durations_in_seconds": {
+      "setup": 13.8,
+      "call": 2.63,
+      "teardown": 1.73,
+      "total": 18.16
+    }
+  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_zipfile": {
     "last_validated_date": "2024-09-12T11:29:52+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, we do not properly catch the case of users specifiying invalid S3 code locations.

This leads to 500 errors with long stacktraces thrown, we should properly handle those cases instead.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Add test for S3 code with invalid locations
* Properly catch the s3 error and return the correct one to the sender

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
