### PR TITLE
handle unsupported resource in CFn v2

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
@@ -22,6 +22,7 @@ from localstack.services.cloudformation.engine.v2.change_set_model import (
     is_nothing,
 )
 from localstack.services.cloudformation.engine.v2.change_set_model_preproc import (
+    MOCKED_REFERENCE,
     ChangeSetModelPreproc,
     PreprocEntityDelta,
     PreprocOutput,
@@ -375,9 +376,7 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                 raise NoResourceProvider
 
         extra_resource_properties = {}
-        event = ProgressEvent(OperationStatus.SUCCESS, resource_model={})
         if resource_provider is not None:
-            # TODO: stack events
             try:
                 event = resource_provider_executor.deploy_loop(
                     resource_provider, extra_resource_properties, payload
@@ -389,22 +388,27 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                     reason,
                     exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
-                stack = self._change_set.stack
-                stack.set_resource_status(
-                    logical_resource_id=logical_resource_id,
-                    # TODO,
-                    physical_resource_id="",
-                    resource_type=resource_type,
-                    status=ResourceStatus.CREATE_FAILED
-                    if action == ChangeAction.Add
-                    else ResourceStatus.UPDATE_FAILED,
-                    resource_status_reason=reason,
-                )
                 event = ProgressEvent(
                     OperationStatus.FAILED,
                     resource_model={},
                     message=f"Resource provider operation failed: {reason}",
                 )
+        elif config.CFN_IGNORE_UNSUPPORTED_RESOURCE_TYPES:
+            LOG.warning(
+                "Resource of type %s is not supported but configuration is set to ignore it",
+                resource_type,
+            )
+            event = ProgressEvent(
+                OperationStatus.SUCCESS,
+                resource_model={},
+                message=f"Resource type {resource_type} not supported but deployed anyways",
+            )
+        else:
+            event = ProgressEvent(
+                OperationStatus.FAILED,
+                resource_model={},
+                message=f"Resource type {resource_type} not supported",
+            )
 
         self.resources.setdefault(logical_resource_id, {"Properties": {}})
         match event.status:
@@ -425,7 +429,11 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                 self.resources[logical_resource_id]["LogicalResourceId"] = logical_resource_id
                 self.resources[logical_resource_id]["Type"] = resource_type
 
-                physical_resource_id = self._get_physical_id(logical_resource_id)
+                physical_resource_id = (
+                    self._get_physical_id(logical_resource_id)
+                    if resource_provider
+                    else MOCKED_REFERENCE
+                )
                 self.resources[logical_resource_id]["PhysicalResourceId"] = physical_resource_id
 
             case OperationStatus.FAILED:

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_reference_resolving.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_reference_resolving.py
@@ -93,7 +93,6 @@ def test_sub_resolving(deploy_cfn_template, aws_client, snapshot):
     assert topic_arn in topic_arns
 
 
-@pytest.mark.skip(reason="CFNV2:Validation")
 @markers.aws.only_localstack
 def test_reference_unsupported_resource(deploy_cfn_template, aws_client):
     """


### PR DESCRIPTION
## Motivation
- This PR adds to the CFn v2 the capability to handle  unsupported resources in a better way.  

## Changes
- if `CFN_IGNORE_UNSUPPORTED_RESOURCE_TYPES` is set to true the engine will ignore nonexistent resource providers and return `unknown` when a property  is requested.
- Removal of duplicated code.

## Testing
- Unskipped test.