### PR TITLE
Eventstudio: Move fixtures to make them available in Pro

### DIFF
--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -2604,7 +2604,7 @@ def sqs_as_events_target(aws_client, sqs_get_queue_arn):
         sqs_client.set_queue_attributes(
             QueueUrl=queue_url, Attributes={"Policy": json.dumps(policy)}
         )
-        return queue_url, queue_arn
+        return queue_url, queue_arn, queue_name
 
     yield _sqs_as_events_target
 

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -31,42 +31,6 @@ def events_create_default_or_custom_event_bus(events_create_event_bus, region_na
 
 
 @pytest.fixture
-def create_role_event_bus_source_to_bus_target(create_iam_role_with_policy):
-    def _create_role_event_bus_to_bus():
-        assume_role_policy_document_bus_source_to_bus_target = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": "events.amazonaws.com"},
-                    "Action": "sts:AssumeRole",
-                }
-            ],
-        }
-
-        policy_document_bus_source_to_bus_target = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Sid": "",
-                    "Effect": "Allow",
-                    "Action": "events:PutEvents",
-                    "Resource": "arn:aws:events:*:*:event-bus/*",
-                }
-            ],
-        }
-
-        role_arn_bus_source_to_bus_target = create_iam_role_with_policy(
-            RoleDefinition=assume_role_policy_document_bus_source_to_bus_target,
-            PolicyDefinition=policy_document_bus_source_to_bus_target,
-        )
-
-        return role_arn_bus_source_to_bus_target
-
-    yield _create_role_event_bus_to_bus
-
-
-@pytest.fixture
 def events_create_archive(aws_client, region_name, account_id):
     archives = []
 
@@ -348,47 +312,6 @@ def add_resource_policy_logs_events_access(aws_client):
 
     for policy_name in policies:
         aws_client.logs.delete_resource_policy(policyName=policy_name)
-
-
-@pytest.fixture
-def get_primary_secondary_client(
-    aws_client_factory,
-    secondary_aws_client_factory,
-    region_name,
-    secondary_region_name,
-    account_id,
-    secondary_account_id,
-):
-    def _get_primary_secondary_clients(cross_scenario: str):
-        secondary_region = secondary_region_name
-        secondary_account = secondary_account_id
-        if cross_scenario not in ["region", "account", "region_account"]:
-            raise ValueError(f"cross_scenario {cross_scenario} not supported")
-
-        primary_client = aws_client_factory(region_name=region_name)
-
-        if cross_scenario == "region":
-            secondary_account = account_id
-            secondary_client = aws_client_factory(region_name=secondary_region_name)
-
-        elif cross_scenario == "account":
-            secondary_region = region_name
-            secondary_client = secondary_aws_client_factory(region_name=region_name)
-
-        elif cross_scenario == "region_account":
-            secondary_client = secondary_aws_client_factory(region_name=secondary_region)
-
-        else:
-            raise ValueError(f"cross_scenario {cross_scenario} not supported")
-
-        return {
-            "primary_aws_client": primary_client,
-            "secondary_aws_client": secondary_client,
-            "secondary_region_name": secondary_region,
-            "secondary_account_id": secondary_account,
-        }
-
-    return _get_primary_secondary_clients
 
 
 @pytest.fixture

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -203,7 +203,7 @@ def put_events_with_filter_to_sqs(
             event_bus_name = f"test-bus-{short_uid()}"
             events_create_event_bus(Name=event_bus_name)
 
-        queue_url, queue_arn = sqs_as_events_target()
+        queue_url, queue_arn, _ = sqs_as_events_target()
 
         events_put_rule(
             Name=rule_name,

--- a/tests/aws/services/events/test_archive_and_replay.py
+++ b/tests/aws/services/events/test_archive_and_replay.py
@@ -393,7 +393,7 @@ class TestReplay:
         rule_arn = response["RuleArn"]
 
         # setup sqs target
-        queue_url, queue_arn = sqs_as_events_target()
+        queue_url, queue_arn, _ = sqs_as_events_target()
         target_id = f"target-{short_uid()}"
         aws_client.events.put_targets(
             Rule=rule_name,

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -293,8 +293,8 @@ class TestEvents:
     ):
         """Test that put_events response contains each EventId only once, even with multiple targets."""
 
-        queue_url_1, queue_arn_1 = sqs_as_events_target()
-        queue_url_2, queue_arn_2 = sqs_as_events_target()
+        queue_url_1, queue_arn_1, _ = sqs_as_events_target()
+        queue_url_2, queue_arn_2, _ = sqs_as_events_target()
 
         rule_name = f"test-rule-{short_uid()}"
 
@@ -454,7 +454,7 @@ class TestEvents:
     ):
         """Test that EventBridge correctly handles datetime serialization in events."""
         rule_name = f"test-rule-{short_uid()}"
-        queue_url, queue_arn = sqs_as_events_target()
+        queue_url, queue_arn, _ = sqs_as_events_target()
 
         snapshot.add_transformers_list(
             [
@@ -954,7 +954,7 @@ class TestEventBus:
         )
 
         # Create sqs target
-        queue_url, queue_arn = sqs_as_events_target()
+        queue_url, queue_arn, _ = sqs_as_events_target()
 
         # Rule and target bus 2 to sqs
         rule_name_bus_two = f"rule-{short_uid()}"

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -36,7 +36,7 @@ INPUT_TEMPLATE_PREDEFINED_VARIABLES_JSON = '{"originalEvent": <aws.events.event>
 def test_put_event_input_path_and_input_transformer(
     sqs_as_events_target, events_create_event_bus, events_put_rule, aws_client, snapshot
 ):
-    _, queue_arn = sqs_as_events_target()
+    _, queue_arn, _ = sqs_as_events_target()
     bus_name = f"test-bus-{short_uid()}"
     events_create_event_bus(Name=bus_name)
 
@@ -355,7 +355,7 @@ class TestInputTransformer:
         aws_client_factory,
         snapshot,
     ):
-        _, queue_arn = sqs_as_events_target()
+        _, queue_arn, _ = sqs_as_events_target()
 
         bus_name = f"test-bus-{short_uid()}"
         events_create_event_bus(Name=bus_name)

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -164,8 +164,8 @@ class TestInputPath:
         snapshot,
     ):
         # prepare target queues
