### PR TITLE
CFNV2: remove/rescope CFNV2:Validation errors

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_executor.py
@@ -441,7 +441,7 @@ class ChangeSetModelExecutor(ChangeSetModelPreproc):
                 LOG.warning(
                     "Resource provider operation failed: '%s'",
                     reason,
-                    exc_info=LOG.isEnabledFor(logging.DEBUG),
+                    exc_info=LOG.isEnabledFor(logging.DEBUG) and config.CFN_VERBOSE_ERRORS,
                 )
                 event = ProgressEvent(
                     OperationStatus.FAILED,

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -381,7 +381,7 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             error_key = "::".join([map_name, top_level_key, second_level_key])
             raise ValidationError(f"Template error: Unable to get mapping for {error_key}")
         second_level_value = top_level_value.bindings.get(second_level_key)
-        if not isinstance(second_level_value, NodeObject):
+        if not isinstance(second_level_value, TerminalValue):
             error_key = "::".join([map_name, top_level_key, second_level_key])
             raise ValidationError(f"Template error: Unable to get mapping for {error_key}")
         mapping_value_delta = self.visit(second_level_value)

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -226,7 +226,9 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             if node_resource.name == resource_name:
                 self.visit(node_resource)
                 return node_resource
-        raise RuntimeError(f"No resource '{resource_name}' was found")
+        raise ValidationError(
+            f"Template format error: Unresolved resource dependencies [{resource_name}] in the Resources block of the template"
+        )
 
     def _get_node_property_for(
         self, property_name: str, node_resource: NodeResource

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -378,6 +378,9 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             error_key = "::".join([map_name, top_level_key, second_level_key])
             raise ValidationError(f"Template error: Unable to get mapping for {error_key}")
         second_level_value = top_level_value.bindings.get(second_level_key)
+        if not isinstance(second_level_value, NodeObject):
+            error_key = "::".join([map_name, top_level_key, second_level_key])
+            raise ValidationError(f"Template error: Unable to get mapping for {error_key}")
         mapping_value_delta = self.visit(second_level_value)
         return mapping_value_delta
 

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -76,6 +76,8 @@ TAfter = TypeVar("TAfter")
 
 MOCKED_REFERENCE = "unknown"
 
+VALID_LOGICAL_RESOURCE_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
+
 
 class PreprocEntityDelta(Generic[TBefore, TAfter]):
     before: Maybe[TBefore]
@@ -1055,6 +1057,10 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
     def visit_node_resource(
         self, node_resource: NodeResource
     ) -> PreprocEntityDelta[PreprocResource, PreprocResource]:
+        if not VALID_LOGICAL_RESOURCE_ID_RE.match(node_resource.name):
+            raise ValidationError(
+                f"Template format error: Resource name {node_resource.name} is non alphanumeric."
+            )
         change_type = node_resource.change_type
         condition_before = Nothing
         condition_after = Nothing

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -47,6 +47,7 @@ from localstack.services.cloudformation.engine.v2.resolving import (
     extract_dynamic_reference,
     perform_dynamic_reference_lookup,
 )
+from localstack.services.cloudformation.engine.validations import ValidationError
 from localstack.services.cloudformation.stores import (
     exports_map,
 )
@@ -372,7 +373,8 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
         node_mapping: NodeMapping = self._get_node_mapping(map_name=map_name)
         top_level_value = node_mapping.bindings.bindings.get(top_level_key)
         if not isinstance(top_level_value, NodeObject):
-            raise RuntimeError()
+            error_key = "::".join([map_name, top_level_key, second_level_key])
+            raise ValidationError(f"Template error: Unable to get mapping for {error_key}")
         second_level_value = top_level_value.bindings.get(second_level_key)
         mapping_value_delta = self.visit(second_level_value)
         return mapping_value_delta

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -243,7 +243,8 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
     def _deployed_property_value_of(
         self, resource_logical_id: str, property_name: str, resolved_resources: dict
     ) -> Any:
-        # TODO: typing around resolved resources is needed and should be reflected here.
+        # We have to override this function to make sure it does not try to access the
+        # resolved resource
 
         # Before we can obtain deployed value for a resource, we need to first ensure to
         # process the resource if this wasn't processed already. Ideally, values should only

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_validator.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_validator.py
@@ -1,3 +1,6 @@
+import re
+from typing import Any
+
 from localstack.services.cloudformation.engine.v2.change_set_model import (
     Maybe,
     NodeIntrinsicFunction,
@@ -6,8 +9,10 @@ from localstack.services.cloudformation.engine.v2.change_set_model import (
     is_nothing,
 )
 from localstack.services.cloudformation.engine.v2.change_set_model_preproc import (
+    _PSEUDO_PARAMETERS,
     ChangeSetModelPreproc,
     PreprocEntityDelta,
+    PreprocResource,
 )
 
 
@@ -34,4 +39,103 @@ class ChangeSetModelValidator(ChangeSetModelPreproc):
         if is_nothing(after) and not is_nothing(after_arguments):
             after = ".".join(after_arguments)
 
+        return PreprocEntityDelta(before=before, after=after)
+
+    def visit_node_intrinsic_function_fn_sub(
+        self, node_intrinsic_function: NodeIntrinsicFunction
+    ) -> PreprocEntityDelta:
+        def _compute_sub(args: str | list[Any], select_before: bool) -> str:
+            # TODO: add further schema validation.
+            string_template: str
+            sub_parameters: dict
+            if isinstance(args, str):
+                string_template = args
+                sub_parameters = dict()
+            elif (
+                isinstance(args, list)
+                and len(args) == 2
+                and isinstance(args[0], str)
+                and isinstance(args[1], dict)
+            ):
+                string_template = args[0]
+                sub_parameters = args[1]
+            else:
+                raise RuntimeError(
+                    "Invalid arguments shape for Fn::Sub, expected a String "
+                    f"or a Tuple of String and Map but got '{args}'"
+                )
+            sub_string = string_template
+            template_variable_names = re.findall("\\${([^}]+)}", string_template)
+            for template_variable_name in template_variable_names:
+                template_variable_value = Nothing
+
+                # Try to resolve the variable name as pseudo parameter.
+                if template_variable_name in _PSEUDO_PARAMETERS:
+                    template_variable_value = self._resolve_pseudo_parameter(
+                        pseudo_parameter_name=template_variable_name
+                    )
+
+                # Try to resolve the variable name as an entry to the defined parameters.
+                elif template_variable_name in sub_parameters:
+                    template_variable_value = sub_parameters[template_variable_name]
+
+                # Try to resolve the variable name as GetAtt.
+                elif "." in template_variable_name:
+                    try:
+                        template_variable_value = self._resolve_attribute(
+                            arguments=template_variable_name, select_before=select_before
+                        )
+                    except RuntimeError:
+                        pass
+
+                # Try to resolve the variable name as Ref.
+                else:
+                    try:
+                        resource_delta = self._resolve_reference(logical_id=template_variable_name)
+                        template_variable_value = (
+                            resource_delta.before if select_before else resource_delta.after
+                        )
+                        if isinstance(template_variable_value, PreprocResource):
+                            template_variable_value = template_variable_value.physical_resource_id
+                    except RuntimeError:
+                        pass
+
+                if is_nothing(template_variable_value):
+                    # override the base method just for this line to prevent accessing the
+                    # resource properties since we are not deploying any resources
+                    template_variable_value = ""
+
+                if not isinstance(template_variable_value, str):
+                    template_variable_value = str(template_variable_value)
+
+                sub_string = sub_string.replace(
+                    f"${{{template_variable_name}}}", template_variable_value
+                )
+
+            # FIXME: the following type reduction is ported from v1; however it appears as though such
+            #        reduction is not performed by the engine, and certainly not at this depth given the
+            #        lack of context. This section should be removed with Fn::Sub always retuning a string
+            #        and the resource providers reviewed.
+            account_id = self._change_set.account_id
+            is_another_account_id = sub_string.isdigit() and len(sub_string) == len(account_id)
+            if sub_string == account_id or is_another_account_id:
+                result = sub_string
+            elif sub_string.isdigit():
+                result = int(sub_string)
+            else:
+                try:
+                    result = float(sub_string)
+                except ValueError:
+                    result = sub_string
+            return result
+
+        arguments_delta = self.visit(node_intrinsic_function.arguments)
+        arguments_before = arguments_delta.before
+        arguments_after = arguments_delta.after
+        before = self._before_cache.get(node_intrinsic_function.scope, Nothing)
+        if is_nothing(before) and not is_nothing(arguments_before):
+            before = _compute_sub(args=arguments_before, select_before=True)
+        after = self._after_cache.get(node_intrinsic_function.scope, Nothing)
+        if is_nothing(after) and not is_nothing(arguments_after):
+            after = _compute_sub(args=arguments_after, select_before=False)
         return PreprocEntityDelta(before=before, after=after)

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_validator.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_validator.py
@@ -1,42 +1,30 @@
-import re
-
 from localstack.services.cloudformation.engine.v2.change_set_model import (
     NodeParameters,
-    NodeResource,
     NodeTemplate,
     is_nothing,
 )
 from localstack.services.cloudformation.engine.v2.change_set_model_preproc import (
+    ChangeSetModelPreproc,
     PreprocEntityDelta,
 )
-from localstack.services.cloudformation.engine.v2.change_set_model_visitor import (
-    ChangeSetModelVisitor,
-)
 from localstack.services.cloudformation.engine.validations import ValidationError
-from localstack.services.cloudformation.v2.entities import ChangeSet
-
-VALID_LOGICAL_RESOURCE_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
 
 
-class ChangeSetModelValidator(ChangeSetModelVisitor):
-    def __init__(self, change_set: ChangeSet):
-        self._change_set = change_set
-
+class ChangeSetModelValidator(ChangeSetModelPreproc):
     def validate(self):
-        self.visit(self._change_set.update_model.node_template)
+        self.process()
 
     def visit_node_template(self, node_template: NodeTemplate):
         self.visit(node_template.parameters)
+        self.visit(node_template.mappings)
         self.visit(node_template.resources)
 
     def visit_node_parameters(self, node_parameters: NodeParameters) -> PreprocEntityDelta:
         # check that all parameters have values
         invalid_parameters = []
         for node_parameter in node_parameters.parameters:
-            self.visit(node_parameter)
-            if is_nothing(node_parameter.default_value.value) and is_nothing(
-                node_parameter.dynamic_value.value
-            ):
+            parameter_value = self.visit(node_parameter)
+            if is_nothing(parameter_value.before) and is_nothing(parameter_value.after):
                 invalid_parameters.append(node_parameter.name)
 
         if invalid_parameters:
@@ -44,10 +32,3 @@ class ChangeSetModelValidator(ChangeSetModelVisitor):
 
         # continue visiting
         return super().visit_node_parameters(node_parameters)
-
-    def visit_node_resource(self, node_resource: NodeResource) -> PreprocEntityDelta:
-        if not VALID_LOGICAL_RESOURCE_ID_RE.match(node_resource.name):
-            raise ValidationError(
-                f"Template format error: Resource name {node_resource.name} is non alphanumeric."
-            )
-        return super().visit_node_resource(node_resource)

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -236,7 +236,7 @@ def get_resource_type(resource: dict) -> str:
         LOG.warning(
             "Failed to retrieve resource type %s",
             resource.get("Type"),
-            exc_info=LOG.isEnabledFor(logging.DEBUG),
+            exc_info=LOG.isEnabledFor(logging.DEBUG) and config.CFN_VERBOSE_ERRORS,
         )
 
 
@@ -577,7 +577,7 @@ class ResourceProviderExecutor:
                 LOG.warning(
                     "Failed to load PRO resource type %s as a ResourceProvider.",
                     resource_type,
-                    exc_info=LOG.isEnabledFor(logging.DEBUG),
+                    exc_info=LOG.isEnabledFor(logging.DEBUG) and config.CFN_VERBOSE_ERRORS,
                 )
 
         # 2. try to load community resource provider
@@ -592,7 +592,7 @@ class ResourceProviderExecutor:
                 LOG.warning(
                     "Failed to load community resource type %s as a ResourceProvider.",
                     resource_type,
-                    exc_info=LOG.isEnabledFor(logging.DEBUG),
+                    exc_info=LOG.isEnabledFor(logging.DEBUG) and config.CFN_VERBOSE_ERRORS,
                 )
 
         # we could not find the resource provider

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -215,6 +215,7 @@ class CloudformationProviderV2(CloudformationProvider):
     ) -> dict[str, EngineParameter]:
         template_parameters = template.get("Parameters", {})
         resolved_parameters = {}
+        invalid_parameters = []
         for name, parameter in template_parameters.items():
             given_value = parameters.get(name)
             default_value = parameter.get("Default")
@@ -233,9 +234,13 @@ class CloudformationProviderV2(CloudformationProvider):
                         f"Parameter {name} should either have input value or default value"
                     )
             elif given_value is None and default_value is None:
-                raise ValidationError(f"Parameters: [{name}] must have values")
+                invalid_parameters.append(name)
+                continue
 
             resolved_parameters[name] = resolved_parameter
+
+        if invalid_parameters:
+            raise ValidationError(f"Parameters: [{','.join(invalid_parameters)}] must have values")
 
         for name, parameter in resolved_parameters.items():
             if (

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -78,6 +78,7 @@ from localstack.aws.api.cloudformation import (
     Stack as ApiStack,
 )
 from localstack.aws.connect import connect_to
+from localstack.config import CFN_VERBOSE_ERRORS
 from localstack.services.cloudformation import api_utils
 from localstack.services.cloudformation.engine import template_preparer
 from localstack.services.cloudformation.engine.parameters import resolve_ssm_parameter
@@ -533,7 +534,9 @@ class CloudformationProviderV2(CloudformationProvider):
                 change_set.stack.template_body = change_set.template_body
             except Exception as e:
                 LOG.error(
-                    "Execute change set failed: %s", e, exc_info=LOG.isEnabledFor(logging.WARNING)
+                    "Execute change set failed: %s",
+                    e,
+                    exc_info=LOG.isEnabledFor(logging.DEBUG) and CFN_VERBOSE_ERRORS,
                 )
                 new_stack_status = StackStatus.UPDATE_FAILED
                 if change_set.change_set_type == ChangeSetType.CREATE:

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from datetime import UTC, datetime
 from typing import Any
 
+from localstack import config
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.cloudformation import (
     AlreadyExistsException,
@@ -78,7 +79,6 @@ from localstack.aws.api.cloudformation import (
     Stack as ApiStack,
 )
 from localstack.aws.connect import connect_to
-from localstack.config import CFN_VERBOSE_ERRORS
 from localstack.services.cloudformation import api_utils
 from localstack.services.cloudformation.engine import template_preparer
 from localstack.services.cloudformation.engine.parameters import resolve_ssm_parameter
@@ -536,7 +536,7 @@ class CloudformationProviderV2(CloudformationProvider):
                 LOG.error(
                     "Execute change set failed: %s",
                     e,
-                    exc_info=LOG.isEnabledFor(logging.DEBUG) and CFN_VERBOSE_ERRORS,
+                    exc_info=LOG.isEnabledFor(logging.DEBUG) and config.CFN_VERBOSE_ERRORS,
                 )
                 new_stack_status = StackStatus.UPDATE_FAILED
                 if change_set.change_set_type == ChangeSetType.CREATE:
@@ -741,7 +741,9 @@ class CloudformationProviderV2(CloudformationProvider):
                 stack.resolved_parameters = change_set.resolved_parameters
             except Exception as e:
                 LOG.error(
-                    "Create Stack set failed: %s", e, exc_info=LOG.isEnabledFor(logging.WARNING)
+                    "Create Stack set failed: %s",
+                    e,
+                    exc_info=LOG.isEnabledFor(logging.WARNING) and config.CFN_VERBOSE_ERRORS,
                 )
                 stack.set_stack_status(StackStatus.CREATE_FAILED)
 
@@ -1371,7 +1373,11 @@ class CloudformationProviderV2(CloudformationProvider):
                 stack.template_body = change_set.template_body
                 stack.resolved_parameters = change_set.resolved_parameters
             except Exception as e:
-                LOG.error("Update Stack failed: %s", e, exc_info=LOG.isEnabledFor(logging.WARNING))
+                LOG.error(
+                    "Update Stack failed: %s",
+                    e,
+                    exc_info=LOG.isEnabledFor(logging.WARNING) and config.CFN_VERBOSE_ERRORS,
+                )
                 stack.set_stack_status(StackStatus.UPDATE_FAILED)
 
         start_worker_thread(_run)
@@ -1434,7 +1440,7 @@ class CloudformationProviderV2(CloudformationProvider):
                     "Failed to delete stack '%s': %s",
                     stack.stack_name,
                     e,
-                    exc_info=LOG.isEnabledFor(logging.DEBUG),
+                    exc_info=LOG.isEnabledFor(logging.DEBUG) and config.CFN_VERBOSE_ERRORS,
                 )
                 stack.set_stack_status(StackStatus.DELETE_FAILED)
 

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -219,7 +219,6 @@ class TestStacksApi:
         resources = aws_client.cloudformation.describe_stack_resources(StackName=stack_name)
         snapshot.match("stack_resources", resources)
 
-    @skip_if_v2_provider(reason="CFNV2:Validation")
     @markers.aws.validated
     def test_update_stack_with_same_template_withoutchange(
         self, deploy_cfn_template, aws_client, snapshot
@@ -239,7 +238,7 @@ class TestStacksApi:
 
         snapshot.match("no_change_exception", ctx.value.response)
 
-    @skip_if_v2_provider(reason="CFNV2:Validation")
+    @skip_if_v2_provider(reason="CFNV2:Transform")
     @markers.aws.validated
     def test_update_stack_with_same_template_withoutchange_transformation(
         self, deploy_cfn_template, aws_client

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -702,9 +702,9 @@ Resources:
 """
 
 
-@skip_if_v2_provider(reason="CFNV2:Validation")
 @markers.snapshot.skip_snapshot_verify(
     paths=["$..EnableTerminationProtection", "$..LastUpdatedTime"]
+    + skipped_v2_items("$..Capabilities")
 )
 @markers.aws.validated
 def test_name_conflicts(aws_client, snapshot, cleanups):

--- a/tests/aws/services/cloudformation/engine/test_mappings.py
+++ b/tests/aws/services/cloudformation/engine/test_mappings.py
@@ -70,7 +70,7 @@ class TestCloudFormationMappings:
             )
         snapshot.match("mapping_nonexisting_key_exc", e.value.response)
 
-    @skip_if_v2_provider(reason="CFNV2:Validation")
+    @skip_if_v2_provider(reason="CFNV2:Validation replaced with v2 test below")
     @markers.aws.only_localstack
     def test_async_mapping_error_first_level(self, deploy_cfn_template):
         """
@@ -119,7 +119,7 @@ class TestCloudFormationMappings:
 
         snapshot.match("error", exc_info.value)
 
-    @skip_if_v2_provider(reason="CFNV2:Validation")
+    @skip_if_v2_provider(reason="CFNV2:Validation replaced with v2 test below")
     @markers.aws.only_localstack
     def test_async_mapping_error_second_level(self, deploy_cfn_template):
         """

--- a/tests/aws/services/cloudformation/engine/test_mappings.py
+++ b/tests/aws/services/cloudformation/engine/test_mappings.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from botocore.exceptions import ClientError
-from tests.aws.services.cloudformation.conftest import skip_if_v2_provider
+from tests.aws.services.cloudformation.conftest import skip_if_v1_provider, skip_if_v2_provider
 
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.fixtures import StackDeployError
@@ -94,6 +94,7 @@ class TestCloudFormationMappings:
         assert "Cannot find map key 'C' in mapping 'TopicSuffixMap'" in str(exc_info.value)
 
     @markers.aws.validated
+    @skip_if_v1_provider(reason="V1 provider is not in parity with AWS")
     def test_async_mapping_error_first_level_v2(self, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.cloudformation_api())
         topic_name = f"test-topic-{short_uid()}"
@@ -145,6 +146,7 @@ class TestCloudFormationMappings:
         )
 
     @markers.aws.validated
+    @skip_if_v1_provider(reason="V1 provider is not in parity with AWS")
     def test_async_mapping_error_second_level_v2(self, aws_client, snapshot):
         """
         Similar to the `test_async_mapping_error_first_level` test above, but

--- a/tests/aws/services/cloudformation/engine/test_mappings.snapshot.json
+++ b/tests/aws/services/cloudformation/engine/test_mappings.snapshot.json
@@ -62,5 +62,11 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_async_mapping_error_first_level_v2": {
+    "recorded-date": "07-08-2025, 14:34:05",
+    "recorded-content": {
+      "error": "An error occurred (ValidationError) when calling the CreateChangeSet operation: Template error: Unable to get mapping for TopicSuffixMap::C::Suffix"
+    }
   }
 }

--- a/tests/aws/services/cloudformation/engine/test_mappings.snapshot.json
+++ b/tests/aws/services/cloudformation/engine/test_mappings.snapshot.json
@@ -68,5 +68,11 @@
     "recorded-content": {
       "error": "An error occurred (ValidationError) when calling the CreateChangeSet operation: Template error: Unable to get mapping for TopicSuffixMap::C::Suffix"
     }
+  },
+  "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_async_mapping_error_second_level_v2": {
+    "recorded-date": "07-08-2025, 15:05:47",
+    "recorded-content": {
+      "error": "An error occurred (ValidationError) when calling the CreateChangeSet operation: Template error: Unable to get mapping for TopicSuffixMap::A::NotValid"
+    }
   }
 }

