### PR TITLE
feat: add the pro activation to the tracked environment variables

### DIFF
--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -8,6 +8,7 @@ from localstack.utils.analytics import log
 LOG = logging.getLogger(__name__)
 
 TRACKED_ENV_VAR = [
+    "ACTIVATE_PRO",
     "ALLOW_NONSTANDARD_REGIONS",
     "BEDROCK_PREWARM",
     "CLOUDFRONT_LAMBDA_EDGE",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Tracking the `ACTIVATE_PRO` will enable us to identify sessions that use the pro image with an invalid token and fall back to the community image.

**Context:**
Some users set an invalid token using the pro image and set the `ACTIVATE_PRO=0` variable.
Without this, it appears that someone started a session with an invalid token using the pro image, which is misleading, as they would fall back to the community in this situation.


## What changes does this PR make?
Adds `ACTIVATE_PRO` to the list of tracked environment variables that are sent to the analytics backend, so that it's ingested into TinyBird.

<!-- Optional section: How to test these changes? -->
<!--
## Testing
No changes
-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--


What's left to do:

- [ ] .
- [ ] ...
-->
