### PR TITLE
Ec2/fix/vpc endpoint dns entries

### DIFF
--- a/localstack-core/localstack/services/ec2/patches.py
+++ b/localstack-core/localstack/services/ec2/patches.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 from moto.ec2 import models as ec2_models
+from moto.ec2.models.vpcs import VPCEndPoint
 from moto.utilities.id_generator import Tags
 
 from localstack.services.ec2.exceptions import (
@@ -15,6 +16,8 @@ from localstack.utils.id_generator import (
     localstack_id,
 )
 from localstack.utils.patch import patch
+from localstack.utils.strings import short_uid
+from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 
@@ -93,6 +96,25 @@ class SubnetIdentifier(ResourceIdentifier):
 
 
 def apply_patches():
+    @patch(ec2_models.vpcs.VPCBackend.create_vpc_endpoint)
+    def ec2_create_vpc_endpoint(
+        fn: ec2_models.VPCBackend.create_vpc_endpoint, self: ec2_models.VPCBackend, **kwargs
+    ) -> VPCEndPoint:
+        vpc_endpoint: VPCEndPoint = fn(self=self, **kwargs)
+
+        # moto returns the dns entries as `<vpc-id>.com.amazonaws.<region>.<service>`
+        # to keep the aws style `<vpc-id>.<service>.<region>.vpce.amazonaws.com` and ensure it can be routed
+        # by the individual services in LocalStack we will be creating the following entries:
+        # `<vpc-id>.<service>.<region>.vpce.<localstack host and port>`
+        if service_name := kwargs.get("service_name"):
+            ls_service_name = ".".join(service_name.split(".")[::-1]).replace(
+                "amazonaws.com", f"vpce.{localstack_host()}"
+            )
+            for dns_entry in vpc_endpoint.dns_entries or []:
+                dns_entry["dns_name"] = f"{vpc_endpoint.id}-{short_uid()}.{ls_service_name}"
+
+        return vpc_endpoint
+
     @patch(ec2_models.subnets.SubnetBackend.create_subnet)
     def ec2_create_subnet(
         fn: ec2_models.subnets.SubnetBackend.create_subnet,

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -6,7 +6,7 @@ import os
 import re
 import textwrap
 import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Unpack
 
 import botocore.auth
 import botocore.config
@@ -21,7 +21,7 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
 from localstack import config
-from localstack.aws.api.ec2 import CreateSecurityGroupRequest
+from localstack.aws.api.ec2 import CreateSecurityGroupRequest, CreateVpcEndpointRequest, VpcEndpoint
 from localstack.aws.connect import ServiceLevelClientFactory
 from localstack.services.stores import (
     AccountRegionBundle,
@@ -2044,6 +2044,45 @@ def ec2_create_security_group(aws_client):
             aws_client.ec2.delete_security_group(GroupId=sg_group_id)
         except Exception as e:
             LOG.debug("Error cleaning up EC2 security group: %s, %s", sg_group_id, e)
+
+
+@pytest.fixture
+def ec2_create_vpc_endpoint(aws_client):
+    vpc_endpoints = []
+
+    def _create(**kwargs: Unpack[CreateVpcEndpointRequest]) -> VpcEndpoint:
+        endpoint = aws_client.ec2.create_vpc_endpoint(**kwargs)
+        endpoint_id = endpoint["VpcEndpoint"]["VpcEndpointId"]
+        vpc_endpoints.append(endpoint_id)
+
+        def _check_available() -> VpcEndpoint:
+            result = aws_client.ec2.describe_vpc_endpoints(VpcEndpointIds=[endpoint_id])
+            _endpoint_details = result["VpcEndpoints"][0]
+            assert _endpoint_details["State"] == "available"
+
+            return _endpoint_details
+
+        return retry(_check_available, retries=30, sleep=5 if is_aws_cloud() else 1)
+
+    yield _create
+
+    try:
+        aws_client.ec2.delete_vpc_endpoints(VpcEndpointIds=vpc_endpoints)
+    except Exception as e:
+        LOG.error("Error cleaning up VPC endpoint: %s, %s", vpc_endpoints, e)
+
+    def wait_for_endpoint_deleted():
+        try:
+            endpoints = aws_client.ec2.describe_vpc_endpoints(VpcEndpointIds=vpc_endpoints)
+            assert len(endpoints["VpcEndpoints"]) == 0 or all(
+                endpoint["State"] == "Deleted" for endpoint in endpoints["VpcEndpoints"]
+            )
+        except botocore.exceptions.ClientError:
+            pass
+
+    # the vpc can't be deleted if an endpoint exists
+    if is_aws_cloud():
+        retry(wait_for_endpoint_deleted, retries=30, sleep=10 if is_aws_cloud() else 1)
 
 
 @pytest.fixture

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -4,7 +4,7 @@ import logging
 import pytest
 from botocore.exceptions import ClientError
 from localstack_snapshot.snapshots.transformer import SortingTransformer
-from moto.ec2 import ec2_backends
+from moto.ec2.models import ec2_backends
 from moto.ec2.utils import (
     random_security_group_id,
     random_subnet_id,
@@ -13,10 +13,12 @@ from moto.ec2.utils import (
 
 from localstack.constants import AWS_REGION_US_EAST_1, TAG_KEY_CUSTOM_ID
 from localstack.services.ec2.patches import SecurityGroupIdentifier, VpcIdentifier
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.id_generator import localstack_id_manager
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
+from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 
@@ -410,6 +412,51 @@ class TestEc2Integrations:
 
         # clean up
         aws_client.ec2.delete_vpc(VpcId=vpc_id)
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Groups", "$..ServiceRegion"])
+    def test_vpc_endpoint_dns_names(
+        self, aws_client, create_vpc, region_name, snapshot, cleanups, ec2_create_vpc_endpoint
+    ):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("GroupId"),
+                snapshot.transform.key_value("VpcEndpointId"),
+                snapshot.transform.key_value("VpcId"),
+                snapshot.transform.key_value("HostedZoneId"),
+                snapshot.transform.key_value("subnet-id"),
+                snapshot.transform.key_value("network-interface-id"),
+                snapshot.transform.key_value("dns-suffix"),
+                snapshot.transform.key_value("host"),
+            ]
+        )
+        host = "amazonaws.com" if is_aws_cloud() else localstack_host().host_and_port()
+        snapshot.match("host", host)
+
+        vpc = create_vpc(cidr_block="10.0.0.0/24")
+        vpc_id = vpc["Vpc"]["VpcId"]
+        aws_client.ec2.modify_vpc_attribute(VpcId=vpc_id, EnableDnsSupport={"Value": True})
+        aws_client.ec2.modify_vpc_attribute(VpcId=vpc_id, EnableDnsHostnames={"Value": True})
+        subnet = aws_client.ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/24")
+        subnet_id = subnet["Subnet"]["SubnetId"]
+        snapshot.match("subnet-id", subnet_id)
+
+        service_name = f"com.amazonaws.{region_name}.execute-api"
+        vpc_endpoint = ec2_create_vpc_endpoint(
+            VpcId=vpc["Vpc"]["VpcId"],
+            ServiceName=service_name,
+            VpcEndpointType="Interface",
+            PrivateDnsEnabled=True,
+            SubnetIds=[subnet_id],
+        )
+
+        # LS only returns one dns entry
+        vpc_endpoint["DnsEntries"] = vpc_endpoint["DnsEntries"][:1]
+        snapshot.match(
+            "dns-suffix", vpc_endpoint["DnsEntries"][0]["DnsName"].split(".")[0].split("-")[-1]
+        )
+        snapshot.match("network-interface-id", vpc_endpoint["NetworkInterfaceIds"][0])
+        snapshot.match("available-endpoint", vpc_endpoint)
 
     @markers.aws.validated
     @pytest.mark.parametrize("id_type", ["id", "name"])

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -425,7 +425,10 @@ class TestEc2Integrations:
                 snapshot.transform.key_value("VpcId"),
                 snapshot.transform.key_value("HostedZoneId"),
                 snapshot.transform.key_value("subnet-id"),
-                snapshot.transform.key_value("network-interface-id"),
+                snapshot.transform.jsonpath(
+                    "$.available-endpoint.NetworkInterfaceIds[*]",
+                    value_replacement="network-interface-id",
+                ),
                 snapshot.transform.key_value("dns-suffix"),
                 snapshot.transform.key_value("host"),
             ]
@@ -455,7 +458,6 @@ class TestEc2Integrations:
         snapshot.match(
             "dns-suffix", vpc_endpoint["DnsEntries"][0]["DnsName"].split(".")[0].split("-")[-1]
         )
-        snapshot.match("network-interface-id", vpc_endpoint["NetworkInterfaceIds"][0])
         snapshot.match("available-endpoint", vpc_endpoint)
 
     @markers.aws.validated

--- a/tests/aws/services/ec2/test_ec2.snapshot.json
+++ b/tests/aws/services/ec2/test_ec2.snapshot.json
@@ -494,5 +494,60 @@
         }
       }
     }
