### PR TITLE
mitigate issues with pip-tools 7.5.0 with dependency limit

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -93,7 +93,8 @@ jobs:
           bin/release-helper.sh set-dep-ver awscli "==$AWSCLI_VERSION"
 
           # upgrade the requirements files only for the botocore package
-          pip install pip-tools
+          # FIXME remove pin on pip-tools when https://github.com/jazzband/pip-tools/issues/2215 us resolved
+          pip install "pip-tools<7.5.0"
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --extra base-runtime -o requirements-base-runtime.txt pyproject.toml
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra runtime -o requirements-runtime.txt pyproject.toml
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra test -o requirements-test.txt pyproject.toml

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ freeze:                   ## Run pip freeze -l in the virtual environment
 	@$(VENV_RUN); pip freeze -l
 
 upgrade-pinned-dependencies: venv
-	$(VENV_RUN); $(PIP_CMD) install --upgrade pip-tools pre-commit
+	# FIXME remove pin on pip-tools when https://github.com/jazzband/pip-tools/issues/2215 us resolved
+	$(VENV_RUN); $(PIP_CMD) install --upgrade "pip-tools<7.5.0" pre-commit
 	$(VENV_RUN); pip-compile --strip-extras --upgrade -o requirements-basic.txt pyproject.toml
 	$(VENV_RUN); pip-compile --strip-extras --upgrade --extra runtime -o requirements-runtime.txt pyproject.toml
 	$(VENV_RUN); pip-compile --strip-extras --upgrade --extra test -o requirements-test.txt pyproject.toml


### PR DESCRIPTION
## Motivation
A few days ago, `pip-tools==7.5.0` [has been released](https://github.com/jazzband/pip-tools/releases/tag/v7.5.0).
With our [weekly ASF update action](https://github.com/localstack/localstack/actions/runs/16714602516/job/47305613559), we are now facing an issue which was introduced by this version: https://github.com/jazzband/pip-tools/issues/2215
Immediately on the first call of `pip-compile` in this workflow the execution fails with the following trace:
```
 Traceback (most recent call last):
  File "/home/runner/work/localstack/localstack/.venv/bin/pip-compile", line 7, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/piptools/scripts/compile.py", line 371, in cli
    metadata = build_project_metadata(
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/piptools/build.py", line 159, in build_project_metadata
    project_metadata = maybe_statically_parse_project_metadata(src_file)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/piptools/build.py", line 106, in maybe_statically_parse_project_metadata
    requirement.url = src_file.parent.as_uri()
                      ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/pathlib.py", line 566, in as_uri
    raise ValueError("relative path can't be expressed as a file URI")
ValueError: relative path can't be expressed as a file URI
Error: Process completed with exit code 1.
```
This PR mitigates this issue by avoiding this release / introducing dependency limits when installing `pip-tools`.
This PR should be reverted once the issue has been resolved by the `pip-tools` team.

## Changes
- Limit the version of `pip-tools` to less than `7.5.0` (i.e. install `7.4.1` instead of `7.5.0` to avoid https://github.com/jazzband/pip-tools/issues/2215.

## Testing
- ✅ Trigger an ASF Update action from this branch to verify that it works correctly:
  - Workflow run: https://github.com/localstack/localstack/actions/runs/16718436403
  - Created PR: https://github.com/localstack/localstack/pull/12948