### PR TITLE
SNS: support passing `MessageGroupId` to non-FIFO topic

### DIFF
--- a/localstack-core/localstack/services/sns/provider.py
+++ b/localstack-core/localstack/services/sns/provider.py
@@ -583,10 +583,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             raise InvalidParameterException(
                 "Invalid parameter: MessageDeduplicationId Reason: The request includes MessageDeduplicationId parameter that is not valid for this topic type"
             )
-        elif message_group_id:
-            raise InvalidParameterException(
-                "Invalid parameter: MessageGroupId Reason: The request includes MessageGroupId parameter that is not valid for this topic type"
-            )
+
         is_endpoint_publish = target_arn and ":endpoint/" in target_arn
         if message_structure == "json":
             try:

--- a/localstack-core/localstack/services/sns/publisher.py
+++ b/localstack-core/localstack/services/sns/publisher.py
@@ -338,22 +338,31 @@ class SqsTopicPublisher(TopicPublisher):
         if is_raw_message_delivery(subscriber) and msg_context.message_attributes:
             kwargs["MessageAttributes"] = msg_context.message_attributes
 
-        if msg_context.message_group_id:
-            kwargs["MessageGroupId"] = msg_context.message_group_id
-
         # SNS now allows regular non-fifo subscriptions to FIFO topics. Validate that the subscription target is fifo
         # before passing the FIFO-only parameters
-        if subscriber["Endpoint"].endswith(".fifo"):
-            if msg_context.message_deduplication_id:
-                kwargs["MessageDeduplicationId"] = msg_context.message_deduplication_id
-            elif subscriber["TopicArn"].endswith(".fifo"):
-                # Amazon SNS uses the message body provided to generate a unique hash value to use as the deduplication
-                # ID for each message, so you don't need to set a deduplication ID when you send each message.
-                # https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
-                content = msg_context.message_content("sqs")
-                kwargs["MessageDeduplicationId"] = hashlib.sha256(
-                    content.encode("utf-8")
-                ).hexdigest()
+
+        # SNS will only forward the `MessageGroupId` for Fair Queues in some scenarios:
+        # - non-FIFO SNS topic to Fair Queue
+        # - FIFO topic to FIFO queue
+        # It will NOT forward it with FIFO topic to regular Queue (possibly used for internal grouping without relying
+        # on SQS capabilities)
+        if subscriber["TopicArn"].endswith(".fifo"):
+            if subscriber["Endpoint"].endswith(".fifo"):
+                if msg_context.message_group_id:
+                    kwargs["MessageGroupId"] = msg_context.message_group_id
+                if msg_context.message_deduplication_id:
+                    kwargs["MessageDeduplicationId"] = msg_context.message_deduplication_id
+                else:
+                    # SNS uses the message body provided to generate a unique hash value to use as the deduplication ID
+                    # for each message, so you don't need to set a deduplication ID when you send each message.
+                    # https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
+                    content = msg_context.message_content("sqs")
+                    kwargs["MessageDeduplicationId"] = hashlib.sha256(
+                        content.encode("utf-8")
+                    ).hexdigest()
+
+        elif msg_context.message_group_id:
+            kwargs["MessageGroupId"] = msg_context.message_group_id
 
         # TODO: for message deduplication, we are using the underlying features of the SQS queue
         # however, SQS queue only deduplicate at the Queue level, where the SNS topic deduplicate on the topic level

--- a/localstack-core/localstack/services/sns/publisher.py
+++ b/localstack-core/localstack/services/sns/publisher.py
@@ -338,11 +338,12 @@ class SqsTopicPublisher(TopicPublisher):
         if is_raw_message_delivery(subscriber) and msg_context.message_attributes:
             kwargs["MessageAttributes"] = msg_context.message_attributes
 
+        if msg_context.message_group_id:
+            kwargs["MessageGroupId"] = msg_context.message_group_id
+
         # SNS now allows regular non-fifo subscriptions to FIFO topics. Validate that the subscription target is fifo
         # before passing the FIFO-only parameters
         if subscriber["Endpoint"].endswith(".fifo"):
-            if msg_context.message_group_id:
-                kwargs["MessageGroupId"] = msg_context.message_group_id
             if msg_context.message_deduplication_id:
                 kwargs["MessageDeduplicationId"] = msg_context.message_deduplication_id
             elif subscriber["TopicArn"].endswith(".fifo"):

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -771,7 +771,11 @@ class StandardQueue(SqsQueue):
                 f"request includes a parameter that is not valid for this queue type."
             )
 
