### PR TITLE
Ignore all type errors from mypy when debugpy is installed

### DIFF
--- a/localstack-core/localstack/packages/debugpy.py
+++ b/localstack-core/localstack/packages/debugpy.py
@@ -20,7 +20,7 @@ class DebugPyPackageInstaller(PackageInstaller):
 
     def is_installed(self) -> bool:
         try:
-            import debugpy  # type: ignore[import-not-found]  # noqa: T100
+            import debugpy  # type: ignore  # noqa: T100
 
             assert debugpy
             return True


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Our pre-push hook runs mypy, but if `debugpy` is installed, I get the following error:

```
localstack/packages/debugpy.py:23: error: Unused "type: ignore" comment  [unused-ignore]
localstack/packages/debugpy.py:23: error: Skipping analyzing "debugpy": module is installed, but missing library stubs or py.typed marker  [import-untyped]
localstack/packages/debugpy.py:23: note: Error code "import-untyped" not covered by "type: ignore" comment
localstack/packages/debugpy.py:23: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 2 errors in 1 file (checked 15 source files)
make: *** [Makefile:124: lint] Error 1
error: failed to push some refs to 'github.com:localstack/localstack.git'
```

This prevents the push for a reason that is not important.




<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Ignore all type errors with `debugpy` as it's not a crucial part of our typing setup

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
