### PR TITLE
support ResponseStream mode for functionUrl

### DIFF
--- a/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_url.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/aws_lambda_url.py
@@ -67,7 +67,7 @@ class LambdaUrlProvider(ResourceProvider[LambdaUrlProperties]):
         """
         model = request.desired_state
         lambda_client = request.aws_client_factory.lambda_
-        params = util.select_attributes(model, ["Qualifier", "Cors", "AuthType"])
+        params = util.select_attributes(model, ["Qualifier", "Cors", "AuthType", "InvokeMode"])
         params["FunctionName"] = model["TargetFunctionArn"]
 
         response = lambda_client.create_function_url_config(**params)

--- a/tests/aws/services/lambda_/functions/lambda_response_streaming.js
+++ b/tests/aws/services/lambda_/functions/lambda_response_streaming.js
@@ -1,0 +1,17 @@
+exports.handler = awslambda.streamifyResponse(
+    async (event, responseStream, context) => {
+        const metadata = {
+            status: 200,
+            headers: {
+                'Content-Type': 'text/html',
+                'Cache-Control': 'no-cache',
+            },
+        }
+
+        responseStream = awslambda.HttpResponseStream.from(responseStream, metadata)
+
+        responseStream.write('Hello,');
+        responseStream.write(' world!');
+        responseStream.end();
+    }
+);

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4604,5 +4604,12 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_function_url_with_response_streaming": {
+    "recorded-date": "30-07-2025, 20:58:56",
+    "recorded-content": {
+      "response_status": 200,
+      "response_data": "Hello, world!"
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -203,6 +203,15 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaPermissions::test_lambda_permission_url_invocation": {
     "last_validated_date": "2024-04-08T16:57:37+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_function_url_with_response_streaming": {
+    "last_validated_date": "2025-07-30T21:16:00+00:00",
+    "durations_in_seconds": {
+      "setup": 10.91,
+      "call": 3.45,
+      "teardown": 0.83,
+      "total": 15.19
+    }
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_update_function_url_config": {
     "last_validated_date": "2024-04-08T16:57:17+00:00"
   },


### PR DESCRIPTION
## Motivation
This Pr implements the capability to handle LambdaURL invocations of type StreamResponse [See here for more info](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)

## Changes
- AWS::Lambda::Url  accepts the InvokeMode parameter to create a LambdaUrl
- UrlRouter can handle results with streaming separator
- UrlRouter can handle results with simple strings


## Testing
- New AWS validated test