### PR TITLE
improve Patch utility: add idempotency

### DIFF
--- a/localstack-core/localstack/utils/patch.py
+++ b/localstack-core/localstack/utils/patch.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import threading
 import types
 from typing import Any, Callable, List, Type
 
@@ -72,6 +73,7 @@ def create_patch_proxy(target: Callable, new: Callable):
 
 class Patch:
     applied_patches: List["Patch"] = []
+    _lock: threading.RLock = threading.RLock()
     """Bookkeeping for patches that are applied. You can use this to debug patches. For instance,
     you could write something like::
 
@@ -95,40 +97,29 @@ class Patch:
             self.old = None
         self.new = new
         self.is_applied = False
-        print(f"init: {self.obj=}")
-        print(f"init: {self.name=}")
-        print(f"init: {self.old=}")
-        print(f"init: {self.new=}")
 
     def apply(self):
-        if self.is_applied:
-            return
+        with self._lock:
+            if self.is_applied:
+                return
 
-        print(f"apply: {self.obj=}")
-        print(f"apply: {self.name=}")
-        print(f"apply: {self.old=}")
-        print(f"apply: {self.new=}")
-
-        if self.old and self.name == "__getattr__":
-            raise Exception("You can't patch class types implementing __getattr__")
-        if not self.old and self.name != "__getattr__":
-            raise AttributeError(f"`{self.obj.__name__}` object has no attribute `{self.name}`")
-        setattr(self.obj, self.name, self.new)
-        Patch.applied_patches.append(self)
-        self.is_applied = True
+            if self.old and self.name == "__getattr__":
+                raise Exception("You can't patch class types implementing __getattr__")
+            if not self.old and self.name != "__getattr__":
+                raise AttributeError(f"`{self.obj.__name__}` object has no attribute `{self.name}`")
+            setattr(self.obj, self.name, self.new)
+            Patch.applied_patches.append(self)
+            self.is_applied = True
 
     def undo(self):
-        if not self.is_applied:
-            return
+        with self._lock:
+            if not self.is_applied:
+                return
 
-        print(f"undo: {self.obj=}")
-        print(f"undo: {self.name=}")
-        print(f"undo: {self.old=}")
-        print(f"undo: {self.new=}")
-        # If we added a method to a class type, we don't have a self.old. We just delete __getattr__
-        setattr(self.obj, self.name, self.old) if self.old else delattr(self.obj, self.name)
-        Patch.applied_patches.remove(self)
-        self.is_applied = False
+            # If we added a method to a class type, we don't have a self.old. We just delete __getattr__
+            setattr(self.obj, self.name, self.old) if self.old else delattr(self.obj, self.name)
+            Patch.applied_patches.remove(self)
+            self.is_applied = False
 
     def __enter__(self):
         self.apply()
@@ -151,7 +142,6 @@ class Patch:
     @staticmethod
     def function(target: Callable, fn: Callable, pass_target: bool = True):
         obj = get_defining_object(target)
-        print(f"{obj=}")
         name = target.__name__
 
         is_class_instance = not inspect.isclass(obj) and not inspect.ismodule(obj)

--- a/localstack-core/localstack/utils/patch.py
+++ b/localstack-core/localstack/utils/patch.py
@@ -95,21 +95,40 @@ class Patch:
             self.old = None
         self.new = new
         self.is_applied = False
+        print(f"init: {self.obj=}")
+        print(f"init: {self.name=}")
+        print(f"init: {self.old=}")
+        print(f"init: {self.new=}")
 
     def apply(self):
+        if self.is_applied:
+            return
+
+        print(f"apply: {self.obj=}")
+        print(f"apply: {self.name=}")
+        print(f"apply: {self.old=}")
+        print(f"apply: {self.new=}")
+
         if self.old and self.name == "__getattr__":
             raise Exception("You can't patch class types implementing __getattr__")
         if not self.old and self.name != "__getattr__":
             raise AttributeError(f"`{self.obj.__name__}` object has no attribute `{self.name}`")
         setattr(self.obj, self.name, self.new)
-        self.is_applied = True
         Patch.applied_patches.append(self)
+        self.is_applied = True
 
     def undo(self):
+        if not self.is_applied:
+            return
+
+        print(f"undo: {self.obj=}")
+        print(f"undo: {self.name=}")
+        print(f"undo: {self.old=}")
+        print(f"undo: {self.new=}")
         # If we added a method to a class type, we don't have a self.old. We just delete __getattr__
         setattr(self.obj, self.name, self.old) if self.old else delattr(self.obj, self.name)
-        self.is_applied = False
         Patch.applied_patches.remove(self)
+        self.is_applied = False
 
     def __enter__(self):
         self.apply()
@@ -132,6 +151,7 @@ class Patch:
     @staticmethod
     def function(target: Callable, fn: Callable, pass_target: bool = True):
         obj = get_defining_object(target)
+        print(f"{obj=}")
         name = target.__name__
 
         is_class_instance = not inspect.isclass(obj) and not inspect.ismodule(obj)

--- a/tests/unit/utils/test_patch.py
+++ b/tests/unit/utils/test_patch.py
@@ -228,3 +228,67 @@ def test_patch_class_type():
         @patch(MyEchoer.new_echo)
         def new_echo(self, *args):
             pass
+
+
+def test_idempotency():
+    def monkey(self, *args):
+        return f"monkey: {args[-1]}"
+
+    with Patch.function(MyEchoer.do_echo, monkey) as patch_1:
+        patch_1.apply()
+
+        assert len([p for p in Patch.applied_patches if p is patch_1]) == 1
+
+
+def test_multiple_patches_same_target_sequentially():
+    def _new_echo(fn, *args):
+        return fn(*args) + " new"
+
+    def _newer_echo(fn, *args):
+        return fn(*args) + " newer"
+
+    with Patch.function(echo, _new_echo):
+        with Patch.function(echo, _newer_echo):
+            assert echo("foo") == "echo: foo new newer"
+
+    assert echo("foo") == "echo: foo"
+
+
+@pytest.mark.xfail("Not yet working: it removes all patches")
+def test_multiple_patches_same_target_sequentially_undone():
+    def _new_echo(fn, *args):
+        return fn(*args) + " new"
+
+    def _newer_echo(fn, *args):
+        return fn(*args) + " newer"
+
+    patch_1 = Patch.function(echo, _new_echo)
+    patch_1.apply()
+    assert echo("foo") == "echo: foo new"
+
+    patch_2 = Patch.function(echo, _newer_echo)
+    patch_2.apply()
+    assert echo("foo") == "echo: foo new newer"
+
+    patch_1.undo()
+    assert echo("foo") == "echo: foo newer"
+
+
+@pytest.mark.xfail("Not yet working: it only applies latest")
+def test_multiple_patches_same_target_apply_concurrently():
+    def test_echo(arg):
+        return f"echo: {arg}"
+
+    def _new_echo(fn, *args):
+        return fn(*args) + " new"
+
+    def _newer_echo(fn, *args):
+        return fn(*args) + " newer"
+
+    patch1 = Patch.function(test_echo, _new_echo)
+    patch2 = Patch.function(test_echo, _newer_echo)
+
+    patch1.apply()
+    patch2.apply()
+
+    assert test_echo("foo") == "echo: foo new newer"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While using the Patch utility, we realize we had to manually check `if patch.is_applied` before applying it again because it did not check itself if it was already applied. 

This PR adds this check internally to avoid applying the patch twice.

It also adds a test for it, and some more patches for some issues we realized and should keep track of. 

I've added a single lock for the `Patch` class as we're mutating the global class variable `applied_patches`, and it feels like once we start adding more checks for multiple patches mutating the same function, this kind of global lock could be useful. 

Linearizing the Patching mechanism over one single lock sounds a bit safer than having a single lock per Patch, and will probably end up using a little bit less memory. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add an internal check for `Patch.apply` and `Patch.undo` to verify if the patch was already applied, locked with a single lock for the Patch class
- add xfailed tests for the Patch class over multiple patching of the same function

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
