### PR TITLE
avoid coverage reporting when only executing test subset

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -96,6 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
+    if: ${{ inputs.onlyAcceptanceTests == false && inputs.enableTestSelection == false }}
     steps:
         - name: Checkout
           uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/12923 we fixed the upload of our coverage data, which didn't work since we moved from CircleCI to GitHub actions (implemented with https://github.com/localstack/localstack/pull/12708).

Unfortunately, we now publish the coverage data also for runs where we only execute a small subset of our tests (i.e. only the acceptance tests).
This PR aims at fixing this issue.

## Changes
- Only execute the reporting step in the main pipeline if `onlyAcceptanceTests` and `enableTestSelection` are `false`, i.e. we also run our integration tests and do not select the tests to execute (but execute all of them).

## Testing
- [x] Check if a partial test run skip the coverage upload.
  - https://github.com/localstack/localstack/actions/runs/16596600205
- [x] Check if a full test run uploads the coverage data.
  - https://github.com/localstack/localstack/actions/runs/16599353262