### PR TITLE
add python project section to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,9 +24,9 @@
 /bin/release-helper.sh @thrau @alexrashed
 
 # Python project, packaging, and dependencies
-/pyproject.toml @alexrashed @silv-io
-/requirements-*.txt @alexrashed @silv-io
-/.pre-commit-config.yaml @alexrashed @silv-io
+/pyproject.toml @alexrashed @silv-io @k-a-il @bentsku @sannya-singal
+/requirements-*.txt @alexrashed @silv-io @k-a-il @bentsku @sannya-singal
+/.pre-commit-config.yaml @alexrashed @silv-io @k-a-il @bentsku @sannya-singal
 
 # ASF
 /localstack-core/localstack/aws/ @thrau


### PR DESCRIPTION
## Motivation
In order to prepare this repo for https://github.com/localstack/meta/pull/23, this PR updates the `CODEOWNERS` file such that me and @silv-io own the `pyproject.toml` file as well as all files defining dependencies.

## Changes
- - Update the `CODEOWNERS` file such that me, @silv-io, @k-a-il, @sannya-singal, and @bentsku own everything related to the Python project, packaging, and dependencies.