### PR TITLE
Step Functions: variable-reference parsing to skip string and regex literals

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/jsonata/jsonata.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/jsonata/jsonata.py
@@ -17,13 +17,19 @@ VariableReference = str
 VariableDeclarations = str
 
 
-# TODO: move the extraction logic to a formal ANTLR-base
-#       parser, as done with legacy Intrinsic Functions.
+# TODO: move the extraction logic to a formal ANTLR-base parser, as done with legacy
+#       Intrinsic Functions in package localstack.services.stepfunctions.asl.antlr
+#       with grammars ASLIntrinsicLexer and ASLIntrinsicParser, later used by upstream
+#       logics such as in:
+#       localstack.services.stepfunctions.asl.parse.intrinsic.preprocessor.Preprocessor
 _PATTERN_VARIABLE_REFERENCE = re.compile(
-    # 1) Non-capturing branch for JSONata regex literal /.../, allowing escaped \/
+    # 1) Non-capturing branch for JSONata regex literal
+    #    /.../ (slash delimited), allowing escaped slashes \/
     r"(?:\/(?:\\.|[^\\/])*\/[a-zA-Z]*)"
     r"|"
-    # 2) Non-capturing branch for JSONata string literal: "..." or '...', allowing escapes
+    # 2) Non-capturing branch for JSONata string literal:
+    #    "..." (double quotes) or '...' (single quotes),
+    #    allowing escapes
     r"(?:\"(?:\\.|[^\"\\])*\"|\'(?:\\.|[^\'\\])*\')"
     r"|"
     # 3) Capturing branch for $$, $identifier[.prop…], or lone $

--- a/localstack-core/localstack/services/stepfunctions/asl/jsonata/jsonata.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/jsonata/jsonata.py
@@ -16,9 +16,20 @@ JSONataExpression = str
 VariableReference = str
 VariableDeclarations = str
 
-_PATTERN_VARIABLE_REFERENCE: Final[re.Pattern] = re.compile(
-    r"\$\$|\$[a-zA-Z0-9_$]+(?:\.[a-zA-Z0-9_][a-zA-Z0-9_$]*)*|\$"
+
+# TODO: move the extraction logic to a formal ANTLR-base
+#       parser, as done with legacy Intrinsic Functions.
+_PATTERN_VARIABLE_REFERENCE = re.compile(
+    # 1) Non-capturing branch for JSONata regex literal /.../, allowing escaped \/
+    r"(?:\/(?:\\.|[^\\/])*\/[a-zA-Z]*)"
+    r"|"
+    # 2) Non-capturing branch for JSONata string literal: "..." or '...', allowing escapes
+    r"(?:\"(?:\\.|[^\"\\])*\"|\'(?:\\.|[^\'\\])*\')"
+    r"|"
+    # 3) Capturing branch for $$, $identifier[.prop…], or lone $
+    r"(\$\$|\$[A-Za-z0-9_$]+(?:\.[A-Za-z0-9_][A-Za-z0-9_$]*)*|\$)"
 )
+
 _ILLEGAL_VARIABLE_REFERENCES: Final[set[str]] = {"$", "$$"}
 _VARIABLE_REFERENCE_ASSIGNMENT_OPERATOR: Final[str] = ":="
 _VARIABLE_REFERENCE_ASSIGNMENT_STOP_SYMBOL: Final[str] = ";"
@@ -111,13 +122,17 @@ def extract_jsonata_variable_references(
 ) -> set[VariableReference]:
     if not jsonata_expression:
         return set()
-    variable_references: list[VariableReference] = _PATTERN_VARIABLE_REFERENCE.findall(
-        jsonata_expression
-    )
+    # Extract all recognised patterns.
+    all_references: list[Any] = _PATTERN_VARIABLE_REFERENCE.findall(jsonata_expression)
+    # Filter non-empty patterns (this includes consumed blocks such as jsonata
+    # regular expressions, delimited between non-escaped slashes).
+    variable_references: set[VariableReference] = {
+        reference for reference in all_references if reference and isinstance(reference, str)
+    }
     for variable_reference in variable_references:
         if variable_reference in _ILLEGAL_VARIABLE_REFERENCES:
             raise IllegalJSONataVariableReference(variable_reference=variable_reference)
-    return set(variable_references)
+    return variable_references
 
 
 def encode_jsonata_variable_declarations(

--- a/tests/aws/services/stepfunctions/templates/evaluatejsonata/evaluate_jsonata_templates.py
+++ b/tests/aws/services/stepfunctions/templates/evaluatejsonata/evaluate_jsonata_templates.py
@@ -11,6 +11,11 @@ class EvaluateJsonataTemplate(TemplateLoader):
     JSONATA_ARRAY_ELEMENT_EXPRESSION_DOUBLE_QUOTES = [1, "{% $number('2') %}", 3]
     JSONATA_ARRAY_ELEMENT_EXPRESSION = [1, '{% $number("2") %}', 3]
     JSONATA_STATE_INPUT_EXPRESSION = "{% $states.input.input_value %}"
+    JSONATA_REGEX_EXPRESSION_BASE = r'{% $contains("hello$world", /^hello\$/) %}'
+    JSONATA_REGEX_EXPRESSION_BASE_FALSE = r'{% $contains("hello$world", /^hello\ /) %}'
+    JSONATA_REGEX_EXPRESSION_BASE_SINGLE_QUOTE = r"{% $contains('hello$world', /^hello\$/) %}"
+    JSONATA_REGEX_EXPRESSION_BASE_SINGLE_QUOTE_FALSE = r"{% $contains('hello$world', /^hello\ /) %}"
 
     BASE_MAP = os.path.join(_THIS_FOLDER, "statemachines/base_map.json5")
     BASE_TASK = os.path.join(_THIS_FOLDER, "statemachines/base_task.json5")
+    BASE_PASS = os.path.join(_THIS_FOLDER, "statemachines/base_pass.json5")

--- a/tests/aws/services/stepfunctions/templates/evaluatejsonata/statemachines/base_pass.json5
+++ b/tests/aws/services/stepfunctions/templates/evaluatejsonata/statemachines/base_pass.json5
@@ -1,0 +1,12 @@
+{
+  "Comment": "BASE_PASS",
+  "QueryLanguage": "JSONata",
+  "StartAt": "Start",
+  "States": {
+    "Start": {
+      "Type": "Pass",
+      "Output": "__tbd__",
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py
+++ b/tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py
@@ -129,6 +129,43 @@ class TestBaseEvaluateJsonata:
 
     @markers.aws.validated
     @pytest.mark.parametrize(
+        "expression_string",
+        [
+            EJT.JSONATA_REGEX_EXPRESSION_BASE,
+            EJT.JSONATA_REGEX_EXPRESSION_BASE_FALSE,
+            EJT.JSONATA_REGEX_EXPRESSION_BASE_SINGLE_QUOTE,
+            EJT.JSONATA_REGEX_EXPRESSION_BASE_SINGLE_QUOTE_FALSE,
+        ],
+        ids=[
+            "BASE",
+            "BASE_FALSE",
+            "BASE_SINGLE_QUOTE",
+            "BASE_SINGLE_QUOTE_FALSE",
+        ],
+    )
+    def test_base_jsonata_regular_expressions(
+        self,
+        aws_client,
+        create_state_machine_iam_role,
+        create_state_machine,
+        sfn_snapshot,
+        expression_string,
+    ):
+        template = EJT.load_sfn_template(EJT.BASE_PASS)
+        template["States"]["Start"]["Output"] = expression_string
+        definition = json.dumps(template)
+        exec_input = json.dumps({})
+        create_and_record_execution(
+            aws_client,
+            create_state_machine_iam_role=create_state_machine_iam_role,
+            create_state_machine=create_state_machine,
+            sfn_snapshot=sfn_snapshot,
+            definition=definition,
+            execution_input=exec_input,
+        )
+
+    @markers.aws.validated
+    @pytest.mark.parametrize(
         "field,input_value",
         [
             pytest.param(

--- a/tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.snapshot.json
@@ -1,6 +1,262 @@
 {
+  "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_jsonata_regular_expressions[BASE]": {
+    "recorded-date": "22-07-2025, 13:32:38",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Start",
+              "output": "true",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "true",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_jsonata_regular_expressions[BASE_SINGLE_QUOTE]": {
+    "recorded-date": "22-07-2025, 13:33:07",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Start",
+              "output": "true",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "true",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_jsonata_regular_expressions[BASE_FALSE]": {
+    "recorded-date": "22-07-2025, 13:32:53",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Start",
+              "output": "false",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "false",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_jsonata_regular_expressions[BASE_SINGLE_QUOTE_FALSE]": {
+    "recorded-date": "22-07-2025, 13:33:22",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Start",
+              "output": "false",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "false",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_task[TIMEOUT_SECONDS]": {
-    "recorded-date": "13-11-2024, 15:36:52",
+    "recorded-date": "22-07-2025, 13:30:50",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -74,9 +330,7 @@
                     "Connection": [
                       "keep-alive"
                     ],
-                    "x-amzn-RequestId": [
-                      "<uuid:1>"
-                    ],
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "Content-Length": [
                       "2"
                     ],
@@ -93,13 +347,13 @@
                     "Date": "date",
                     "X-Amz-Executed-Version": "$LATEST",
                     "x-amzn-Remapped-Content-Length": "0",
-                    "x-amzn-RequestId": "<uuid:1>",
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
                   },
                   "HttpStatusCode": 200
                 },
                 "SdkResponseMetadata": {
-                  "RequestId": "<uuid:1>"
+                  "RequestId": "RequestId"
                 },
                 "StatusCode": 200
               },
@@ -131,9 +385,7 @@
                     "Connection": [
                       "keep-alive"
                     ],
-                    "x-amzn-RequestId": [
-                      "<uuid:1>"
-                    ],
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "Content-Length": [
                       "2"
                     ],
@@ -150,13 +402,13 @@
                     "Date": "date",
                     "X-Amz-Executed-Version": "$LATEST",
                     "x-amzn-Remapped-Content-Length": "0",
-                    "x-amzn-RequestId": "<uuid:1>",
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
                   },
                   "HttpStatusCode": 200
                 },
                 "SdkResponseMetadata": {
-                  "RequestId": "<uuid:1>"
+                  "RequestId": "RequestId"
                 },
                 "StatusCode": 200
               },
@@ -183,9 +435,7 @@
                     "Connection": [
                       "keep-alive"
                     ],
-                    "x-amzn-RequestId": [
-                      "<uuid:1>"
-                    ],
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "Content-Length": [
                       "2"
                     ],
@@ -202,13 +452,13 @@
                     "Date": "date",
                     "X-Amz-Executed-Version": "$LATEST",
                     "x-amzn-Remapped-Content-Length": "0",
-                    "x-amzn-RequestId": "<uuid:1>",
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
                   },
                   "HttpStatusCode": 200
                 },
                 "SdkResponseMetadata": {
-                  "RequestId": "<uuid:1>"
+                  "RequestId": "RequestId"
                 },
                 "StatusCode": 200
               },
@@ -230,7 +480,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_task[HEARTBEAT_SECONDS]": {
-    "recorded-date": "13-11-2024, 15:37:14",
+    "recorded-date": "22-07-2025, 13:31:08",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -304,9 +554,7 @@
                     "Connection": [
                       "keep-alive"
                     ],
-                    "x-amzn-RequestId": [
-                      "<uuid:1>"
-                    ],
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "Content-Length": [
                       "2"
                     ],
@@ -323,13 +571,13 @@
                     "Date": "date",
                     "X-Amz-Executed-Version": "$LATEST",
                     "x-amzn-Remapped-Content-Length": "0",
-                    "x-amzn-RequestId": "<uuid:1>",
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
                   },
                   "HttpStatusCode": 200
                 },
                 "SdkResponseMetadata": {
-                  "RequestId": "<uuid:1>"
+                  "RequestId": "RequestId"
                 },
                 "StatusCode": 200
               },
