### PR TITLE
CFNV2: fix select in mapping test

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -381,7 +381,7 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             error_key = "::".join([map_name, top_level_key, second_level_key])
             raise ValidationError(f"Template error: Unable to get mapping for {error_key}")
         second_level_value = top_level_value.bindings.get(second_level_key)
-        if not isinstance(second_level_value, TerminalValue):
+        if not isinstance(second_level_value, (TerminalValue, NodeArray, NodeObject)):
             error_key = "::".join([map_name, top_level_key, second_level_key])
             raise ValidationError(f"Template error: Unable to get mapping for {error_key}")
         mapping_value_delta = self.visit(second_level_value)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

I merged a PR (#12980) without rebasing on top of #12955, and so introduced an error that was not caught in each individual PR. My PR added stricter validations of types when looking up values in maps, and the test involved looking up values in maps. The return type for the lookup was an array which was not included in my allowlist of valid types. As such a `ValidationError` is thrown when it should not be.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Fix the test to include `NodeArray` and `NodeObject` types as well as `TerminalValue`. Note: the secondary level key is visited, so if it is itself a nested intrinsic function (if that's even possible in CFn) then the value is subsequently resolved.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
