### PR TITLE
fix partial coverage reporting

### DIFF
--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -4,33 +4,6 @@ on:
   schedule:
     - cron: 0 2 * * MON-FRI
   push:
-    paths:
-      - '**'
-      - '!.github/**'
-      - '.github/actions/**'
-      - '.github/workflows/aws-main.yml'
-      - '.github/workflows/aws-tests.yml'
-      - '!CODEOWNERS'
-      - '!README.md'
-      - '!.gitignore'
-      - '!.git-blame-ignore-revs'
-      - '!docs/**'
-    branches:
-      - main
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-  pull_request:
-    paths:
-      - '**'
-      - '!.github/**'
-      - '.github/actions/**'
-      - '.github/workflows/aws-main.yml'
-      - '.github/workflows/aws-tests.yml'
-      - '!CODEOWNERS'
-      - '!README.md'
-      - '!.gitignore'
-      - '!.git-blame-ignore-revs'
-      - '!docs/**'
   workflow_dispatch:
     inputs:
       onlyAcceptanceTests:

--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -96,7 +96,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
-    if: ${{ inputs.onlyAcceptanceTests == false && inputs.enableTestSelection == false }}
+    # Do not push coverage data if only parts of the tests were executed
+    if: ${{ !(inputs.onlyAcceptanceTests == true || inputs.enableTestSelection == true || github.event_name == 'push') }}
     steps:
         - name: Checkout
           uses: actions/checkout@v4

--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -56,7 +56,7 @@ jobs:
       # default "disableCaching" to `false` if it's a push or schedule event
       disableCaching: ${{ inputs.disableCaching == true }}
       # default "disableTestSelection" to `true` if it's a push or schedule event
-      disableTestSelection: ${{ (inputs.enableTestSelection != '' && inputs.enableTestSelection) || github.event_name == 'push' }}
+      disableTestSelection: ${{ (inputs.enableTestSelection != '' && !inputs.enableTestSelection) || github.event_name == 'push' }}
       PYTEST_LOGLEVEL: ${{ inputs.PYTEST_LOGLEVEL }}
       forceARMTests: ${{ inputs.forceARMTests == true }}
     secrets:

--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -4,6 +4,33 @@ on:
   schedule:
     - cron: 0 2 * * MON-FRI
   push:
+    paths:
+      - '**'
+      - '!.github/**'
+      - '.github/actions/**'
+      - '.github/workflows/aws-main.yml'
+      - '.github/workflows/aws-tests.yml'
+      - '!CODEOWNERS'
+      - '!README.md'
+      - '!.gitignore'
+      - '!.git-blame-ignore-revs'
+      - '!docs/**'
+    branches:
+      - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    paths:
+      - '**'
+      - '!.github/**'
+      - '.github/actions/**'
+      - '.github/workflows/aws-main.yml'
+      - '.github/workflows/aws-tests.yml'
+      - '!CODEOWNERS'
+      - '!README.md'
+      - '!.gitignore'
+      - '!.git-blame-ignore-revs'
+      - '!docs/**'
   workflow_dispatch:
     inputs:
       onlyAcceptanceTests:

--- a/.github/workflows/aws-main.yml
+++ b/.github/workflows/aws-main.yml
@@ -70,7 +70,7 @@ jobs:
     needs:
       - test
     # Do not push coverage data if only parts of the tests were executed
-    if: ${{ !(inputs.onlyAcceptanceTests == true || inputs.enableTestSelection == true || github.event_name == 'push') }}
+    if: ${{ !(inputs.onlyAcceptanceTests == true || inputs.enableTestSelection == true || github.event_name == 'push') && !failure() && !cancelled() && github.repository == 'localstack/localstack' }}
     steps:
         - name: Checkout
           uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation
With #12923 we fixed the coverage upload, and with #12924 we tried to fix the issue of reporting partial results.
Unfortunately, debugging job level conditionals in GitHub actions is notoriously hard / [there isn't really a way to get proper debug information](https://github.com/orgs/community/discussions/20640) on how the conditions are evaluated.

## Changes
- Fixes the conditional for uploading the coverage report by switching to "not explicitly true" for the test selection and aceptancfe tests and considering the push event.
- Fixes a conditional to forward the `enableTestSelection` correctly on the workflow call.

## Testing
- [x] [Test full run is reported](https://github.com/localstack/localstack/actions/runs/16645199459)
- [x] [Test run triggered by a push event](https://github.com/localstack/localstack/actions/runs/16647895400)
- [x] [Test only acceptance test run is not reported](https://github.com/localstack/localstack/actions/runs/16645189125)
- [x] [Test run with enabled test selection is not reported](https://github.com/localstack/localstack/actions/runs/16645179453)