### PR TITLE
pre-commit: validate json files on commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: check-json
 
   - repo: https://github.com/localstack/pre-commit-hooks
     rev: v1.2.1


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->

## Motivation

Sometimes I have to update snapshot files manually. For example when moving tests from one file to another. I regularly mess up the syntax so the tests fail once CI has run.

We have a series of pre-commit hooks that are run before code is committed. As part of the "push left" initiative (of which LocalStack itself is part!) we should be able to catch these checks before committing code, and _definitely_ before pushing code up to GitHub.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->

## Changes

- Add the `check-json` hook in our pre-commit configuration file

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
