### PR TITLE
CFNv2: implement describe-stack-resource

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
@@ -18,6 +18,7 @@ from localstack.services.cloudformation.engine.v2.change_set_model import (
     NodeDependsOn,
     NodeOutput,
     NodeParameter,
+    NodeParameters,
     NodeResource,
     is_nothing,
 )
@@ -68,6 +69,10 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
         return ChangeSetModelExecutorResult(
             resources=self.resources, parameters=self.resolved_parameters, outputs=self.outputs
         )
+
+    def visit_node_parameters(self, node_parameters: NodeParameters) -> PreprocEntityDelta:
+        delta = super().visit_node_parameters(node_parameters)
+        return delta
 
     def visit_node_parameter(self, node_parameter: NodeParameter) -> PreprocEntityDelta:
         delta = super().visit_node_parameter(node_parameter)

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
@@ -37,7 +37,7 @@ from localstack.services.cloudformation.resource_provider import (
     ResourceProviderExecutor,
     ResourceProviderPayload,
 )
-from localstack.services.cloudformation.v2.entities import ChangeSet
+from localstack.services.cloudformation.v2.entities import ChangeSet, ResolvedResource
 
 LOG = logging.getLogger(__name__)
 
@@ -46,14 +46,14 @@ EventOperationFromAction = {"Add": "CREATE", "Modify": "UPDATE", "Remove": "DELE
 
 @dataclass
 class ChangeSetModelExecutorResult:
-    resources: dict
+    resources: dict[str, ResolvedResource]
     parameters: dict
     outputs: dict
 
 
 class ChangeSetModelExecutor(ChangeSetModelPreproc):
     # TODO: add typing for resolved resources and parameters.
-    resources: Final[dict]
+    resources: Final[dict[str, ResolvedResource]]
     outputs: Final[dict]
     resolved_parameters: Final[dict]
 

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_validator.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_validator.py
@@ -1,44 +1,35 @@
-from typing import Final
-
 from localstack.services.cloudformation.engine.v2.change_set_model import (
     NodeParameters,
+    NodeTemplate,
+    is_nothing,
 )
 from localstack.services.cloudformation.engine.v2.change_set_model_preproc import (
     ChangeSetModelPreproc,
     PreprocEntityDelta,
 )
 from localstack.services.cloudformation.engine.validations import ValidationError
-from localstack.services.cloudformation.v2.entities import ChangeSet
 
 
 class ChangeSetModelValidator(ChangeSetModelPreproc):
-    _before_parameters: Final[dict]
-    _after_parameters: Final[dict]
-
-    def __init__(
-        self,
-        change_set: ChangeSet,
-        before_parameters: dict,
-        after_parameters: dict,
-    ):
-        super().__init__(change_set)
-        self._before_parameters = before_parameters
-        self._after_parameters = after_parameters
-
     def validate(self):
         # validate parameters are all given
         self.visit(self._change_set.update_model.node_template.parameters)
 
-    def visit_node_parameters(self, node_parameters: NodeParameters) -> PreprocEntityDelta:
-        delta = super().visit_node_parameters(node_parameters)
-        # assert before
-        if self._before_parameters:
-            missing_values = [key for key in delta.before if delta.before[key] is None]
-            if missing_values:
-                raise ValidationError()
-        if self._after_parameters:
-            missing_values = [key for key in delta.after if delta.before[key] is None]
-            if missing_values:
-                raise ValidationError()
+    def visit_node_template(self, node_template: NodeTemplate):
+        self.visit_node_parameters(node_template.parameters)
 
-        return delta
+    def visit_node_parameters(self, node_parameters: NodeParameters) -> PreprocEntityDelta:
+        # check that all parameters have values
+        invalid_parameters = []
+        for node_parameter in node_parameters.parameters:
+            self.visit(node_parameter)
+            if is_nothing(node_parameter.default_value.value) and is_nothing(
+                node_parameter.dynamic_value.value
+            ):
+                invalid_parameters.append(node_parameter.name)
+
+        if invalid_parameters:
+            raise ValidationError(f"Parameters: [{','.join(invalid_parameters)}] must have values")
+
+        # continue visiting
+        return super().visit_node_parameters(node_parameters)

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_validator.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_validator.py
@@ -1,0 +1,44 @@
+from typing import Final
+
+from localstack.services.cloudformation.engine.v2.change_set_model import (
+    NodeParameters,
+)
+from localstack.services.cloudformation.engine.v2.change_set_model_preproc import (
+    ChangeSetModelPreproc,
+    PreprocEntityDelta,
+)
+from localstack.services.cloudformation.engine.validations import ValidationError
+from localstack.services.cloudformation.v2.entities import ChangeSet
+
+
+class ChangeSetModelValidator(ChangeSetModelPreproc):
+    _before_parameters: Final[dict]
+    _after_parameters: Final[dict]
+
+    def __init__(
+        self,
+        change_set: ChangeSet,
+        before_parameters: dict,
+        after_parameters: dict,
+    ):
+        super().__init__(change_set)
+        self._before_parameters = before_parameters
+        self._after_parameters = after_parameters
+
+    def validate(self):
+        # validate parameters are all given
+        self.visit(self._change_set.update_model.node_template.parameters)
+
+    def visit_node_parameters(self, node_parameters: NodeParameters) -> PreprocEntityDelta:
+        delta = super().visit_node_parameters(node_parameters)
+        # assert before
+        if self._before_parameters:
+            missing_values = [key for key in delta.before if delta.before[key] is None]
+            if missing_values:
+                raise ValidationError()
+        if self._after_parameters:
+            missing_values = [key for key in delta.after if delta.before[key] is None]
+            if missing_values:
+                raise ValidationError()
+
+        return delta

--- a/localstack-core/localstack/services/cloudformation/v2/entities.py
+++ b/localstack-core/localstack/services/cloudformation/v2/entities.py
@@ -34,8 +34,12 @@ from localstack.utils.strings import long_uid, short_uid
 
 
 class ResolvedResource(TypedDict):
+    LogicalResourceId: str
     Type: str
     Properties: dict
+    ResourceStatus: ResourceStatus
+    PhysicalResourceId: str | None
+    LastUpdatedTimestamp: datetime | None
 
 
 class Stack:

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -198,8 +198,6 @@ class CloudformationProviderV2(CloudformationProvider):
         # perform validations
         validator = ChangeSetModelValidator(
             change_set=change_set,
-            before_parameters=before_parameters,
-            after_parameters=after_parameters,
         )
         validator.validate()
 

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.py
@@ -1,0 +1,11 @@
+import os
+
+from localstack.testing.pytest import markers
+
+
+@markers.aws.validated
+def test_describe_non_existent_resource(aws_client, deploy_cfn_template, snapshot):
+    template_path = os.path.join(
+        os.path.dirname(__file__), "../../../../../templates/ssm_parameter_defaultname.yaml"
+    )
+    stack = deploy_cfn_template(template_path=template_path)

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.py
@@ -7,6 +7,16 @@ from localstack.testing.pytest import markers
 
 
 @markers.aws.validated
+def test_describe_non_existent_stack(aws_client, deploy_cfn_template, snapshot):
+    with pytest.raises(ClientError) as err:
+        aws_client.cloudformation.describe_stack_resource(
+            StackName="not-a-valid-stack", LogicalResourceId="not-a-valid-resource"
+        )
+
+    snapshot.match("error", err.value)
+
+
+@markers.aws.validated
 def test_describe_non_existent_resource(aws_client, deploy_cfn_template, snapshot):
     template_path = os.path.join(
         os.path.dirname(__file__), "../../../../../templates/ssm_parameter_defaultname.yaml"

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.snapshot.json
@@ -1,6 +1,8 @@
 {
   "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.py::test_describe_non_existent_resource": {
-    "recorded-date": "25-07-2025, 15:24:21",
-    "recorded-content": {}
+    "recorded-date": "25-07-2025, 22:01:35",
+    "recorded-content": {
+      "error": "An error occurred (ValidationError) when calling the DescribeStackResource operation: Resource not-a-valid-resource does not exist for stack <stack-id>"
+    }
   }
 }

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.snapshot.json
@@ -4,5 +4,11 @@
     "recorded-content": {
       "error": "An error occurred (ValidationError) when calling the DescribeStackResource operation: Resource not-a-valid-resource does not exist for stack <stack-id>"
     }
+  },
+  "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.py::test_describe_non_existent_stack": {
+    "recorded-date": "25-07-2025, 22:02:38",
+    "recorded-content": {
+      "error": "An error occurred (ValidationError) when calling the DescribeStackResource operation: Stack 'not-a-valid-stack' does not exist"
+    }
   }
 }

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.snapshot.json
@@ -1,0 +1,6 @@
+{
+  "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.py::test_describe_non_existent_resource": {
+    "recorded-date": "25-07-2025, 15:24:21",
+    "recorded-content": {}
+  }
+}

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.validation.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.validation.json
@@ -7,5 +7,14 @@
       "teardown": 4.37,
       "total": 15.81
     }
