### PR TITLE
Reduce image size by properly avoiding duplicated java installation

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/packages.py
+++ b/localstack-core/localstack/services/stepfunctions/packages.py
@@ -40,5 +40,9 @@ class JSONataPackageInstaller(JavaInstallerMixin, MavenPackageInstaller):
         # override to install correct java version
         java_package.get_installer(self.java_version).install(target)
 
+    def get_java_home(self) -> str | None:
+        """Override to use the specific Java version"""
+        return java_package.get_installer(self.java_version).get_java_home()
+
 
 jpype_jsonata_package = JSONataPackage()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, we install both JRE 11 and 21 in our docker image.
This is not intended however, as the comment in the stepfunctions package highlights:
```
# Match the dynamodb-local JRE version to reduce the LocalStack image size by sharing the same JRE version
```

We set the java version in the jsonata package, but never reference it.

Gzipped image size will be reduced by around 39MB, decompressed ~70MB

In the future, we should adapt the JavaInstallerMixin to take a version, but this requires some a bit bigger changes.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Properly set the jsonata java version to 21, to reduce duplicated installs

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
