### PR TITLE
Improve handling of LDM shutdowns during invocations

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack-core/localstack/services/lambda_/invocation/version_manager.py
@@ -213,12 +213,16 @@ class LambdaVersionManager:
                 self.store_logs(
                     invocation_result=invocation_result, execution_env=ldm_execution_environment
                 )
-            except CancelledError:
+            except CancelledError as e:
                 # Timeouts for invocation futures are managed by LDM, a cancelled error here is
                 # aligned with the debug container terminating whilst debugging/invocation.
+                LOG.debug("LDM invocation future encountered a cancelled error: '%s'", e)
                 invocation_result = InvocationResult(
                     request_id="",
-                    payload=to_bytes("Invocation was cancelled"),
+                    payload=to_bytes(
+                        "The invocation was canceled because the debug configuration "
+                        "was removed or the operation timed out"
+                    ),
                     is_error=True,
                     logs="",
                     executed_version=self.function_version.id.qualifier,

--- a/localstack-core/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack-core/localstack/services/lambda_/invocation/version_manager.py
@@ -232,6 +232,8 @@ class LambdaVersionManager:
                     logs="",
                     executed_version=self.function_version.id.qualifier,
                 )
+            finally:
+                ldm_execution_environment.release()
             return invocation_result
 
         with self.counting_service.get_invocation_lease(

--- a/localstack-core/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack-core/localstack/services/lambda_/invocation/version_manager.py
@@ -5,7 +5,6 @@ import time
 from concurrent.futures import Future
 from concurrent.futures._base import CancelledError
 
-from aws.services.lambda_.functions.lambda_integration import to_bytes
 from localstack import config
 from localstack.aws.api.lambda_ import (
     ProvisionedConcurrencyStatusEnum,
@@ -33,7 +32,7 @@ from localstack.services.lambda_.invocation.metrics import (
 )
 from localstack.services.lambda_.invocation.runtime_executor import get_runtime_executor
 from localstack.services.lambda_.ldm import LDMProvisioner
-from localstack.utils.strings import long_uid, truncate
+from localstack.utils.strings import long_uid, to_bytes, truncate
 from localstack.utils.threads import FuncThread, start_thread
 
 LOG = logging.getLogger(__name__)


### PR DESCRIPTION

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The current Lambda version manager invocation logic for LDM does not handle cases correctly when an LDM configuration is removed during invocation. These changes improve the process to ensure such scenarios are handled more gracefully.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Handle canceled errors during LDM invokes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
