### PR TITLE
CFnV2: add stack events when there are errors during preprocessing

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
@@ -177,7 +177,19 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
         Overrides the default preprocessing for NodeResource objects by annotating the
         `after` delta with the physical resource ID, if side effects resulted in an update.
         """
-        delta = super().visit_node_resource(node_resource=node_resource)
+        try:
+            delta = super().visit_node_resource(node_resource=node_resource)
+        except Exception as e:
+            # TODO: change action may not match the change type
+            self._process_event(
+                ChangeAction.Modify,
+                node_resource.name,
+                OperationStatus.FAILED,
+                reason=str(e),
+                resource_type=node_resource.type_.value,
+            )
+            raise e
+
         before = delta.before
         after = delta.after
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While the provider is still new with edge cases, it's frustrating to find out the cause of the error if it occurs during preprocessing.

With this change, a stack event is captured during resource deployment time so at least the error message is shown in the stack events.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Add stack event on resource preprocessing failure

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
