### PR TITLE
add(utils/archives): Support .whl files in download_and_extract

### DIFF
--- a/localstack-core/localstack/utils/archives.py
+++ b/localstack-core/localstack/utils/archives.py
@@ -233,7 +233,7 @@ def download_and_extract(
             rm_rf(tmp_archive)
             raise e
 
-    if ext == ".zip":
+    if ext in (".zip", ".whl"):
         unzip(tmp_archive, target_dir)
     elif ext in (
         ".bz2",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Python wheels are considered valid `.zip` archives and can be extracted using the same functionality. This change allows us to extend the `ArchiveDownloadAndExtractInstaller` to download and unzip python wheels.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Python `.whl` files are unzipped when doing a `download_and_extract` whereas previously an exception was raised.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
