### PR TITLE
Remove buildjet from s3 image arm pipeline

### DIFF
--- a/.github/workflows/aws-tests-s3-image.yml
+++ b/.github/workflows/aws-tests-s3-image.yml
@@ -3,7 +3,7 @@ name: AWS / S3 Image Integration Tests
 on:
   push:
     paths:
-      - .github/workflows/tests-s3-image.yml
+      - .github/workflows/aws-tests-s3-image.yml
       - localstack-core/localstack/aws/*.py
       - localstack-core/localstack/aws/handlers/*¨
       - localstack-core/localstack/aws/protocol/**
@@ -22,7 +22,7 @@ on:
       - main
   pull_request:
     paths:
-      - .github/workflows/tests-s3-image.yml
+      - .github/workflows/aws-tests-s3-image.yml
       - localstack-core/localstack/aws/*.py
       - localstack-core/localstack/aws/handlers/*¨
       - localstack-core/localstack/aws/protocol/**

--- a/.github/workflows/aws-tests-s3-image.yml
+++ b/.github/workflows/aws-tests-s3-image.yml
@@ -83,7 +83,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
-            runner: buildjet-2vcpu-ubuntu-2204-arm
+            runner: ubuntu-24.04-arm
     name: "Build and Test S3 image"
     env:
       PLATFORM: ${{ matrix.arch }}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We are currently seeing issues in the s3 pipeline after #12995 updated the checkout action, which requires node24. Example run: https://github.com/localstack/localstack/actions/runs/16937609832/job/47997914093?pr=13003

This node version is not available in the buildjet runners, failing the pipeline.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Use github actions runner instead of buildjet for s3 image pipeline
* Correct pipeline trigger paths for s3 image pipeline, to trigger if the workflow file is edited. This is likely why this issue failed to be discovered in #12995

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
