### PR TITLE
Fix make format targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,12 @@ check-aws-markers:     		  ## Lightweight check to ensure all AWS tests have pro
 	($(VENV_RUN); python -m pytest --co tests/aws/)
 
 format:            		  ## Run ruff to format the whole codebase
-	($(VENV_RUN); python -m ruff format .; python -m ruff check --output-format=full --fix .)
+	($(VENV_RUN); python -m ruff check --output-format=full --fix .; python -m ruff format .)
 
 format-modified:          ## Run ruff to format only modified code
-	($(VENV_RUN); python -m ruff format `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs`; python -m ruff check --output-format=full --fix `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs`)
+	($(VENV_RUN); \
+	  python -m ruff check --output-format=full --fix `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs`; \
+	  python -m ruff format `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs`)
 
 init-precommit:    		  ## install te pre-commit hook into your local git repository
 	($(VENV_RUN); pre-commit install)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
After the introduction of the new UP rules, we saw the "Update ASF API" workflow start failing due to a linting issue (see https://github.com/localstack/localstack/pull/13015).
We noticed that to properly format the code, we would need to run the `format` (or `format-modified`) target twice.

Our `format` target was sequentially executing the following two commands:
- `python -m ruff format .` to run the formatter;
- `python -m ruff check --fix .` to run the linter and automatically apply safe fixes, if needed.

However, the lint command can likely rewrite the code and leave it in a state that needs a new format.
Therefore, the sequence of commands should be switched.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Switch the format and lint `ruff` commands in the `make format` and `make format-modified` targets.

### Testing
I tested the changes on a local branch with the following commands (basically replaying the ASF workflow):
- removing the last "Update ASF API" commit;
- upgrading botocore;
- generate the APIs;
- running `ruff check --select F401 --unsafe-fixes --fix . --config "lint.preview = true"`
- running `make format-modified`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
