### PR TITLE
feat(kinesis): implement resource policies CRUD operations (#12488)

### DIFF
--- a/localstack-core/localstack/services/kinesis/models.py
+++ b/localstack-core/localstack/services/kinesis/models.py
@@ -1,7 +1,18 @@
 from collections import defaultdict
 
-from localstack.aws.api.kinesis import ConsumerDescription, MetricsName, StreamName
-from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
+from localstack.aws.api.kinesis import (
+    ConsumerDescription,
+    MetricsName,
+    Policy,
+    ResourceARN,
+    StreamName,
+)
+from localstack.services.stores import (
+    AccountRegionBundle,
+    BaseStore,
+    CrossAccountAttribute,
+    LocalAttribute,
+)
 
 
 class KinesisStore(BaseStore):
@@ -12,6 +23,8 @@ class KinesisStore(BaseStore):
     enhanced_metrics: dict[StreamName, set[MetricsName]] = LocalAttribute(
         default=lambda: defaultdict(set)
     )
+
+    resource_policies: dict[ResourceARN, Policy] = CrossAccountAttribute(default=dict)
 
 
 kinesis_stores = AccountRegionBundle("kinesis", KinesisStore)

--- a/tests/aws/services/kinesis/test_kinesis.snapshot.json
+++ b/tests/aws/services/kinesis/test_kinesis.snapshot.json
@@ -235,5 +235,85 @@
         "message": "Stream wrong-stream-name under account 111111111111 not found."
       }
     }
+  },
+  "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_resource_policy_crud": {
+    "recorded-date": "01-08-2025, 13:00:05",
+    "recorded-content": {
+      "default_policy_if_not_set": {
+        "Policy": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put_resource_policy_if_not_set": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_resource_policy_after_set": {
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowCrossAccountWrite",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:<partition>:iam::111111111111:root"
+              },
+              "Action": "kinesis:PutRecord",
+              "Resource": "arn:<partition>:kinesis:<region>:111111111111:<stream-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update_resource_policy": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_resource_policy_after_update": {
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowCrossAccountReadWrite",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:<partition>:iam::111111111111:root"
+              },
+              "Action": [
+                "kinesis:PutRecord",
+                "kinesis:GetRecords"
+              ],
+              "Resource": "arn:<partition>:kinesis:<region>:111111111111:<stream-name>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_resource_policy": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_resource_policy_after_delete": {
+        "Policy": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/kinesis/test_kinesis.validation.json
+++ b/tests/aws/services/kinesis/test_kinesis.validation.json
@@ -29,6 +29,15 @@
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_record_lifecycle_data_integrity": {
     "last_validated_date": "2022-08-25T10:39:44+00:00"
   },
+  "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_resource_policy_crud": {
+    "last_validated_date": "2025-08-05T15:23:27+00:00",
+    "durations_in_seconds": {
+      "setup": 0.63,
+      "call": 6.43,
+      "teardown": 0.08,
+      "total": 7.14
+    }
+  },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_stream_consumers": {
     "last_validated_date": "2022-08-26T08:23:46+00:00"
   },


### PR DESCRIPTION
## Motivation

The mock server does not implement resource policy operations, but the provider redirects to it, generating an AccessDenied exception. see [the original bug](https://github.com/localstack/localstack/issues/12488
) for details.

## Changes

The PR implements the resource policy crud operations and provides snapshot integration tests tested against AWS.

## Testing

See the original bug for details #12488. You can test with terraform:

```terraform
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 5.0"
    }
  }
  required_version = ">= 1.0"
}

resource "aws_kinesis_stream" "kinesis_stream" {
  name             = "my-kinesis-stream"
  shard_count      = 1
  retention_period = 24
}

data "aws_iam_policy_document" "kinesis_data_stream_policy" {
  statement {
    actions = [
      "kinesis:PutRecord",
      "kinesis:PutRecords"
    ]

    resources = [
      aws_kinesis_stream.kinesis_stream.arn
    ]

    principals {
      type        = "AWS"
      identifiers = ["*"]
    }

    effect = "Allow"
  }
}

resource "aws_kinesis_resource_policy" "stream_policy" {
  resource_arn = aws_kinesis_stream.kinesis_stream.arn
  policy       = data.aws_iam_policy_document.kinesis_data_stream_policy.json
}

```


Or with plain awscli:

```bash
#!/bin/bash

set -e

STREAM_NAME="sample-table-dynamodb-stream"
REGION="us-east-1"
ACCOUNT_ID="000000000000"
STREAM_ARN="arn:aws:kinesis:$REGION:$ACCOUNT_ID:stream/$STREAM_NAME"

echo "Creating Kinesis stream: $STREAM_NAME"
awslocal kinesis create-stream \
  --stream-name "$STREAM_NAME" \
  --shard-count 1

echo "Waiting for the stream to become ACTIVE..."
while true; do
  STATUS=$(awslocal kinesis describe-stream-summary --stream-name "$STREAM_NAME" \
    --query "StreamDescriptionSummary.StreamStatus" --output text)
  if [ "$STATUS" == "ACTIVE" ]; then
    echo "Stream is ACTIVE."
    break
  fi
  sleep 1
done

awslocal kinesis put-resource-policy \
  --resource-arn "$STREAM_ARN" \
  --policy '{
    "Version": "2012-10-17",
    "Statement": [
      {
        "Effect": "Allow",
        "Principal": {
          "AWS": "arn:aws:iam::000000000000:role/service-role"
        },
        "Action": [
          "kinesis:DescribeStreamSummary",
          "kinesis:GetShardIterator",
          "kinesis:GetRecords",
          "kinesis:ListShards"
        ],
        "Resource": "'"$STREAM_ARN"'"
      }
    ]
  }'

echo "✅ Policy attached successfully."
```

It also passes the terraform aws provider integration test:

<img width="1276" height="238" alt="image" src="https://github.com/user-attachments/assets/1e771c57-e384-40a0-81f3-b0afd43986e5" />