-        standard_message = SqsMessage(time.time(), message)
+        standard_message = SqsMessage(
+            time.time(),
+            message,
+            message_group_id=message_group_id,
+        )
 
         if visibility_timeout is not None:
             standard_message.visibility_timeout = visibility_timeout

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -2561,11 +2561,6 @@ class TestSNSSubscriptionSQSFifo:
         assert e.match("MessageDeduplicationId")
         snapshot.match("no-msg-dedup-regular-topic", e.value.response)
 
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(TopicArn=topic_arn, Message="test", MessageGroupId=short_uid())
-        assert e.match("MessageGroupId")
-        snapshot.match("no-msg-group-id-regular-topic", e.value.response)
-
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -2329,6 +2329,33 @@ class TestSNSSubscriptionSQS:
         # if the verification failed, it would raise `InvalidSignature`
         assert is_valid is None
 
+    @markers.aws.validated
+    def test_publish_message_group_id(
+        self,
+        aws_client,
+        sns_topic,
+        sqs_create_queue,
+        sns_create_sqs_subscription,
+        snapshot,
+    ):
+        topic_arn = sns_topic["Attributes"]["TopicArn"]
+        queue_url = sqs_create_queue()
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message="test signature value with attributes",
+            MessageGroupId="my-group-id-1",
+            MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "1"}},
+        )
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            WaitTimeSeconds=10,
+            AttributeNames=["All"],
+            MessageAttributeNames=["All"],
+        )
+        snapshot.match("messages", response)
+
 
 class TestSNSSubscriptionSQSFifo:
     @markers.aws.validated

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -2206,7 +2206,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_message_to_fifo_sqs[True]": {
-    "recorded-date": "07-12-2023, 10:13:37",
+    "recorded-date": "18-08-2025, 16:25:29",
     "recorded-content": {
       "messages": {
         "Messages": [
@@ -2248,7 +2248,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_message_to_fifo_sqs[False]": {
-    "recorded-date": "07-12-2023, 10:13:41",
+    "recorded-date": "18-08-2025, 16:25:32",
     "recorded-content": {
       "messages": {
         "Messages": [
@@ -2290,7 +2290,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_validations_for_fifo": {
-    "recorded-date": "24-08-2023, 23:55:19",
+    "recorded-date": "18-08-2025, 16:21:40",
     "recorded-content": {
       "not-fifo-topic": {
         "Error": {
@@ -2351,17 +2351,6 @@
         "Error": {
           "Code": "InvalidParameter",
           "Message": "Invalid parameter: MessageDeduplicationId Reason: The request includes MessageDeduplicationId parameter that is not valid for this topic type",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "no-msg-group-id-regular-topic": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: MessageGroupId Reason: The request includes MessageGroupId parameter that is not valid for this topic type",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -3321,7 +3310,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_fifo_topic_to_regular_sqs[True]": {
-    "recorded-date": "24-08-2023, 23:53:59",
+    "recorded-date": "18-08-2025, 16:18:41",
     "recorded-content": {
       "messages": {
         "Messages": [
@@ -3360,7 +3349,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_fifo_topic_to_regular_sqs[False]": {
-    "recorded-date": "24-08-2023, 23:54:05",
+    "recorded-date": "18-08-2025, 16:18:46",
     "recorded-content": {
       "messages": {
         "Messages": [

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -5223,5 +5223,47 @@
         }
       }
     }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_publish_message_group_id": {
+    "recorded-date": "18-08-2025, 15:21:27",
+    "recorded-content": {
+      "messages": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageGroupId": "my-group-id-1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>",
+              "Message": "test signature value with attributes",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:<partition>:sns:<region>:111111111111:<resource:1>:<resource:2>",
+              "MessageAttributes": {
+                "attr1": {
+                  "Type": "Number",
+                  "Value": "1"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -152,6 +152,15 @@
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_publish_batch_messages_without_topic": {
     "last_validated_date": "2023-08-24T21:36:13+00:00"
   },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_publish_message_group_id": {
+    "last_validated_date": "2025-08-18T15:21:27+00:00",
+    "durations_in_seconds": {
+      "setup": 1.14,
+      "call": 1.56,
+      "teardown": 0.52,
+      "total": 3.22
+    }
+  },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_publish_sqs_from_sns": {
     "last_validated_date": "2023-08-24T21:36:09+00:00"
   },

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -189,16 +189,40 @@
     "last_validated_date": "2023-08-24T21:36:32+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_fifo_topic_to_regular_sqs[False]": {
-    "last_validated_date": "2023-08-24T21:54:05+00:00"
+    "last_validated_date": "2025-08-18T16:18:46+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 5.09,
+      "teardown": 0.56,
+      "total": 5.65
+    }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_fifo_topic_to_regular_sqs[True]": {
-    "last_validated_date": "2023-08-24T21:53:59+00:00"
+    "last_validated_date": "2025-08-18T16:18:41+00:00",
+    "durations_in_seconds": {
+      "setup": 0.52,
+      "call": 5.91,
+      "teardown": 0.54,
+      "total": 6.97
+    }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_message_to_fifo_sqs[False]": {
-    "last_validated_date": "2023-11-09T20:12:07+00:00"
+    "last_validated_date": "2025-08-18T16:25:32+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.09,
+      "teardown": 0.53,
+      "total": 3.62
+    }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_message_to_fifo_sqs[True]": {
-    "last_validated_date": "2023-11-09T20:12:03+00:00"
+    "last_validated_date": "2025-08-18T16:25:29+00:00",
+    "durations_in_seconds": {
+      "setup": 0.5,
+      "call": 3.81,
+      "teardown": 0.59,
+      "total": 4.9
+    }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_message_to_fifo_sqs_ordering": {
     "last_validated_date": "2025-02-19T01:29:14+00:00"
@@ -225,7 +249,13 @@
     "last_validated_date": "2023-08-24T21:38:14+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_validations_for_fifo": {
-    "last_validated_date": "2023-08-24T21:55:19+00:00"
+    "last_validated_date": "2025-08-18T16:21:40+00:00",
+    "durations_in_seconds": {
+      "setup": 0.46,
+      "call": 3.5,
+      "teardown": 1.25,
+      "total": 5.21
+    }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_create_duplicate_topic_check_idempotency": {
     "last_validated_date": "2023-08-24T20:30:47+00:00"

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -4782,6 +4782,11 @@ class TestSqsProvider:
         )
         snapshot.match("send_message", send_result)
 
+        response = aws_sqs_client.receive_message(
+            QueueUrl=sqs_queue, WaitTimeSeconds=5, AttributeNames=["All"]
+        )
+        snapshot.match("get-message-with-deduplication-id", response)
+
 
 @pytest.fixture()
 def sqs_http_client(aws_http_client_factory, region_name):

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3963,7 +3963,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fair_queue_with_message_group_id[sqs]": {
-    "recorded-date": "30-07-2025, 09:52:06",
+    "recorded-date": "18-08-2025, 15:27:03",
     "recorded-content": {
       "send_message": {
         "MD5OfMessageBody": "78e731027d8fd50ed642340b7c9a63b3",
@@ -3972,15 +3972,57 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "get-message-with-deduplication-id": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageGroupId": "test",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": "message",
+            "MD5OfBody": "78e731027d8fd50ed642340b7c9a63b3",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fair_queue_with_message_group_id[sqs_query]": {
-    "recorded-date": "30-07-2025, 09:52:07",
+    "recorded-date": "18-08-2025, 15:27:04",
     "recorded-content": {
       "send_message": {
         "MD5OfMessageBody": "78e731027d8fd50ed642340b7c9a63b3",
         "MessageId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-message-with-deduplication-id": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageGroupId": "test",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": "message",
+            "MD5OfBody": "78e731027d8fd50ed642340b7c9a63b3",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -117,21 +117,21 @@
     "last_validated_date": "2024-04-30T13:49:31+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fair_queue_with_message_group_id[sqs]": {
-    "last_validated_date": "2025-07-30T09:52:07+00:00",
+    "last_validated_date": "2025-08-18T15:27:03+00:00",
     "durations_in_seconds": {
-      "setup": 1.2,
-      "call": 0.17,
-      "teardown": 0.18,
-      "total": 1.55
+      "setup": 1.05,
+      "call": 0.28,
+      "teardown": 0.16,
+      "total": 1.49
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fair_queue_with_message_group_id[sqs_query]": {
-    "last_validated_date": "2025-07-30T09:52:07+00:00",
+    "last_validated_date": "2025-08-18T15:27:04+00:00",
     "durations_in_seconds": {
-      "setup": 0.18,
-      "call": 0.58,
-      "teardown": 0.19,
-      "total": 0.95
+      "setup": 0.14,
+      "call": 0.56,
+      "teardown": 0.16,
+      "total": 0.86
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_high_throughput_after_creation[sqs]": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Related to #13008 -> https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-sns-standard-topics-sqs-fair-queues/

Since adding support for SQS Fair Queues, we can now pass a `MessageGroupId` to non-FIFO topic.

This PR implements that behavior in SNS, removing the previously raised exception, and properly passing the attribute. 

This also fixes the behavior in SQS itself following #12930, because we were not adding the `MessageGroupId` to the `Attributes` of the received Message, as this only done for FIFO queue. I've updated the SQS test to verify this


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- remove raising an exception for non-FIFO topics
- remove the check for FIFO topic before passing the attribute as kwarg to `SQS.SendMessage`
- fix the behavior in SQS to return the `MessageGroupId` as `Attributes` of the message
- update SQS test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
