### PR TITLE
CFNV2: extract propagate_to_stack

### DIFF
--- a/localstack-core/localstack/services/cloudformation/v2/types.py
+++ b/localstack-core/localstack/services/cloudformation/v2/types.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import NotRequired, TypedDict
+
+from localstack.aws.api.cloudformation import Output, ResourceStatus
+
+
+class EngineParameter(TypedDict):
+    """
+    Parameters supplied by the user. The resolved value field is populated by the engine
+    """
+
+    type_: str
+    given_value: NotRequired[str | None]
+    resolved_value: NotRequired[str | None]
+    default_value: NotRequired[str | None]
+
+
+def engine_parameter_value(parameter: EngineParameter) -> str:
+    value = parameter.get("given_value") or parameter.get("default_value")
+    if value is None:
+        raise RuntimeError("Parameter value is None")
+
+    return value
+
+
+class ResolvedResource(TypedDict):
+    LogicalResourceId: str
+    Type: str
+    Properties: dict
+    ResourceStatus: ResourceStatus
+    PhysicalResourceId: str | None
+    LastUpdatedTimestamp: datetime | None
+
+
+@dataclass
+class ChangeSetModelExecutorResult:
+    resources: dict[str, ResolvedResource]
+    outputs: list[Output]
+    exports: dict
+
+    error_message: str | None = None


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We have a few places where change set data should be propagated to the parent stack. The longer we leave things in this state the more discrepency between behaviours we will have, so let's extract a helper method to do this for us


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Create `types` submodule to prevent circular imports
* Add helper function to propagate state from the change set to the parent stack

## Testing

If tests pass then this refactoring was a success

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
