### PR TITLE
Migrate from jpype1-ext to jpype1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,8 @@ runtime = [
     "aws-sam-translator>=1.15.1",
     "crontab>=0.22.6",
     "cryptography>=41.0.5",
-    # allow Python programs full access to Java class libraries. Used for opt-in event ruler.
-    "jpype1-ext>=0.0.1",
+    # allow Python programs full access to Java class libraries. Used for stepfunctions jsonata support
+    "jpype1>=1.6.0",
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -193,7 +193,7 @@ jmespath==1.0.1
     #   botocore
 joserfc==1.2.2
     # via moto-ext
-jpype1-ext==0.0.2
+jpype1==1.6.0
     # via localstack-core
 jsii==1.113.0
     # via
@@ -289,7 +289,7 @@ packaging==25.0
     # via
     #   apispec
     #   build
-    #   jpype1-ext
+    #   jpype1
     #   pytest
     #   pytest-rerunfailures
 pandoc==2.4

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -141,7 +141,7 @@ jmespath==1.0.1
     #   botocore
 joserfc==1.2.2
     # via moto-ext
-jpype1-ext==0.0.2
+jpype1==1.6.0
     # via localstack-core (pyproject.toml)
 json5==0.12.1
     # via localstack-core (pyproject.toml)
@@ -216,7 +216,7 @@ packaging==25.0
     # via
     #   apispec
     #   build
-    #   jpype1-ext
+    #   jpype1
 parse==1.20.2
     # via openapi-core
 pathable==0.4.4

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -177,7 +177,7 @@ jmespath==1.0.1
     #   botocore
 joserfc==1.2.2
     # via moto-ext
-jpype1-ext==0.0.2
+jpype1==1.6.0
     # via localstack-core
 jsii==1.113.0
     # via
@@ -264,7 +264,7 @@ packaging==25.0
     # via
     #   apispec
     #   build
-    #   jpype1-ext
+    #   jpype1
     #   pytest
     #   pytest-rerunfailures
 parse==1.20.2

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -197,7 +197,7 @@ jmespath==1.0.1
     #   botocore
 joserfc==1.2.2
     # via moto-ext
-jpype1-ext==0.0.2
+jpype1==1.6.0
     # via localstack-core
 jsii==1.113.0
     # via
@@ -499,7 +499,7 @@ packaging==25.0
     # via
     #   apispec
     #   build
-    #   jpype1-ext
+    #   jpype1
     #   pytest
     #   pytest-rerunfailures
 pandoc==2.4


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With the addition of jpype1 last year, we had the issue that jpype would not pass control back to the python process on SIGTERM, but only on SIGINT.

This lead to issues with shutdown, which we fixed in our fork `jpype1-ext`. However, we have since contributed this fix upstream, and jpype1 1.6.0 should have this fix in by default, which was released recently.

With the effort to use python 3.13 as well, this provides a good opportunity to switch back, as `jpype1` provides wheels for python3.13, while `jpype1-ext` currently does not (it would be fairly easy to add, but unnecessary as we want to deprecate the fork anyway).


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Move from `jpype1-ext` to `jpype`
* General dependency updates that came in with `make upgrade-pinned-dependencies`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