+  },
+  "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.py::test_describe_non_existent_stack": {
+    "last_validated_date": "2025-07-25T22:02:38+00:00",
+    "durations_in_seconds": {
+      "setup": 1.04,
+      "call": 0.2,
+      "teardown": 0.0,
+      "total": 1.24
+    }
   }
 }

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.validation.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.validation.json
@@ -1,0 +1,11 @@
+{
+  "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_resources.py::test_describe_non_existent_resource": {
+    "last_validated_date": "2025-07-25T22:01:40+00:00",
+    "durations_in_seconds": {
+      "setup": 1.11,
+      "call": 10.33,
+      "teardown": 4.37,
+      "total": 15.81
+    }
+  }
+}

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.py
@@ -1044,7 +1044,6 @@ def test_no_echo_parameter(snapshot, aws_client, deploy_cfn_template):
     snapshot.match("describe_updated_stacks_no_echo_false", describe_stacks)
 
 
-@pytest.mark.skip(reason="CFNV2:Validation")
 @markers.aws.validated
 def test_stack_resource_not_found(deploy_cfn_template, aws_client, snapshot):
     stack = deploy_cfn_template(
@@ -1069,5 +1068,5 @@ def test_no_parameters_given(aws_client, deploy_cfn_template, snapshot):
         os.path.dirname(__file__), "../../../../../templates/ssm_parameter_defaultname.yaml"
     )
     with pytest.raises(ClientError) as exc_info:
