### PR TITLE
implement string replacement feature in CFn v2

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
@@ -14,11 +14,13 @@ from localstack.constants import INTERNAL_AWS_SECRET_ACCESS_KEY
 from localstack.services.cloudformation.analytics import track_resource_operation
 from localstack.services.cloudformation.deployment_utils import log_not_available_message
 from localstack.services.cloudformation.engine.parameters import resolve_ssm_parameter
+from localstack.services.cloudformation.engine.template_deployer import REGEX_OUTPUT_APIGATEWAY
 from localstack.services.cloudformation.engine.v2.change_set_model import (
     NodeDependsOn,
     NodeOutput,
     NodeParameter,
     NodeResource,
+    TerminalValueCreated,
     is_nothing,
 )
 from localstack.services.cloudformation.engine.v2.change_set_model_preproc import (
@@ -37,6 +39,7 @@ from localstack.services.cloudformation.resource_provider import (
     ResourceProviderPayload,
 )
 from localstack.services.cloudformation.v2.entities import ChangeSet
+from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 
@@ -500,3 +503,17 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
             },
         }
         return resource_provider_payload
+
+    def visit_terminal_value_created(self, value: TerminalValueCreated):
+        if not isinstance(value.value, str):
+            return PreprocEntityDelta(after=value.value)
+
+        api_match = REGEX_OUTPUT_APIGATEWAY.match(value.value)
+        if api_match and value.value not in config.CFN_STRING_REPLACEMENT_DENY_LIST:
+            prefix = api_match[1]
+            host = api_match[2]
+            path = api_match[3]
+            port = localstack_host().port
+            value.value = f"{prefix}{host}:{port}/{path}"
+
+        return PreprocEntityDelta(after=value.value)

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_lambda.py
@@ -8,8 +8,7 @@ from localstack_snapshot.snapshots.transformer import SortingTransformer
 
 from localstack import config
 from localstack.aws.api.lambda_ import InvocationType, Runtime, State
-from localstack.services.cloudformation.v2.utils import is_v2_engine
-from localstack.testing.aws.util import in_default_partition, is_aws_cloud
+from localstack.testing.aws.util import in_default_partition
 from localstack.testing.pytest import markers
 from localstack.utils.aws.arns import get_partition
 from localstack.utils.common import short_uid
@@ -19,10 +18,10 @@ from localstack.utils.strings import to_bytes, to_str
 from localstack.utils.sync import retry, wait_until
 from localstack.utils.testutil import create_lambda_archive, get_lambda_log_events
 
-pytestmark = pytest.mark.skipif(
-    condition=not is_v2_engine() and not is_aws_cloud(),
-    reason="Only targeting the new engine",
-)
+# pytestmark = pytest.mark.skipif(
+#     condition=not is_v2_engine() and not is_aws_cloud(),
+#     reason="Only targeting the new engine",
+# )
 
 
 @markers.aws.validated
@@ -470,7 +469,6 @@ def test_lambda_cfn_run(deploy_cfn_template, aws_client):
     aws_client.lambda_.invoke(FunctionName=fn_name, LogType="Tail", Payload=b"{}")
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.aws.only_localstack(reason="This is functionality specific to Localstack")
 def test_lambda_cfn_run_with_empty_string_replacement_deny_list(
     deploy_cfn_template, aws_client, monkeypatch
@@ -505,7 +503,6 @@ def test_lambda_cfn_run_with_empty_string_replacement_deny_list(
     )
 
 
-@pytest.mark.skip(reason="CFNV2:Other")
 @markers.aws.only_localstack(reason="This is functionality specific to Localstack")
 def test_lambda_cfn_run_with_non_empty_string_replacement_deny_list(
     deploy_cfn_template, aws_client, monkeypatch


### PR DESCRIPTION
## Motivation
This PR implements the capability to replace AWS URLs in CFn templates for CFn v2.

## Changes
- Override `visit_terminal_value_created` to replace strings if necessary

## Testing
- more unskipped tests

## Notes
- Possibly needs to be implemented also in `visit_terminal_value_updated`.
- Consider moving the code to the Preproc.