--- a/tests/aws/services/cloudformation/engine/test_mappings.validation.json
+++ b/tests/aws/services/cloudformation/engine/test_mappings.validation.json
@@ -1,4 +1,13 @@
 {
+  "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_async_mapping_error_first_level_v2": {
+    "last_validated_date": "2025-08-07T14:34:05+00:00",
+    "durations_in_seconds": {
+      "setup": 0.87,
+      "call": 0.28,
+      "teardown": 0.0,
+      "total": 1.15
+    }
+  },
   "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_aws_refs_in_mappings": {
     "last_validated_date": "2024-10-15T17:22:43+00:00"
   },

--- a/tests/aws/services/cloudformation/engine/test_mappings.validation.json
+++ b/tests/aws/services/cloudformation/engine/test_mappings.validation.json
@@ -8,6 +8,15 @@
       "total": 1.15
     }
   },
+  "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_async_mapping_error_second_level_v2": {
+    "last_validated_date": "2025-08-07T15:05:47+00:00",
+    "durations_in_seconds": {
+      "setup": 1.01,
+      "call": 0.36,
+      "teardown": 0.0,
+      "total": 1.37
+    }
+  },
   "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_aws_refs_in_mappings": {
     "last_validated_date": "2024-10-15T17:22:43+00:00"
   },