-        deploy_cfn_template(template_path=template_path, parameters={"Input": "Foo"})
+        deploy_cfn_template(template_path=template_path)
     snapshot.match("deploy-error", exc_info.value)

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.py
@@ -910,7 +910,6 @@ def test_stack_deploy_order(deploy_cfn_template, aws_client, snapshot, deploy_or
     snapshot.match("events", filtered_events)
 
 
-@pytest.mark.skip(reason="CFNV2:DescribeStack")
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         # TODO: this property is present in the response from LocalStack when

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.py
@@ -6,7 +6,7 @@ from itertools import permutations
 import botocore.exceptions
 import pytest
 import yaml
-from botocore.exceptions import WaiterError
+from botocore.exceptions import ClientError, WaiterError
 from localstack_snapshot.snapshots.transformer import SortingTransformer
 
 from localstack.aws.api.cloudformation import Capability
@@ -1061,3 +1061,13 @@ def test_stack_resource_not_found(deploy_cfn_template, aws_client, snapshot):
 
     snapshot.add_transformer(snapshot.transform.regex(stack.stack_name, "<stack-name>"))
     snapshot.match("Error", ex.value.response)
+
+
+@markers.aws.validated
+def test_no_parameters_given(aws_client, deploy_cfn_template, snapshot):
+    template_path = os.path.join(
+        os.path.dirname(__file__), "../../../../../templates/ssm_parameter_defaultname.yaml"
+    )
+    with pytest.raises(ClientError) as exc_info:
+        deploy_cfn_template(template_path=template_path, parameters={"Input": "Foo"})
+    snapshot.match("deploy-error", exc_info.value)

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.snapshot.json
@@ -2286,5 +2286,11 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.py::test_no_parameters_given": {
+    "recorded-date": "25-07-2025, 15:34:21",
+    "recorded-content": {
+      "deploy-error": "An error occurred (ValidationError) when calling the CreateChangeSet operation: Parameters: [Input] must have values"
+    }
   }
 }

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.validation.json
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.validation.json
@@ -62,6 +62,15 @@
   "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.py::test_no_echo_parameter": {
     "last_validated_date": "2024-12-19T11:35:15+00:00"
   },
