### PR TITLE
CFNv2: support resolve:ssm: and resolve:secretsmanager: strings

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/resolving.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/resolving.py
@@ -1,0 +1,100 @@
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from botocore.exceptions import ClientError
+
+from localstack.aws.connect import connect_to
+from localstack.utils import json
+
+LOG = logging.getLogger(__name__)
+
+REGEX_DYNAMIC_REF = re.compile(r"{{resolve:([^:]+):(.+)}}")
+
+
+@dataclass
+class DynamicReference:
+    service_name: str
+    reference_key: str
+
+
+def extract_dynamic_reference(value: Any) -> DynamicReference | None:
+    if isinstance(value, str):
+        if dynamic_ref_match := REGEX_DYNAMIC_REF.match(value):
+            return DynamicReference(dynamic_ref_match[1], dynamic_ref_match[2])
+    return None
+
+
+def perform_dynamic_reference_lookup(
+    reference: DynamicReference, account_id: str, region_name: str
+) -> str | None:
+    # basic dynamic reference support
+    # see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html
+    # technically there are more restrictions for each of these services but checking each of these
+    # isn't really necessary for the current level of emulation
+
+    # only these 3 services are supported for dynamic references right now
+    if reference.service_name == "ssm":
+        ssm_client = connect_to(aws_access_key_id=account_id, region_name=region_name).ssm
+        try:
+            return ssm_client.get_parameter(Name=reference.reference_key)["Parameter"]["Value"]
+        except ClientError as e:
+            LOG.error("client error accessing SSM parameter '%s': %s", reference.reference_key, e)
+            raise
+    elif reference.service_name == "ssm-secure":
+        ssm_client = connect_to(aws_access_key_id=account_id, region_name=region_name).ssm
+        try:
+            return ssm_client.get_parameter(Name=reference.reference_key, WithDecryption=True)[
+                "Parameter"
+            ]["Value"]
+        except ClientError as e:
+            LOG.error("client error accessing SSM parameter '%s': %s", reference.reference_key, e)
+            raise
+    elif reference.service_name == "secretsmanager":
+        # reference key needs to be parsed further
+        # because {{resolve:secretsmanager:secret-id:secret-string:json-key:version-stage:version-id}}
+        # we match for "secret-id:secret-string:json-key:version-stage:version-id"
+        # where
+        #   secret-id can either be the secret name or the full ARN of the secret
+        #   secret-string *must* be SecretString
+        #   all other values are optional
+        secret_id = reference.reference_key
+        [json_key, version_stage, version_id] = [None, None, None]
+        if "SecretString" in reference.reference_key:
+            parts = reference.reference_key.split(":SecretString:")
+            secret_id = parts[0]
+            # json-key, version-stage and version-id are optional.
+            [json_key, version_stage, version_id] = f"{parts[1]}::".split(":")[:3]
+
+        kwargs = {}  # optional args for get_secret_value
+        if version_id:
+            kwargs["VersionId"] = version_id
+        if version_stage:
+            kwargs["VersionStage"] = version_stage
+
+        secretsmanager_client = connect_to(
+            aws_access_key_id=account_id, region_name=region_name
+        ).secretsmanager
+        try:
+            secret_value = secretsmanager_client.get_secret_value(SecretId=secret_id, **kwargs)[
+                "SecretString"
+            ]
+        except ClientError:
+            LOG.error("client error while trying to access key '%s': %s", secret_id)
+            raise
+
+        if json_key:
+            json_secret = json.loads(secret_value)
+            if json_key not in json_secret:
+                raise RuntimeError(
+                    f"JSON value for {reference.service_name}.{reference.reference_key} not present"
+                )
+            return json_secret[json_key]
+        else:
+            return secret_value
+
+    LOG.warning(
+        "Unsupported service for dynamic parameter: service_name=%s", reference.service_name
+    )
+    return None

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -304,8 +304,8 @@ class TestImports:
         assert stack2.outputs["MessageQueueArn2"] == queue_arn2
 
 
-@skip_if_v2_provider(reason="CFNV2:Resolve")
 class TestSsmParameters:
+    @skip_if_v2_provider(reason="CFNV2:Resolve")
     @markers.aws.validated
     def test_create_stack_with_ssm_parameters(
         self, create_parameter, deploy_cfn_template, snapshot, aws_client
@@ -354,6 +354,7 @@ class TestSsmParameters:
         topic_name = result.outputs["TopicName"]
         assert topic_name == parameter_value
 
+    @skip_if_v2_provider(reason="CFNV2:Resolve")
     @markers.aws.validated
     def test_resolve_ssm_with_version(self, create_parameter, deploy_cfn_template, aws_client):
         parameter_key = f"param-key-{short_uid()}"
@@ -380,6 +381,7 @@ class TestSsmParameters:
         topic_name = result.outputs["TopicName"]
         assert topic_name == parameter_value_v1
 
+    @skip_if_v2_provider(reason="CFNV2:Resolve")
     @markers.aws.needs_fixing
     def test_resolve_ssm_secure(self, create_parameter, deploy_cfn_template):
         parameter_key = f"param-key-{short_uid()}"
@@ -397,6 +399,7 @@ class TestSsmParameters:
         topic_name = result.outputs["TopicName"]
         assert topic_name == parameter_value
 
+    @skip_if_v2_provider(reason="CFNV2:Resolve")
     @markers.aws.validated
     def test_ssm_nested_with_nested_stack(self, s3_create_bucket, deploy_cfn_template, aws_client):
         """
@@ -432,6 +435,7 @@ class TestSsmParameters:
 
         assert ssm_parameter == key_value
 
+    @skip_if_v2_provider(reason="CFNV2:Resolve")
     @markers.aws.validated
     def test_create_change_set_with_ssm_parameter_list(
         self, deploy_cfn_template, aws_client, region_name, account_id, snapshot

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -354,7 +354,6 @@ class TestSsmParameters:
         topic_name = result.outputs["TopicName"]
         assert topic_name == parameter_value
 
-    @skip_if_v2_provider(reason="CFNV2:Resolve")
     @markers.aws.validated
     def test_resolve_ssm_with_version(self, create_parameter, deploy_cfn_template, aws_client):
         parameter_key = f"param-key-{short_uid()}"
@@ -468,7 +467,6 @@ class TestSsmParameters:
 
 
 class TestSecretsManagerParameters:
-    @skip_if_v2_provider(reason="CFNV2:Resolve")
     @pytest.mark.parametrize(
         "template_name",
         [


### PR DESCRIPTION
# Motivation

The V2 engine does not currently support resolving dynamic parameter values, e.g.

```
{{resolve:secretsmanager:secret-id:secret-string:json-key:version-stage:version-id}}
```

# Changes

* Duplicate the existing resolving functionality into its own module
* Replace/resolve dynamic references when visiting node properties in the preprocessor
* Unskip ssm and secretsmanager resolving tests in template engine tests
