### PR TITLE
remove copy-pasta in parity testing guide

### DIFF
--- a/docs/testing/parity-testing/README.md
+++ b/docs/testing/parity-testing/README.md
@@ -1,5 +1,3 @@
-from conftest import aws_client
-
 # Parity Testing
 
 Parity tests (also called snapshot tests) are a special form of integration tests that should verify and improve the correctness of LocalStack compared to AWS.


### PR DESCRIPTION
## Motivation
It seems like with https://github.com/localstack/localstack/pull/11839, some copy-pasta slipped into the README of the parity testing guide. This PR removes this line.

## Changes
- Remove `from conftest import aws_client` from parity testing README.