+  "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.py::test_no_parameters_given": {
+    "last_validated_date": "2025-07-25T15:34:21+00:00",
+    "durations_in_seconds": {
+      "setup": 1.24,
+      "call": 0.3,
+      "teardown": 0.0,
+      "total": 1.54
+    }
+  },
   "tests/aws/services/cloudformation/v2/ported_from_v1/api/test_stacks.py::test_stack_deploy_order2": {
     "last_validated_date": "2024-05-21T09:48:14+00:00"
   },

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_cdk.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_cdk.py
@@ -99,7 +99,6 @@ class TestCdkInit:
 
 
 class TestCdkSampleApp:
-    @pytest.mark.skip(reason="CFNV2:Describe")
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..Attributes.Policy.Statement..Condition",

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_ec2.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_ec2.py
@@ -128,7 +128,6 @@ def test_cfn_with_multiple_route_table_associations(deploy_cfn_template, aws_cli
     snapshot.add_transformer(snapshot.transform.key_value("VpcId"))
 
 
-@pytest.mark.skip(reason="CFNV2:Describe")
 @markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(paths=["$..DriftInformation", "$..Metadata"])
 def test_internet_gateway_ref_and_attr(deploy_cfn_template, snapshot, aws_client):

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_events.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_events.py
@@ -47,7 +47,6 @@ def test_cfn_event_api_destination_resource(deploy_cfn_template, region_name, aw
     _assert(0)
 
 
-@pytest.mark.skip(reason="CFNV2:Describe")
 @markers.aws.validated
 def test_eventbus_policies(deploy_cfn_template, aws_client):
     event_bus_name = f"event-bus-{short_uid()}"

--- a/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/v2/ported_from_v1/resources/test_lambda.py
@@ -157,7 +157,6 @@ def test_update_lambda_function_name(s3_create_bucket, deploy_cfn_template, aws_
     aws_client.lambda_.get_function(FunctionName=function_name_2)
 
 
-@pytest.mark.skip(reason="CFNV2:Describe")
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         "$..Metadata",
@@ -728,7 +727,6 @@ class TestCfnLambdaIntegrations:
 
         assert wait_until(wait_logs)
 
-    @pytest.mark.skip(reason="CFNV2:DescribeStackResources")
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             # Lambda
@@ -887,7 +885,6 @@ class TestCfnLambdaIntegrations:
         sleep = 10 if os.getenv("TEST_TARGET") == "AWS_CLOUD" else 1
         assert wait_until(_send_events, wait=sleep, max_retries=50)
 
-    @pytest.mark.skip(reason="CFNV2:Describe")
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             # Lambda
@@ -1025,7 +1022,6 @@ class TestCfnLambdaIntegrations:
         with pytest.raises(aws_client.lambda_.exceptions.ResourceNotFoundException):
             aws_client.lambda_.get_event_source_mapping(UUID=esm_id)
 
-    @pytest.mark.skip(reason="CFNV2:Describe")
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..Role.Description",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The current V2 CloudFormation provider does not support the describe_stack_resource operation. In order to reach parity with the v1 provider it must do.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Provide typing for the NodeResource in various places
* Rework the way the resolved resources are propagated to provide more type safety and structure
* Add ChangeSetModelValidator for validations we _know_ happen before `create_change_set` returns (i.e. during the modeling phase). This can be a place to hook other validations as well 
* Validate logical resource ids are valid
* Update the StackNotFoundError to handle yet another case, this time through an explicit message override
* Implement DescribeStackResource
* Add tests for describing non-existent things
* Add test validating that stack parameters are given
* Unskip 9 tests

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
