### PR TITLE
CFNV2: finish URL replacements for API Gateway

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
@@ -112,6 +112,30 @@ class ChangeSetModelDescriber(ChangeSetModelPreproc):
             delta.after = CHANGESET_KNOWN_AFTER_APPLY
         return delta
 
+    def visit_node_intrinsic_function_fn_select(
+        self, node_intrinsic_function: NodeIntrinsicFunction
+    ):
+        # TODO: should this not _ALWAYS_ return CHANGESET_KNOWN_AFTER_APPLY?
+        arguments_delta = self.visit(node_intrinsic_function.arguments)
+        delta = PreprocEntityDelta()
+        if not is_nothing(arguments_delta.before):
+            idx = arguments_delta.before[0]
+            arr = arguments_delta.before[1]
+            try:
+                delta.before = arr[int(idx)]
+            except Exception:
+                delta.before = CHANGESET_KNOWN_AFTER_APPLY
+
+        if not is_nothing(arguments_delta.after):
+            idx = arguments_delta.after[0]
+            arr = arguments_delta.after[1]
+            try:
+                delta.after = arr[int(idx)]
+            except Exception:
+                delta.after = CHANGESET_KNOWN_AFTER_APPLY
+
+        return delta
+
     def _register_resource_change(
         self,
         logical_id: str,

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -630,8 +630,12 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
     def visit_node_intrinsic_function_fn_not(
         self, node_intrinsic_function: NodeIntrinsicFunction
     ) -> PreprocEntityDelta:
-        def _compute_fn_not(arg: bool) -> bool:
-            return not arg
+        def _compute_fn_not(arg: list[bool] | bool) -> bool:
+            # Is the argument ever a lone boolean?
+            if isinstance(arg, list):
+                return not arg[0]
+            else:
+                return not arg
 
         arguments_delta = self.visit(node_intrinsic_function.arguments)
         delta = self._cached_apply(

--- a/tests/aws/services/cloudformation/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.py
@@ -166,11 +166,6 @@ def test_cfn_apigateway_swagger_import(
     assert content["url"].endswith("/post")
 
 
-@skip_if_v2_provider(
-    "Provider",
-    reason="The v2 provider appears to instead return the correct url: "
-    "https://e1i3grfiws.execute-api.us-east-1.localhost.localstack.cloud/prod/",
-)
 @markers.aws.only_localstack
 def test_url_output(httpserver, deploy_cfn_template):
     httpserver.expect_request("").respond_with_data(b"", 200)

--- a/tests/aws/services/cloudformation/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.py
@@ -5,7 +5,7 @@ from operator import itemgetter
 import requests
 from localstack_snapshot.snapshots.transformer import SortingTransformer
 from tests.aws.services.apigateway.apigateway_fixtures import api_invoke_url
-from tests.aws.services.cloudformation.conftest import skip_if_v2_provider, skipped_v2_items
+from tests.aws.services.cloudformation.conftest import skipped_v2_items
 
 from localstack import constants
 from localstack.aws.api.lambda_ import Runtime
@@ -576,9 +576,6 @@ def test_api_gateway_with_policy_as_dict(deploy_cfn_template, snapshot, aws_clie
     snapshot.match("rest-api", rest_api)
 
 
-@skip_if_v2_provider(
-    "Other", reason="lambda function fails on creation due to invalid function name"
-)
 @markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(
     paths=[

--- a/tests/aws/services/cloudformation/resources/test_secretsmanager.py
+++ b/tests/aws/services/cloudformation/resources/test_secretsmanager.py
@@ -4,7 +4,6 @@ import os
 import aws_cdk as cdk
 import botocore.exceptions
 import pytest
-from tests.aws.services.cloudformation.conftest import skip_if_v2_provider
 
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
@@ -77,7 +76,6 @@ def test_cfn_secret_policy(deploy_cfn_template, block_public_policy, aws_client,
     snapshot.add_transformer(snapshot.transform.key_value("Name", "policy-name"))
 
 
-@skip_if_v2_provider("Other")
 @markers.aws.validated
 def test_cdk_deployment_generates_secret_value_if_no_value_is_provided(
     aws_client, snapshot, infrastructure_setup

--- a/tests/aws/services/cloudformation/resources/test_sns.py
+++ b/tests/aws/services/cloudformation/resources/test_sns.py
@@ -2,7 +2,6 @@ import os.path
 
 import aws_cdk as cdk
 import pytest
-from tests.aws.services.cloudformation.conftest import skip_if_v2_provider
 
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
@@ -80,7 +79,6 @@ def test_sns_subscription(deploy_cfn_template, aws_client):
     assert len(subscriptions["Subscriptions"]) > 0
 
 
-@skip_if_v2_provider("Engine")
 @markers.aws.validated
 def test_deploy_stack_with_sns_topic(deploy_cfn_template, aws_client):
     stack = deploy_cfn_template(

--- a/tests/aws/services/cloudformation/resources/test_sns.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_sns.validation.json
@@ -1,9 +1,27 @@
 {
+  "tests/aws/services/cloudformation/resources/test_sns.py::test_deploy_stack_with_sns_topic": {
+    "last_validated_date": "2025-08-18T12:05:15+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 96.67,
+      "teardown": 0.12,
+      "total": 96.79
+    }
+  },
   "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_subscription_region": {
     "last_validated_date": "2025-05-28T10:46:56+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_fifo_with_deduplication": {
     "last_validated_date": "2023-11-27T20:27:29+00:00"
+  },
+  "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_policy_resets_to_default": {
+    "last_validated_date": "2025-07-04T00:04:32+00:00",
+    "durations_in_seconds": {
+      "setup": 1.08,
+      "call": 22.27,
+      "teardown": 0.09,
+      "total": 23.44
+    }
   },
   "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_update_attributes": {
     "last_validated_date": "2025-07-03T17:19:44+00:00",
@@ -21,15 +39,6 @@
       "call": 73.16,
       "teardown": 50.36,
       "total": 124.06
-    }
-  },
-  "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_policy_resets_to_default": {
-    "last_validated_date": "2025-07-04T00:04:32+00:00",
-    "durations_in_seconds": {
-      "setup": 1.08,
-      "call": 22.27,
-      "teardown": 0.09,
-      "total": 23.44
     }
   },
   "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_with_attributes": {

--- a/tests/aws/services/cloudformation/resources/test_stepfunctions.py
+++ b/tests/aws/services/cloudformation/resources/test_stepfunctions.py
@@ -4,7 +4,6 @@ import urllib.parse
 
 import pytest
 from localstack_snapshot.snapshots.transformer import JsonpathTransformer
-from tests.aws.services.cloudformation.conftest import skip_if_v2_provider
 
 from localstack import config
 from localstack.testing.pytest import markers
@@ -47,10 +46,6 @@ def test_statemachine_definitionsubstitution(deploy_cfn_template, aws_client):
     assert "hello from statemachine" in execution_desc["output"]
 
 
-@skip_if_v2_provider(
-    "Engine",
-    reason="During change set describe the a Ref to a not yet deployed resource returns null which is an invalid input for Fn::Split",
-)
 @markers.aws.validated
 def test_nested_statemachine_with_sync2(deploy_cfn_template, aws_client):
     stack = deploy_cfn_template(

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -365,7 +365,6 @@ class TestSsmParameters:
         topic_name = result.outputs["TopicName"]
         assert topic_name == parameter_value
 
-    @skip_if_v2_provider("Resolve")
     @markers.aws.validated
     def test_resolve_ssm_with_version(self, create_parameter, deploy_cfn_template, aws_client):
         parameter_key = f"param-key-{short_uid()}"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

One remaining case where we replace API Gateway urls with LocalStack URLs remains.

Note: this is needed for APIGWv1 because the URL is not an output of the API so we have to adjust it in CFn :( 

> [!NOTE]
> This forms a stack on top of #13011  

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Handle URL replacements in Join and Sub

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
