### PR TITLE
APIGW: support `DeploymentCanarySettings` for `AWS::ApiGateway::Deployment`

### DIFF
--- a/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_deployment.py
+++ b/localstack-core/localstack/services/apigateway/resource_providers/aws_apigateway_deployment.py
@@ -126,6 +126,9 @@ class ApiGatewayDeploymentProvider(ResourceProvider[ApiGatewayDeploymentProperti
         if model.get("Description"):
             params["description"] = model["Description"]
 
+        if model.get("DeploymentCanarySettings"):
+            params["canarySettings"] = model["DeploymentCanarySettings"]
+
         response = api.create_deployment(**params)
 
         model["DeploymentId"] = response["id"]

--- a/tests/aws/services/cloudformation/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.py
@@ -724,3 +724,30 @@ class TestServerlessApigwLambda:
         )
         get_fn_2 = aws_client.lambda_.get_function(FunctionName="test-service-local-api")
         assert get_fn_2["Configuration"]["Handler"] == "index.handler2"
+
+
+@markers.snapshot.skip_snapshot_verify(paths=["$..tags"])
+@markers.aws.validated
+def test_apigateway_deployment_canary_settings(deploy_cfn_template, snapshot, aws_client):
+    snapshot.add_transformers_list(
+        [
+            snapshot.transform.key_value("deploymentId"),
+            snapshot.transform.key_value("aws:cloudformation:stack-name"),
+            snapshot.transform.resource_name(),
+            SortingTransformer("items", itemgetter("description")),
+        ]
+    )
+
+    api_name = f"api-{short_uid()}"
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/apigateway_canary_deployment.yml"
+        ),
+        parameters={"RestApiName": api_name},
+    )
+    api_id = stack.outputs["RestApiId"]
+    stage = aws_client.apigateway.get_stages(restApiId=api_id)
+    snapshot.match("get-stages", stage)
+
+    deployments = aws_client.apigateway.get_deployments(restApiId=api_id)
+    snapshot.match("get-deployments", deployments)

--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -734,5 +734,62 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_apigateway.py::test_apigateway_deployment_canary_settings": {
+    "recorded-date": "23-07-2025, 23:07:05",
+    "recorded-content": {
+      "get-stages": {
+        "item": [
+          {
+            "cacheClusterEnabled": false,
+            "cacheClusterStatus": "NOT_AVAILABLE",
+            "canarySettings": {
+              "deploymentId": "<deployment-id:1>",
+              "percentTraffic": 50.0,
+              "stageVariableOverrides": {
+                "lambdaAlias": "Dev"
+              },
+              "useStageCache": false
+            },
+            "createdDate": "datetime",
+            "deploymentId": "<deployment-id:2>",
+            "lastUpdatedDate": "datetime",
+            "methodSettings": {},
+            "stageName": "prod",
+            "tags": {
+              "aws:cloudformation:logical-id": "Stage",
+              "aws:cloudformation:stack-id": "arn:<partition>:cloudformation:<region>:111111111111:stack/<aws:cloudformation:stack-name:1>/<resource:1>",
+              "aws:cloudformation:stack-name": "<aws:cloudformation:stack-name:1>"
+            },
+            "tracingEnabled": false,
+            "variables": {
+              "lambdaAlias": "Prod"
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-deployments": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "description": "basic deployment",
+            "id": "<deployment-id:2>"
+          },
+          {
+            "createdDate": "datetime",
+            "description": "canary description",
+            "id": "<deployment-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
@@ -11,6 +11,15 @@
       "total": 16.99
     }
   },
+  "tests/aws/services/cloudformation/resources/test_apigateway.py::test_apigateway_deployment_canary_settings": {
+    "last_validated_date": "2025-07-23T23:07:16+00:00",
+    "durations_in_seconds": {
+      "setup": 0.44,
+      "call": 22.5,
+      "teardown": 11.11,
+      "total": 34.05
+    }
+  },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_apigateway_rest_api": {
     "last_validated_date": "2025-05-05T14:50:14+00:00"
   },

--- a/tests/aws/templates/apigateway_canary_deployment.yml
+++ b/tests/aws/templates/apigateway_canary_deployment.yml
@@ -1,0 +1,59 @@
+Parameters:
+  RestApiName:
+    Type: String
+
+Resources:
+  RestApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: !Ref RestApiName
+  Stage:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      RestApiId:
+        Ref: RestApi
+      DeploymentId:
+        Ref: ApiDeployment
+      StageName: prod
+      Variables:
+        lambdaAlias: Prod
+
+  MockMethod:
+    Type: 'AWS::ApiGateway::Method'
+    Properties:
+      RestApiId: !Ref RestApi
+      ResourceId: !GetAtt
+        - RestApi
+        - RootResourceId
+      HttpMethod: POST
+      AuthorizationType: NONE
+      Integration:
+        Type: MOCK
+
+  ApiDeployment:
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      RestApiId:
+        Ref: RestApi
+      Description: "basic deployment"
+    DependsOn:
+      - MockMethod
+
+  ApiCanaryDeployment:
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      RestApiId:
+        Ref: RestApi
+      Description: "canary description"
+      DeploymentCanarySettings:
+        PercentTraffic: 50
+        StageVariableOverrides:
+          lambdaAlias: Dev
+      StageName: prod
+    DependsOn:
+      - MockMethod
+      - Stage
+
+Outputs:
+    RestApiId:
+        Value: !GetAtt RestApi.RestApiId


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As part of some testing ([for this sample](https://github.com/aws-samples/serverless-patterns/tree/main/apigw-canary-deployment-cdk-java), I encountered an issue with LocalStack ignoring some configuration. 

It did not handle the `DeploymentCanarySettings` property for `AWS::ApiGateway::Deployment`

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a new test for `DeploymentCanarySettings` property and template
- add support for `DeploymentCanarySettings` in the resource provider

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
