### PR TITLE
CFNV2: improve parity with describe operations

### DIFF
--- a/localstack-core/localstack/services/cloudformation/v2/entities.py
+++ b/localstack-core/localstack/services/cloudformation/v2/entities.py
@@ -62,6 +62,7 @@ class ResolvedResource(TypedDict):
 
 class Stack:
     stack_name: str
+    description: str | None
     parameters: list[ApiParameter]
     change_set_id: str | None
     status: StackStatus
@@ -123,6 +124,7 @@ class Stack:
         self.resource_states = {}
         self.events = []
         self.resolved_exports = {}
+        self.description = None
 
     def set_stack_status(self, status: StackStatus, reason: StackStatusReason | None = None):
         self.status = status

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -48,7 +48,6 @@ from localstack.aws.api.cloudformation import (
     ListStacksOutput,
     LogicalResourceId,
     NextToken,
-    Output,
     Parameter,
     PhysicalResourceId,
     RetainExceptOnCreate,
@@ -530,7 +529,6 @@ class CloudformationProviderV2(CloudformationProvider):
                 change_set.stack.resolved_resources = result.resources
                 change_set.stack.resolved_parameters = change_set.resolved_parameters
                 change_set.stack.resolved_outputs = result.outputs
-                change_set.stack.resolved_exports = result.exports
                 change_set.stack.change_set_id = change_set.change_set_id
                 change_set.stack.change_set_ids.append(change_set.change_set_id)
 
@@ -813,17 +811,7 @@ class CloudformationProviderV2(CloudformationProvider):
                     stack_description["Parameters"].append(parameter)
 
             if stack.resolved_outputs:
-                describe_outputs = []
-                for key, value in stack.resolved_outputs.items():
-                    describe_outputs.append(
-                        Output(
-                            # TODO(parity): Description, ExportName
-                            # TODO(parity): what happens on describe stack when the stack has not been deployed yet?
-                            OutputKey=key,
-                            OutputValue=value,
-                        )
-                    )
-                stack_description["Outputs"] = describe_outputs
+                stack_description["Outputs"] = stack.resolved_outputs
 
             describe_stack_output.append(stack_description)
 

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -537,6 +537,7 @@ class CloudformationProviderV2(CloudformationProvider):
                 # if the deployment succeeded, update the stack's template representation to that
                 # which was just deployed
                 change_set.stack.template = change_set.template
+                change_set.stack.description = change_set.template.get("Description")
                 change_set.stack.processed_template = change_set.processed_template
                 change_set.stack.template_body = change_set.template_body
             except Exception as e:
@@ -768,6 +769,7 @@ class CloudformationProviderV2(CloudformationProvider):
         describe_stack_output: list[ApiStack] = []
         for stack in stacks:
             stack_description = ApiStack(
+                Description=stack.description,
                 CreationTime=stack.creation_time,
                 DeletionTime=stack.deletion_time,
                 StackId=stack.stack_id,

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -471,7 +471,7 @@ class CloudformationProviderV2(CloudformationProvider):
 
             change_set.set_change_set_status(ChangeSetStatus.CREATE_COMPLETE)
 
-        stack.change_set_id = change_set.change_set_id
+        # stack.change_set_id = change_set.change_set_id
         stack.change_set_ids.append(change_set.change_set_id)
         state.change_sets[change_set.change_set_id] = change_set
 
@@ -531,6 +531,8 @@ class CloudformationProviderV2(CloudformationProvider):
                 change_set.stack.resolved_parameters = change_set.resolved_parameters
                 change_set.stack.resolved_outputs = result.outputs
                 change_set.stack.resolved_exports = result.exports
+                change_set.stack.change_set_id = change_set.change_set_id
+                change_set.stack.change_set_ids.append(change_set.change_set_id)
 
                 # if the deployment succeeded, update the stack's template representation to that
                 # which was just deployed
@@ -547,6 +549,8 @@ class CloudformationProviderV2(CloudformationProvider):
 
                 change_set.stack.set_stack_status(new_stack_status)
                 change_set.set_execution_status(ExecutionStatus.EXECUTE_FAILED)
+                change_set.stack.change_set_id = change_set.change_set_id
+                change_set.stack.change_set_ids.append(change_set.change_set_id)
 
         start_worker_thread(_run)
 

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -759,7 +759,6 @@ def test_create_and_then_remove_supported_resource_change_set(deploy_cfn_templat
 
 @markers.snapshot.skip_snapshot_verify(
     paths=[
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Parameters",
     ]

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -1012,8 +1012,13 @@ def test_multiple_create_changeset(aws_client, snapshot, cleanups):
     )
 
 
-@skip_if_v2_provider(reason="CFNV2:DescribeStacks")
-@markers.snapshot.skip_snapshot_verify(paths=["$..LastUpdatedTime", "$..StackStatusReason"])
+@markers.snapshot.skip_snapshot_verify(
+    paths=["$..LastUpdatedTime", "$..StackStatusReason"]
+    + skipped_v2_items(
+        # TODO
+        "$..Capabilities",
+    )
+)
 @markers.aws.validated
 def test_create_changeset_with_stack_id(aws_client, snapshot, cleanups):
     """

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -78,7 +78,6 @@ class TestStacksApi:
         assert "DeletionTime" in deleted
         snapshot.match("deleted", deleted)
 
-    @skip_if_v2_provider(reason="CFNV2:DescribeStacks")
     @markers.aws.validated
     def test_stack_description_special_chars(self, deploy_cfn_template, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.cloudformation_api())

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -26,7 +26,6 @@ from localstack.utils.sync import retry, wait_until
 
 
 class TestStacksApi:
-    @skip_if_v2_provider(reason="CFNV2:DescribeStacks")
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..ChangeSetId", "$..EnableTerminationProtection"]
         + skipped_v2_items(
@@ -978,7 +977,7 @@ def test_stack_deletion_order(
     snapshot.match("all-events", to_snapshot)
 
 
-@skip_if_v2_provider(reason="CFNV2:DescribeStack")
+@skip_if_v2_provider(reason="CFNV2:DescribeStack(noecho)")
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         # TODO: this property is present in the response from LocalStack when

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -968,7 +968,6 @@ def test_stack_deploy_order(deploy_cfn_template, aws_client, snapshot, deploy_or
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",
@@ -1045,7 +1044,6 @@ def test_stack_deletion_order(
         "$..Capabilities",
         "$..IncludeNestedStacks",
         "$..LastUpdatedTime",
-        "$..NotificationARNs",
         "$..ResourceChange",
         "$..StackResourceDetail.Metadata",
     ]

--- a/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_description_special_chars": {
-    "recorded-date": "05-08-2022, 13:03:43",
+    "recorded-date": "08-08-2025, 15:32:46",
     "recorded-content": {
       "describe_stack": {
         "Capabilities": [

--- a/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
@@ -4069,5 +4069,71 @@
         ]
       ]
     }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_description_lifecycle": {
+    "recorded-date": "08-08-2025, 15:30:34",
+    "recorded-content": {
+      "change-set-pre-execute": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-name:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "TestResource",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stack-pre-execute": {
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "REVIEW_IN_PROGRESS",
+        "StackStatusReason": "User Initiated",
+        "Tags": []
+      },
+      "stack-post-execute": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "Description": "test <env>.test.net",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_stacks.validation.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.validation.json
@@ -27,7 +27,13 @@
     "last_validated_date": "2022-10-05T11:33:55+00:00"
   },
   "tests/aws/services/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_description_special_chars": {
-    "last_validated_date": "2022-08-05T11:03:43+00:00"
+    "last_validated_date": "2025-08-08T15:20:07+00:00",
+    "durations_in_seconds": {
+      "setup": 1.41,
+      "call": 61.6,
+      "teardown": 4.47,
+      "total": 67.48
+    }
   },
   "tests/aws/services/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_lifecycle": {
     "last_validated_date": "2023-11-28T12:24:40+00:00"

--- a/tests/aws/services/cloudformation/api/test_stacks.validation.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.validation.json
@@ -26,6 +26,15 @@
   "tests/aws/services/cloudformation/api/test_stacks.py::TestStacksApi::test_list_events_after_deployment": {
     "last_validated_date": "2022-10-05T11:33:55+00:00"
   },
+  "tests/aws/services/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_description_lifecycle": {
+    "last_validated_date": "2025-08-08T15:30:34+00:00",
+    "durations_in_seconds": {
+      "setup": 1.09,
+      "call": 8.6,
+      "teardown": 0.2,
+      "total": 9.89
+    }
+  },
   "tests/aws/services/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_description_special_chars": {
     "last_validated_date": "2025-08-08T15:20:07+00:00",
     "durations_in_seconds": {

--- a/tests/aws/services/cloudformation/resources/test_cdk.py
+++ b/tests/aws/services/cloudformation/resources/test_cdk.py
@@ -115,8 +115,6 @@ class TestCdkInit:
             "$..Changes..Scope",
             # provider
             "$..IncludeNestedStacks",
-            # CFNV2:Describe not supported yet
-            "$..Outputs..ExportName",
             # mismatch between amazonaws.com and localhost.localstack.cloud
             "$..Outputs..OutputValue",
         ]

--- a/tests/aws/services/cloudformation/resources/test_cdk.py
+++ b/tests/aws/services/cloudformation/resources/test_cdk.py
@@ -115,7 +115,6 @@ class TestCdkInit:
             "$..Changes..Scope",
             # provider
             "$..IncludeNestedStacks",
-            "$..NotificationARNs",
             # CFNV2:Describe not supported yet
             "$..Outputs..ExportName",
             # mismatch between amazonaws.com and localhost.localstack.cloud

--- a/tests/aws/services/cloudformation/resources/test_ssm.py
+++ b/tests/aws/services/cloudformation/resources/test_ssm.py
@@ -3,7 +3,6 @@ import os.path
 import botocore.exceptions
 import pytest
 from localstack_snapshot.snapshots.transformer import SortingTransformer
-from tests.aws.services.cloudformation.conftest import skip_if_v2_provider
 
 from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
@@ -116,7 +115,6 @@ def test_update_ssm_parameter_tag(deploy_cfn_template, aws_client):
     # assert ssm_tags == []
 
 
-@skip_if_v2_provider(reason="CFNV2:DescribeStackResource")
 @markers.snapshot.skip_snapshot_verify(paths=["$..DriftInformation", "$..Metadata"])
 @markers.aws.validated
 def test_deploy_patch_baseline(deploy_cfn_template, aws_client, snapshot):

--- a/tests/aws/services/cloudformation/test_change_set_conditions.py
+++ b/tests/aws/services/cloudformation/test_change_set_conditions.py
@@ -13,7 +13,6 @@ from localstack.utils.strings import long_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_depends_on.py
+++ b/tests/aws/services/cloudformation/test_change_set_depends_on.py
@@ -13,7 +13,6 @@ from localstack.utils.strings import long_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_exports_imports.py
+++ b/tests/aws/services/cloudformation/test_change_set_exports_imports.py
@@ -33,10 +33,7 @@ def execute_change_set(aws_client):
     paths=[
         "$..Changes..ResourceChange.Details",
         "$..Changes..ResourceChange.Scope",
-        "$..IncludeNestedStacks",
-        "$..NotificationARNs",
         "$..Parameters",
-        "$..Capabilities",
     ]
 )
 class TestChangeSetImportExport:

--- a/tests/aws/services/cloudformation/test_change_set_fn_base64.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_base64.py
@@ -13,7 +13,6 @@ from localstack.utils.strings import long_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_fn_get_attr.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_get_attr.py
@@ -14,7 +14,6 @@ from localstack.utils.strings import long_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_fn_join.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_join.py
@@ -13,7 +13,6 @@ from localstack.utils.strings import long_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_fn_select.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_select.py
@@ -13,7 +13,6 @@ from localstack.utils.strings import long_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_fn_split.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_split.py
@@ -13,7 +13,6 @@ from localstack.utils.strings import long_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_fn_sub.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_sub.py
@@ -13,7 +13,6 @@ from localstack.utils.strings import long_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_fn_transform.py
+++ b/tests/aws/services/cloudformation/test_change_set_fn_transform.py
@@ -16,7 +16,6 @@ from localstack.utils.strings import short_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_global_macros.py
+++ b/tests/aws/services/cloudformation/test_change_set_global_macros.py
@@ -19,7 +19,6 @@ from localstack.utils.strings import short_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_mappings.py
+++ b/tests/aws/services/cloudformation/test_change_set_mappings.py
@@ -13,7 +13,6 @@ from localstack.utils.strings import long_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_parameters.py
+++ b/tests/aws/services/cloudformation/test_change_set_parameters.py
@@ -13,7 +13,6 @@ from localstack.utils.strings import long_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_ref.py
+++ b/tests/aws/services/cloudformation/test_change_set_ref.py
@@ -13,7 +13,6 @@ from localstack.utils.strings import long_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_set_values.py
+++ b/tests/aws/services/cloudformation/test_change_set_values.py
@@ -13,7 +13,6 @@ from localstack.utils.strings import long_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/test_change_sets.py
+++ b/tests/aws/services/cloudformation/test_change_sets.py
@@ -17,7 +17,6 @@ from localstack.utils.strings import short_uid
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",
@@ -789,7 +788,6 @@ class TestCaptureUpdateProcess:
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",
@@ -868,7 +866,6 @@ def test_dynamic_ssm_parameter_lookup(
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",

--- a/tests/aws/services/cloudformation/v2/test_dynamic_resolving.py
+++ b/tests/aws/services/cloudformation/v2/test_dynamic_resolving.py
@@ -12,7 +12,6 @@ pytestmark = skip_if_v1_provider(reason="Only valid for the V2 provider")
         #
         # Before/After Context
         "$..Capabilities",
-        "$..NotificationARNs",
         "$..IncludeNestedStacks",
         "$..Scope",
         "$..Details",


### PR DESCRIPTION
- **Only set change set id on deployment completion**
- **Unskip and update skip**
- **Support propagating stack description**
- **Increase parity with describe stacks and change sets**
- **Remove parity check for notification arns**
- **Better parity with outputs**

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
