### PR TITLE
extend the Encoder/Decoder state API to be type-aware

### DIFF
--- a/localstack-core/localstack/state/core.py
+++ b/localstack-core/localstack/state/core.py
@@ -97,42 +97,48 @@ class AssetDirectory:
 
 
 class Encoder:
-    def encodes(self, obj: Any) -> bytes:
+    def encodes(self, obj: Any, py_type: type = None) -> bytes:
         """
         Encode an object into bytes.
 
         :param obj: the object to encode
+        :param py_type: the type of the object. needed by some encoders that don't have implicit type knowledge.
         :return: the encoded object
         """
         b = io.BytesIO()
         self.encode(obj, b)
         return b.getvalue()
 
-    def encode(self, obj: Any, file: IO[bytes]):
+    def encode(self, obj: Any, file: IO[bytes], py_type: type = None):
         """
         Encode an object into bytes.
 
         :param obj: the object to encode
+        :param py_type: the type of the object. needed by some encoders that don't have implicit type knowledge.
         :param file: the file to write the encoded data into
         """
         raise NotImplementedError
 
 
 class Decoder:
-    def decodes(self, data: bytes) -> Any:
+    def decodes(self, data: bytes, py_type: type = None) -> Any:
         """
         Decode a previously encoded object.
 
         :param data: the encoded object to decode
+        :param py_type: the type that is expected as return type. Needed by some decoders that don't have implicit
+        type knowledge.
         :return: the decoded object
         """
-        return self.decode(io.BytesIO(data))
+        return self.decode(io.BytesIO(data), py_type)
 
-    def decode(self, file: IO[bytes]) -> Any:
+    def decode(self, file: IO[bytes], py_type: type = None) -> Any:
         """
         Decode a previously encoded object.
 
         :param file: the io object containing the object to decode
+        :param py_type: the type that is expected as return type. Needed by some decoders that don't have implicit
+        type knowledge.
         :return: the decoded object
         """
         raise NotImplementedError

--- a/localstack-core/localstack/state/pickle.py
+++ b/localstack-core/localstack/state/pickle.py
@@ -237,7 +237,7 @@ class PickleEncoder(Encoder):
     def __init__(self, pickler_class: type[dill.Pickler] = None):
         self.pickler_class = pickler_class or Pickler
 
-    def encode(self, obj: Any, file: BinaryIO):
+    def encode(self, obj: Any, file: BinaryIO, py_type: type = None) -> Any:
         return self.pickler_class(file).dump(obj)
 
 
@@ -252,7 +252,7 @@ class PickleDecoder(Decoder):
     def __init__(self, unpickler_class: type[dill.Unpickler] = None):
         self.unpickler_class = unpickler_class or dill.Unpickler
 
-    def decode(self, file: BinaryIO) -> Any:
+    def decode(self, file: BinaryIO, py_type=None) -> Any:
         return self.unpickler_class(file).load()
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Currently our decoders serve as adapter only to dill pickle. Because they type information is stored in the pickle, you can de-serialize a pickle and get the correct type without having to specify it at deserialization. Unfortunately this process breaks down when you've moved or renamed a class that you want to deserialize into.

So to be able to de-couple code and data serialization, and separate reader/writer schema, we need the decoder to be type-aware. The Encoder has to be type aware for certain operations as well, for example if we pass a TypedDict to encode, we won't know which type to encode since python doesn't retain type information for typed dicts. So this is just to make the encoding API a more flexible.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* state Encoder and Decoder APIs now optionally take a expected_type argument that allows an underlying implementation to be specific about the python type to serialize or deserialize into

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
