### PR TITLE
S3/ASF parser: fix parsing header `list` shape type with multivalue headers

### DIFF
--- a/localstack-core/localstack/aws/protocol/parser.py
+++ b/localstack-core/localstack/aws/protocol/parser.py
@@ -240,14 +240,12 @@ class RequestParser(abc.ABC):
                     # Header lists can contain optional whitespace, so we strip it
                     # https://www.rfc-editor.org/rfc/rfc9110.html#name-lists-rule-abnf-extension
                     # It can also directly contain a list of headers
+                    # See https://datatracker.ietf.org/doc/html/rfc2616
                     payload = request.headers.getlist(header_name)
-                    if len(payload) == 1:
-                        header_values = payload[0].split(",")
-                        payload = [value.strip() for value in header_values]
+                    if payload:
+                        headers = ",".join(payload)
+                        payload = [value.strip() for value in headers.split(",")]
 
-                    # we set the payload to None in case the list in empty, as `getlist` returns an empty list
-                    if not payload:
-                        payload = None
                 else:
                     payload = request.headers.get(header_name)
 

--- a/localstack-core/localstack/aws/protocol/parser.py
+++ b/localstack-core/localstack/aws/protocol/parser.py
@@ -241,7 +241,7 @@ class RequestParser(abc.ABC):
                     # https://www.rfc-editor.org/rfc/rfc9110.html#name-lists-rule-abnf-extension
                     # It can also directly contain a list of headers
                     # See https://datatracker.ietf.org/doc/html/rfc2616
-                    payload = request.headers.getlist(header_name)
+                    payload = request.headers.getlist(header_name) or None
                     if payload:
                         headers = ",".join(payload)
                         payload = [value.strip() for value in headers.split(",")]

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -7,6 +7,7 @@ import io
 import json
 import logging
 import os
+import random
 import re
 import shutil
 import tempfile
@@ -5189,6 +5190,80 @@ class TestS3:
         assert resp.status_code == 204
         assert resp.headers.get("Content-Type") is None
         assert resp.headers.get("Content-Length") is None
+
+    @markers.aws.validated
+    def test_response_structure_get_obj_attrs(self, aws_http_client_factory, s3_bucket, aws_client):
+        """
+        Test that the response structure is correct for the S3 API for GetObjectAttributes
+        The order is important for the Java SDK
+        """
+        key_name = "get-obj-attrs"
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=key_name, Body="test")
+        headers = {"x-amz-content-sha256": "UNSIGNED-PAYLOAD"}
+
+        s3_http_client = aws_http_client_factory("s3", signer_factory=SigV4Auth)
+        bucket_url = _bucket_url(s3_bucket)
+
+        possible_attrs = ["StorageClass", "ETag", "ObjectSize", "ObjectParts", "Checksum"]
+
+        # GetObjectAttributes
+        get_object_attributes_url = f"{bucket_url}/{key_name}?attributes"
+        headers["x-amz-object-attributes"] = ",".join(possible_attrs)
+        resp = s3_http_client.get(get_object_attributes_url, headers=headers)
+
+        # shuffle the original list
+        shuffled_attrs = possible_attrs.copy()
+        while shuffled_attrs == possible_attrs:
+            random.shuffle(shuffled_attrs)
+
+        assert shuffled_attrs != possible_attrs
+
+        # check that the order of Attributes in the request should not affect the order in the response
+        headers["x-amz-object-attributes"] = ",".join(shuffled_attrs)
+        resp_randomized = s3_http_client.get(get_object_attributes_url, headers=headers)
+        assert resp_randomized.content == resp.content
+
+        def get_ordered_keys(content: bytes) -> list[str]:
+            resp_dict = xmltodict.parse(content)
+            get_attrs_response = resp_dict["GetObjectAttributesResponse"]
+            get_attrs_response.pop("@xmlns", None)
+            return list(get_attrs_response.keys())
+
+        ordered_keys = get_ordered_keys(resp.content)
+        assert ordered_keys[0] == "ETag"
+        assert ordered_keys[1] == "Checksum"
+        assert ordered_keys[2] == "StorageClass"
+        assert ordered_keys[3] == "ObjectSize"
+
+        # create a Multipart Upload to validate the `ObjectParts` field order
+        multipart_key = "multipart-key"
+        create_multipart = aws_client.s3.create_multipart_upload(
+            Bucket=s3_bucket, Key=multipart_key
+        )
+        upload_id = create_multipart["UploadId"]
+        upload_part = aws_client.s3.upload_part(
+            Bucket=s3_bucket,
+            Key=multipart_key,
+            Body="test",
+            PartNumber=1,
+            UploadId=upload_id,
+        )
+        aws_client.s3.complete_multipart_upload(
+            Bucket=s3_bucket,
+            Key=multipart_key,
+            MultipartUpload={"Parts": [{"ETag": upload_part["ETag"], "PartNumber": 1}]},
+            UploadId=upload_id,
+        )
+
+        get_object_attributes_url = f"{bucket_url}/{multipart_key}?attributes"
+        headers["x-amz-object-attributes"] = ",".join(possible_attrs)
+        resp = s3_http_client.get(get_object_attributes_url, headers=headers)
+        mpu_ordered_keys = get_ordered_keys(resp.content)
+        assert mpu_ordered_keys[0] == "ETag"
+        assert mpu_ordered_keys[1] == "Checksum"
+        assert mpu_ordered_keys[2] == "ObjectParts"
+        assert mpu_ordered_keys[3] == "StorageClass"
+        assert mpu_ordered_keys[4] == "ObjectSize"
 
     @markers.aws.validated
     def test_s3_timestamp_precision(self, s3_bucket, aws_client, aws_http_client_factory):

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -23,6 +23,7 @@ import boto3 as boto3
 import botocore
 import pytest
 import requests
