### PR TITLE
Add handling of tags in docker-helper

### DIFF
--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -80,6 +80,13 @@ function _enforce_tagged_or_main_branch() {
     echo "Current git branch: '$CURRENT_BRANCH'"
     echo "Current tag: '$CURRENT_TAG'"
     test -n "$CURRENT_TAG" || test "$CURRENT_BRANCH" == "$MAIN_BRANCH" || _fail "Current branch ($CURRENT_BRANCH) is not $MAIN_BRANCH and current tag ($CURRENT_TAG) is not set."
+
+    # if we're not on the main branch but have a tag, ensure it's a version tag like v1.2.3
+    if [[ "$CURRENT_BRANCH" != "$MAIN_BRANCH" && -n "$CURRENT_TAG" ]]; then
+      if ! [[ "$CURRENT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        _fail "tag '$CURRENT_TAG' is not a version tag of the shape ^v[0-9]+\.[0-9]+\.[0-9]+$"
+      fi
+    fi
 }
 
 function _enforce_no_fork() {

--- a/tests/bin/test.docker-helper.bats
+++ b/tests/bin/test.docker-helper.bats
@@ -148,6 +148,19 @@ setup_file() {
   [[ "$output" =~ "docker push $IMAGE_NAME:stable-$PLATFORM" ]]
 }
 
+@test "push fails on malformed tag" {
+  export MAIN_BRANCH="non-existing-branch"
+  export IMAGE_NAME="localstack/test"
+  export DOCKER_USERNAME=test
+  export DOCKER_PASSWORD=test
+  export PLATFORM=amd64
+  export TEST_TAG=not-a-version
+  run bin/docker-helper.sh push
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "tag '$TEST_TAG' is not a version tag" ]]
+}
+
+
 @test "push fails without PLATFORM" {
   export IMAGE_NAME="localstack/test"
   export MAIN_BRANCH="main"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

With the latest release we still had issues with pushing docker images on pipeline runs triggered by the tag push.

This is because the docker helper assumes that only the `main` branch should be allowed for pushing the images. Since tags are not bound to a branch, a tag-triggered run will not have a branch ref. 

We need to add extra provisions for allowing tagged commits to also push images. 

/cc @dfangl (and thanks for providing the patch files)

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Allow tagged commits to also successfully push images
- Add bats test to assure this is possible


## Testing

To avoid further issues we'll do a run in a forked repository where we push into a different DockerHub account.

## TODO

What's left to do:

- [x] Thorough testing:
   - [x] Test that regular pushes to main will still work: https://github.com/silv-io/localstack/actions/runs/16909810881
   - [x] Test that tag pushes to main will start working: https://github.com/silv-io/localstack/actions/runs/16909892613 -> see [here](https://hub.docker.com/r/agihi/localstack/tags)
- [ ] ...