+  },
+  "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_vpc_endpoint_dns_names": {
+    "recorded-date": "29-07-2025, 23:29:35",
+    "recorded-content": {
+      "host": "<host:1>",
+      "subnet-id": "<subnet-id:1>",
+      "dns-suffix": "<dns-suffix:1>",
+      "network-interface-id": "<network-interface-id:1>",
+      "available-endpoint": {
+        "CreationTimestamp": "<datetime>",
+        "DnsEntries": [
+          {
+            "DnsName": "<vpc-endpoint-id:1>-<dns-suffix:1>.execute-api.<region>.vpce.<host:1>",
+            "HostedZoneId": "<hosted-zone-id:1>"
+          }
+        ],
+        "DnsOptions": {
+          "DnsRecordIpType": "ipv4"
+        },
+        "Groups": [
+          {
+            "GroupId": "<group-id:1>",
+            "GroupName": "default"
+          }
+        ],
+        "IpAddressType": "ipv4",
+        "NetworkInterfaceIds": [
+          "<network-interface-id:1>"
+        ],
+        "OwnerId": "111111111111",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "*",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": "*"
+            }
+          ]
+        },
+        "PrivateDnsEnabled": true,
+        "RequesterManaged": false,
+        "RouteTableIds": [],
+        "ServiceName": "com.amazonaws.<region>.execute-api",
+        "ServiceRegion": "<region>",
+        "State": "available",
+        "SubnetIds": [
+          "<subnet-id:1>"
+        ],
+        "Tags": [],
+        "VpcEndpointId": "<vpc-endpoint-id:1>",
+        "VpcEndpointType": "Interface",
+        "VpcId": "<vpc-id:1>"
+      }
+    }
   }
 }

--- a/tests/aws/services/ec2/test_ec2.validation.json
+++ b/tests/aws/services/ec2/test_ec2.validation.json
@@ -17,6 +17,15 @@
   "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_vcp_peering_difference_regions": {
     "last_validated_date": "2024-06-07T21:28:25+00:00"
   },
+  "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_vpc_endpoint_dns_names": {
+    "last_validated_date": "2025-07-29T23:29:36+00:00",
+    "durations_in_seconds": {
+      "setup": 0.75,
+      "call": 59.53,
+      "teardown": 122.78,
+      "total": 183.06
+    }
+  },
   "tests/aws/services/ec2/test_ec2.py::test_describe_availability_zones_filter_with_zone_ids": {
     "last_validated_date": "2025-05-28T09:17:24+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This pr improves on the dns entries returned by moto so they both follow the structure of AWS DNS entries and include localstack hostname for services to be able to register the endpoint.

In the future, if we implement networking in ec2, those endpoints should instead be routed from ec2 to the appropriate service, but since this isn't implemented, for the time being, letting the individual services do their own routing is favorable.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- flip the service name around from `com.amazonws.<region>.<service>` to `<service>.<region>.amazonaws.com`, replacing `amazonaws.com` with LocalStack host and port.
- add test for the structure

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
