### PR TITLE
Step Functions: Fix Batch error handling

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_batch.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_batch.py
@@ -118,7 +118,7 @@ class StateTaskServiceBatch(StateTaskServiceCallback):
                     "Proxy: null",
                 ]
             )
-            cause = f"Error executing request, Exception : {error_message}, RequestId: {request_id} ({response_details})"
+            cause = f"{error_message} ({response_details})"
             return FailureEvent(
                 env=env,
                 error_name=CustomErrorName(error_name),


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The error message originally included in the failure event's error message is part of the Batch service's error message format. This shouldn't be handled in the Step Functions handler, but should be part of the Batch service implementation. 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Removes extra handling for Batch service errors in `StateTaskServiceBatch`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