+import urllib3
 import xmltodict
 from boto3.s3.transfer import KB, TransferConfig
 from botocore import UNSIGNED
@@ -30,6 +31,7 @@ from botocore.auth import SigV4Auth
 from botocore.client import Config
 from botocore.exceptions import ClientError
 from localstack_snapshot.snapshots.transformer import RegexTransformer
+from urllib3 import HTTPHeaderDict
 
 import localstack.config
 from localstack import config
@@ -5264,6 +5266,54 @@ class TestS3:
         assert mpu_ordered_keys[2] == "ObjectParts"
         assert mpu_ordered_keys[3] == "StorageClass"
         assert mpu_ordered_keys[4] == "ObjectSize"
+
+    @markers.aws.only_localstack
+    def test_get_obj_attrs_multi_headers_behavior(self, s3_bucket, aws_client, region_name):
+        """
+        The Botocore serializer will by default encode the header list by concatenating it in a comma-separated string
+        Some different serializers, like the Java SDK or Go, will add a header entry for each value.
+        See https://github.com/aws/aws-sdk-go-v2/issues/1620 for example
+        We validate that we can properly parse the request when receiving the following:
+        X-Amz-Object-Attributes: Checksum
+        X-Amz-Object-Attributes: ObjectParts
+
+        Botocore default behavior would be:
+        X-Amz-Object-Attributes: Checksum,ObjectParts
+        """
+        key_name = "get-obj-attrs"
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=key_name, Body="test")
+
+        bucket_url = _bucket_url(s3_bucket)
+
+        def get_urllib_headers_for_attributes(attributes: list[str]) -> HTTPHeaderDict:
+            _headers = mock_aws_request_headers(
+                "s3",
+                aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
+                region_name=region_name,
+            )
+
+            urllib_headers = HTTPHeaderDict(headers=_headers)
+            for attr in attributes:
+                urllib_headers.add("x-amz-object-attributes", attr)
+            return urllib_headers
+
+        get_object_attributes_url = f"{bucket_url}/{key_name}?attributes"
+
+        possible_attrs = ["StorageClass", "ETag", "ObjectSize", "ObjectParts", "Checksum"]
+        # we use the low level `urllib3` and `HTTPHeaderDict` to make sure the headers are properly serialized
+        # as distinct headers and not a concatenated value
+        headers = get_urllib_headers_for_attributes(possible_attrs)
+        resp = urllib3.request(method="GET", url=get_object_attributes_url, headers=headers)
+
+        resp_dict = xmltodict.parse(resp.data)
+        get_attrs_response = resp_dict["GetObjectAttributesResponse"]
+        get_attrs_response.pop("@xmlns", None)
+        attributes_keys = list(get_attrs_response.keys())
+
+        assert attributes_keys[0] == "ETag"
+        assert attributes_keys[1] == "Checksum"
+        assert attributes_keys[2] == "StorageClass"
+        assert attributes_keys[3] == "ObjectSize"
 
     @markers.aws.validated
     def test_s3_timestamp_precision(self, s3_bucket, aws_client, aws_http_client_factory):

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -317,6 +317,15 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_response_structure": {
     "last_validated_date": "2025-01-21T18:41:38+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_response_structure_get_obj_attrs": {
+    "last_validated_date": "2025-08-18T16:12:31+00:00",
+    "durations_in_seconds": {
+      "setup": 0.71,
+      "call": 1.55,
+      "teardown": 1.3,
+      "total": 3.56
+    }
+  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_analytics_configurations": {
     "last_validated_date": "2025-01-21T18:42:41+00:00"
   },

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1213,6 +1213,29 @@ def test_restxml_header_list_parsing():
     )
 
 
