### PR TITLE
fix coveralls upload

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -138,6 +138,7 @@ jobs:
         - name: Report coverage statistics
           env:
             COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
             source .venv/bin/activate
             coverage report || true


### PR DESCRIPTION
## Motivation
@simonrw just discovered that we are currently not properly uploading our coverage measurements to [Coveralls](https://coveralls.io/github/localstack/localstack).
In the [latest main run](https://github.com/localstack/localstack/actions/runs/16589279437/job/46927136067), we can see that the "Report coverage statistics" step is executed, but there is an error reported (but swallowed):
```
Error running coveralls: Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.
Traceback (most recent call last):
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/coveralls/cli.py", line 65, in main
    coverallz = Coveralls(
                ^^^^^^^^^^
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/coveralls/api.py", line 47, in __init__
    self.ensure_token()
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/coveralls/api.py", line 54, in ensure_token
    raise CoverallsException(
coveralls.exception.CoverallsException: Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.
```
This PR tries to fix this issue by explicitly setting the token on this workflow step.

## Changes
- Explicitly set the `GITHUB_TOKEN` when executing `coveralls` to fix the upload.

## Testing
- [ ] Trigger the execution of the main pipeline on this branch and check whether the coverage data is being uploaded:
  - https://github.com/localstack/localstack/actions/runs/16594368620