### PR TITLE
SSM: add dependency on secretsmanager used by GetParameter

### DIFF
--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -66,6 +66,8 @@ API_DEPENDENCIES = {
     "transcribe": ["s3"],
     # secretsmanager uses lambda for rotation
     "secretsmanager": ["kms", "lambda"],
+    # ssm uses secretsmanager for get_parameter
+    "ssm": ["secretsmanager"],
 }
 
 # Optional dependencies of services on other services


### PR DESCRIPTION
## Motivation

SSM `GetParameter` uses secretsmanager service if the parameter matches the secrets pattern:

```python
        if SsmProvider._has_secrets(names):
            return SsmProvider._get_params_and_secrets(context.account_id, context.region, names)
```

This means if localstack is ran with `SERVICES`, GetParameter operations fail:

```
awslocal ssm get-parameter --name "/aws/reference/secretsmanager/foo" --with-decryption

An error occurred (InternalError) when calling the GetParameter operation (reached max retries: 4): exception while calling ssm.GetParameter: Traceback (most recent call last):
...
botocore.exceptions.ClientError: An error occurred (InternalFailure) when calling the GetSecretValue operation: Service 'secretsmanager' is not enabled. Please check your 'SERVICES' configuration variable.
```

## Changes

This PR adds an explicit dependency between the services.

## Testing

Start localstack with `SERVICES=ssm` and run:

```
awslocal ssm get-parameter --name "/aws/reference/secretsmanager/foo" --with-decryption
```

- Before the change you would get the exception about secretmanager not enabled.
- After you will get:

```
An error occurred (ParameterNotFound) when calling the GetParameter operation: An error occurred (ParameterNotFound) when referencing Secrets Manager: Secret /aws/reference/secretsmanager/foo not found.
```
