### PR TITLE
CFNv2: Support stack sets

### DIFF
--- a/localstack-core/localstack/services/cloudformation/provider.py
+++ b/localstack-core/localstack/services/cloudformation/provider.py
@@ -137,6 +137,9 @@ ARN_CHANGESET_REGEX = re.compile(
 ARN_STACK_REGEX = re.compile(
     r"arn:(aws|aws-us-gov|aws-cn):cloudformation:[-a-zA-Z0-9]+:\d{12}:stack/[a-zA-Z][-a-zA-Z0-9]*/[-a-zA-Z0-9:/._+]+"
 )
+ARN_STACK_SET_REGEX = re.compile(
+    r"arn:(aws|aws-us-gov|aws-cn):cloudformation:[-a-zA-Z0-9]+:\d{12}:stack-set/[a-zA-Z][-a-zA-Z0-9]*/[-a-zA-Z0-9:/._+]+"
+)
 
 
 def clone_stack_params(stack_params):

--- a/localstack-core/localstack/services/cloudformation/stores.py
+++ b/localstack-core/localstack/services/cloudformation/stores.py
@@ -5,6 +5,7 @@ from localstack.aws.api.cloudformation import StackStatus
 from localstack.services.cloudformation.engine.entities import Stack, StackChangeSet, StackSet
 from localstack.services.cloudformation.v2.entities import ChangeSet as ChangeSetV2
 from localstack.services.cloudformation.v2.entities import Stack as StackV2
+from localstack.services.cloudformation.v2.entities import StackSet as StackSetV2
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
 
 LOG = logging.getLogger(__name__)
@@ -19,6 +20,7 @@ class CloudFormationStore(BaseStore):
 
     # maps stack set ID to stack set details
     stack_sets: dict[str, StackSet] = LocalAttribute(default=dict)
+    stack_sets_v2: dict[str, StackSetV2] = LocalAttribute(default=dict)
 
     # maps macro ID to macros
     macros: dict[str, dict] = LocalAttribute(default=dict)

--- a/localstack-core/localstack/services/cloudformation/v2/entities.py
+++ b/localstack-core/localstack/services/cloudformation/v2/entities.py
@@ -8,6 +8,7 @@ from localstack.aws.api.cloudformation import (
     ChangeSetType,
     CreateChangeSetInput,
     CreateStackInput,
+    CreateStackSetInput,
     ExecutionStatus,
     Output,
     Parameter,
@@ -15,7 +16,11 @@ from localstack.aws.api.cloudformation import (
     StackDriftInformation,
     StackDriftStatus,
     StackEvent,
+    StackInstanceComprehensiveStatus,
+    StackInstanceDetailedStatus,
+    StackInstanceStatus,
     StackResource,
+    StackSetOperation,
     StackStatus,
     StackStatusReason,
 )
@@ -270,3 +275,36 @@ class ChangeSet:
     @property
     def region_name(self) -> str:
         return self.stack.region_name
+
+
+class StackInstance:
+    def __init__(
+        self, account_id: str, region_name: str, stack_set_id: str, operation_id: str, stack_id: str
+    ):
+        self.account_id = account_id
+        self.region_name = region_name
+        self.stack_set_id = stack_set_id
+        self.operation_id = operation_id
+        self.stack_id = stack_id
+
+        self.status: StackInstanceStatus = StackInstanceStatus.CURRENT
+        self.stack_instance_status = StackInstanceComprehensiveStatus(
+            DetailedStatus=StackInstanceDetailedStatus.SUCCEEDED
+        )
+
+
+class StackSet:
+    stack_instances: list[StackInstance]
+    operations: dict[str, StackSetOperation]
+
+    def __init__(self, account_id: str, region_name: str, request_payload: CreateStackSetInput):
+        self.account_id = account_id
+        self.region_name = region_name
+
+        self.stack_set_name = request_payload["StackSetName"]
+        self.stack_set_id = f"{self.stack_set_name}:{long_uid()}"
+        self.template_body = request_payload.get("TemplateBody")
+        self.template_url = request_payload.get("TemplateURL")
+
+        self.stack_instances = []
+        self.operations = {}

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.cloudformation import (
+    CallAs,
     Changes,
     ChangeSetNameOrId,
     ChangeSetNotFoundException,
@@ -16,12 +17,20 @@ from localstack.aws.api.cloudformation import (
     CreateChangeSetInput,
     CreateChangeSetOutput,
     CreateStackInput,
+    CreateStackInstancesInput,
+    CreateStackInstancesOutput,
     CreateStackOutput,
+    CreateStackSetInput,
+    CreateStackSetOutput,
     DeleteChangeSetOutput,
+    DeleteStackInstancesInput,
+    DeleteStackInstancesOutput,
+    DeleteStackSetOutput,
     DeletionMode,
     DescribeChangeSetOutput,
     DescribeStackEventsOutput,
     DescribeStackResourcesOutput,
+    DescribeStackSetOperationOutput,
     DescribeStacksOutput,
     DisableRollback,
     EnableTerminationProtection,
@@ -44,6 +53,11 @@ from localstack.aws.api.cloudformation import (
     RollbackConfiguration,
     StackName,
     StackNameOrId,
+    StackSetName,
+    StackSetNotFoundException,
+    StackSetOperation,
+    StackSetOperationAction,
+    StackSetOperationStatus,
     StackStatus,
     StackStatusFilter,
     TemplateStage,
@@ -51,6 +65,7 @@ from localstack.aws.api.cloudformation import (
     UpdateStackOutput,
     UpdateTerminationProtectionOutput,
 )
+from localstack.aws.connect import connect_to
 from localstack.services.cloudformation import api_utils
 from localstack.services.cloudformation.engine import template_preparer
 from localstack.services.cloudformation.engine.v2.change_set_model import (
@@ -71,14 +86,16 @@ from localstack.services.cloudformation.engine.validations import ValidationErro
 from localstack.services.cloudformation.provider import (
     ARN_CHANGESET_REGEX,
     ARN_STACK_REGEX,
+    ARN_STACK_SET_REGEX,
     CloudformationProvider,
 )
 from localstack.services.cloudformation.stores import (
     CloudFormationStore,
     get_cloudformation_store,
 )
-from localstack.services.cloudformation.v2.entities import ChangeSet, Stack
+from localstack.services.cloudformation.v2.entities import ChangeSet, Stack, StackInstance, StackSet
 from localstack.utils.collections import select_attributes
+from localstack.utils.strings import short_uid
 from localstack.utils.threads import start_worker_thread
 
 LOG = logging.getLogger(__name__)
@@ -92,12 +109,21 @@ def is_changeset_arn(change_set_name_or_id: str) -> bool:
     return ARN_CHANGESET_REGEX.match(change_set_name_or_id) is not None
 
 
+def is_stack_set_arn(stack_set_name_or_id: str) -> bool:
+    return ARN_STACK_SET_REGEX.match(stack_set_name_or_id) is not None
+
+
 class StackNotFoundError(ValidationError):
     def __init__(self, stack_name_or_id: str):
         if is_stack_arn(stack_name_or_id):
             super().__init__(f"Stack with id {stack_name_or_id} does not exist")
         else:
             super().__init__(f"Stack [{stack_name_or_id}] does not exist")
+
+
+class StackSetNotFoundError(StackSetNotFoundException):
+    def __init__(self, stack_set_name: str):
+        super().__init__(f"StackSet {stack_set_name} not found")
 
 
 def find_stack_v2(state: CloudFormationStore, stack_name: str | None) -> Stack | None:
@@ -136,6 +162,24 @@ def find_change_set_v2(
                     return change_set_candidate
         else:
             raise ValueError("No stack name specified when finding change set")
+
+
+def find_stack_set_v2(state: CloudFormationStore, stack_set_name: str) -> StackSet | None:
+    if is_stack_set_arn(stack_set_name):
+        return state.stack_sets.get(stack_set_name)
+
+    for stack_set in state.stack_sets_v2.values():
+        if stack_set.stack_set_name == stack_set_name:
+            return stack_set
+
+    return None
+
+
+def find_stack_instance(stack_set: StackSet, account: str, region: str) -> StackInstance | None:
+    for instance in stack_set.stack_instances:
+        if instance.account_id == account and instance.region_name == region:
+            return instance
+    return None
 
 
 class CloudformationProviderV2(CloudformationProvider):
@@ -596,6 +640,16 @@ class CloudformationProviderV2(CloudformationProvider):
 
         return CreateStackOutput(StackId=stack.stack_id)
 
+    @handler("CreateStackSet", expand=False)
+    def create_stack_set(
+        self, context: RequestContext, request: CreateStackSetInput
+    ) -> CreateStackSetOutput:
+        state = get_cloudformation_store(context.account_id, context.region)
+        stack_set = StackSet(context.account_id, context.region, request)
+        state.stack_sets_v2[stack_set.stack_set_id] = stack_set
+
+        return CreateStackSetOutput(StackSetId=stack_set.stack_set_id)
+
     @handler("DescribeStacks")
     def describe_stacks(
         self,
@@ -666,6 +720,195 @@ class CloudformationProviderV2(CloudformationProvider):
                 status.setdefault("DriftInformation", {"StackResourceDriftStatus": "NOT_CHECKED"})
                 statuses.append(status)
         return DescribeStackResourcesOutput(StackResources=statuses)
+
+    @handler("CreateStackInstances", expand=False)
+    def create_stack_instances(
+        self,
+        context: RequestContext,
+        request: CreateStackInstancesInput,
+    ) -> CreateStackInstancesOutput:
+        state = get_cloudformation_store(context.account_id, context.region)
+
+        stack_set_name = request["StackSetName"]
+        stack_set = find_stack_set_v2(state, stack_set_name)
+        if not stack_set:
+            raise StackSetNotFoundError(stack_set_name)
+
+        op_id = request.get("OperationId") or short_uid()
+        accounts = request["Accounts"]
+        regions = request["Regions"]
+
+        stacks_to_await = []
+        for account in accounts:
+            for region in regions:
+                # deploy new stack
+                LOG.debug(
+                    'Deploying instance for stack set "%s" in account: %s region %s',
+                    stack_set_name,
+                    account,
+                    region,
+                )
+                cf_client = connect_to(aws_access_key_id=account, region_name=region).cloudformation
+                if stack_set.template_body:
+                    kwargs = {
+                        "TemplateBody": stack_set.template_body,
+                    }
+                elif stack_set.template_url:
+                    kwargs = {
+                        "TemplateURL": stack_set.template_url,
+                    }
+                else:
+                    # TODO: wording
+                    raise ValueError("Neither StackSet Template URL nor TemplateBody provided")
+                stack_name = f"sset-{stack_set_name}-{account}-{region}"
+
+                # skip creation of existing stacks
+                if find_stack_v2(state, stack_name):
+                    continue
+
+                result = cf_client.create_stack(StackName=stack_name, **kwargs)
+                # store stack instance
+                stack_instance = StackInstance(
+                    account_id=account,
+                    region_name=region,
+                    stack_set_id=stack_set.stack_set_id,
+                    operation_id=op_id,
+                    stack_id=result["StackId"],
+                )
+                stack_set.stack_instances.append(stack_instance)
+
+                stacks_to_await.append((stack_name, account, region))
+
+        # wait for completion of stack
+        for stack_name, account_id, region_name in stacks_to_await:
+            client = connect_to(
+                aws_access_key_id=account_id, region_name=region_name
+            ).cloudformation
+            client.get_waiter("stack_create_complete").wait(StackName=stack_name)
+
+        # record operation
+        operation = StackSetOperation(
+            OperationId=op_id,
+            StackSetId=stack_set.stack_set_id,
+            Action=StackSetOperationAction.CREATE,
+            Status=StackSetOperationStatus.SUCCEEDED,
+        )
+        stack_set.operations[op_id] = operation
+
+        return CreateStackInstancesOutput(OperationId=op_id)
+
+    @handler("DescribeStackSetOperation")
+    def describe_stack_set_operation(
+        self,
+        context: RequestContext,
+        stack_set_name: StackSetName,
+        operation_id: ClientRequestToken,
+        call_as: CallAs = None,
+        **kwargs,
+    ) -> DescribeStackSetOperationOutput:
+        state = get_cloudformation_store(context.account_id, context.region)
+        stack_set = find_stack_set_v2(state, stack_set_name)
+        if not stack_set:
+            raise StackSetNotFoundError(stack_set_name)
+
+        result = stack_set.operations.get(operation_id)
+        if not result:
+            LOG.debug(
+                'Unable to find operation ID "%s" for stack set "%s" in list: %s',
+                operation_id,
+                stack_set_name,
+                list(stack_set.operations.keys()),
+            )
+            # TODO: proper exception
+            raise ValueError(
+                f'Unable to find operation ID "{operation_id}" for stack set "{stack_set_name}"'
+            )
+
+        return DescribeStackSetOperationOutput(StackSetOperation=result)
+
+    @handler("DeleteStackInstances", expand=False)
+    def delete_stack_instances(
+        self,
+        context: RequestContext,
+        request: DeleteStackInstancesInput,
+    ) -> DeleteStackInstancesOutput:
+        state = get_cloudformation_store(context.account_id, context.region)
+
+        stack_set_name = request["StackSetName"]
+        stack_set = find_stack_set_v2(state, stack_set_name)
+        if not stack_set:
+            raise StackSetNotFoundError(stack_set_name)
+
+        op_id = request.get("OperationId") or short_uid()
+
+        accounts = request["Accounts"]
+        regions = request["Regions"]
+
+        operations_to_await = []
+        for account in accounts:
+            for region in regions:
+                cf_client = connect_to(aws_access_key_id=account, region_name=region).cloudformation
+                instance = find_stack_instance(stack_set, account, region)
+
+                # TODO: check parity with AWS
+                # TODO: delete stack instance?
+                if not instance:
+                    continue
+
+                cf_client.delete_stack(StackName=instance.stack_id)
+                operations_to_await.append(instance)
+
+        for instance in operations_to_await:
+            cf_client = connect_to(
+                aws_access_key_id=instance.account_id, region_name=instance.region_name
+            ).cloudformation
+            cf_client.get_waiter("stack_delete_complete").wait(StackName=instance.stack_id)
+            stack_set.stack_instances.remove(instance)
+
+        # record operation
+        operation = StackSetOperation(
+            OperationId=op_id,
+            StackSetId=stack_set.stack_set_id,
+            Action=StackSetOperationAction.DELETE,
+            Status=StackSetOperationStatus.SUCCEEDED,
+        )
+        stack_set.operations[op_id] = operation
+
+        return DeleteStackInstancesOutput(OperationId=op_id)
+
+    @handler("DeleteStackSet")
+    def delete_stack_set(
+        self,
+        context: RequestContext,
+        stack_set_name: StackSetName,
+        call_as: CallAs = None,
+        **kwargs,
+    ) -> DeleteStackSetOutput:
+        state = get_cloudformation_store(context.account_id, context.region)
+        stack_set = find_stack_set_v2(state, stack_set_name)
+        if not stack_set:
+            # operation is idempotent
+            return DeleteStackSetOutput()
+
+        # clean up any left-over instances
+        operations_to_await = []
+        for instance in stack_set.stack_instances:
+            cf_client = connect_to(
+                aws_access_key_id=instance.account_id, region_name=instance.region_name
+            ).cloudformation
+            cf_client.delete_stack(StackName=instance.stack_id)
+            operations_to_await.append(instance)
+
+        for instance in operations_to_await:
+            cf_client = connect_to(
+                aws_access_key_id=instance.account_id, region_name=instance.region_name
+            ).cloudformation
+            cf_client.get_waiter("stack_delete_complete").wait(StackName=instance.stack_id)
+            stack_set.stack_instances.remove(instance)
+
+        state.stack_sets_v2.pop(stack_set.stack_set_id)
+
+        return DeleteStackSetOutput()
 
     @handler("DescribeStackEvents")
     def describe_stack_events(

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_stack_sets.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_stack_sets.py
@@ -1,12 +1,14 @@
 import os
 
 import pytest
+from botocore.exceptions import ClientError
 
 from localstack.services.cloudformation.v2.utils import is_v2_engine
 from localstack.testing.aws.util import is_aws_cloud
+from localstack.testing.config import SECONDARY_TEST_AWS_ACCOUNT_ID, SECONDARY_TEST_AWS_REGION_NAME
 from localstack.testing.pytest import markers
 from localstack.utils.files import load_file
-from localstack.utils.strings import short_uid
+from localstack.utils.strings import long_uid, short_uid
 from localstack.utils.sync import wait_until
 
 pytestmark = pytest.mark.skipif(
@@ -30,8 +32,7 @@ def wait_stack_set_operation(aws_client):
     return waiter
 
 
-@pytest.mark.skip("CFNV2:StackSets")
-@markers.aws.validated
+@markers.aws.manual_setup_required
 def test_create_stack_set_with_stack_instances(
     account_id,
     region_name,
@@ -39,6 +40,7 @@ def test_create_stack_set_with_stack_instances(
     snapshot,
     wait_stack_set_operation,
 ):
+    """ "Account <...> should have 'AWSCloudFormationStackSetAdministrationRole' role with trust relationship to CloudFormation service."""
     snapshot.add_transformer(snapshot.transform.key_value("StackSetId", "stack-set-id"))
 
     stack_set_name = f"StackSet-{short_uid()}"
@@ -85,3 +87,42 @@ def test_create_stack_set_with_stack_instances(
     wait_stack_set_operation(stack_set_name, delete_instances_result["OperationId"])
 
     aws_client.cloudformation.delete_stack_set(StackSetName=stack_set_name)
+
+
+@markers.aws.validated
+def test_delete_nonexistent_stack_set(aws_client, snapshot):
+    # idempotent
+    aws_client.cloudformation.delete_stack_set(
+        StackSetName="non-existent-stack-set-id",
+    )
+
+    bad_stack_set_id = f"foo:{long_uid()}"
+    snapshot.add_transformer(snapshot.transform.regex(bad_stack_set_id, "<stack-id>"))
+
+    aws_client.cloudformation.delete_stack_set(
+        StackSetName=bad_stack_set_id,
+    )
+
+
+@markers.aws.validated
+def test_fetch_non_existent_stack_set_instances(aws_client, snapshot):
+    with pytest.raises(ClientError) as e:
+        aws_client.cloudformation.create_stack_instances(
+            StackSetName="non-existent-stack-set-id",
+            Accounts=[SECONDARY_TEST_AWS_ACCOUNT_ID],
+            Regions=[SECONDARY_TEST_AWS_REGION_NAME],
+        )
+
+    snapshot.match("non-existent-stack-set-name", e.value)
+
+    bad_stack_set_id = f"foo:{long_uid()}"
+    snapshot.add_transformer(snapshot.transform.regex(bad_stack_set_id, "<stack-id>"))
+
+    with pytest.raises(ClientError) as e:
+        aws_client.cloudformation.create_stack_instances(
+            StackSetName=bad_stack_set_id,
+            Accounts=[SECONDARY_TEST_AWS_ACCOUNT_ID],
+            Regions=[SECONDARY_TEST_AWS_REGION_NAME],
+        )
+
+    snapshot.match("non-existent-stack-set-id", e.value)

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_stack_sets.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_stack_sets.snapshot.json
@@ -17,5 +17,16 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_stack_sets.py::test_fetch_non_existent_stack_set_instances": {
+    "recorded-date": "25-07-2025, 14:15:09",
+    "recorded-content": {
+      "non-existent-stack-set-name": "An error occurred (StackSetNotFoundException) when calling the CreateStackInstances operation: StackSet non-existent-stack-set-id not found",
+      "non-existent-stack-set-id": "An error occurred (StackSetNotFoundException) when calling the CreateStackInstances operation: StackSet <stack-id> not found"
+    }
+  },
+  "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_stack_sets.py::test_delete_nonexistent_stack_set": {
+    "recorded-date": "25-07-2025, 14:57:22",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_stack_sets.validation.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_stack_sets.validation.json
@@ -1,5 +1,23 @@
 {
   "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_stack_sets.py::test_create_stack_set_with_stack_instances": {
     "last_validated_date": "2023-05-24T13:32:47+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_stack_sets.py::test_delete_nonexistent_stack_set": {
+    "last_validated_date": "2025-07-25T14:57:22+00:00",
+    "durations_in_seconds": {
+      "setup": 1.04,
+      "call": 0.34,
+      "teardown": 0.0,
+      "total": 1.38
+    }
+  },
+  "tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_stack_sets.py::test_fetch_non_existent_stack_set_instances": {
+    "last_validated_date": "2025-07-25T14:15:09+00:00",
+    "durations_in_seconds": {
+      "setup": 1.7,
+      "call": 0.6,
+      "teardown": 0.0,
+      "total": 2.3
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The CloudFormation V1 provider had basic support for stack sets, with a single test covering the functionality. This functionality should be ported over to the new provider.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Implement stack sets in parity with the old provider (i.e. unskip the test)
* Implement instance and stack deletion when deleting a stack set (beyond parity)
* Add additional tests for edge cases of creating stack instances for non-existent stacks
* Add test covering deleting a non-existent stack set


## Testing

Unfortunately there is manual set up required for testing stack sets. See the docs here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs-self-managed.html so this change does not test/assert the behaviour of deployed resources though they were manually verified.

<!-- Optional section: How to test these changes? -->
<!--


-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
