### PR TITLE
introduce `get-release-version` in docker helper

### DIFF
--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -54,8 +54,7 @@ function _fail {
 function _get_current_version() {
     # check if setuptools_scm is installed, if not prompt to install. python3 is expected to be present
     if ! python3 -m pip -qqq show setuptools_scm > /dev/null ; then
-      echo "ERROR: setuptools_scm is not installed. Run 'pip install --upgrade setuptools setuptools_scm'" >&2
-      exit 1
+      _fail "ERROR: setuptools_scm is not installed. Run 'pip install --upgrade setuptools setuptools_scm'"
     fi
     python3 -m setuptools_scm
 }
@@ -282,7 +281,7 @@ function cmd-get-release-version() {
     if _is_release_commit; then
         _get_current_version
     else
-        echo "Not a release commit."
+        _fail "Not a release commit."
     fi
 }
 

--- a/tests/bin/test.docker-helper.bats
+++ b/tests/bin/test.docker-helper.bats
@@ -276,9 +276,9 @@ setup_file() {
   [[ "$output" == "4.0.0" ]]
 }
 
-@test "get-release-version returns empty for a non-release commit" {
+@test "get-release-version throws error for non-release commits" {
   export TEST_SPECIFIC_VERSION="4.0.0.dev123"
   run bin/docker-helper.sh get-release-version
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 1 ]
   [[ "$output" == "Not a release commit." ]]
 }


### PR DESCRIPTION
## Motivation

- I want to be able to get the release version if `HEAD` is a release tag via `docker-helper.sh`.

## Changes

- Introduce `get-release-version` command which checks if commit is a release, and if so, outputs the version. Otherwise just a message telling that the commit is not a release.