### PR TITLE
KMS: Add support for `RSA_AES_KEY_WRAP_SHA_256` in import key material

### DIFF
--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -1564,10 +1564,13 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         match algo:
             case AlgorithmSpec.RSAES_PKCS1_V1_5:
                 padding_scheme = padding.PKCS1v15()
+                return decrypt_key.decrypt(encrypted_key_material, padding_scheme)
             case AlgorithmSpec.RSAES_OAEP_SHA_1:
                 padding_scheme = padding.OAEP(padding.MGF1(hashes.SHA1()), hashes.SHA1(), None)
+                return decrypt_key.decrypt(encrypted_key_material, padding_scheme)
             case AlgorithmSpec.RSAES_OAEP_SHA_256:
                 padding_scheme = padding.OAEP(padding.MGF1(hashes.SHA256()), hashes.SHA256(), None)
+                return decrypt_key.decrypt(encrypted_key_material, padding_scheme)
             case AlgorithmSpec.RSA_AES_KEY_WRAP_SHA_256:
                 rsa_key_size_bytes = decrypt_key.key_size // 8
                 wrapped_aes_key = encrypted_key_material[:rsa_key_size_bytes]
@@ -1590,8 +1593,6 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
                 raise KMSInvalidStateException(
                     f"Unsupported padding, requested wrapping algorithm: '{algo}'"
                 )
-
-        return decrypt_key.decrypt(encrypted_key_material, padding_scheme)
 
     def _validate_plaintext_key_type_based(
         self,

--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -6,7 +6,8 @@ import os
 from typing import Dict, Tuple
 
 from cryptography.exceptions import InvalidTag
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, keywrap
 from cryptography.hazmat.primitives.asymmetric import padding
 
 from localstack.aws.api import CommonServiceException, RequestContext, handler
@@ -1164,22 +1165,10 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
             disabled_key_allowed=True,
         )
 
-        if import_state.wrapping_algo == AlgorithmSpec.RSAES_PKCS1_V1_5:
-            decrypt_padding = padding.PKCS1v15()
-        elif import_state.wrapping_algo == AlgorithmSpec.RSAES_OAEP_SHA_1:
-            decrypt_padding = padding.OAEP(padding.MGF1(hashes.SHA1()), hashes.SHA1(), None)
-        elif import_state.wrapping_algo == AlgorithmSpec.RSAES_OAEP_SHA_256:
-            decrypt_padding = padding.OAEP(padding.MGF1(hashes.SHA256()), hashes.SHA256(), None)
-        else:
-            raise KMSInvalidStateException(
-                f"Unsupported padding, requested wrapping algorithm:'{import_state.wrapping_algo}'"
-            )
-
         # TODO check if there was already a key imported for this kms key
         # if so, it has to be identical. We cannot change keys by reimporting after deletion/expiry
-        key_material = import_state.key.crypto_key.key.decrypt(
-            encrypted_key_material, decrypt_padding
-        )
+        key_material = self._decrypt_wrapped_key_material(import_state, encrypted_key_material)
+
         if expiration_model:
             key_to_import_material_to.metadata["ExpirationModel"] = expiration_model
         else:
@@ -1563,6 +1552,43 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
                     f"Value {['Operations']} at 'operations' failed to satisfy constraint: Member must satisfy"
                     f" constraint: [Member must satisfy enum value set: {VALID_OPERATIONS}]"
                 )
+
+    def _decrypt_wrapped_key_material(
+        self,
+        import_state: KeyImportState,
+        encrypted_key_material: CiphertextType,
+    ) -> bytes:
+        algo = import_state.wrapping_algo
+        decrypt_key = import_state.key.crypto_key.key
+
+        if algo == AlgorithmSpec.RSAES_PKCS1_V1_5:
+            padding_scheme = padding.PKCS1v15()
+        elif algo == AlgorithmSpec.RSAES_OAEP_SHA_1:
+            padding_scheme = padding.OAEP(padding.MGF1(hashes.SHA1()), hashes.SHA1(), None)
+        elif algo == AlgorithmSpec.RSAES_OAEP_SHA_256:
+            padding_scheme = padding.OAEP(padding.MGF1(hashes.SHA256()), hashes.SHA256(), None)
+        elif algo == AlgorithmSpec.RSA_AES_KEY_WRAP_SHA_256:
+            rsa_key_size_bytes = decrypt_key.key_size // 8
+            wrapped_aes_key = encrypted_key_material[:rsa_key_size_bytes]
+            wrapped_key_material = encrypted_key_material[rsa_key_size_bytes:]
+
+            aes_key = decrypt_key.decrypt(
+                wrapped_aes_key,
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                    algorithm=hashes.SHA256(),
+                    label=None,
+                ),
+            )
+            return keywrap.aes_key_unwrap_with_padding(
+                aes_key, wrapped_key_material, default_backend()
+            )
+        else:
+            raise KMSInvalidStateException(
+                f"Unsupported padding, requested wrapping algorithm: '{algo}'"
+            )
+
+        return decrypt_key.decrypt(encrypted_key_material, padding_scheme)
 
     def _validate_plaintext_key_type_based(
         self,

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -2297,5 +2297,86 @@
         }
       }
     }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_import_key_rsa_aes_wrap_sha256": {
