### PR TITLE
bug fix: add missing proxies to the http request for the GitHub Installer

### DIFF
--- a/localstack-core/localstack/packages/core.py
+++ b/localstack-core/localstack/packages/core.py
@@ -13,7 +13,7 @@ from localstack import config
 from ..constants import LOCALSTACK_VENV_FOLDER, MAVEN_REPO_URL
 from ..utils.archives import download_and_extract
 from ..utils.files import chmod_r, chown_r, mkdir, rm_rf
-from ..utils.http import download
+from ..utils.http import download, get_proxies
 from ..utils.run import is_root, run
 from ..utils.venv import VirtualEnvironment
 from .api import InstallTarget, PackageException, PackageInstaller
@@ -155,7 +155,7 @@ class GitHubReleaseInstaller(PermissionDownloadInstaller):
         gh_token = os.environ.get("GITHUB_API_TOKEN")
         if gh_token:
             headers = {"authorization": f"Bearer {gh_token}"}
-        response = requests.get(self.github_tag_url, headers=headers)
+        response = requests.get(self.github_tag_url, headers=headers, proxies=get_proxies())
         if not response.ok:
             raise PackageException(
                 f"Could not get list of releases from {self.github_tag_url}: {response.text}"

--- a/localstack-core/localstack/packages/java.py
+++ b/localstack-core/localstack/packages/java.py
@@ -8,6 +8,7 @@ from localstack.constants import USER_AGENT_STRING
 from localstack.packages import InstallTarget, Package
 from localstack.packages.core import ArchiveDownloadAndExtractInstaller
 from localstack.utils.files import rm_rf
+from localstack.utils.http import get_proxies
 from localstack.utils.platform import Arch, get_arch, is_linux, is_mac_os
 from localstack.utils.run import run
 
@@ -166,7 +167,7 @@ class JavaPackageInstaller(ArchiveDownloadAndExtractInstaller):
             f"os={self.os_name}&architecture={self.arch}&image_type=jdk"
         )
         # Override user-agent because Adoptium API denies service to `requests` library
-        response = requests.get(endpoint, headers={"user-agent": USER_AGENT_STRING}).json()
+        response = requests.get(endpoint, headers={"user-agent": USER_AGENT_STRING}, proxies=get_proxies()).json()
         return response[0]["binary"]["package"]["link"]
 
     def _download_url_fallback(self) -> str:

--- a/localstack-core/localstack/packages/java.py
+++ b/localstack-core/localstack/packages/java.py
@@ -167,7 +167,9 @@ class JavaPackageInstaller(ArchiveDownloadAndExtractInstaller):
             f"os={self.os_name}&architecture={self.arch}&image_type=jdk"
         )
         # Override user-agent because Adoptium API denies service to `requests` library
-        response = requests.get(endpoint, headers={"user-agent": USER_AGENT_STRING}, proxies=get_proxies()).json()
+        response = requests.get(
+            endpoint, headers={"user-agent": USER_AGENT_STRING}, proxies=get_proxies()
+        ).json()
         return response[0]["binary"]["package"]["link"]
 
     def _download_url_fallback(self) -> str:


### PR DESCRIPTION
Ensure requests done with the GitHub Installer can resolve when an HTTP Proxy is used and configured via OUTBOUND_HTTP_PROXY / OUTBOUND_HTTPS_PROXY

Identified and tested with LocalStack pro by trying to install the EKS module via LPM.

Added 2nd / similar change (setting proxy on outbound request)  - the impact in java.py appears more limited/non-breaking and impacts a check to help identify latest/specific jdk version to use.

Confirmed and validated 2nd change via LPM module install of non-default java version