### PR TITLE
SQS: Allow usage of message-group-id param when using a Fair Queue

### DIFF
--- a/localstack-core/localstack/services/sqs/constants.py
+++ b/localstack-core/localstack/services/sqs/constants.py
@@ -9,7 +9,7 @@ MSG_CONTENT_REGEX = "^[\u0009\u000a\u000d\u0020-\ud7ff\ue000-\ufffd\U00010000-\U
 ATTR_NAME_CHAR_REGEX = "^[\u00c0-\u017fa-zA-Z0-9_.-]*$"
 ATTR_NAME_PREFIX_SUFFIX_REGEX = r"^(?!(aws\.|amazon\.|\.)).*(?<!\.)$"
 ATTR_TYPE_REGEX = "^(String|Number|Binary).*$"
-FIFO_MSG_REGEX = "^[0-9a-zA-z!\"#$%&'()*+,./:;<=>?@[\\]^_`{|}~-]*$"
+FIFO_MSG_REGEX = "^[0-9a-zA-z!\"#$%&'()*+,./:;<=>?@[\\]^_`{|}~-]{1,128}$"
 
 DEDUPLICATION_INTERVAL_IN_SEC = 5 * 60
 

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -771,11 +771,6 @@ class StandardQueue(SqsQueue):
                 f"Value {message_deduplication_id} for parameter MessageDeduplicationId is invalid. Reason: The "
                 f"request includes a parameter that is not valid for this queue type."
             )
-        if isinstance(message_group_id, str):
-            raise InvalidParameterValueException(
-                f"Value {message_group_id} for parameter MessageGroupId is invalid. Reason: The request include "
-                f"parameter that is not valid for this queue type."
-            )
 
         standard_message = SqsMessage(time.time(), message)
 

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -621,17 +621,13 @@ def check_attributes(message_attributes: MessageBodyAttributeMap):
                 raise InvalidParameterValueException(e.args[0])
 
 
-def check_fifo_id(fifo_id, parameter):
-    if not fifo_id:
+def check_fifo_id(fifo_id: str | None, parameter: str):
+    if fifo_id is None:
         return
-    if len(fifo_id) > 128:
-        raise InvalidParameterValueException(
-            f"Value {fifo_id} for parameter {parameter} is invalid. Reason: {parameter} can only include alphanumeric and punctuation characters. 1 to 128 in length."
-        )
     if not re.match(sqs_constants.FIFO_MSG_REGEX, fifo_id):
         raise InvalidParameterValueException(
-            "Invalid characters found. Deduplication ID and group ID can only contain"
-            "alphanumeric characters as well as TODO"
+            f"Value {fifo_id} for parameter {parameter} is invalid. "
+            f"Reason: {parameter} can only include alphanumeric and punctuation characters. 1 to 128 in length."
         )
 
 

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -279,40 +279,6 @@
       }
     }
   },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_too_long": {
