### PR TITLE
Re-enabling ruff rule E721

### DIFF
--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -89,8 +89,8 @@ def make_hash(o):
     return hash(frozenset(sorted(new_o.items())))
 
 
-def config_equality_patch(self, other: object):
-    return type(self) == type(other) and self._user_provided_options == other._user_provided_options
+def config_equality_patch(self, other: object) -> bool:
+    return type(self) is type(other) and self._user_provided_options == other._user_provided_options
 
 
 def config_hash_patch(self):

--- a/localstack-core/localstack/aws/skeleton.py
+++ b/localstack-core/localstack/aws/skeleton.py
@@ -53,7 +53,7 @@ def create_dispatch_table(delegate: object) -> DispatchTable:
     handlers: dict[str, HandlerAttributes] = {}
     cls_tree = reversed(list(cls_tree))
     for cls in cls_tree:
-        if cls == object:
+        if cls is object:
             continue
 
         for name, fn in inspect.getmembers(cls, inspect.isfunction):

--- a/localstack-core/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack-core/localstack/services/cloudformation/deployment_utils.py
@@ -224,7 +224,7 @@ def fix_boto_parameters_based_on_report(original_params: dict, report: str) -> d
         cast_class = getattr(builtins, valid_class)
         old_value = get_nested(params, param_name)
 
-        if cast_class == bool and str(old_value).lower() in ["true", "false"]:
+        if isinstance(cast_class, bool) and str(old_value).lower() in ["true", "false"]:
             new_value = str(old_value).lower() == "true"
         else:
             new_value = cast_class(old_value)
@@ -252,15 +252,17 @@ def convert_data_types(type_conversions: dict[str, Callable], params: dict) -> d
     attr_names = type_conversions.keys() or []
 
     def cast(_obj, _type):
-        if _type == bool:
-            return _obj in ["True", "true", True]
-        if _type == str:
-            if isinstance(_obj, bool):
-                return str(_obj).lower()
-            return str(_obj)
-        if _type in (int, float):
-            return _type(_obj)
-        return _obj
+        match _type:
+            case builtins.bool:
+                return _obj in ["True", "true", True]
+            case builtins.str:
+                if isinstance(_obj, bool):
+                    return str(_obj).lower()
+                return str(_obj)
+            case builtins.int | builtins.float:
+                return _type(_obj)
+            case _:
+                return _obj
 
     def fix_types(o, **kwargs):
         if isinstance(o, dict):

--- a/localstack-core/localstack/services/cloudformation/provider_utils.py
+++ b/localstack-core/localstack/services/cloudformation/provider_utils.py
@@ -152,7 +152,7 @@ def fix_boto_parameters_based_on_report(original_params: dict, report: str) -> d
         cast_class = getattr(builtins, valid_class)
         old_value = get_nested(params, param_name)
 
-        if cast_class == bool and str(old_value).lower() in ["true", "false"]:
+        if isinstance(cast_class, bool) and str(old_value).lower() in ["true", "false"]:
             new_value = str(old_value).lower() == "true"
         else:
             new_value = cast_class(old_value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,6 @@ ignore = [
     "C901", # TODO function is too complex
     "E402", # TODO Module level import not at top of file
     "E501", # E501 Line too long - handled by black, see https://docs.astral.sh/ruff/faq/#is-ruff-compatible-with-black
-    "E721", # TODO Do not compare types, use `isinstance()`
     "T201", # TODO `print` found
     "T203", # TODO `pprint` found
     "UP008",# TODO Use `super()` instead of `super(__class__, self)`

--- a/tests/integration/services/test_internal.py
+++ b/tests/integration/services/test_internal.py
@@ -60,4 +60,4 @@ class TestInfoEndpoint:
         assert doc["session_id"]
         assert doc["machine_id"]
         assert doc["system"]
-        assert type(doc["is_license_activated"]) == bool
+        assert isinstance(doc["is_license_activated"], bool)

--- a/tests/unit/aws/test_skeleton.py
+++ b/tests/unit/aws/test_skeleton.py
@@ -330,7 +330,7 @@ class TestServiceRequestDispatcher:
             ArgTwo: int
 
         def fn(context, arg_one, arg_two):
-            assert type(context) == RequestContext
+            assert isinstance(context, RequestContext)
             assert arg_one == "foo"
             assert arg_two == 69
 
@@ -340,7 +340,7 @@ class TestServiceRequestDispatcher:
     def test_without_context_without_expand(self):
         def fn(*args):
             assert len(args) == 1
-            assert type(args[0]) == dict
+            assert isinstance(args[0], dict)
 
         dispatcher = ServiceRequestDispatcher(
             fn, "SomeAction", pass_context=False, expand_parameters=False
@@ -350,8 +350,8 @@ class TestServiceRequestDispatcher:
     def test_without_expand(self):
         def fn(*args):
             assert len(args) == 2
-            assert type(args[0]) == RequestContext
-            assert type(args[1]) == dict
+            assert isinstance(args[0], RequestContext)
+            assert isinstance(args[1], dict)
 
         dispatcher = ServiceRequestDispatcher(
             fn, "SomeAction", pass_context=True, expand_parameters=False
@@ -360,7 +360,7 @@ class TestServiceRequestDispatcher:
 
     def test_dispatch_without_args(self):
         def fn(context):
-            assert type(context) == RequestContext
+            assert isinstance(context, RequestContext)
 
         dispatcher = ServiceRequestDispatcher(fn, "SomeAction")
         dispatcher(RequestContext(None), ServiceRequest())

--- a/tests/unit/services/cloudformation/test_deployment_utils.py
+++ b/tests/unit/services/cloudformation/test_deployment_utils.py
@@ -12,7 +12,7 @@ class TestFixBotoParametersBasedOnReport:
         fixed_params = fix_boto_parameters_based_on_report(params, message)
         value = fixed_params["LaunchTemplate"]["Version"]
         assert value == "1"
-        assert type(value) == str
+        assert isinstance(value, str)
 
     def test_top_level_parameters_are_converted(self):
         params = {"Version": 1}
@@ -21,4 +21,4 @@ class TestFixBotoParametersBasedOnReport:
         fixed_params = fix_boto_parameters_based_on_report(params, message)
         value = fixed_params["Version"]
         assert value == "1"
-        assert type(value) == str
+        assert isinstance(value, str)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following up on our efforts for a better linting (e.g., #12953 and [#5018](https://github.com/localstack/localstack-pro/pull/5018)), this PR re-enables the rule E721 and adjusts the code to be compliant.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
<!-- ## Changes -->

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
