### PR TITLE
SES: fix infinite loop with SNS event destination

### DIFF
--- a/localstack-core/localstack/services/ses/models.py
+++ b/localstack-core/localstack/services/ses/models.py
@@ -8,7 +8,7 @@ class SentEmailBody(TypedDict):
     text_part: str
 
 
-class SentEmail(TypedDict):
+class SentEmail(TypedDict, total=False):
     Id: str
     Region: str
     Timestamp: str

--- a/localstack-core/localstack/services/ses/provider.py
+++ b/localstack-core/localstack/services/ses/provider.py
@@ -30,6 +30,7 @@ from localstack.aws.api.ses import (
     EventDestination,
     EventDestinationDoesNotExistException,
     EventDestinationName,
+    EventType,
     GetIdentityVerificationAttributesResponse,
     Identity,
     IdentityList,
@@ -214,7 +215,9 @@ class SesProvider(SesApi, ServiceLifecycleHook):
             emitter = SNSEmitter(context)
             emitter.emit_create_configuration_set_event_destination_test_message(sns_topic_arn)
 
-        # only register the event destiation if emitting the message worked
+        # FIXME: Moto stores the Event Destinations as a single value when it should be a list
+        #  it only considers the last Event Destination created, when AWS is able to store multiple configurations
+        # only register the event destination if emitting the message worked
         try:
             result = call_moto(context)
         except CommonServiceException as e:
@@ -273,6 +276,9 @@ class SesProvider(SesApi, ServiceLifecycleHook):
             # FIXME: inconsistent state
             LOGGER.warning("inconsistent state encountered in ses backend")
 
+        # FIXME: Moto stores the Event Destinations as a single value when it should be a list
+        #  it only considers the last Event Destination created, when AWS is able to store multiple configurations
+        #  don't pop the whole value which should be a list but is currently a dict
         backend.config_set_event_destination.pop(configuration_set_name)
 
         return DeleteConfigurationSetEventDestinationResponse()
@@ -362,25 +368,20 @@ class SesProvider(SesApi, ServiceLifecycleHook):
         response = call_moto(context)
 
         backend = get_ses_backend(context)
-        emitter = SNSEmitter(context)
-        recipients = recipients_from_destination(destination)
 
-        for event_destination in backend.config_set_event_destination.values():
-            if not event_destination["Enabled"]:
-                continue
-
-            sns_destination_arn = event_destination.get("SNSDestination")
-            if not sns_destination_arn:
-                continue
-
-            payload = SNSPayload(
+        if event_destinations := backend.config_set_event_destination.get(configuration_set_name):
+            recipients = recipients_from_destination(destination)
+            payload = EventDestinationPayload(
                 message_id=response["MessageId"],
                 sender_email=source,
                 destination_addresses=recipients,
                 tags=tags,
             )
-            emitter.emit_send_event(payload, sns_destination_arn)
-            emitter.emit_delivery_event(payload, sns_destination_arn)
+            notify_event_destinations(
+                context=context,
+                event_destinations=event_destinations,
+                payload=payload,
+            )
 
         text_part = message["Body"].get("Text", {}).get("Data")
         html_part = message["Body"].get("Html", {}).get("Data")
@@ -418,25 +419,20 @@ class SesProvider(SesApi, ServiceLifecycleHook):
         response = call_moto(context)
 
         backend = get_ses_backend(context)
-        emitter = SNSEmitter(context)
-        recipients = recipients_from_destination(destination)
 
-        for event_destination in backend.config_set_event_destination.values():
-            if not event_destination["Enabled"]:
-                continue
-
-            sns_destination_arn = event_destination.get("SNSDestination")
-            if not sns_destination_arn:
-                continue
-
-            payload = SNSPayload(
+        if event_destinations := backend.config_set_event_destination.get(configuration_set_name):
+            recipients = recipients_from_destination(destination)
+            payload = EventDestinationPayload(
                 message_id=response["MessageId"],
                 sender_email=source,
                 destination_addresses=recipients,
                 tags=tags,
             )
-            emitter.emit_send_event(payload, sns_destination_arn, emit_source_arn=False)
-            emitter.emit_delivery_event(payload, sns_destination_arn)
+            notify_event_destinations(
+                context=context,
+                event_destinations=event_destinations,
+                payload=payload,
+            )
 
         save_for_retrospection(
             SentEmail(
@@ -481,23 +477,18 @@ class SesProvider(SesApi, ServiceLifecycleHook):
         backend = get_ses_backend(context)
         message = backend.send_raw_email(source, destinations, raw_data)
 
-        emitter = SNSEmitter(context)
-        for event_destination in backend.config_set_event_destination.values():
-            if not event_destination["Enabled"]:
-                continue
-
-            sns_destination_arn = event_destination.get("SNSDestination")
-            if not sns_destination_arn:
-                continue
-
-            payload = SNSPayload(
+        if event_destinations := backend.config_set_event_destination.get(configuration_set_name):
+            payload = EventDestinationPayload(
                 message_id=message.id,
                 sender_email=source,
                 destination_addresses=destinations,
                 tags=tags,
             )
-            emitter.emit_send_event(payload, sns_destination_arn)
-            emitter.emit_delivery_event(payload, sns_destination_arn)
+            notify_event_destinations(
+                context=context,
+                event_destinations=event_destinations,
+                payload=payload,
+            )
 
         save_for_retrospection(
             SentEmail(
@@ -566,7 +557,7 @@ class SesProvider(SesApi, ServiceLifecycleHook):
 
 
 @dataclasses.dataclass(frozen=True)
-class SNSPayload:
+class EventDestinationPayload:
     message_id: str
     sender_email: Address
     destination_addresses: AddressList
@@ -598,7 +589,7 @@ class SNSEmitter:
         )
 
     def emit_send_event(
-        self, payload: SNSPayload, sns_topic_arn: str, emit_source_arn: bool = True
+        self, payload: EventDestinationPayload, sns_topic_arn: str, emit_source_arn: bool = True
     ):
         now = datetime.now(tz=UTC)
 
@@ -634,7 +625,7 @@ class SNSEmitter:
         except ClientError:
             LOGGER.exception("sending SNS message")
 
-    def emit_delivery_event(self, payload: SNSPayload, sns_topic_arn: str):
+    def emit_delivery_event(self, payload: EventDestinationPayload, sns_topic_arn: str):
         now = datetime.now(tz=UTC)
 
         tags = defaultdict(list)
@@ -678,6 +669,32 @@ class SNSEmitter:
             aws_access_key_id=access_key_id,
             aws_secret_access_key=INTERNAL_AWS_SECRET_ACCESS_KEY,
         ).sns
+
+
+def notify_event_destinations(
+    context: RequestContext,
+    # FIXME: Moto stores the Event Destinations as a single value when it should be a list
+    event_destinations: dict,
+    payload: EventDestinationPayload,
+):
+    emitter = SNSEmitter(context)
+
+    if not isinstance(event_destinations, list):
+        event_destinations = [event_destinations]
+
+    for event_destination in event_destinations:
+        if not event_destination["Enabled"]:
+            continue
+
+        sns_destination_arn = event_destination.get("SNSDestination")
+        if not sns_destination_arn:
+            continue
+
+        matching_event_types = event_destination.get("EventMatchingTypes") or []
+        if EventType.send in matching_event_types:
+            emitter.emit_send_event(payload, sns_destination_arn)
+        if EventType.delivery in matching_event_types:
+            emitter.emit_delivery_event(payload, sns_destination_arn)
 
 
 class InvalidParameterValue(CommonServiceException):

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -12,7 +12,7 @@ from localstack.services.ses.provider import EMAILS, EMAILS_ENDPOINT
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
-from localstack.utils.sync import retry
+from localstack.utils.sync import poll_condition, retry
 
 SAMPLE_TEMPLATE = {
     "TemplateName": "hello-world",
@@ -917,6 +917,79 @@ class TestSES:
             )
 
         assert exc.match("MessageRejected")
+
+    # we cannot really introspect received emails in AWS
+    @markers.aws.only_localstack
+    def test_ses_sns_topic_integration_send_email_ses_destination(
+        self,
+        sns_topic,
+        sns_subscription,
+        ses_configuration_set,
+        ses_configuration_set_sns_event_destination,
+        setup_email_addresses,
+        aws_client,
+    ):
+        """
+        Validates that configure Event Destinations and sending an email does not trigger an infinite loop of sending
+        SNS notifications that sends an email that would trigger SNS.
+        """
+
+        sender_email_address, recipient_email_address = setup_email_addresses()
+        config_set_name = f"config-set-{short_uid()}"
+
+        EMAILS.clear()
+
+        # create subscription to get notified about SES events
+        topic_arn = sns_topic["Attributes"]["TopicArn"]
+        sns_subscription(
+            TopicArn=topic_arn,
+            Protocol="email",
+            Endpoint=sender_email_address,
+        )
+
+        # create the config set
+        ses_configuration_set(config_set_name)
+        event_destination_name = f"config-set-event-destination-{short_uid()}"
+        ses_configuration_set_sns_event_destination(
+            config_set_name, event_destination_name, topic_arn
+        )
+
+        # send an email to trigger the SNS message and SES message
+        destination = {
+            "ToAddresses": [recipient_email_address],
+        }
+        send_email = aws_client.ses.send_email(
+            Destination=destination,
+            Message=SAMPLE_SIMPLE_EMAIL,
+            ConfigurationSetName=config_set_name,
+            Source=sender_email_address,
+            Tags=[
+                {
+                    "Name": "custom-tag",
+                    "Value": "tag-value",
+                }
+            ],
+        )
+        poll_condition(lambda: len(EMAILS) >= 4, timeout=3)
+        assert EMAILS.pop(send_email["MessageId"])
+
+        # we assert that we only received 3 emails
+        assert len(EMAILS) == 3
+
+        emails = sorted(EMAILS.values(), key=lambda x: x["Body"]["text_part"])
+        # the first email is the validation of SNS confirming the SES subscription
+        ses_delivery_notification = emails[1]
+        ses_send_notification = emails[2]
+
+        assert ses_delivery_notification["Subject"] == "SNS-Subscriber-Endpoint"
+        delivery_payload = json.loads(ses_delivery_notification["Body"]["text_part"])
+        assert delivery_payload["eventType"] == "Delivery"
+        assert delivery_payload["mail"]["source"] == sender_email_address
+
+        assert ses_send_notification["Subject"] == "SNS-Subscriber-Endpoint"
+        send_payload = json.loads(ses_send_notification["Body"]["text_part"])
+        assert send_payload["eventType"] == "Send"
+        assert send_payload["mail"]["source"] == sender_email_address
 
 
 @pytest.mark.usefixtures("openapi_validate")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While testing an SES/SNS sample, we encountered an issue where sending an email with SES with an SNS event destination configured that would have another SES subscriber, it would trigger an infinite loop. 

There were 2 problems:
- SNS was sending the `send` and `delivery` notification even if you didn't configure it
- it was sending for event destinations that exists for all `ConfigurationSet`, even if you did not specify a `ConfigurationSetName`. SES only sends event notification if you pass a `ConfigurationSetName` because `EventDestinations` are inherently linked to a configuration set, see https://docs.aws.amazon.com/ses/latest/dg/monitor-sending-using-event-publishing-setup.html

> The following steps required for setting up event publishing are covered in the topics below:
>
> - You must create a configuration set using the Amazon SES console or API.
> - Add one or more event destinations (CloudWatch, Firehose, Pinpoint, or SNS) to the configuration set, and configure parameters unique to the event destination.
> - **When you send an email, you specify which configuration set to use that contains your event destination.**

There is still one somewhat big issue because Moto only accepts one `EventDestination` per configuration set, even if AWS accepts multiple, Moto will overwrite it every time you call `CreateConfigurationSetEventDestination`, but this is out of scope. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- refactor a bit the SNS sending to centralize in one point and not have to modify the code 3 times, and for it to be easy to extend. We will probably need to refactor it again if we want to extend the `SNSEmitter` and add new kind of destinations
- add a new LocalStack only test because we cannot really look into received emails when validating against AWS
- write some TODOs about behavior problem of Event Destinations

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