--- a/tests/aws/services/cloudformation/engine/test_references.py
+++ b/tests/aws/services/cloudformation/engine/test_references.py
@@ -3,7 +3,6 @@ import os
 
 import pytest
 from botocore.exceptions import ClientError
-from tests.aws.services.cloudformation.conftest import skip_if_v2_provider
 
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
@@ -75,7 +74,6 @@ class TestFnSub:
         snapshot.match("get-parameter-result", get_param_res)
 
 
-@skip_if_v2_provider(reason="CFNV2:Validation")
 @markers.aws.validated
 def test_useful_error_when_invalid_ref(deploy_cfn_template, snapshot):
     """

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -862,7 +862,7 @@ class TestMacros:
         )
         snapshot.match("processed_template", processed_template)
 
-    @skip_if_v2_provider(reason="CFNV2:Validation")
+    @skip_if_v2_provider(reason="CFNV2:Transform")
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[
@@ -994,7 +994,7 @@ class TestMacros:
             processed_template["TemplateBody"]["Resources"]["Parameter"]["Properties"]["Value"],
         )
 
-    @skip_if_v2_provider(reason="CFNV2:Validation")
+    @skip_if_v2_provider(reason="CFNV2:Transform")
     @markers.aws.validated
     def test_to_validate_template_limit_for_macro(
         self, deploy_cfn_template, create_lambda_function, snapshot, aws_client
@@ -1047,7 +1047,7 @@ class TestMacros:
         )
         snapshot.match("error_response", response)
 
-    @skip_if_v2_provider(reason="CFNV2:Validation")
+    @skip_if_v2_provider(reason="CFNV2:Transform")
     @markers.aws.validated
     def test_error_pass_macro_as_reference(self, snapshot, aws_client):
         """
