### PR TITLE
Apigw/enable vpce routing

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -145,7 +145,7 @@ class ApiGatewayEndpoint:
         )
         return not_found
 
-    def vpe_endpoint_handler(
+    def vpc_endpoint_handler(
         self, request: Request, **kwargs: Unpack[RouteHostPathParameters]
     ) -> Response:
         # TODO validate the vpc endpoint exists in the account/region before routing
@@ -228,21 +228,21 @@ class ApiGatewayRouter:
             self.router.add(
                 path="/",
                 host=vpce_host_pattern,
-                endpoint=self.handler.vpe_endpoint_handler,
+                endpoint=self.handler.vpc_endpoint_handler,
                 defaults={"path": "", "stage": None},
                 strict_slashes=True,
             ),
             self.router.add(
                 path="/<stage>/",
                 host=vpce_host_pattern,
-                endpoint=self.handler.vpe_endpoint_handler,
+                endpoint=self.handler.vpc_endpoint_handler,
                 defaults={"path": ""},
                 strict_slashes=False,
             ),
             self.router.add(
                 path="/<stage>/<greedy_path:path>",
                 host=vpce_host_pattern,
-                endpoint=self.handler.vpe_endpoint_handler,
+                endpoint=self.handler.vpc_endpoint_handler,
                 strict_slashes=True,
             ),
         ]

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/router.py
@@ -33,6 +33,7 @@ class RouteHostPathParameters(TypedDict, total=False):
     server: str | None
     stage: str | None
     vpce_suffix: str | None
+    vpce_dns: str | None
 
 
 class ApiGatewayEndpoint:
@@ -144,6 +145,13 @@ class ApiGatewayEndpoint:
         )
         return not_found
 
+    def vpe_endpoint_handler(
+        self, request: Request, **kwargs: Unpack[RouteHostPathParameters]
+    ) -> Response:
+        # TODO validate the vpc endpoint exists in the account/region before routing
+        kwargs["api_id"] = request.headers.get("x-apigw-api-id")
+        return self.__call__(request, **kwargs)
+
 
 class ApiGatewayRouter:
     router: Router[Handler]
@@ -158,6 +166,9 @@ class ApiGatewayRouter:
     def register_routes(self) -> None:
         LOG.debug("Registering API Gateway routes.")
         host_pattern = "<regex('.+?'):api_id><regex('(-vpce-[^.]+)?'):vpce_suffix>.execute-api.<regex('.*'):server>"
+        vpce_host_pattern = (
+            "<regex('vpce-.+'):vpce_dns>.execute-api.<regex('.*'):region>vpce.<regex('.*'):server>"
+        )
         deprecated_route_endpoint = deprecated_endpoint(
             endpoint=self.handler,
             previous_path="/restapis/<api_id>/<stage>/_user_request_",
@@ -212,6 +223,26 @@ class ApiGatewayRouter:
             self.router.add(
                 path=f"{self.EXECUTE_API_INTERNAL_PATH}/<api_id>/<stage>/<greedy_path:path>",
                 endpoint=self.handler,
+                strict_slashes=True,
+            ),
+            self.router.add(
+                path="/",
+                host=vpce_host_pattern,
+                endpoint=self.handler.vpe_endpoint_handler,
+                defaults={"path": "", "stage": None},
+                strict_slashes=True,
+            ),
+            self.router.add(
+                path="/<stage>/",
+                host=vpce_host_pattern,
+                endpoint=self.handler.vpe_endpoint_handler,
+                defaults={"path": ""},
+                strict_slashes=False,
+            ),
+            self.router.add(
+                path="/<stage>/<greedy_path:path>",
+                host=vpce_host_pattern,
+                endpoint=self.handler.vpe_endpoint_handler,
                 strict_slashes=True,
             ),
         ]

