### PR TITLE
KMS: return `NotImplementedError` for rotation of imported keys

### DIFF
--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -1408,9 +1408,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         if key.metadata["KeySpec"] != KeySpec.SYMMETRIC_DEFAULT:
             raise UnsupportedOperationException()
         if key.metadata["Origin"] == OriginType.EXTERNAL:
-            raise UnsupportedOperationException(
-                f"{key.metadata['Arn']} origin is EXTERNAL which is not valid for this operation."
-            )
+            raise NotImplementedError("Rotation of imported keys is not supported yet.")
 
         key.rotate_key_on_demand()
 

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -138,6 +138,21 @@ class TestKMS:
         assert f":{region_name}:" in response["Arn"]
         assert f":{account_id}:" in response["Arn"]
 
+    @markers.aws.only_localstack
+    def test_unsupported_rotate_key_on_demand_with_imported_key_material(
+        self, kms_create_key, aws_client, snapshot
+    ):
+        key_id = kms_create_key(Origin="EXTERNAL")["KeyId"]
+
+        with pytest.raises(ClientError) as e:
+            aws_client.kms.rotate_key_on_demand(KeyId=key_id)
+
+        assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 501
+        assert (
+            e.value.response["Error"]["Message"]
+            == "Rotation of imported keys is not supported yet."
+        )
+
     @markers.aws.validated
     def test_tag_existing_key_and_untag(
         self, kms_client_for_region, kms_create_key, snapshot, region_name

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -1474,6 +1474,9 @@ class TestKMS:
         snapshot.match("error-response", e.value.response)
 
     @markers.aws.validated
+    @pytest.mark.skip(
+        reason="This needs to be fixed as AWS introduced support for on demand rotation of imported keys."
+    )
     def test_rotate_key_on_demand_raises_error_given_key_with_imported_key_material(
         self, kms_create_key, aws_client, snapshot
     ):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
After the launch of [this feature](https://aws.amazon.com/blogs/security/how-to-use-on-demand-rotation-for-aws-kms-imported-keys/), AWS introduced support for on demand rotation of imported keys i.e. keys with `Origin` set to `EXTERNAL`. 

At the moment, LocalStack does not support this feature and we return a `400` error with `UnsupportedOperationException` even though the request itself is valid.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Raise appropriate error response with error code `501` when rotation of keys is done with imported keys. 

Please note, this PR does not aim to fix existing tests and other logic in the code which revolves around assuming that external keys are unsupported, this should be tackled in a separate PR. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
