### PR TITLE
fix port subrange from subclass

### DIFF
--- a/localstack-core/localstack/utils/net.py
+++ b/localstack-core/localstack/utils/net.py
@@ -343,7 +343,7 @@ class PortRange:
             raise ValueError(f"end not in range ({end} < {self.end})")
 
         # ensures that we return an instance of a subclass
-        port_range = self.__class__(start, end)
+        port_range = type(self)(start, end)
         port_range._ports_cache = self._ports_cache
         port_range._ports_lock = self._ports_lock
         return port_range

--- a/localstack-core/localstack/utils/net.py
+++ b/localstack-core/localstack/utils/net.py
@@ -342,7 +342,8 @@ class PortRange:
         if end > self.end:
             raise ValueError(f"end not in range ({end} < {self.end})")
 
-        port_range = PortRange(start, end)
+        # ensures that we return an instance of a subclass
+        port_range = self.__class__(start, end)
         port_range._ports_cache = self._ports_cache
         port_range._ports_lock = self._ports_lock
         return port_range

--- a/tests/unit/utils/test_net_utils.py
+++ b/tests/unit/utils/test_net_utils.py
@@ -23,6 +23,10 @@ from localstack.utils.net import (
 )
 
 
+class TestPortRange(PortRange):
+    pass
+
+
 @markers.skip_offline
 def test_resolve_hostname():
     assert "127." in resolve_hostname(LOCALHOST)
@@ -115,6 +119,14 @@ def test_subrange():
 
     sr.mark_reserved(50005)
     assert r.is_port_reserved(50005)
+
+
+def test_subrange_from_subclass():
+    r = TestPortRange(1000, 5000)
+    sr = r.subrange(1000, 2000)
+
+    assert isinstance(sr, TestPortRange)
+    assert sr.as_range() == range(1000, 2001)
 
 
 def test_get_free_tcp_port_range_fails_if_reserved(monkeypatch):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR aims to fix `PortRange.subrange` to return an instance of a subclass instead of harcoding `PortRange`.

While working on Elasticache and MemoryDb in container, I realised it was not possible to create more than 1 Redis/Valkey container at once. This was due to `PortRange` not validating that the port is available on the host. Using `_DockerPortRange` would fix the issue, however the `subrange` method would return an instance of `PortRange` instead of `_DockerPortRange`.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- use `self.__class__` to retrieve the instance's class
- Add simple unit test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
