### PR TITLE
Fix ContinuationSequenceNumber in SubscribeToShard

### DIFF
--- a/localstack-core/localstack/services/kinesis/provider.py
+++ b/localstack-core/localstack/services/kinesis/provider.py
@@ -127,6 +127,9 @@ class KinesisProvider(KinesisApi, ServiceLifecycleHook):
                 records = result.get("Records", [])
                 if records:
                     # Update the last sequence number to the last record's sequence number
+                    # TODO: This will suffice for now but does not properly capture checkpointing when
+                    # no data is written to a shard. See AWS docs:
+                    # https://docs.aws.amazon.com/kinesis/latest/APIReference/API_SubscribeToShardEvent.html#API_SubscribeToShardEvent_Contents
                     last_sequence_number = records[-1].get("SequenceNumber", last_sequence_number)
                 else:
                     # On AWS there is *at least* 1 event every 5 seconds
@@ -139,7 +142,7 @@ class KinesisProvider(KinesisApi, ServiceLifecycleHook):
                         Records=records,
                         ContinuationSequenceNumber=str(last_sequence_number),
                         MillisBehindLatest=0,
-                        ChildShards=[],
+                        ChildShards=None,  # TODO: Include shard children info
                     )
                 )
 

--- a/localstack-core/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack-core/localstack/testing/snapshots/transformer_utility.py
@@ -500,7 +500,7 @@ class TransformerUtility:
                 replacement="<stream-name>",
             ),
             TransformerUtility.key_value(
-                "ContinuationSequenceNumber", "<continuation_sequence_number>"
+                "ContinuationSequenceNumber", "continuation_sequence_number"
             ),
         ]
 

--- a/tests/aws/services/kinesis/test_kinesis.snapshot.json
+++ b/tests/aws/services/kinesis/test_kinesis.snapshot.json
@@ -144,38 +144,44 @@
     }
   },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard": {
-    "recorded-date": "26-08-2022, 09:33:29",
+    "recorded-date": "19-08-2025, 13:10:10",
     "recorded-content": {
-      "Records": [
+      "Events": [
         {
-          "SequenceNumber": "<sequence_number:1>",
-          "ApproximateArrivalTimestamp": "timestamp",
-          "Data": "b'Hello world_0'",
-          "PartitionKey": "1"
-        },
-        {
-          "SequenceNumber": "<sequence_number:2>",
-          "ApproximateArrivalTimestamp": "timestamp",
-          "Data": "b'Hello world_1'",
-          "PartitionKey": "1"
-        },
-        {
-          "SequenceNumber": "<sequence_number:3>",
-          "ApproximateArrivalTimestamp": "timestamp",
-          "Data": "b'Hello world_2'",
-          "PartitionKey": "1"
-        },
-        {
-          "SequenceNumber": "<sequence_number:4>",
-          "ApproximateArrivalTimestamp": "timestamp",
-          "Data": "b'Hello world_3'",
-          "PartitionKey": "1"
-        },
-        {
-          "SequenceNumber": "<sequence_number:5>",
-          "ApproximateArrivalTimestamp": "timestamp",
-          "Data": "b'Hello world_4'",
-          "PartitionKey": "1"
+          "Records": [
+            {
+              "SequenceNumber": "<sequence_number:1>",
+              "ApproximateArrivalTimestamp": "timestamp",
+              "Data": "b'Hello world_0'",
+              "PartitionKey": "1"
+            },
+            {
+              "SequenceNumber": "<sequence_number:2>",
+              "ApproximateArrivalTimestamp": "timestamp",
+              "Data": "b'Hello world_1'",
+              "PartitionKey": "1"
+            },
+            {
+              "SequenceNumber": "<sequence_number:3>",
+              "ApproximateArrivalTimestamp": "timestamp",
+              "Data": "b'Hello world_2'",
+              "PartitionKey": "1"
+            },
+            {
+              "SequenceNumber": "<sequence_number:4>",
+              "ApproximateArrivalTimestamp": "timestamp",
+              "Data": "b'Hello world_3'",
+              "PartitionKey": "1"
+            },
+            {
+              "SequenceNumber": "<sequence_number:5>",
+              "ApproximateArrivalTimestamp": "timestamp",
+              "Data": "b'Hello world_4'",
+              "PartitionKey": "1"
+            }
+          ],
+          "ContinuationSequenceNumber": "<continuation_sequence_number:1>",
+          "MillisBehindLatest": 0
         }
       ]
     }

--- a/tests/aws/services/kinesis/test_kinesis.validation.json
+++ b/tests/aws/services/kinesis/test_kinesis.validation.json
@@ -24,7 +24,13 @@
     "last_validated_date": "2022-08-26T08:23:46+00:00"
   },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard": {
-    "last_validated_date": "2022-08-26T07:33:29+00:00"
+    "last_validated_date": "2025-08-19T13:10:10+00:00",
+    "durations_in_seconds": {
+      "setup": 0.73,
+      "call": 10.61,
+      "teardown": 0.43,
+      "total": 11.77
+    }
   },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_at_timestamp": {
     "last_validated_date": "2024-06-21T15:20:46+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, when using SubscribeToShard, SubscribeToShardEvents will always have a ContinuationSequenceNumber of 0.

https://github.com/localstack/localstack/issues/10000

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
When using Kinesis SubscribeToShard, ContinuationSequenceNumber will now match the sequence number of the last record sent, rather than 0

<!-- Optional section: How to test these changes? -->
## Testing
Tested locally with a WIP consumer
