### PR TITLE
CFNV2: implement NoEcho support

### DIFF
--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -226,7 +226,10 @@ class CloudformationProviderV2(CloudformationProvider):
             given_value = parameters.get(name)
             default_value = parameter.get("Default")
             resolved_parameter = EngineParameter(
-                type_=parameter["Type"], given_value=given_value, default_value=default_value
+                type_=parameter["Type"],
+                given_value=given_value,
+                default_value=default_value,
+                no_echo=parameter.get("NoEcho"),
             )
 
             # TODO: support other parameter types
@@ -501,9 +504,7 @@ class CloudformationProviderV2(CloudformationProvider):
             change_set.set_execution_status(ExecutionStatus.UNAVAILABLE)
             change_set.status_reason = "The submitted information didn't contain changes. Submit different information to create a change set."
         else:
-            if stack.status in [StackStatus.CREATE_COMPLETE, StackStatus.UPDATE_COMPLETE]:
-                stack.set_stack_status(StackStatus.UPDATE_IN_PROGRESS)
-            else:
+            if stack.status not in [StackStatus.CREATE_COMPLETE, StackStatus.UPDATE_COMPLETE]:
                 stack.set_stack_status(StackStatus.REVIEW_IN_PROGRESS)
 
             change_set.set_change_set_status(ChangeSetStatus.CREATE_COMPLETE)
@@ -613,6 +614,10 @@ class CloudformationProviderV2(CloudformationProvider):
             )
             if resolved_value := resolved_parameter.get("resolved_value"):
                 parameter["ResolvedValue"] = resolved_value
+
+            # TODO :what happens to the resolved value?
+            if resolved_parameter.get("no_echo", False):
+                parameter["ParameterValue"] = "****"
             result.append(parameter)
 
         return result

--- a/localstack-core/localstack/services/cloudformation/v2/types.py
+++ b/localstack-core/localstack/services/cloudformation/v2/types.py
@@ -13,6 +13,7 @@ class EngineParameter(TypedDict):
     given_value: NotRequired[str | None]
     resolved_value: NotRequired[str | None]
     default_value: NotRequired[str | None]
+    no_echo: NotRequired[bool | None]
 
 
 def engine_parameter_value(parameter: EngineParameter) -> str:

--- a/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
@@ -1573,7 +1573,7 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_stacks.py::test_no_echo_parameter": {
-    "recorded-date": "19-12-2024, 11:35:19",
+    "recorded-date": "15-08-2025, 12:01:58",
     "recorded-content": {
       "describe_stacks": {
         "Stacks": [
@@ -1646,6 +1646,141 @@
           "HTTPStatusCode": 200
         }
       },
+      "describe_change_set_on_create_complete": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-name:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "CausingEntity": "SecretParameter",
+                  "ChangeSource": "ParameterReference",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Metadata",
+                    "RequiresRecreation": "Never"
+                  }
+                },
+                {
+                  "CausingEntity": "SecretParameter",
+                  "ChangeSource": "ParameterReference",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Tags",
+                    "RequiresRecreation": "Never"
+                  }
+                },
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
+                  "Target": {
+                    "Attribute": "Metadata",
+                    "RequiresRecreation": "Never"
+                  }
+                },
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Tags",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "LocalBucket",
+              "PhysicalResourceId": "cfn-noecho-bucket",
+              "Replacement": "False",
+              "ResourceType": "AWS::S3::Bucket",
+              "Scope": [
+                "Metadata",
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "NormalParameter",
+            "ParameterValue": "Some default value here"
+          },
+          {
+            "ParameterKey": "SecretParameter",
+            "ParameterValue": "****"
+          },
+          {
+            "ParameterKey": "SecretParameterWithDefault",
+            "ParameterValue": "****"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_stack_on_create_complete": {
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_AUTO_EXPAND",
+              "CAPABILITY_IAM",
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "LastUpdatedTime": "datetime",
+            "NotificationARNs": [],
+            "Outputs": [
+              {
+                "Description": "Secret value from parameter",
+                "OutputKey": "SecretValue",
+                "OutputValue": "SecretValue"
+              }
+            ],
+            "Parameters": [
+              {
+                "ParameterKey": "NormalParameter",
+                "ParameterValue": "Some default value here"
+              },
+              {
+                "ParameterKey": "SecretParameter",
+                "ParameterValue": "****"
+              },
+              {
+                "ParameterKey": "SecretParameterWithDefault",
+                "ParameterValue": "****"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "CREATE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "describe_updated_stacks": {
         "Stacks": [
           {
@@ -1697,8 +1832,8 @@
       },
       "describe_updated_change_set": {
         "Capabilities": [],
-        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
-        "ChangeSetName": "<change-set-name:1>",
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:4>",
+        "ChangeSetName": "<change-set-name:2>",
         "Changes": [
           {
             "ResourceChange": {
@@ -1831,8 +1966,8 @@
       },
       "describe_updated_change_set_no_echo_true": {
         "Capabilities": [],
-        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:4>",
-        "ChangeSetName": "<change-set-name:2>",
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:5>",
+        "ChangeSetName": "<change-set-name:3>",
         "Changes": [
           {
             "ResourceChange": {
@@ -1965,8 +2100,8 @@
       },
       "describe_updated_change_set_no_echo_false": {
         "Capabilities": [],
-        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:5>",
-        "ChangeSetName": "<change-set-name:3>",
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:6>",
+        "ChangeSetName": "<change-set-name:4>",
         "Changes": [
           {
             "ResourceChange": {

--- a/tests/aws/services/cloudformation/api/test_stacks.validation.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.validation.json
@@ -75,7 +75,13 @@
     "last_validated_date": "2024-03-26T17:59:43+00:00"
   },
   "tests/aws/services/cloudformation/api/test_stacks.py::test_no_echo_parameter": {
-    "last_validated_date": "2024-12-19T11:35:15+00:00"
+    "last_validated_date": "2025-08-15T12:01:58+00:00",
+    "durations_in_seconds": {
+      "setup": 1.28,
+      "call": 67.64,
+      "teardown": 4.43,
+      "total": 73.35
+    }
   },
   "tests/aws/services/cloudformation/api/test_stacks.py::test_no_parameters_given": {
     "last_validated_date": "2025-07-31T16:12:14+00:00",

--- a/tests/aws/services/cloudformation/api/test_transformers.py
+++ b/tests/aws/services/cloudformation/api/test_transformers.py
@@ -72,10 +72,6 @@ def test_duplicate_resources(deploy_cfn_template, s3_bucket, snapshot, aws_clien
     snapshot.match("api-resources", resources)
 
 
-@skip_if_v2_provider(
-    "AWS::Include",
-    reason="The transformation is run however the physical resource id for the resource is not available",
-)
 @markers.aws.validated
 def test_transformer_property_level(deploy_cfn_template, s3_bucket, aws_client, snapshot):
     api_spec = textwrap.dedent("""


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

NoEcho allows sensitive parameter values to be masked in the the `describe_` operations.
<!-- What changes does this PR make? How does LocalStack behave differently now? -->

> [!NOTE]
> This forms a stack on top of #13010  

## Changes

* Implement enough to make the one test pass
* Expand the test to make sure we understand the state changes when creating change sets for existing stacks

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
