### PR TITLE
Log stack traces only in debug mode

### DIFF
--- a/localstack-core/localstack/aws/handlers/internal_requests.py
+++ b/localstack-core/localstack/aws/handlers/internal_requests.py
@@ -20,7 +20,12 @@ class InternalRequestParamsEnricher(Handler):
             try:
                 dto = MappingProxyType(load_dto(header))
             except Exception as e:
-                LOG.exception("Error loading request parameters '%s', Error: %s", header, e)
+                LOG.error(
+                    "Error loading request parameters '%s', Error: %s",
+                    header,
+                    e,
+                    exc_info=LOG.isEnabledFor(logging.DEBUG),
+                )
                 return
 
             context.internal_request_params = dto

--- a/localstack-core/localstack/aws/spec.py
+++ b/localstack-core/localstack/aws/spec.py
@@ -343,8 +343,9 @@ def get_service_catalog() -> ServiceCatalog:
                 index = build_service_index_cache(cache_catalog_file)
         return ServiceCatalog(index)
     except Exception:
-        LOG.exception(
-            "error while processing service catalog index cache, falling back to lazy-loaded index"
+        LOG.error(
+            "error while processing service catalog index cache, falling back to lazy-loaded index",
+            exc_info=LOG.isEnabledFor(logging.DEBUG),
         )
         return ServiceCatalog()
 

--- a/localstack-core/localstack/services/apigateway/legacy/invocations.py
+++ b/localstack-core/localstack/services/apigateway/legacy/invocations.py
@@ -142,8 +142,9 @@ class RequestValidator:
         # try to get the resolved model first
         resolved_schema = model_resolver.get_resolved_model()
         if not resolved_schema:
-            LOG.exception(
-                "An exception occurred while trying to validate the request: could not find the model"
+            LOG.error(
+                "An exception occurred while trying to validate the request: could not find the model",
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
             return False
 
@@ -334,7 +335,7 @@ def invoke_rest_api_integration(invocation_context: ApiInvocationContext):
         return e.to_response()
     except Exception as e:
         msg = f"Error invoking integration for API Gateway ID '{invocation_context.api_id}': {e}"
-        LOG.exception(msg)
+        LOG.error(msg, exc_info=LOG.isEnabledFor(logging.DEBUG))
         return make_error_response(msg, 400)
 
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_request.py
@@ -91,9 +91,10 @@ class MethodRequestHandler(RestApiGatewayHandler):
         # try to get the resolved model first
         resolved_schema = model_resolver.get_resolved_model()
         if not resolved_schema:
-            LOG.exception(
+            LOG.error(
                 "An exception occurred while trying to validate the request: could not resolve the model '%s'",
                 model_name,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
             return False
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_request.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/method_request.py
@@ -50,7 +50,11 @@ class MethodRequestHandler(RestApiGatewayHandler):
         # check if there is a validator for this request
         if not (validator := rest_api.validators.get(request_validator_id)):
             # TODO Should we raise an exception instead?
-            LOG.exception("No validator were found with matching id: '%s'", request_validator_id)
+            LOG.error(
+                "No validator were found with matching id: '%s'",
+                request_validator_id,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
+            )
             return
 
         if self.should_validate_request(validator) and (

--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -1479,10 +1479,11 @@ class TemplateDeployer:
                         # correct order yet.
                         continue
                     case OperationStatus.FAILED:
-                        LOG.exception(
+                        LOG.error(
                             "Failed to delete resource with id %s. Reason: %s",
                             resource_id,
                             event.message or "unknown",
+                            exc_info=LOG.isEnabledFor(logging.DEBUG),
                         )
                     case OperationStatus.IN_PROGRESS:
                         # the resource provider executor should not return this state, so
@@ -1494,10 +1495,11 @@ class TemplateDeployer:
                         raise Exception(f"Use of unsupported status found: {other_status}")
 
             except Exception as e:
-                LOG.exception(
+                LOG.error(
                     "Failed to delete resource with id %s. Final exception: %s",
                     resource_id,
                     e,
+                    exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
 
         # update status

--- a/localstack-core/localstack/services/cloudformation/provider.py
+++ b/localstack-core/localstack/services/cloudformation/provider.py
@@ -306,7 +306,7 @@ class CloudformationProvider(CloudformationApi):
         except Exception as e:
             stack.set_stack_status("CREATE_FAILED")
             msg = 'Unable to create stack "%s": %s' % (stack.stack_name, e)
-            LOG.exception("%s")
+            LOG.error("%s", exc_info=LOG.isEnabledFor(logging.DEBUG))
             raise ValidationError(msg) from e
 
         return CreateStackOutput(StackId=stack.stack_id)
@@ -423,7 +423,7 @@ class CloudformationProvider(CloudformationApi):
         except Exception as e:
             stack.set_stack_status("UPDATE_FAILED")
             msg = f'Unable to update stack "{stack_name}": {e}'
-            LOG.exception("%s", msg)
+            LOG.error("%s", msg, exc_info=LOG.isEnabledFor(logging.DEBUG))
             raise ValidationError(msg) from e
 
         return UpdateStackOutput(StackId=stack.stack_id)
@@ -1052,7 +1052,7 @@ class CloudformationProvider(CloudformationApi):
                 Description=valid_template.get("Description"), Parameters=parameters
             )
         except Exception as e:
-            LOG.exception("Error validating template")
+            LOG.error("Error validating template", exc_info=LOG.isEnabledFor(logging.DEBUG))
             raise ValidationError("Template Validation Error") from e
 
     # =======================================

--- a/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
@@ -69,7 +69,10 @@ class AlarmScheduler:
         schedule_period = evaluation_periods * period
 
         def on_error(e):
-            LOG.exception("Error executing scheduled alarm", exc_info=e)
+            if LOG.isEnabledFor(logging.DEBUG):
+                LOG.exception("Error executing scheduled alarm", exc_info=e)
+            else:
+                LOG.error("Error executing scheduled alarm")
 
         task = self.scheduler.schedule(
             func=calculate_alarm_state,

--- a/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
@@ -69,10 +69,7 @@ class AlarmScheduler:
         schedule_period = evaluation_periods * period
 
         def on_error(e):
-            if LOG.isEnabledFor(logging.DEBUG):
-                LOG.exception("Error executing scheduled alarm", exc_info=e)
-            else:
-                LOG.error("Error executing scheduled alarm")
+            LOG.error("Error executing scheduled alarm", exc_info=LOG.isEnabledFor(logging.DEBUG))
 
         task = self.scheduler.schedule(
             func=calculate_alarm_state,

--- a/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack-core/localstack/services/cloudwatch/alarm_scheduler.py
@@ -69,7 +69,10 @@ class AlarmScheduler:
         schedule_period = evaluation_periods * period
 
         def on_error(e):
-            LOG.error("Error executing scheduled alarm", exc_info=LOG.isEnabledFor(logging.DEBUG))
+            if LOG.isEnabledFor(logging.DEBUG):
+                LOG.exception("Error executing scheduled alarm", exc_info=e)
+            else:
+                LOG.error("Error executing scheduled alarm")
 
         task = self.scheduler.schedule(
             func=calculate_alarm_state,

--- a/localstack-core/localstack/services/dynamodb/server.py
+++ b/localstack-core/localstack/services/dynamodb/server.py
@@ -219,7 +219,7 @@ class DynamodbServer(Server):
                 aws_secret_access_key=DEFAULT_AWS_ACCOUNT_ID,
             ).dynamodb.list_tables()
         except Exception:
-            LOG.exception("DynamoDB health check failed")
+            LOG.error("DynamoDB health check failed", exc_info=LOG.isEnabledFor(logging.DEBUG))
         if expect_shutdown:
             assert out is None
         else:

--- a/localstack-core/localstack/services/firehose/provider.py
+++ b/localstack-core/localstack/services/firehose/provider.py
@@ -706,7 +706,11 @@ class FirehoseProvider(FirehoseApi):
                 try:
                     requests.post(url, json=record_to_send, headers=headers)
                 except Exception as e:
-                    LOG.exception("Unable to put Firehose records to HTTP endpoint %s.", url)
+                    LOG.error(
+                        "Unable to put Firehose records to HTTP endpoint %s.",
+                        url,
+                        exc_info=LOG.isEnabledFor(logging.DEBUG),
+                    )
                     raise e
             if "RedshiftDestinationDescription" in destination:
                 s3_dest_desc = destination["RedshiftDestinationDescription"][
@@ -782,7 +786,11 @@ class FirehoseProvider(FirehoseApi):
             try:
                 db_connection.create(index=search_db_index, id=obj_id, body=body)
             except Exception as e:
-                LOG.exception("Unable to put record to stream %s.", delivery_stream_name)
+                LOG.error(
+                    "Unable to put record to stream %s.",
+                    delivery_stream_name,
+                    exc_info=LOG.isEnabledFor(logging.DEBUG),
+                )
                 raise e
 
     def _add_missing_record_attributes(self, records: list[dict]) -> None:

--- a/localstack-core/localstack/services/firehose/provider.py
+++ b/localstack-core/localstack/services/firehose/provider.py
@@ -868,9 +868,10 @@ class FirehoseProvider(FirehoseApi):
             LOG.debug("Publishing to S3 destination: %s. Data: %s", bucket, batched_data)
             s3.put_object(Bucket=bucket, Key=obj_path, Body=batched_data)
         except Exception as e:
-            LOG.exception(
+            LOG.error(
                 "Unable to put records %s to s3 bucket.",
                 records,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
             raise e
 
@@ -925,9 +926,10 @@ class FirehoseProvider(FirehoseApi):
                 )
                 redshift_data.execute_statement(Parameters=row_to_insert, **execute_statement)
             except Exception as e:
-                LOG.exception(
+                LOG.error(
                     "Unable to put records %s to redshift cluster.",
                     row_to_insert,
+                    exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
                 raise e
 

--- a/localstack-core/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack-core/localstack/services/lambda_/invocation/lambda_service.py
@@ -478,7 +478,7 @@ class LambdaService:
             ] = new_version_state
 
         except Exception:
-            LOG.exception("Failed to update function version for arn %s", function_arn)
+            LOG.error("Failed to update function version for arn %s", function_arn)
 
     def update_alias(self, old_alias: VersionAlias, new_alias: VersionAlias, function: Function):
         # if pointer changed, need to restart provisioned

--- a/localstack-core/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack-core/localstack/services/lambda_/invocation/lambda_service.py
@@ -478,7 +478,11 @@ class LambdaService:
             ] = new_version_state
 
         except Exception:
-            LOG.error("Failed to update function version for arn %s", function_arn)
+            LOG.error(
+                "Failed to update function version for arn %s",
+                function_arn,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
+            )
 
     def update_alias(self, old_alias: VersionAlias, new_alias: VersionAlias, function: Function):
         # if pointer changed, need to restart provisioned

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -313,7 +313,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                             LOG.warning(
                                 "Failed to restore function version %s",
                                 fn_version.id.qualified_arn(),
-                                exc_info=True,
+                                exc_info=LOG.isEnabledFor(logging.DEBUG),
                             )
                     # restore provisioned concurrency per function considering both versions and aliases
                     for (
@@ -344,7 +344,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                                 "Failed to restore provisioned concurrency %s for function %s",
                                 provisioned_config,
                                 fn_arn,
-                                exc_info=True,
+                                exc_info=LOG.isEnabledFor(logging.DEBUG),
                             )
 
                 for esm in state.event_source_mappings.values():

--- a/localstack-core/localstack/services/opensearch/provider.py
+++ b/localstack-core/localstack/services/opensearch/provider.py
@@ -466,10 +466,11 @@ class OpensearchProvider(OpensearchApi, ServiceLifecycleHook):
                         preferred_port=preferred_port,
                     )
                 except Exception:
-                    LOG.exception(
+                    LOG.error(
                         "Could not restore domain %s in region %s.",
                         domain_name,
                         region,
+                        exc_info=LOG.isEnabledFor(logging.DEBUG),
                     )
 
     def on_before_state_reset(self):

--- a/localstack-core/localstack/services/plugins.py
+++ b/localstack-core/localstack/services/plugins.py
@@ -709,5 +709,7 @@ def eager_load_services():
             LOG.debug("%s", e)
         except Exception:
             LOG.error(
-                "could not load service plugin %s", api, exc_info=LOG.isEnabledFor(logging.DEBUG)
+                "could not load service plugin %s",
+                api,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
             )

--- a/localstack-core/localstack/services/plugins.py
+++ b/localstack-core/localstack/services/plugins.py
@@ -708,4 +708,6 @@ def eager_load_services():
         except ServiceDisabled as e:
             LOG.debug("%s", e)
         except Exception:
-            LOG.exception("could not load service plugin %s", api)
+            LOG.error(
+                "could not load service plugin %s", api, exc_info=LOG.isEnabledFor(logging.DEBUG)
+            )

--- a/localstack-core/localstack/services/s3/notifications.py
+++ b/localstack-core/localstack/services/s3/notifications.py
@@ -403,7 +403,11 @@ class SqsNotifier(BaseNotifier):
                 QueueName=arn_data["resource"], QueueOwnerAWSAccountId=arn_data["account"]
             )["QueueUrl"]
         except ClientError:
-            LOG.exception("Could not validate the notification destination %s", target_arn)
+            LOG.exception(
+                "Could not validate the notification destination %s",
+                target_arn,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
+            )
             raise _create_invalid_argument_exc(
                 "Unable to validate the following destination configurations",
                 name=target_arn,

--- a/localstack-core/localstack/services/s3/website_hosting.py
+++ b/localstack-core/localstack/services/s3/website_hosting.py
@@ -93,8 +93,10 @@ class S3WebsiteHostingHandler:
             return Response(response_body, status=e.response["ResponseMetadata"]["HTTPStatusCode"])
 
         except Exception:
-            LOG.exception(
-                "Exception encountered while trying to serve s3-website at %s", request.url
+            LOG.error(
+                "Exception encountered while trying to serve s3-website at %s",
+                request.url,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
             return Response(_create_500_error_string(), status=500)
 

--- a/localstack-core/localstack/services/ses/provider.py
+++ b/localstack-core/localstack/services/ses/provider.py
@@ -626,7 +626,7 @@ class SNSEmitter:
                 Subject="Amazon SES Email Event Notification",
             )
         except ClientError:
-            LOGGER.exception("sending SNS message")
+            LOGGER.error("sending SNS message", exc_info=LOGGER.isEnabledFor(logging.DEBUG))
 
     def emit_delivery_event(self, payload: EventDestinationPayload, sns_topic_arn: str):
         now = datetime.now(tz=UTC)
@@ -659,7 +659,7 @@ class SNSEmitter:
                 Subject="Amazon SES Email Event Notification",
             )
         except ClientError:
-            LOGGER.exception("sending SNS message")
+            LOGGER.error("sending SNS message", exc_info=LOGGER.isEnabledFor(logging.DEBUG))
 
     @staticmethod
     def _client_for_topic(topic_arn: str) -> "SNSClient":

--- a/localstack-core/localstack/services/sns/executor.py
+++ b/localstack-core/localstack/services/sns/executor.py
@@ -18,7 +18,10 @@ def _worker(work_queue: queue.Queue):
             del work_item
 
     except Exception:
-        LOG.exception("Exception in worker")
+        LOG.error(
+            "Exception in worker",
+            exc_info=LOG.isEnabledFor(logging.DEBUG),
+        )
 
 
 class _WorkItem:
@@ -31,7 +34,11 @@ class _WorkItem:
         try:
             self.fn(*self.args, **self.kwargs)
         except Exception:
-            LOG.exception("Unhandled Exception in while running %s", self.fn.__name__)
+            LOG.error(
+                "Unhandled Exception in while running %s",
+                self.fn.__name__,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
+            )
 
 
 class TopicPartitionedThreadPoolExecutor:

--- a/localstack-core/localstack/services/sns/publisher.py
+++ b/localstack-core/localstack/services/sns/publisher.py
@@ -295,7 +295,10 @@ class SqsTopicPublisher(TopicPublisher):
             )
             kwargs = self.get_sqs_kwargs(msg_context=message_context, subscriber=subscriber)
         except Exception:
-            LOG.exception("An internal error occurred while trying to format the message for SQS")
+            LOG.error(
+                "An internal error occurred while trying to format the message for SQS",
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
+            )
             return
         try:
             queue_url: str = sqs_queue_url_for_arn(subscriber["Endpoint"])

--- a/localstack-core/localstack/services/sns/publisher.py
+++ b/localstack-core/localstack/services/sns/publisher.py
@@ -89,9 +89,10 @@ class TopicPublisher(abc.ABC):
         try:
             self._publish(context=context, subscriber=subscriber)
         except Exception:
-            LOG.exception(
+            LOG.error(
                 "An internal error occurred while trying to send the SNS message %s",
                 context.message,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
             return
 
@@ -147,9 +148,10 @@ class EndpointPublisher(abc.ABC):
         try:
             self._publish(context=context, endpoint=endpoint)
         except Exception:
-            LOG.exception(
+            LOG.error(
                 "An internal error occurred while trying to send the SNS message %s",
                 context.message,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
             return
 

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -405,18 +405,27 @@ class QueueUpdateWorker:
             try:
                 queue.requeue_inflight_messages()
             except Exception:
-                LOG.exception("error re-queueing inflight messages")
+                LOG.error(
+                    "error re-queueing inflight messages",
+                    exc_info=LOG.isEnabledFor(logging.DEBUG),
+                )
 
             try:
                 queue.enqueue_delayed_messages()
             except Exception:
-                LOG.exception("error enqueueing delayed messages")
+                LOG.error(
+                    "error enqueueing delayed messages",
+                    exc_info=LOG.isEnabledFor(logging.DEBUG),
+                )
 
             if config.SQS_ENABLE_MESSAGE_RETENTION_PERIOD:
                 try:
                     queue.remove_expired_messages()
                 except Exception:
-                    LOG.exception("error removing expired messages")
+                    LOG.error(
+                        "error removing expired messages",
+                        exc_info=LOG.isEnabledFor(logging.DEBUG),
+                    )
 
     def start(self):
         with self.mutex:
@@ -697,8 +706,10 @@ class SqsDeveloperEndpoints:
         try:
             account_id, region, queue_name = parse_queue_url(service_request.get("QueueUrl"))
         except ValueError:
-            LOG.exception(
-                "Error while parsing Queue URL from request values: %s", service_request.get
+            LOG.error(
+                "Error while parsing Queue URL from request values: %s",
+                service_request.get,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
             raise InvalidAddress()
 

--- a/localstack-core/localstack/services/sqs/query_api.py
+++ b/localstack-core/localstack/services/sqs/query_api.py
@@ -166,7 +166,7 @@ def handle_request(request: Request, region: str) -> Response:
         op = service.operation_model(service.operation_names[0])
         return serializer.serialize_error_to_response(e, op, request.headers, request_id)
     except Exception as e:
-        LOG.exception("exception")
+        LOG.error("exception", exc_info=LOG.isEnabledFor(logging.DEBUG))
         op = service.operation_model(service.operation_names[0])
         return serializer.serialize_error_to_response(
             CommonServiceException(

--- a/localstack-core/localstack/services/stepfunctions/backend/execution.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/execution.py
@@ -356,10 +356,11 @@ class Execution:
         try:
             self._get_events_client().put_events(Entries=[entry])
         except Exception:
-            LOG.exception(
+            LOG.error(
                 "Unable to send notification of Entry='%s' for Step Function execution with Arn='%s' to EventBridge.",
                 entry,
                 self.exec_arn,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
 
 

--- a/localstack-core/localstack/services/transcribe/provider.py
+++ b/localstack-core/localstack/services/transcribe/provider.py
@@ -412,4 +412,9 @@ class TranscribeProvider(TranscribeApi):
             job["FailureReason"] = failure_reason or str(exc)
             job["TranscriptionJobStatus"] = TranscriptionJobStatus.FAILED
 
-            LOG.exception("Transcription job %s failed: %s", job_name, job["FailureReason"])
+            LOG.error(
+                "Transcription job %s failed: %s",
+                job_name,
+                job["FailureReason"],
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
+            )

--- a/localstack-core/localstack/utils/analytics/metadata.py
+++ b/localstack-core/localstack/utils/analytics/metadata.py
@@ -148,7 +148,10 @@ def is_license_activated() -> bool:
 
         return licensingv2.get_licensed_environment().activated
     except Exception:
-        LOG.exception("Could not determine license activation status")
+        LOG.error(
+            "Could not determine license activation status",
+            exc_info=LOG.isEnabledFor(logging.DEBUG),
+        )
         return False
 
 

--- a/localstack-core/localstack/utils/http.py
+++ b/localstack-core/localstack/utils/http.py
@@ -298,11 +298,12 @@ def download_github_artifact(url: str, target_file: str, timeout: int = None):
             return True
         except Exception as e:
             if print_error:
-                LOG.exception(
+                LOG.error(
                     "Unable to download Github artifact from %s to %s: %s %s",
                     url,
                     target_file,
                     e,
+                    exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
 
     # if a GitHub API token is set, use it to avoid rate limiting issues

--- a/localstack-core/localstack/utils/net.py
+++ b/localstack-core/localstack/utils/net.py
@@ -97,7 +97,12 @@ def is_port_open(
                         sock.recvfrom(1024)
                 except Exception:
                     if not quiet:
-                        LOG.exception("Error connecting to UDP port %s:%s", host, port)
+                        LOG.error(
+                            "Error connecting to UDP port %s:%s",
+                            host,
+                            port,
+                            exc_info=LOG.isEnabledFor(logging.DEBUG),
+                        )
                     return False
             elif nw_protocol == socket.SOCK_STREAM:
                 result = sock.connect_ex((host, port))


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As a part of the initiative for improving Localstack error messages and stack traces, this PR aims to ensure that stack traces are logged when debug mode is enabled. Currently, in some use cases stack traces are logged without checking if debug mode is enabled or not. This causes excessive log noise even when `DEBUG=0`. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This PR cleans up logging across different use cases to ensure that stack traces are only logged when debug mode is enabled.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