+def test_restxml_header_list_parsing_with_multiple_header_values():
+    """
+    Tests that list attributes that are encoded into headers are parsed correctly.
+    However, our serializer will by default encode the header list by concatenating it in a comma-separated string
+    Some different serializers, like the Java SDK or Go, will add a header entry for each value.
+    See https://github.com/aws/aws-sdk-go-v2/issues/1620 for example
+    It will send:
+    X-Amz-Object-Attributes: Checksum
+    X-Amz-Object-Attributes: ObjectParts
+    Instead of:
+    X-Amz-Object-Attributes: Checksum,ObjectParts
+    """
+    _botocore_parser_integration_test(
+        service="s3",
+        action="GetObjectAttributes",
+        Bucket="test-bucket",
+        Key="/test-key",
+        ObjectAttributes=["ObjectSize", "StorageClass"],
+        # override serialized headers with a manual list
+        headers={"X-Amz-Object-Attributes": ["ObjectSize", "StorageClass"]},
+    )
+
+
 def test_restxml_header_optional_list_parsing():
     """Tests that non-existing header list attributes are working correctly."""
     # OptionalObjectAttributes (the "x-amz-optional-object-attributes") in ListObjectsV2Request is optional


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We got a report with #12999 that sending a `GetObjectAttributes` request would fail depending on the order of the fields being passed.

While debugging and printing out low level HTTP request on the Java side, I realized that Java was sending the request with multiple headers for the same key, like some others SDK (Go in particular)

```
GET /test-key?attributes= HTTP/1.1
[...]
Amz-Sdk-Invocation-Id: 5cb65548-6947-4436-b731-ee6d618bc91c
Amz-Sdk-Request: attempt=1; max=3
Authorization: ---
X-Amz-Date: 20220316T000334Z
X-Amz-Object-Attributes: Checksum
X-Amz-Object-Attributes: ObjectParts
```

When receiving headers that way, our web server will return them as a list of values, accessible via `Headers.getlist()`.

Because the parser was calling `Headers.get()`, it would only get the first value, and in the user sample above, would not even return the second requested attribute. 

This PR adapts the parser to use `getlist` in the header shape type is `list`, and keep the old automatic splitting on `,` that is still required. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add a parser unit test (thanks a lot for adding the `headers` override! This was so much easier to write a test for it!!!)
- fix the parsing logic to handle multivalue headers
- add an S3 test around multivalue headers (`requests` concatenates multivalue headers by default but `urllib3` does not-
- add an order S3 test because my first intuition was related to the order of returned fields


## Testing

If you remove the parser fix, the tests now fail.
I also validated that the user-provided sample in the linked issue now works 👍 