### PR TITLE
Add schemas to stores

### DIFF
--- a/localstack-core/localstack/state/schema.py
+++ b/localstack-core/localstack/state/schema.py
@@ -42,13 +42,13 @@ class StoreSchema(typing.TypedDict):
     attributes: AttributeSchema
 
 
-def get_fully_qualified_name(obj: type) -> str:
+def get_fully_qualified_name(obj: type, separator: str = "::") -> str:
     """Get the fully qualified name of a type"""
     try:
         module = getattr(obj, "__module__", None)
         qualname = getattr(obj, "__qualname__", None)
         if module and qualname:
-            return f"{module}.{qualname}"
+            return f"{module}{separator}{qualname}"
         return getattr(obj, "__name__", str(obj))
     except Exception as e:
         LOG.debug("Unable to compute the FQN for '%s': %s", obj, e)

--- a/tests/unit/state/test_schema.py
+++ b/tests/unit/state/test_schema.py
@@ -71,20 +71,20 @@ def test_simple_store():
     build = StoreSchemaBuilder(MyStore)
     schema = build.build_schema()
     assert schema["attributes"]["field1"] == {
-        "LS/TYPE": "builtins.dict",
-        "LS/ARGS": ["builtins.str", "builtins.str"],
+        "LS/TYPE": "builtins::dict",
+        "LS/ARGS": ["builtins::str", "builtins::str"],
     }
     assert schema["attributes"]["field2"] == {
-        "LS/TYPE": "builtins.list",
-        "LS/ARGS": ["builtins.str"],
+        "LS/TYPE": "builtins::list",
+        "LS/ARGS": ["builtins::str"],
     }
     assert schema["attributes"]["field3"] == {
-        "LS/TYPE": "types.UnionType",
-        "LS/ARGS": ["builtins.str", "builtins.int"],
+        "LS/TYPE": "types::UnionType",
+        "LS/ARGS": ["builtins::str", "builtins::int"],
     }
     assert schema["attributes"]["field4"] == {
-        "LS/TYPE": "builtins.tuple",
-        "LS/ARGS": ["builtins.str", "builtins.int"],
+        "LS/TYPE": "builtins::tuple",
+        "LS/ARGS": ["builtins::str", "builtins::int"],
     }
 
 
@@ -95,13 +95,13 @@ def test_nested_attributes():
     build = StoreSchemaBuilder(MyStore)
     schema = build.build_schema()
     assert schema["attributes"]["field1"] == {
-        "LS/TYPE": "builtins.dict",
+        "LS/TYPE": "builtins::dict",
         "LS/ARGS": [
-            "builtins.str",
+            "builtins::str",
             {
-                "LS/TYPE": "builtins.list",
+                "LS/TYPE": "builtins::list",
                 "LS/ARGS": [
-                    {"LS/TYPE": "builtins.dict", "LS/ARGS": ["builtins.str", "builtins.str"]}
+                    {"LS/TYPE": "builtins::dict", "LS/ARGS": ["builtins::str", "builtins::str"]}
                 ],
             },
         ],
@@ -125,6 +125,6 @@ def test_additional_classes(monkeypatch):
     assert schema["attributes"]["move_tasks"]["LS/ARGS"][1] == mmt_fqn
     assert mmt_fqn in schema["additional_classes"]
     assert schema["additional_classes"][mmt_fqn]["source_arn"] == {
-        "LS/TYPE": "types.UnionType",
-        "LS/ARGS": ["builtins.str", "builtins.NoneType"],
+        "LS/TYPE": "types::UnionType",
+        "LS/ARGS": ["builtins::str", "builtins::NoneType"],
     }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR introduces a heuristic to extract a schema representation for a given store class.

### Context
Service providers implemented in LocalStack store their data (if they are not `moto` based or rely on 3rd party services) in `stores` (see https://github.com/localstack/localstack/pull/6444 for more details). 

LocalStack serializes these classes to implement persistence. Therefore, we should treat them as public APIs and avoid breaking them. As stores evolve within the LocalStack codebase, a few issues can occur when deserializing a previous state:
- A class gets renamed, and we are not able to load that module and class anymore;
- One attribute in the store is removed. Therefore, the information stored there is lost.

Unfortunately, we don't have much visibility on how the structure of the stores changes over time.
For this reason, this PR introduces a heuristic to extract a schema representation from a store definition.
It allows us to reason about store changes. For instance:
- If a type can't be loaded anymore, we can compare an old and a new schema version to understand which new type should be used instead.
- By comparing the schema across two versions, we can detect if an attribute has been removed and come up with a migration path.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Introducing a new `localstack.state.schema` module that returns a schema definition from a `BaseStore` subclass. To achieve this goal, we heavily rely on the type hints of the store attributes. The docstring of the `StoreSchemaBuilder` class reports a few examples.
- A few unit tests.

Closes PNX-46.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