@@ -361,9 +609,7 @@
                     "Connection": [
                       "keep-alive"
                     ],
-                    "x-amzn-RequestId": [
-                      "<uuid:1>"
-                    ],
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "Content-Length": [
                       "2"
                     ],
@@ -380,13 +626,13 @@
                     "Date": "date",
                     "X-Amz-Executed-Version": "$LATEST",
                     "x-amzn-Remapped-Content-Length": "0",
-                    "x-amzn-RequestId": "<uuid:1>",
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
                   },
                   "HttpStatusCode": 200
                 },
                 "SdkResponseMetadata": {
-                  "RequestId": "<uuid:1>"
+                  "RequestId": "RequestId"
                 },
                 "StatusCode": 200
               },
@@ -413,9 +659,7 @@
                     "Connection": [
                       "keep-alive"
                     ],
-                    "x-amzn-RequestId": [
-                      "<uuid:1>"
-                    ],
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "Content-Length": [
                       "2"
                     ],
@@ -432,13 +676,13 @@
                     "Date": "date",
                     "X-Amz-Executed-Version": "$LATEST",
                     "x-amzn-Remapped-Content-Length": "0",
-                    "x-amzn-RequestId": "<uuid:1>",
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
                   },
                   "HttpStatusCode": 200
                 },
                 "SdkResponseMetadata": {
-                  "RequestId": "<uuid:1>"
+                  "RequestId": "RequestId"
                 },
                 "StatusCode": 200
               },