-    "recorded-date": "30-04-2024, 13:35:34",
-    "recorded-content": {
-      "error-response": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "Value aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa for parameter MessageDeduplicationId is invalid. Reason: MessageDeduplicationId can only include alphanumeric and punctuation characters. 1 to 128 in length.",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_group_id_too_long": {
-    "recorded-date": "30-04-2024, 13:35:35",
-    "recorded-content": {
-      "error-response": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "Value aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa for parameter MessageGroupId is invalid. Reason: MessageGroupId can only include alphanumeric and punctuation characters. 1 to 128 in length.",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_queue_with_different_attributes_raises_exception[sqs]": {
     "recorded-date": "30-04-2024, 13:33:18",
     "recorded-content": {
@@ -964,23 +930,6 @@
         "Error": {
           "Code": "InvalidParameterValue",
           "Message": "The request must contain the parameter MessageGroupId.",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_to_standard_queue_with_empty_message_group_id": {
-    "recorded-date": "08-11-2024, 12:04:39",
-    "recorded-content": {
-      "error-response": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "Value  for parameter MessageGroupId is invalid. Reason: The request include parameter that is not valid for this queue type.",
           "QueryErrorCode": "InvalidParameterValueException",
           "Type": "Sender"
         },
@@ -4012,5 +3961,137 @@
         "ReceiptHandle": "<receipt-handle:1>"
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fair_queue_with_message_group_id[sqs]": {
+    "recorded-date": "30-07-2025, 09:52:06",
+    "recorded-content": {
+      "send_message": {
+        "MD5OfMessageBody": "78e731027d8fd50ed642340b7c9a63b3",
+        "MessageId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fair_queue_with_message_group_id[sqs_query]": {
+    "recorded-date": "30-07-2025, 09:52:07",
+    "recorded-content": {
+      "send_message": {
+        "MD5OfMessageBody": "78e731027d8fd50ed642340b7c9a63b3",
+        "MessageId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_to_standard_queue_with_invalid_message_group_id[empty]": {
+    "recorded-date": "30-07-2025, 10:01:38",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value  for parameter MessageGroupId is invalid. Reason: MessageGroupId can only include alphanumeric and punctuation characters. 1 to 128 in length.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_to_standard_queue_with_invalid_message_group_id[too_long]": {
+    "recorded-date": "30-07-2025, 10:01:39",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa for parameter MessageGroupId is invalid. Reason: MessageGroupId can only include alphanumeric and punctuation characters. 1 to 128 in length.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_to_standard_queue_with_invalid_message_group_id[spaces]": {
+    "recorded-date": "30-07-2025, 10:01:39",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value group 123 for parameter MessageGroupId is invalid. Reason: MessageGroupId can only include alphanumeric and punctuation characters. 1 to 128 in length.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_invalid[empty]": {
+    "recorded-date": "30-07-2025, 10:25:50",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value  for parameter MessageDeduplicationId is invalid. Reason: MessageDeduplicationId can only include alphanumeric and punctuation characters. 1 to 128 in length.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_invalid[too_long]": {
+    "recorded-date": "30-07-2025, 10:25:51",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa for parameter MessageDeduplicationId is invalid. Reason: MessageDeduplicationId can only include alphanumeric and punctuation characters. 1 to 128 in length.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_invalid[spaces]": {
+    "recorded-date": "30-07-2025, 10:25:51",
+    "recorded-content": {
+      "error-response": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value group 123 for parameter MessageDeduplicationId is invalid. Reason: MessageDeduplicationId can only include alphanumeric and punctuation characters. 1 to 128 in length.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_success": {
+    "recorded-date": "30-07-2025, 10:26:48",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -116,6 +116,24 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_with_too_large_batch[sqs_query]": {
     "last_validated_date": "2024-04-30T13:49:31+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fair_queue_with_message_group_id[sqs]": {
+    "last_validated_date": "2025-07-30T09:52:07+00:00",
+    "durations_in_seconds": {
+      "setup": 1.2,
+      "call": 0.17,
+      "teardown": 0.18,
+      "total": 1.55
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fair_queue_with_message_group_id[sqs_query]": {
+    "last_validated_date": "2025-07-30T09:52:07+00:00",
+    "durations_in_seconds": {
+      "setup": 0.18,
+      "call": 0.58,
+      "teardown": 0.19,
+      "total": 0.95
+    }
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_high_throughput_after_creation[sqs]": {
     "last_validated_date": "2024-05-24T10:00:47+00:00"
   },
@@ -209,8 +227,41 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_marker_serialization_query_protocol": {
     "last_validated_date": "2024-04-29T06:07:04+00:00"
   },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_too_long": {
-    "last_validated_date": "2024-04-30T13:35:34+00:00"
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_invalid[empty]": {
+    "last_validated_date": "2025-07-30T10:25:50+00:00",
+    "durations_in_seconds": {
+      "setup": 0.59,
+      "call": 0.73,
+      "teardown": 0.18,
+      "total": 1.5
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_invalid[spaces]": {
+    "last_validated_date": "2025-07-30T10:25:51+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.38,
+      "teardown": 0.19,
+      "total": 0.57
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_invalid[too_long]": {
+    "last_validated_date": "2025-07-30T10:25:51+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.31,
+      "teardown": 0.19,
+      "total": 0.5
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_success": {
+    "last_validated_date": "2025-07-30T10:26:48+00:00",
+    "durations_in_seconds": {
+      "setup": 0.59,
+      "call": 0.75,
+      "teardown": 0.2,
+      "total": 1.54
+    }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_group_id_too_long": {
     "last_validated_date": "2024-04-30T13:35:35+00:00"
@@ -314,8 +365,32 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents_with_updated_maximum_message_size[sqs_query]": {
     "last_validated_date": "2024-04-30T13:33:10+00:00"
   },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_to_standard_queue_with_empty_message_group_id": {
-    "last_validated_date": "2024-11-08T12:08:17+00:00"
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_to_standard_queue_with_invalid_message_group_id[empty]": {
+    "last_validated_date": "2025-07-30T10:01:38+00:00",
+    "durations_in_seconds": {
+      "setup": 1.71,
+      "call": 0.23,
+      "teardown": 0.26,
+      "total": 2.2
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_to_standard_queue_with_invalid_message_group_id[spaces]": {
+    "last_validated_date": "2025-07-30T10:01:39+00:00",
+    "durations_in_seconds": {
+      "setup": 0.24,
+      "call": 0.22,
+      "teardown": 0.27,
+      "total": 0.73
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_to_standard_queue_with_invalid_message_group_id[too_long]": {
+    "last_validated_date": "2025-07-30T10:01:39+00:00",
+    "durations_in_seconds": {
+      "setup": 0.24,
+      "call": 0.22,
+      "teardown": 0.26,
+      "total": 0.72
+    }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_binary_attributes[sqs]": {
     "last_validated_date": "2024-04-30T13:33:48+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Closes #12898

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Allows sending message in an SQS using `--message-group-id` parameter

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
