### PR TITLE
S3: fix Expires header behavior

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -909,15 +909,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             version_id=version_id,
             http_method="GET",
         )
-        if s3_object.expires and s3_object.expires < datetime.datetime.now(
-            tz=s3_object.expires.tzinfo
-        ):
-            # TODO: old behaviour was deleting key instantly if expired. AWS cleans up only once a day generally
-            #  you can still HeadObject on it and you get the expiry time until scheduled deletion
-            kwargs = {"Key": object_key}
-            if version_id:
-                kwargs["VersionId"] = version_id
-            raise NoSuchKey("The specified key does not exist.", **kwargs)
 
         if s3_object.storage_class in ARCHIVES_STORAGE_CLASSES and not s3_object.restore:
             raise InvalidObjectState(

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -1088,44 +1088,6 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_expiry": {
-    "recorded-date": "21-01-2025, 18:30:37",
-    "recorded-content": {
-      "head-object-expired": {
-        "AcceptRanges": "bytes",
-        "ContentLength": 3,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"acbd18db4cc2f85cedef654fccc4a4d8\"",
-        "Expires": "datetime",
-        "ExpiresString": "<expires>",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-object-not-yet-expired": {
-        "AcceptRanges": "bytes",
-        "Body": "foo",
-        "ChecksumCRC32": "jHNlIQ==",
-        "ChecksumType": "FULL_OBJECT",
-        "ContentLength": 3,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"acbd18db4cc2f85cedef654fccc4a4d8\"",
-        "Expires": "datetime",
-        "ExpiresString": "<expires>",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_upload_file_with_xml_preamble": {
     "recorded-date": "21-01-2025, 18:30:40",
     "recorded-content": {
@@ -18225,6 +18187,97 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 206
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_expires": {
+    "recorded-date": "22-07-2025, 14:00:54",
+    "recorded-content": {
+      "put-object-expires-future": {
+        "ChecksumCRC32": "jHNlIQ==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"acbd18db4cc2f85cedef654fccc4a4d8\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-expires-future": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 3,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"acbd18db4cc2f85cedef654fccc4a4d8\"",
+        "Expires": "datetime",
+        "ExpiresString": "<expires>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-expires-future": {
+        "AcceptRanges": "bytes",
+        "Body": "foo",
+        "ChecksumCRC32": "jHNlIQ==",
+        "ChecksumType": "FULL_OBJECT",
+        "ContentLength": 3,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"acbd18db4cc2f85cedef654fccc4a4d8\"",
+        "Expires": "datetime",
+        "ExpiresString": "<expires>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-expires-past": {
+        "ChecksumCRC32": "jHNlIQ==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "\"acbd18db4cc2f85cedef654fccc4a4d8\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-expires-past": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 3,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"acbd18db4cc2f85cedef654fccc4a4d8\"",
+        "Expires": "datetime",
+        "ExpiresString": "<expires>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-expires-past": {
+        "AcceptRanges": "bytes",
+        "Body": "foo",
+        "ChecksumCRC32": "jHNlIQ==",
+        "ChecksumType": "FULL_OBJECT",
+        "ContentLength": 3,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"acbd18db4cc2f85cedef654fccc4a4d8\"",
+        "Expires": "datetime",
+        "ExpiresString": "<expires>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -491,8 +491,14 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl_exceptions": {
     "last_validated_date": "2025-01-21T18:30:32+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_expiry": {
-    "last_validated_date": "2025-01-21T18:30:37+00:00"
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_expires": {
+    "last_validated_date": "2025-07-22T15:02:15+00:00",
+    "durations_in_seconds": {
+      "setup": 1.19,
+      "call": 1.34,
+      "teardown": 1.24,
+      "total": 3.77
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_put_inventory_report_exceptions": {
     "last_validated_date": "2025-01-21T18:42:57+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #12890, we had the wrong behavior with the `Expires` parameter. This was ported back from our legacy implementation, which wrong assumptions: the [`Expires`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax) header is only about cache invalidation, and has nothing to do with [Object Expiration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-expire-general-considerations.html), linked with lifecycle rules. 

This PR improves the AWS validated test, and remove the old behavior raising an Exception.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- remove old behavior raising an exception based on `Expires` value
- improve existing test


completes FLC-11
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
