### PR TITLE
add java 24 support in java installer for trino

### DIFF
--- a/localstack-core/localstack/packages/java.py
+++ b/localstack-core/localstack/packages/java.py
@@ -116,25 +116,49 @@ class JavaPackageInstaller(ArchiveDownloadAndExtractInstaller):
 
         # Build a custom JRE with only the necessary bits to minimise disk footprint
         LOG.debug("Optimising JRE installation")
-        cmd = (
-            "bin/jlink --add-modules "
+
+        base_modules = [
             # Required modules
-            "java.base,java.desktop,java.instrument,java.management,"
-            "java.naming,java.scripting,java.sql,java.xml,jdk.compiler,"
-            # Required module for trino latest version
-            "jdk.incubator.vector,"
+            "java.base",
+            "java.desktop",
+            "java.instrument",
+            "java.management",
+            "java.naming",
+            "java.scripting",
+            "java.sql",
+            "java.xml",
+            "jdk.compiler",
             # jdk.unsupported contains sun.misc.Unsafe which is required by some dependencies
-            "jdk.unsupported,"
+            "jdk.unsupported",
             # Additional cipher suites
-            "jdk.crypto.cryptoki,"
+            "jdk.crypto.cryptoki",
             # Archive support
-            "jdk.zipfs,"
+            "jdk.zipfs",
             # Required by MQ broker
-            "jdk.httpserver,jdk.management,jdk.management.agent,"
+            "jdk.httpserver",
+            "jdk.management",
+            "jdk.management.agent",
             # Required by Spark and Hadoop
-            "java.security.jgss,jdk.security.auth,"
+            "java.security.jgss",
+            "jdk.security.auth",
             # Include required locales
-            "jdk.localedata --include-locales en "
+            "jdk.localedata",
+        ]
+
+        # Add version-specific modules, not all versions require/support the same set
+        version_specific_modules = {
+            "24": ["jdk.incubator.vector"],  # Required for Trino latest version
+        }
+
+        modules = base_modules + version_specific_modules.get(self.version, [])
+        modules_str = ",".join(modules)
+
+        cmd = (
+            "bin/jlink "
+            # Add modules
+            f"--add-modules {modules_str} "
+            # Include required locales
+            "--include-locales en "
             # Supplementary args
             "--compress 2 --strip-debug --no-header-files --no-man-pages "
             # Output directory


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds support for Java version 24, which is required for upgrading Trino server from version 389 to 476. Additionally, this PR refactors the module installation commands to improve code maintainability and readability.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Addition of new java version `24`
- Refactored application for more readable module installation command generation
- Addition of `jdk.incubator.vector` java module for java 24 for trino

## Testing
- Existing tests are passing which signifies the existing Java installations are not affected.
- java 24 installer is used in Trino in `pro` which was tested locally.
