### PR TITLE
Replicator/support x account kms

### DIFF
--- a/localstack-core/localstack/services/kms/utils.py
+++ b/localstack-core/localstack/services/kms/utils.py
@@ -8,7 +8,7 @@ from localstack.utils.aws.arns import ARN_PARTITION_REGEX
 T = TypeVar("T")
 
 KMS_KEY_ARN_PATTERN = re.compile(
-    rf"{ARN_PARTITION_REGEX}:kms:(?P<region_name>[^:]+):(?P<account_id>\d{{12}}):key\/(?P<key_id>[^:]+)$"
+    rf"{ARN_PARTITION_REGEX}:kms:(?P<region_name>[^:]+):(?P<account_id>\d{{12}}):((?=key/)key/|(?=alias/))(?P<key_id>[^:]+)$"
 )
 
 

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -2006,6 +2006,22 @@ class TestKMS:
             )
         snapshot.match("response-invalid-public-key", e.value.response)
 
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..CurrentKeyMaterialId"])
+    def test_describe_with_alias_arn(self, kms_create_key, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("CurrentKeyMaterialId"))
+
+        alias_name = f"alias/{short_uid()}"
+        created_key = kms_create_key(Description="test - description")
+        snapshot.match("created-key", created_key)
+
+        aws_client.kms.create_alias(TargetKeyId=created_key["KeyId"], AliasName=alias_name)
+        key_arn = created_key["Arn"]
+        alias_arn = key_arn.rsplit(":", maxsplit=1)[0] + f":{alias_name}"
+
+        describe_response = aws_client.kms.describe_key(KeyId=alias_arn)
+        snapshot.match("describe-key", describe_response)
+
 
 class TestKMSMultiAccounts:
     @markers.aws.needs_fixing

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -2016,8 +2016,8 @@ class TestKMS:
         snapshot.match("created-key", created_key)
 
         aws_client.kms.create_alias(TargetKeyId=created_key["KeyId"], AliasName=alias_name)
-        key_arn = created_key["Arn"]
-        alias_arn = key_arn.rsplit(":", maxsplit=1)[0] + f":{alias_name}"
+        alias = _get_alias(aws_client.kms, alias_name)
+        alias_arn = alias["AliasArn"]
 
         describe_response = aws_client.kms.describe_key(KeyId=alias_arn)
         snapshot.match("describe-key", describe_response)

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -2380,7 +2380,7 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_describe_with_alias_arn": {
-    "recorded-date": "05-08-2025, 04:13:09",
+    "recorded-date": "05-08-2025, 17:00:25",
     "recorded-content": {
       "created-key": {
         "AWSAccountId": "111111111111",

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -2378,5 +2378,54 @@
         }
       }
     }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_describe_with_alias_arn": {
+    "recorded-date": "05-08-2025, 04:13:09",
+    "recorded-content": {
+      "created-key": {
+        "AWSAccountId": "111111111111",
+        "Arn": "arn:<partition>:kms:<region>:111111111111:key/<key-id:1>",
+        "CreationDate": "datetime",
+        "CurrentKeyMaterialId": "<current-key-material-id:1>",
+        "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+        "Description": "test - description",
+        "Enabled": true,
+        "EncryptionAlgorithms": [
+          "SYMMETRIC_DEFAULT"
+        ],
+        "KeyId": "<key-id:1>",
+        "KeyManager": "CUSTOMER",
+        "KeySpec": "SYMMETRIC_DEFAULT",
+        "KeyState": "Enabled",
+        "KeyUsage": "ENCRYPT_DECRYPT",
+        "MultiRegion": false,
+        "Origin": "AWS_KMS"
+      },
+      "describe-key": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:<partition>:kms:<region>:111111111111:key/<key-id:1>",
+          "CreationDate": "datetime",
+          "CurrentKeyMaterialId": "<current-key-material-id:1>",
+          "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+          "Description": "test - description",
+          "Enabled": true,
+          "EncryptionAlgorithms": [
+            "SYMMETRIC_DEFAULT"
+          ],
+          "KeyId": "<key-id:1>",
+          "KeyManager": "CUSTOMER",
+          "KeySpec": "SYMMETRIC_DEFAULT",
+          "KeyState": "Enabled",
+          "KeyUsage": "ENCRYPT_DECRYPT",
+          "MultiRegion": false,
+          "Origin": "AWS_KMS"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -50,6 +50,15 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_describe_and_list_sign_key": {
     "last_validated_date": "2024-04-11T15:53:27+00:00"
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_describe_with_alias_arn": {
+    "last_validated_date": "2025-08-05T04:13:09+00:00",
+    "durations_in_seconds": {
+      "setup": 0.59,
+      "call": 0.86,
+      "teardown": 0.1,
+      "total": 1.55
+    }
+  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_disable_and_enable_key": {
     "last_validated_date": "2024-04-11T15:52:38+00:00"
   },

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -51,12 +51,12 @@
     "last_validated_date": "2024-04-11T15:53:27+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_describe_with_alias_arn": {
-    "last_validated_date": "2025-08-05T04:13:09+00:00",
+    "last_validated_date": "2025-08-05T17:00:25+00:00",
     "durations_in_seconds": {
-      "setup": 0.59,
-      "call": 0.86,
-      "teardown": 0.1,
-      "total": 1.55
+      "setup": 0.83,
+      "call": 0.99,
+      "teardown": 0.16,
+      "total": 1.98
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_disable_and_enable_key": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This pr enables describing a kms key using the alias arn. This is part of solving a support issue with the replicator, where the user is querying a kms key x-account with it's alias.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- the `key_id` returned by the regex will now return `alias/<alias_name>` if an alias arn is found.
- added test to validate the behavior

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