@@ -460,7 +704,224 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map[ITEMS]": {
-    "recorded-date": "13-11-2024, 15:50:15",
+    "recorded-date": "22-07-2025, 13:31:23",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 3
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "id": 4,
+            "mapIterationStartedEventDetails": {
+              "index": 0,
+              "name": "Start"
+            },
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "stateEnteredEventDetails": {
+              "input": "1",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Process"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "Process",
+              "output": "1",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 7,
+            "mapIterationSucceededEventDetails": {
+              "index": 0,
+              "name": "Start"
+            },
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 8,
+            "mapIterationStartedEventDetails": {
+              "index": 1,
+              "name": "Start"
+            },
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 9,
+            "previousEventId": 8,
+            "stateEnteredEventDetails": {
+              "input": "2",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Process"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 10,
+            "previousEventId": 9,
+            "stateExitedEventDetails": {
+              "name": "Process",
+              "output": "2",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 11,
+            "mapIterationSucceededEventDetails": {
+              "index": 1,
+              "name": "Start"
+            },
+            "previousEventId": 10,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 12,
+            "mapIterationStartedEventDetails": {
+              "index": 2,
+              "name": "Start"
+            },
+            "previousEventId": 10,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 13,
+            "previousEventId": 12,
+            "stateEnteredEventDetails": {
+              "input": "3",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Process"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 14,
+            "previousEventId": 13,
+            "stateExitedEventDetails": {
+              "name": "Process",
+              "output": "3",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 15,
+            "mapIterationSucceededEventDetails": {
+              "index": 2,
+              "name": "Start"
+            },
+            "previousEventId": 14,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 16,
+            "previousEventId": 15,
+            "timestamp": "timestamp",
+            "type": "MapStateSucceeded"
+          },
+          {
+            "id": 17,
+            "previousEventId": 15,
+            "stateExitedEventDetails": {
+              "name": "Start",
+              "output": "[1,2,3]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "[1,2,3]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 18,
+            "previousEventId": 17,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map[ITEMS_DOUBLE_QUOTES]": {
+    "recorded-date": "22-07-2025, 13:31:39",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -677,7 +1138,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map[MAX_CONCURRENCY]": {
-    "recorded-date": "13-11-2024, 15:37:45",
+    "recorded-date": "22-07-2025, 13:31:53",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -802,7 +1263,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map[TOLERATED_FAILURE_PERCENTAGE]": {
-    "recorded-date": "13-11-2024, 15:37:57",
+    "recorded-date": "22-07-2025, 13:32:08",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -927,7 +1388,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map[TOLERATED_FAILURE_COUNT]": {
-    "recorded-date": "13-11-2024, 15:38:08",
+    "recorded-date": "22-07-2025, 13:32:23",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -1051,242 +1512,8 @@
       }
     }
   },
-  "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_task_from_input[TIMEOUT_SECONDS]": {
-    "recorded-date": "13-11-2024, 15:38:32",
-    "recorded-content": {
-      "get_execution_history": {
-        "events": [
-          {
-            "executionStartedEventDetails": {
-              "input": {
-                "input_value": 1
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "roleArn": "snf_role_arn"
-            },
-            "id": 1,
-            "previousEventId": 0,
-            "timestamp": "timestamp",
-            "type": "ExecutionStarted"
-          },
-          {
-            "id": 2,
-            "previousEventId": 0,
-            "stateEnteredEventDetails": {
-              "input": {
-                "input_value": 1
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "Start"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskStateEntered"
-          },
-          {
-            "id": 3,
-            "previousEventId": 2,
-            "taskScheduledEventDetails": {
-              "parameters": {
-                "Payload": {},
-                "FunctionName": "arn:<partition>:lambda:<region>:111111111111:function:<lambda-function-name>"
-              },
-              "region": "<region>",
-              "resource": "invoke",
-              "resourceType": "lambda",
-              "timeoutInSeconds": 1
-            },
-            "timestamp": "timestamp",
-            "type": "TaskScheduled"
-          },
-          {
-            "id": 4,
-            "previousEventId": 3,
-            "taskStartedEventDetails": {
-              "resource": "invoke",
-              "resourceType": "lambda"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskStarted"
-          },
-          {
-            "id": 5,
-            "previousEventId": 4,
-            "taskSucceededEventDetails": {
-              "output": {
-                "ExecutedVersion": "$LATEST",
-                "Payload": {},
-                "SdkHttpMetadata": {
-                  "AllHttpHeaders": {
-                    "X-Amz-Executed-Version": [
-                      "$LATEST"
-                    ],
-                    "x-amzn-Remapped-Content-Length": [
-                      "0"
-                    ],
-                    "Connection": [
-                      "keep-alive"
-                    ],
-                    "x-amzn-RequestId": [
-                      "<uuid:1>"
-                    ],
-                    "Content-Length": [
-                      "2"
-                    ],
-                    "Date": "date",
-                    "X-Amzn-Trace-Id": "X-Amzn-Trace-Id",
-                    "Content-Type": [
-                      "application/json"
-                    ]
-                  },
-                  "HttpHeaders": {
-                    "Connection": "keep-alive",
-                    "Content-Length": "2",
-                    "Content-Type": "application/json",
-                    "Date": "date",
-                    "X-Amz-Executed-Version": "$LATEST",
-                    "x-amzn-Remapped-Content-Length": "0",
-                    "x-amzn-RequestId": "<uuid:1>",
-                    "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
-                  },
-                  "HttpStatusCode": 200
-                },
-                "SdkResponseMetadata": {
-                  "RequestId": "<uuid:1>"
-                },
-                "StatusCode": 200
-              },
-              "outputDetails": {
-                "truncated": false
-              },
-              "resource": "invoke",
-              "resourceType": "lambda"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskSucceeded"
-          },
-          {
-            "id": 6,
-            "previousEventId": 5,
-            "stateExitedEventDetails": {
-              "name": "Start",
-              "output": {
-                "ExecutedVersion": "$LATEST",
-                "Payload": {},
-                "SdkHttpMetadata": {
-                  "AllHttpHeaders": {
-                    "X-Amz-Executed-Version": [
-                      "$LATEST"
-                    ],
-                    "x-amzn-Remapped-Content-Length": [
-                      "0"
-                    ],
-                    "Connection": [
-                      "keep-alive"
-                    ],
-                    "x-amzn-RequestId": [
-                      "<uuid:1>"
-                    ],
-                    "Content-Length": [
-                      "2"
-                    ],
-                    "Date": "date",
-                    "X-Amzn-Trace-Id": "X-Amzn-Trace-Id",
-                    "Content-Type": [
-                      "application/json"
-                    ]
-                  },
-                  "HttpHeaders": {
-                    "Connection": "keep-alive",
-                    "Content-Length": "2",
-                    "Content-Type": "application/json",
-                    "Date": "date",
-                    "X-Amz-Executed-Version": "$LATEST",
-                    "x-amzn-Remapped-Content-Length": "0",
-                    "x-amzn-RequestId": "<uuid:1>",
-                    "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
-                  },
-                  "HttpStatusCode": 200
-                },
-                "SdkResponseMetadata": {
-                  "RequestId": "<uuid:1>"
-                },
-                "StatusCode": 200
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "TaskStateExited"
-          },
-          {
-            "executionSucceededEventDetails": {
-              "output": {
-                "ExecutedVersion": "$LATEST",
-                "Payload": {},
-                "SdkHttpMetadata": {
-                  "AllHttpHeaders": {
-                    "X-Amz-Executed-Version": [
-                      "$LATEST"
-                    ],
-                    "x-amzn-Remapped-Content-Length": [
-                      "0"
-                    ],
-                    "Connection": [
-                      "keep-alive"
-                    ],
-                    "x-amzn-RequestId": [
-                      "<uuid:1>"
-                    ],
-                    "Content-Length": [
-                      "2"
-                    ],
-                    "Date": "date",
-                    "X-Amzn-Trace-Id": "X-Amzn-Trace-Id",
-                    "Content-Type": [
-                      "application/json"
-                    ]
-                  },
-                  "HttpHeaders": {
-                    "Connection": "keep-alive",
-                    "Content-Length": "2",
-                    "Content-Type": "application/json",
-                    "Date": "date",
-                    "X-Amz-Executed-Version": "$LATEST",
-                    "x-amzn-Remapped-Content-Length": "0",
-                    "x-amzn-RequestId": "<uuid:1>",
-                    "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
-                  },
-                  "HttpStatusCode": 200
-                },
-                "SdkResponseMetadata": {
-                  "RequestId": "<uuid:1>"
-                },
-                "StatusCode": 200
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "id": 7,
-            "previousEventId": 6,
-            "timestamp": "timestamp",
-            "type": "ExecutionSucceeded"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_task_from_input[HEARTBEAT_SECONDS]": {
-    "recorded-date": "13-11-2024, 15:53:14",
+    "recorded-date": "22-07-2025, 13:33:41",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -1364,9 +1591,7 @@
                     "Connection": [
                       "keep-alive"
                     ],
-                    "x-amzn-RequestId": [
-                      "<uuid:1>"
-                    ],
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "Content-Length": [
                       "2"
                     ],
@@ -1383,13 +1608,13 @@
                     "Date": "date",
                     "X-Amz-Executed-Version": "$LATEST",
                     "x-amzn-Remapped-Content-Length": "0",
-                    "x-amzn-RequestId": "<uuid:1>",
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
                   },
                   "HttpStatusCode": 200
                 },
                 "SdkResponseMetadata": {
-                  "RequestId": "<uuid:1>"
+                  "RequestId": "RequestId"
                 },
                 "StatusCode": 200
               },
@@ -1421,9 +1646,7 @@
                     "Connection": [
                       "keep-alive"
                     ],
-                    "x-amzn-RequestId": [
-                      "<uuid:1>"
-                    ],
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "Content-Length": [
                       "2"
                     ],
@@ -1440,13 +1663,13 @@
                     "Date": "date",
                     "X-Amz-Executed-Version": "$LATEST",
                     "x-amzn-Remapped-Content-Length": "0",
-                    "x-amzn-RequestId": "<uuid:1>",
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
                   },
                   "HttpStatusCode": 200
                 },
                 "SdkResponseMetadata": {
-                  "RequestId": "<uuid:1>"
+                  "RequestId": "RequestId"
                 },
                 "StatusCode": 200
               },
@@ -1473,9 +1696,7 @@
                     "Connection": [
                       "keep-alive"
                     ],
-                    "x-amzn-RequestId": [
-                      "<uuid:1>"
-                    ],
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "Content-Length": [
                       "2"
                     ],
@@ -1492,13 +1713,13 @@
                     "Date": "date",
                     "X-Amz-Executed-Version": "$LATEST",
                     "x-amzn-Remapped-Content-Length": "0",
-                    "x-amzn-RequestId": "<uuid:1>",
+                    "x-amzn-RequestId": "x-amzn-RequestId",
                     "X-Amzn-Trace-Id": "X-Amzn-Trace-Id"
                   },
                   "HttpStatusCode": 200
                 },
                 "SdkResponseMetadata": {
-                  "RequestId": "<uuid:1>"
+                  "RequestId": "RequestId"
                 },
                 "StatusCode": 200
               },
@@ -1520,7 +1741,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map_from_input[ITEMS]": {
-    "recorded-date": "13-11-2024, 15:39:12",
+    "recorded-date": "22-07-2025, 13:34:05",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -1749,7 +1970,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map_from_input[MAX_CONCURRENCY]": {
-    "recorded-date": "13-11-2024, 15:39:39",
+    "recorded-date": "22-07-2025, 13:34:23",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -1878,7 +2099,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map_from_input[TOLERATED_FAILURE_PERCENTAGE]": {
-    "recorded-date": "13-11-2024, 15:40:00",
+    "recorded-date": "22-07-2025, 13:34:40",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -2007,7 +2228,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map_from_input[TOLERATED_FAILURE_COUNT]": {
-    "recorded-date": "13-11-2024, 15:40:16",
+    "recorded-date": "22-07-2025, 13:34:58",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -2124,223 +2345,6 @@
             },
             "id": 10,
             "previousEventId": 9,
-            "timestamp": "timestamp",
-            "type": "ExecutionSucceeded"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map[ITEMS_DOUBLE_QUOTES]": {
-    "recorded-date": "18-11-2024, 09:08:27",
-    "recorded-content": {
-      "get_execution_history": {
-        "events": [
-          {
-            "executionStartedEventDetails": {
-              "input": {},
-              "inputDetails": {
-                "truncated": false
-              },
-              "roleArn": "snf_role_arn"
-            },
-            "id": 1,
-            "previousEventId": 0,
-            "timestamp": "timestamp",
-            "type": "ExecutionStarted"
-          },
-          {
-            "id": 2,
-            "previousEventId": 0,
-            "stateEnteredEventDetails": {
-              "input": {},
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "Start"
-            },
-            "timestamp": "timestamp",
-            "type": "MapStateEntered"
-          },
-          {
-            "id": 3,
-            "mapStateStartedEventDetails": {
-              "length": 3
-            },
-            "previousEventId": 2,
-            "timestamp": "timestamp",
-            "type": "MapStateStarted"
-          },
-          {
-            "id": 4,
-            "mapIterationStartedEventDetails": {
-              "index": 0,
-              "name": "Start"
-            },
-            "previousEventId": 3,
-            "timestamp": "timestamp",
-            "type": "MapIterationStarted"
-          },
-          {
-            "id": 5,
-            "previousEventId": 4,
-            "stateEnteredEventDetails": {
-              "input": "1",
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "Process"
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateEntered"
-          },
-          {
-            "id": 6,
-            "previousEventId": 5,
-            "stateExitedEventDetails": {
-              "name": "Process",
-              "output": "1",
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateExited"
-          },
-          {
-            "id": 7,
-            "mapIterationSucceededEventDetails": {
-              "index": 0,
-              "name": "Start"
-            },
-            "previousEventId": 6,
-            "timestamp": "timestamp",
-            "type": "MapIterationSucceeded"
-          },
-          {
-            "id": 8,
-            "mapIterationStartedEventDetails": {
-              "index": 1,
-              "name": "Start"
-            },
-            "previousEventId": 6,
-            "timestamp": "timestamp",
-            "type": "MapIterationStarted"
-          },
-          {
-            "id": 9,
-            "previousEventId": 8,
-            "stateEnteredEventDetails": {
-              "input": "2",
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "Process"
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateEntered"
-          },
-          {
-            "id": 10,
-            "previousEventId": 9,
-            "stateExitedEventDetails": {
-              "name": "Process",
-              "output": "2",
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateExited"
-          },
-          {
-            "id": 11,
-            "mapIterationSucceededEventDetails": {
-              "index": 1,
-              "name": "Start"
-            },
-            "previousEventId": 10,
-            "timestamp": "timestamp",
-            "type": "MapIterationSucceeded"
-          },
-          {
-            "id": 12,
-            "mapIterationStartedEventDetails": {
-              "index": 2,
-              "name": "Start"
-            },
-            "previousEventId": 10,
-            "timestamp": "timestamp",
-            "type": "MapIterationStarted"
-          },
-          {
-            "id": 13,
-            "previousEventId": 12,
-            "stateEnteredEventDetails": {
-              "input": "3",
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "Process"
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateEntered"
-          },
-          {
-            "id": 14,
-            "previousEventId": 13,
-            "stateExitedEventDetails": {
-              "name": "Process",
-              "output": "3",
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateExited"
-          },
-          {
-            "id": 15,
-            "mapIterationSucceededEventDetails": {
-              "index": 2,
-              "name": "Start"
-            },
-            "previousEventId": 14,
-            "timestamp": "timestamp",
-            "type": "MapIterationSucceeded"
-          },
-          {
-            "id": 16,
-            "previousEventId": 15,
-            "timestamp": "timestamp",
-            "type": "MapStateSucceeded"
-          },
-          {
-            "id": 17,
-            "previousEventId": 15,
-            "stateExitedEventDetails": {
-              "name": "Start",
-              "output": "[1,2,3]",
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "MapStateExited"
-          },
-          {
-            "executionSucceededEventDetails": {
-              "output": "[1,2,3]",
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "id": 18,
-            "previousEventId": 17,
             "timestamp": "timestamp",
             "type": "ExecutionSucceeded"
           }

--- a/tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.validation.json
+++ b/tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.validation.json
@@ -1,41 +1,146 @@
 {
+  "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_jsonata_regular_expressions[BASE]": {
+    "last_validated_date": "2025-07-22T13:32:40+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 13.58,
+      "teardown": 1.63,
+      "total": 15.21
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_jsonata_regular_expressions[BASE_FALSE]": {
+    "last_validated_date": "2025-07-22T13:32:54+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 12.51,
+      "teardown": 1.73,
+      "total": 14.24
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_jsonata_regular_expressions[BASE_SINGLE_QUOTE]": {
+    "last_validated_date": "2025-07-22T13:33:09+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 13.03,
+      "teardown": 1.72,
+      "total": 14.75
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_jsonata_regular_expressions[BASE_SINGLE_QUOTE_FALSE]": {
+    "last_validated_date": "2025-07-22T13:33:23+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 12.63,
+      "teardown": 1.72,
+      "total": 14.35
+    }
+  },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map[ITEMS]": {
-    "last_validated_date": "2024-11-18T09:18:25+00:00"
+    "last_validated_date": "2025-07-22T13:31:25+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 13.55,
+      "teardown": 1.77,
+      "total": 15.32
+    }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map[ITEMS_DOUBLE_QUOTES]": {
-    "last_validated_date": "2024-11-18T09:18:48+00:00"
+    "last_validated_date": "2025-07-22T13:31:40+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 13.63,
+      "teardown": 1.6,
+      "total": 15.23
+    }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map[MAX_CONCURRENCY]": {
-    "last_validated_date": "2024-11-18T09:19:10+00:00"
+    "last_validated_date": "2025-07-22T13:31:54+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 12.37,
+      "teardown": 1.5,
+      "total": 13.87
+    }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map[TOLERATED_FAILURE_COUNT]": {
-    "last_validated_date": "2024-11-18T09:19:39+00:00"
+    "last_validated_date": "2025-07-22T13:32:25+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 12.56,
+      "teardown": 1.57,
+      "total": 14.13
+    }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map[TOLERATED_FAILURE_PERCENTAGE]": {
-    "last_validated_date": "2024-11-18T09:19:28+00:00"
+    "last_validated_date": "2025-07-22T13:32:11+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 13.51,
+      "teardown": 2.79,
+      "total": 16.3
+    }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map_from_input[ITEMS]": {
-    "last_validated_date": "2024-11-13T15:39:11+00:00"
+    "last_validated_date": "2025-07-22T13:34:06+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 20.48,
+      "teardown": 2.42,
+      "total": 22.9
+    }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map_from_input[MAX_CONCURRENCY]": {
-    "last_validated_date": "2024-11-13T15:39:37+00:00"
+    "last_validated_date": "2025-07-22T13:34:24+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 15.56,
+      "teardown": 2.54,
+      "total": 18.1
+    }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map_from_input[TOLERATED_FAILURE_COUNT]": {
-    "last_validated_date": "2024-11-13T15:40:15+00:00"
+    "last_validated_date": "2025-07-22T13:35:01+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 15.69,
+      "teardown": 3.73,
+      "total": 19.42
+    }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_map_from_input[TOLERATED_FAILURE_PERCENTAGE]": {
-    "last_validated_date": "2024-11-13T15:39:58+00:00"
+    "last_validated_date": "2025-07-22T13:34:42+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 15.04,
+      "teardown": 2.58,
+      "total": 17.62
+    }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_task[HEARTBEAT_SECONDS]": {
-    "last_validated_date": "2024-11-13T15:37:13+00:00"
+    "last_validated_date": "2025-07-22T13:31:10+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 16.0,
+      "teardown": 2.43,
+      "total": 18.43
+    }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_task[TIMEOUT_SECONDS]": {
-    "last_validated_date": "2024-11-13T15:36:51+00:00"
+    "last_validated_date": "2025-07-22T13:30:51+00:00",
+    "durations_in_seconds": {
+      "setup": 11.8,
+      "call": 11.98,
+      "teardown": 2.73,
+      "total": 26.51
+    }
   },
   "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_task_from_input[HEARTBEAT_SECONDS]": {
-    "last_validated_date": "2024-11-13T15:53:13+00:00"
-  },
-  "tests/aws/services/stepfunctions/v2/evaluate_jsonata/test_base_evaluate_expressions.py::TestBaseEvaluateJsonata::test_base_task_from_input[TIMEOUT_SECONDS]": {
-    "last_validated_date": "2024-11-13T15:38:29+00:00"
+    "last_validated_date": "2025-07-22T13:33:43+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 17.12,
+      "teardown": 2.73,
+      "total": 19.85
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, the SFN v2 interpreter’s logic for extracting variable references from JSONata expressions can misinterpret dollar signs inside quoted strings or regex literals as variable markers. That leads to spurious validation errors at runtime reporting illegal uses of “$” even when they occur only within "/…/" or "…", ’…’ literals.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Updates the variable-reference regex to first consume any JSONata regex literals (`/…/`) and string literals (`"…"` or `'…'`), including support for escaped slashes and escaped quotes
- Retains the original rules for matching `$$`, `$identifier(.prop…)*` and lone `$`, but only after skipping over consumed literals
- Ensures that only actual variable references are returned by findall
- Add related positive and negative snapshot tests
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