-        queue_url_1, queue_arn_1 = sqs_as_events_target()
-        queue_url_2, queue_arn_2 = sqs_as_events_target()
+        queue_url_1, queue_arn_1, _ = sqs_as_events_target()
+        queue_url_2, queue_arn_2, _ = sqs_as_events_target()
 
         bus_name = f"test-bus-{short_uid()}"
         events_create_event_bus(Name=bus_name)
@@ -424,7 +424,7 @@ class TestInputTransformer:
         # https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-transform-target-input.html#eb-transform-input-predefined
 
         # prepare target queues
-        queue_url, queue_arn = sqs_as_events_target()
+        queue_url, queue_arn, _ = sqs_as_events_target()
 
         bus_name = f"test-bus-{short_uid()}"
         events_create_event_bus(Name=bus_name)

--- a/tests/aws/services/events/test_events_patterns.py
+++ b/tests/aws/services/events/test_events_patterns.py
@@ -446,7 +446,7 @@ class TestRuleWithPattern:
         snapshot,
         aws_client,
     ):
-        queue_url, queue_arn = sqs_as_events_target()
+        queue_url, queue_arn, _ = sqs_as_events_target()
 
         # Create event bus
         event_bus_name = f"event-bus-{short_uid()}"

--- a/tests/aws/services/events/test_events_schedule.py
+++ b/tests/aws/services/events/test_events_schedule.py
@@ -148,7 +148,7 @@ class TestScheduleRate:
     def tests_schedule_rate_custom_input_target_sqs(
         self, sqs_as_events_target, events_put_rule, aws_client, snapshot
     ):
-        queue_url, queue_arn = sqs_as_events_target()
+        queue_url, queue_arn, _ = sqs_as_events_target()
 
         bus_name = "default"
         rule_name = f"test-rule-{short_uid()}"
@@ -343,7 +343,7 @@ class TestScheduleCron:
         aws_client,
         snapshot,
     ):
-        queue_url, queue_arn = sqs_as_events_target()
+        queue_url, queue_arn, _ = sqs_as_events_target()
 
         schedule_cron, target_datetime = get_cron_expression(
             1
@@ -391,7 +391,7 @@ class TestScheduleCron:
     def tests_scheduled_rule_does_not_trigger_on_put_events(
         self, sqs_as_events_target, events_put_rule, aws_client
     ):
-        queue_url, queue_arn = sqs_as_events_target()
+        queue_url, queue_arn, _ = sqs_as_events_target()
 
         bus_name = "default"
         rule_name = f"test-rule-{short_uid()}"

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -639,7 +639,7 @@ class TestEventsTargetEvents:
             EventPattern=json.dumps(TEST_EVENT_PATTERN),
         )
 
-        queue_url, queue_arn = sqs_as_events_target()
+        queue_url, queue_arn, _ = sqs_as_events_target()
         target_id = f"target-{short_uid()}"
         aws_client.events.put_targets(
             Rule=rule_name_target_to_sqs,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR moves several fixtures from eventbridge conftest to the globally defined fixtures to make them available in pro.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- move `create_role_event_bus_source_to_bus_target`
- move `get_primary_secondary_client`
- allow for custom aws client for `sqs_as_events_target` required if sqs is in separate region / account
- return queue_name for `sqs_as_events_target`
