### PR TITLE
Add proper validation for STS role arn and session name parameters

### DIFF
--- a/tests/aws/services/sts/test_sts.snapshot.json
+++ b/tests/aws/services/sts/test_sts.snapshot.json
@@ -207,5 +207,76 @@
         }
       }
     }
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_sts_invalid_parameters": {
+    "recorded-date": "21-07-2025, 19:25:22",
+    "recorded-content": {
+      "malformed-arn": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "nothing-valid-in-here is invalid",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "no-partition": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "arn::b:::something/test-role is invalid",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "no-service": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "arn:a::::something/test-role is invalid",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "not-enough-colons": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "arn:a:::something/test-role is invalid",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "no-resource": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "arn:a:a::aaaaaaaaaa: is invalid",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-session-name": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "1 validation error detected: Value 'Session1:2' at 'roleSessionName' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\w+=,.@-]*",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sts/test_sts.validation.json
+++ b/tests/aws/services/sts/test_sts.validation.json
@@ -5,6 +5,15 @@
   "tests/aws/services/sts/test_sts.py::TestSTSAssumeRoleTagging::test_iam_role_chaining_override_transitive_tags": {
     "last_validated_date": "2025-04-10T08:53:00+00:00"
   },
+  "tests/aws/services/sts/test_sts.py::TestSTSAssumeRoleTagging::test_sts_invalid_parameters": {
+    "last_validated_date": "2025-07-21T18:33:53+00:00",
+    "durations_in_seconds": {
+      "setup": 1.21,
+      "call": 0.67,
+      "teardown": 0.0,
+      "total": 1.88
+    }
+  },
   "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_assume_role": {
     "last_validated_date": "2024-06-05T17:23:49+00:00"
   },
@@ -19,5 +28,14 @@
   },
   "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_iam_role_chaining_override_transitive_tags": {
     "last_validated_date": "2025-04-10T08:08:37+00:00"
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_sts_invalid_parameters": {
+    "last_validated_date": "2025-07-21T19:25:22+00:00",
+    "durations_in_seconds": {
+      "setup": 1.19,
+      "call": 3.28,
+      "teardown": 0.0,
+      "total": 4.47
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We currently do not validate the role arn or the role session name in LocalStack.

This can lead to weird issues when parsing the ARN, like empty account ids or key errors.

With this PR, we make sure the role arn and session name will satisfy some (incredibly basic) requirements, the same as AWS imposes.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Better validation of role arn and role session name for the assume role call

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