--- a/tests/aws/services/apigateway/test_apigateway_integrations.py
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.py
@@ -1099,7 +1099,7 @@ def test_create_execute_api_vpc_endpoint(
     # AWS
     #   url: https://{public-dns-hostname}.execute-api.{region}.vpce.amazonaws.com/{stage}
     #   x-apigw-api-id: {rest-api-id}
-    # LocalStack Not a clue
+    # LocalStack
     #   url: http://{public-dns-hostname}.execute-api.{region}.vpce.{localstack-host}/{stage}
     #   x-apigw-api-id: {rest-api-id}
     protocol = "https" if is_aws_cloud() else "http"
@@ -1115,7 +1115,7 @@ def test_create_execute_api_vpc_endpoint(
     # AWS
     #   url: https://{public-dns-hostname}.execute-api.{region}.vpce.amazonaws.com/{stage}
     #   host: {rest-api-id}.execute-api.{region}.amazonaws.com
-    # LocalStack Not a clue
+    # LocalStack
     #   url: http://{public-dns-hostname}.execute-api.{region}.vpce.{localstack_host}/{stage}
     #   host: {rest-api-id}.execute-api.{region}.{localstack-host}
     host = api_invoke_url(api_id).partition("//")[-1].strip("/")

--- a/tests/aws/services/apigateway/test_apigateway_integrations.py
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.py
@@ -1102,7 +1102,6 @@ def test_create_execute_api_vpc_endpoint(
     # LocalStack Not a clue
     #   url: http://{public-dns-hostname}.execute-api.{region}.vpce.{localstack-host}/{stage}
     #   x-apigw-api-id: {rest-api-id}
-
     protocol = "https" if is_aws_cloud() else "http"
     vpc_endpoint_public_dns = endpoint_details["DnsEntries"][0]["DnsName"]
     public_dns_url = f"{protocol}://{vpc_endpoint_public_dns}/{DEFAULT_STAGE_NAME}/test"

--- a/tests/aws/services/apigateway/test_apigateway_integrations.py
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.py
@@ -14,7 +14,9 @@ from werkzeug import Request, Response
 
 from localstack import config
 from localstack.aws.api.apigateway import IntegrationType
+from localstack.aws.api.ec2 import VpcEndpoint
 from localstack.aws.api.lambda_ import Runtime
+from localstack.config import in_docker
 from localstack.constants import APPLICATION_JSON
 from localstack.services.lambda_.networking import get_main_endpoint_from_container
 from localstack.testing.aws.util import is_aws_cloud
@@ -914,9 +916,14 @@ def create_vpc_endpoint(default_vpc, aws_client):
         "$..endpointConfiguration.types",
         "$..policy.Statement..Resource",
         "$..endpointConfiguration.ipAddressType",
+        "$.endpoint-details.ServiceRegion",
     ]
 )
 @markers.aws.validated
+@pytest.mark.skipif(
+    not is_aws_cloud() and not in_docker(),
+    reason="calling the vpce from a lambda requires LocalStack to run in docker",
+)
 def test_create_execute_api_vpc_endpoint(
     create_rest_api_with_integration,
     dynamodb_create_table,
@@ -926,6 +933,7 @@ def test_create_execute_api_vpc_endpoint(
     ec2_create_security_group,
     snapshot,
     aws_client,
+    region_name,
 ):
     poll_sleep = 5 if is_aws_cloud() else 1
     # TODO: create a re-usable ec2_api() transformer
@@ -955,7 +963,6 @@ def test_create_execute_api_vpc_endpoint(
     request_templates = {APPLICATION_JSON: json.dumps({"TableName": table_name})}
 
     # deploy REST API with integration
-    region_name = aws_client.apigateway.meta.region_name
     integration_uri = f"arn:aws:apigateway:{region_name}:dynamodb:action/Scan"
     api_id = create_rest_api_with_integration(
         integration_uri=integration_uri,
@@ -971,7 +978,10 @@ def test_create_execute_api_vpc_endpoint(
     # create security group
     vpc_id = default_vpc["VpcId"]
     security_group = ec2_create_security_group(
-        VpcId=vpc_id, Description="Test SG for API GW", ports=[443]
+        VpcId=vpc_id,
+        Description="Test SG for API GW",
+        GroupName=f"test-sg-{short_uid()}",
+        ports=[443],
     )
     security_group = security_group["GroupId"]
     subnets = aws_client.ec2.describe_subnets(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}])
@@ -994,15 +1004,16 @@ def test_create_execute_api_vpc_endpoint(
     # wait until VPC endpoint is in state "available"
     def _check_available():
         result = aws_client.ec2.describe_vpc_endpoints(VpcEndpointIds=[endpoint_id])
-        endpoint_details = result["VpcEndpoints"][0]
+        _endpoint_details = result["VpcEndpoints"][0]
         # may have multiple entries in AWS
-        endpoint_details["DnsEntries"] = endpoint_details["DnsEntries"][:1]
-        endpoint_details.pop("SubnetIds", None)
-        endpoint_details.pop("NetworkInterfaceIds", None)
-        assert endpoint_details["State"] == "available"
-        snapshot.match("endpoint-details", endpoint_details)
+        _endpoint_details["DnsEntries"] = _endpoint_details["DnsEntries"][:1]
+        _endpoint_details.pop("SubnetIds", None)
+        _endpoint_details.pop("NetworkInterfaceIds", None)
+        assert _endpoint_details["State"] == "available"
+        snapshot.match("endpoint-details", _endpoint_details)
+        return _endpoint_details
 
-    retry(_check_available, retries=30, sleep=poll_sleep)
+    endpoint_details: VpcEndpoint = retry(_check_available, retries=30, sleep=poll_sleep)
 
     # update API with VPC endpoint
     patches = [
@@ -1012,21 +1023,15 @@ def test_create_execute_api_vpc_endpoint(
     aws_client.apigateway.update_rest_api(restApiId=api_id, patchOperations=patches)
 
     # create Lambda that invokes API via VPC endpoint (required as the endpoint is only accessible within the VPC)
-    subdomain = f"{api_id}-{endpoint_id}"
-    endpoint = api_invoke_url(subdomain, stage=DEFAULT_STAGE_NAME, path="/test")
-    host_header = urlparse(endpoint).netloc
-
-    # create Lambda function that invokes the API GW (private VPC endpoint not accessible from outside of AWS)
-    if not is_aws_cloud():
-        api_host = get_main_endpoint_from_container()
-        endpoint = endpoint.replace(host_header, f"{api_host}:{config.GATEWAY_LISTEN[0].port}")
     lambda_code = textwrap.dedent(
-        f"""
+        """
     def handler(event, context):
         import requests
-        headers = {{"content-type": "application/json", "host": "{host_header}"}}
-        result = requests.post("{endpoint}", headers=headers)
-        return {{"content": result.content.decode("utf-8"), "code": result.status_code}}
+        url = event["url"]
+        headers = event["headers"]
+
+        result = requests.post(url, headers=headers)
+        return {"content": result.content.decode("utf-8"), "code": result.status_code}
     """
     )
     func_name = f"test-{short_uid()}"
@@ -1064,14 +1069,62 @@ def test_create_execute_api_vpc_endpoint(
         aws_client.apigateway, restApiId=api_id, stageName=DEFAULT_STAGE_NAME
     )
 
-    def _invoke_api():
-        invoke_response = aws_client.lambda_.invoke(FunctionName=func_name, Payload="{}")
+    subdomain = f"{api_id}-{endpoint_id}"
+    endpoint = api_invoke_url(subdomain, stage=DEFAULT_STAGE_NAME, path="/test")
+    host_header = urlparse(endpoint).netloc
+
+    # create Lambda function that invokes the API GW (private VPC endpoint not accessible from outside of AWS)
+    if not is_aws_cloud():
+        api_host = get_main_endpoint_from_container()
+        endpoint = endpoint.replace(host_header, f"{api_host}:{config.GATEWAY_LISTEN[0].port}")
+
+    def _invoke_api(url: str, headers: dict[str, str]):
+        invoke_response = aws_client.lambda_.invoke(
+            FunctionName=func_name, Payload=json.dumps({"url": url, "headers": headers})
+        )
         payload = json.load(invoke_response["Payload"])
         items = json.loads(payload["content"])["Items"]
         assert len(items) == len(item_ids)
 
     # invoke Lambda and assert result
-    retry(_invoke_api, retries=15, sleep=poll_sleep)
+    # AWS
+    #   url: https://{rest-api-id}-{vpce-id}.execute-api.{region}.amazonaws.com/{stage}
+    #   host: {rest-api-id}.execute-api.{region}.amazonaws.com
+    # LocalStack
+    #   url: http://localhost.localstack.cloud:4566/{stage}
+    #   host: {rest-api-id}-{vpce-id}.execute-api.localhost.localstack.cloud
+    retry(lambda: _invoke_api(endpoint, {"host": host_header}), retries=15, sleep=poll_sleep)
+
+    # invoke Lambda and assert result
+    # AWS
+    #   url: https://{public-dns-hostname}.execute-api.{region}.vpce.amazonaws.com/{stage}
+    #   x-apigw-api-id: {rest-api-id}
+    # LocalStack Not a clue
+    #   url: http://{public-dns-hostname}.execute-api.{region}.vpce.{localstack-host}/{stage}
+    #   x-apigw-api-id: {rest-api-id}
+
+    protocol = "https" if is_aws_cloud() else "http"
+    vpc_endpoint_public_dns = endpoint_details["DnsEntries"][0]["DnsName"]
+    public_dns_url = f"{protocol}://{vpc_endpoint_public_dns}/{DEFAULT_STAGE_NAME}/test"
+    retry(
+        lambda: _invoke_api(public_dns_url, {"x-apigw-api-id": api_id}),
+        retries=15,
+        sleep=poll_sleep,
+    )
+
+    # invoke Lambda and assert result
+    # AWS
+    #   url: https://{public-dns-hostname}.execute-api.{region}.vpce.amazonaws.com/{stage}
+    #   host: {rest-api-id}.execute-api.{region}.amazonaws.com
+    # LocalStack Not a clue
+    #   url: http://{public-dns-hostname}.execute-api.{region}.vpce.{localstack_host}/{stage}
+    #   host: {rest-api-id}.execute-api.{region}.{localstack-host}
+    host = api_invoke_url(api_id).partition("//")[-1].strip("/")
+    retry(
+        lambda: _invoke_api(public_dns_url, {"Host": host}),
+        retries=15,
+        sleep=poll_sleep,
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/aws/services/apigateway/test_apigateway_integrations.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_create_execute_api_vpc_endpoint": {
-    "recorded-date": "15-04-2024, 23:07:07",
+    "recorded-date": "30-07-2025, 17:56:57",
     "recorded-content": {
       "endpoint-details": {
         "CreationTimestamp": "timestamp",
@@ -35,6 +35,7 @@
         "RequesterManaged": false,
         "RouteTableIds": [],
         "ServiceName": "com.amazonaws.<region>.execute-api",
+        "ServiceRegion": "<region>",
         "State": "available",
         "Tags": [],
         "VpcEndpointId": "<vpc-endpoint-id:1>",
@@ -46,6 +47,7 @@
         "createdDate": "datetime",
         "disableExecuteApiEndpoint": false,
         "endpointConfiguration": {
+          "ipAddressType": "dualstack",
           "types": [
             "PRIVATE"
           ],

--- a/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
@@ -12,7 +12,13 @@
     "last_validated_date": "2024-12-11T15:28:54+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_create_execute_api_vpc_endpoint": {
-    "last_validated_date": "2024-04-15T23:07:07+00:00"
+    "last_validated_date": "2025-07-30T17:57:02+00:00",
+    "durations_in_seconds": {
+      "setup": 12.89,
+      "call": 1064.8,
+      "teardown": 4.99,
+      "total": 1082.68
+    }
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_integration_mock_with_path_param": {
     "last_validated_date": "2024-11-29T19:27:54+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

depends on: #12927 

This pr adds a route to apigw to allow invoking an ApiGateway API through it's vpc endpoint using the `x-apigw-api-id` headers, as describe in [AWS docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-api-test-invoke-url.html#apigateway-private-api-public-dns).

At the moment we are not validating the vpc endpoint exists, so any "valid" VPC endpoint like url targeted at `.vpce.execute-api` will attempt to execute the api provided with the `x-apigw-api-id`. Note this is already the case for the other path style of VPC endpoint and as such falls outside the scope of the current PR.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- expand testing to include targeting with `host` headers (already supported by default, but now tested)
- expand testing to include targeting with host headers
- register routes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
