### PR TITLE
fix unit test reporting

### DIFF
--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -317,7 +317,7 @@ jobs:
         if: success() || failure()
         with:
           files: |
-            test-results-preflight/*.xml
+            **/pytest-junit-*.xml
           check_name: "Test Results ${{ inputs.testAWSAccountId != '000000000000' && '(MA/MR) ' || ''}}- Preflight, Unit"
           test_file_prefix: "-/opt/code/localstack/"
           action_fail_on_inconclusive: true


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/12995 Dependabot proposed updating the `download-artifacts` action.
Unfortunately, the release notes were not fully correct (see https://github.com/actions/download-artifact/issues/419), and the dependabot integration has limited permissions which is why I ignored the errors on the reporting step (which is exactly the step that broke due to the change).
This PR fixes this issue by broadening the file pattern for the picking up the unit tests (such that it fits both formats).

## Changes
- Fix picking up the unit test results after upgrading `actions/download-artifact`