+    "recorded-date": "22-07-2025, 06:11:13",
+    "recorded-content": {
+      "describe-before-import": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:<partition>:kms:<region>:111111111111:key/<key-id:1>",
+          "CreationDate": "datetime",
+          "CustomerMasterKeySpec": "RSA_4096",
+          "Description": "test-key",
+          "Enabled": false,
+          "EncryptionAlgorithms": [
+            "RSAES_OAEP_SHA_1",
+            "RSAES_OAEP_SHA_256"
+          ],
+          "KeyId": "<key-id:1>",
+          "KeyManager": "CUSTOMER",
+          "KeySpec": "RSA_4096",
+          "KeyState": "PendingImport",
+          "KeyUsage": "ENCRYPT_DECRYPT",
+          "MultiRegion": false,
+          "Origin": "EXTERNAL"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "import-key-material-response": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:<partition>:kms:<region>:111111111111:key/<key-id:1>",
+          "CreationDate": "datetime",
+          "CustomerMasterKeySpec": "RSA_4096",
+          "Description": "test-key",
+          "Enabled": true,
+          "EncryptionAlgorithms": [
+            "RSAES_OAEP_SHA_1",
+            "RSAES_OAEP_SHA_256"
+          ],
+          "ExpirationModel": "KEY_MATERIAL_DOES_NOT_EXPIRE",
+          "KeyId": "<key-id:1>",
+          "KeyManager": "CUSTOMER",
+          "KeySpec": "RSA_4096",
+          "KeyState": "Enabled",
+          "KeyUsage": "ENCRYPT_DECRYPT",
+          "MultiRegion": false,
+          "Origin": "EXTERNAL"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-key-after-deleted-import": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:<partition>:kms:<region>:111111111111:key/<key-id:1>",
+          "CreationDate": "datetime",
+          "CustomerMasterKeySpec": "RSA_4096",
+          "Description": "test-key",
+          "Enabled": false,
+          "EncryptionAlgorithms": [
+            "RSAES_OAEP_SHA_1",
+            "RSAES_OAEP_SHA_256"
+          ],
+          "KeyId": "<key-id:1>",
+          "KeyManager": "CUSTOMER",
+          "KeySpec": "RSA_4096",
+          "KeyState": "PendingImport",
+          "KeyUsage": "ENCRYPT_DECRYPT",
+          "MultiRegion": false,
+          "Origin": "EXTERNAL"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -152,6 +152,15 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_import_key_asymmetric": {
     "last_validated_date": "2024-04-11T15:53:35+00:00"
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_import_key_rsa_aes_wrap_sha256": {
+    "last_validated_date": "2025-07-22T06:11:13+00:00",
+    "durations_in_seconds": {
+      "setup": 1.91,
+      "call": 4.8,
+      "teardown": 0.37,
+      "total": 7.08
+    }
+  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_import_key_symmetric": {
     "last_validated_date": "2024-04-11T15:53:31+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds support for the wrapping algorithm `RSA_AES_KEY_WRAP_SHA_256` in the `ImportKeyMaterial`, which raises:

`KMSInvalidStateException: An error occurred (KMSInvalidStateException) when calling the ImportKeyMaterial operation: Unsupported padding, requested wrapping algorithm:'RSA_AES_KEY_WRAP_SHA_256'`

This algorithm is defined by AWS as a hybrid encryption scheme, that combines encrypting the key material with an AES symmetric key that is generated, and encrypting the AES symmetric key with the public wrapping key and the `RSAES_OAEP_SHA_256` wrapping algorithm.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added support for `RSA_AES_KEY_WRAP_SHA_256` in the `import_key_material` method.
- Refactored decryption of wrapped key material into a new, centralized helper: `_decrypt_wrapped_key_material(...) ` now handles both RSA-only and hybrid RSA+AES key wrapping formats.
- Added AWS validated snapshot test: `test_import_key_rsa_aes_wrap_sha256` to validate the implementation. 

## References:
- [AWS official documentation for Importing Key Material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys-conceptual.html)
- [RFC 5649: AES Key Wrap with Padding](https://datatracker.ietf.org/doc/html/rfc5649)


Closes: https://github.com/localstack/localstack/issues/10921