@@ -1120,7 +1120,7 @@ class TestMacros:
             processed_template["TemplateBody"]["Resources"]["Parameter"]["Properties"]["Value"],
         )
 
-    @skip_if_v2_provider(reason="CFNV2:Validation")
+    @skip_if_v2_provider(reason="CFNV2:Transform")
     @pytest.mark.parametrize(
         "macro_function",
         [
@@ -1227,7 +1227,6 @@ class TestMacros:
 
 
 class TestStackEvents:
-    @skip_if_v2_provider(reason="CFNV2:Validation")
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

At time of writing, the CFNV2:Validation errors were the biggest class of errors in the new provider's test suite. This PR attempts to tackle (or at least reassign them) to make the biggest push towards parity.

Since we have made the validator a subclass of the preprocessor, we can now raise `ValidationError`s in the preprocessor which will be turned into proper service exceptions. This is the natural place to put this functionality, but it now can be driven during `CreateChangeSet|CreateStack|UpdateStack` i.e. synchronously 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Hide most logged exceptions from the logs unless `CFN_VERBOSE_ERRORS=1`
* Move the validation of the logical resource ids to the preprocessor
* Improve parity of error messages with looking up missing keys from mappings
* The validator now inherits from the preprocessor to support resolving mapping values
* Fail to create stack if a stack already exists with that name and is active
* Unskiped 4 tests
* Reassigned 5 tests (to `CFNV2:Transform`, sorry @pinzon!)
* Added 2 (passing) tests

## TODO

* Perhaps rethink the parameter resolution from #12934 to use the preprocessor

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
