### PR TITLE
IaC: Add AWS operations and CFN resources catalog

### DIFF
--- a/localstack-core/localstack/aws/handlers/service.py
+++ b/localstack-core/localstack/aws/handlers/service.py
@@ -9,8 +9,8 @@ from botocore.model import OperationModel, ServiceModel
 
 from localstack import config
 from localstack.http import Response
-from localstack.utils.coverage_docs import get_coverage_link_for_service
 
+from ...utils.coverage_docs import get_coverage_link_for_service
 from ..api import CommonServiceException, RequestContext, ServiceException
 from ..api.core import ServiceOperation
 from ..chain import CompositeResponseHandler, ExceptionHandler, Handler, HandlerChain
@@ -176,8 +176,8 @@ class ServiceExceptionSerializer(ExceptionHandler):
             action_name = operation.name
             exception_message: str | None = exception.args[0] if exception.args else None
             message = exception_message or get_coverage_link_for_service(service_name, action_name)
-            LOG.info(message)
             error = CommonServiceException("InternalFailure", message, status_code=501)
+            LOG.info(message)
             context.service_exception = error
 
         elif not isinstance(exception, ServiceException):

--- a/localstack-core/localstack/utils/catalog/catalog.py
+++ b/localstack-core/localstack/utils/catalog/catalog.py
@@ -1,0 +1,135 @@
+import logging
+from abc import abstractmethod
+
+from plux import Plugin
+
+from localstack.services.cloudformation.resource_provider import (
+    plugin_manager as cfn_plugin_manager,
+)
+from localstack.utils.catalog.catalog_loader import RemoteCatalogLoader
+from localstack.utils.catalog.common import (
+    AwsServiceOperationsSupportInLatest,
+    AwsServicesSupportInLatest,
+    AwsServiceSupportAtRuntime,
+    CloudFormationResourcesSupportAtRuntime,
+    CloudFormationResourcesSupportInLatest,
+    LocalstackEmulatorType,
+)
+
+ServiceName = str
+ServiceOperations = set[str]
+ProviderName = str
+CfnResourceName = str
+CfnResourceMethodName = str
+AwsServicesSupportStatus = (
+    AwsServiceSupportAtRuntime | AwsServicesSupportInLatest | AwsServiceOperationsSupportInLatest
+)
+CfnResourceSupportStatus = (
+    CloudFormationResourcesSupportInLatest | CloudFormationResourcesSupportAtRuntime
+)
+
+LOG = logging.getLogger(__name__)
+
+
+class CatalogPlugin(Plugin):
+    namespace = "localstack.utils.catalog"
+
+    @staticmethod
+    def get_cfn_resources_catalog(cloudformation_resources: dict):
+        cfn_resources_catalog = {}
+        for emulator_type, resources in cloudformation_resources.items():
+            for resource_name, resource in resources.items():
+                cfn_resources_catalog[emulator_type] = {resource_name: set(resource.methods)}
+        return cfn_resources_catalog
+
+    @staticmethod
+    def get_aws_services_at_runtime():
+        from localstack.services.plugins import SERVICE_PLUGINS
+
+        return SERVICE_PLUGINS.list_available()
+
+    @abstractmethod
+    def get_aws_service_status(
+        self, service_name: str, operation_name: str | None = None
+    ) -> AwsServicesSupportStatus | None:
+        pass
+
+    @abstractmethod
+    def get_cloudformation_resource_status(
+        self, resource_name: str, service_name: str
+    ) -> CfnResourceSupportStatus | AwsServicesSupportInLatest | None:
+        pass
+
+
+class AwsCatalogRuntimePlugin(CatalogPlugin):
+    name = "aws-catalog-runtime-only"
+
+    def get_aws_service_status(
+        self, service_name: str, operation_name: str | None = None
+    ) -> AwsServicesSupportStatus | None:
+        return None
+
+    def get_cloudformation_resource_status(
+        self, resource_name: str, service_name: str
+    ) -> CfnResourceSupportStatus | AwsServicesSupportInLatest | None:
+        return None
+
+
+class AwsCatalogRemoteStatePlugin(CatalogPlugin):
+    name = "aws-catalog-remote-state"
+    current_emulator_type: LocalstackEmulatorType = LocalstackEmulatorType.COMMUNITY
+    services_in_latest: dict[ServiceName, dict[LocalstackEmulatorType, ServiceOperations]] = {}
+    services_at_runtime: set[ServiceName] = set()
+    cfn_resources_in_latest: dict[
+        LocalstackEmulatorType, dict[CfnResourceName, set[CfnResourceMethodName]]
+    ] = {}
+    cfn_resources_at_runtime: set[CfnResourceName] = set()
+
+    def __init__(self, remote_catalog_loader: RemoteCatalogLoader | None = None) -> None:
+        catalog_loader = remote_catalog_loader or RemoteCatalogLoader()
+        remote_catalog = catalog_loader.get_remote_catalog()
+        for service_name, emulators in remote_catalog.services.items():
+            for emulator_type, service_provider in emulators.items():
+                self.services_in_latest.setdefault(service_name, {})[emulator_type] = set(
+                    service_provider.operations
+                )
+
+        self.cfn_resources_in_latest = AwsCatalogRemoteStatePlugin.get_cfn_resources_catalog(
+            remote_catalog.cloudformation_resources
+        )
+        self.cfn_resources_at_runtime = set(cfn_plugin_manager.list_names())
+        self.services_at_runtime = AwsCatalogRemoteStatePlugin.get_aws_services_at_runtime()
+
+    def get_aws_service_status(
+        self, service_name: str, operation_name: str | None = None
+    ) -> AwsServicesSupportStatus | None:
+        if not self.services_in_latest:
+            return None
+        if service_name not in self.services_in_latest:
+            return AwsServicesSupportInLatest.NOT_SUPPORTED
+        if self.current_emulator_type not in self.services_in_latest[service_name]:
+            return AwsServicesSupportInLatest.SUPPORTED_WITH_LICENSE_UPGRADE
+        if not operation_name:
+            return AwsServicesSupportInLatest.SUPPORTED
+        if operation_name in self.services_in_latest[service_name][self.current_emulator_type]:
+            return AwsServiceOperationsSupportInLatest.SUPPORTED
+        for emulator_type in self.services_in_latest[service_name]:
+            if emulator_type is self.current_emulator_type:
+                continue
+            if operation_name in self.services_in_latest[service_name][emulator_type]:
+                return AwsServiceOperationsSupportInLatest.SUPPORTED_WITH_LICENSE_UPGRADE
+        return AwsServiceOperationsSupportInLatest.NOT_SUPPORTED
+
+    def get_cloudformation_resource_status(
+        self, resource_name: str, service_name: str
+    ) -> CfnResourceSupportStatus | AwsServicesSupportInLatest | None:
+        if resource_name in self.cfn_resources_at_runtime:
+            return CloudFormationResourcesSupportAtRuntime.AVAILABLE
+        if service_name in self.services_at_runtime:
+            if resource_name in self.cfn_resources_in_latest[self.current_emulator_type]:
+                return CloudFormationResourcesSupportInLatest.SUPPORTED
+            else:
+                return CloudFormationResourcesSupportInLatest.NOT_SUPPORTED
+        if service_name in self.services_in_latest:
+            return self.get_aws_service_status(service_name, operation_name=None)
+        return AwsServicesSupportInLatest.NOT_SUPPORTED

--- a/localstack-core/localstack/utils/catalog/catalog.py
+++ b/localstack-core/localstack/utils/catalog/catalog.py
@@ -94,11 +94,11 @@ class AwsCatalogRemoteStatePlugin(CatalogPlugin):
                     service_provider.operations
                 )
 
-        self.cfn_resources_in_latest = AwsCatalogRemoteStatePlugin.get_cfn_resources_catalog(
+        self.cfn_resources_in_latest = self.get_cfn_resources_catalog(
             remote_catalog.cloudformation_resources
         )
         self.cfn_resources_at_runtime = set(cfn_plugin_manager.list_names())
-        self.services_at_runtime = AwsCatalogRemoteStatePlugin.get_aws_services_at_runtime()
+        self.services_at_runtime = self.get_aws_services_at_runtime()
 
     def get_aws_service_status(
         self, service_name: str, operation_name: str | None = None

--- a/localstack-core/localstack/utils/catalog/catalog_loader.py
+++ b/localstack-core/localstack/utils/catalog/catalog_loader.py
@@ -1,0 +1,11 @@
+import json
+
+from localstack.utils.catalog.common import AwsRemoteCatalog
+
+LICENSE_CATALOG_PATH = ""
+
+
+class RemoteCatalogLoader:
+    def get_remote_catalog(self) -> AwsRemoteCatalog:
+        with open(LICENSE_CATALOG_PATH) as f:
+            return AwsRemoteCatalog(**json.load(f))

--- a/localstack-core/localstack/utils/catalog/common.py
+++ b/localstack-core/localstack/utils/catalog/common.py
@@ -1,0 +1,57 @@
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+
+class CloudFormationResource(BaseModel):
+    methods: list[str]
+
+
+class AwsServiceCatalog(BaseModel):
+    provider: str
+    operations: list[str]
+    plans: list[str]
+
+
+class LocalStackMetadata(BaseModel):
+    version: str
+
+
+class AwsRemoteCatalog(BaseModel):
+    schema_version: str
+    localstack: LocalStackMetadata
+    services: dict[str, dict[str, AwsServiceCatalog]]
+    cloudformation_resources: dict[str, dict[str, CloudFormationResource]]
+
+
+class LocalstackEmulatorType(StrEnum):
+    COMMUNITY = "community"
+    PRO = "pro"
+
+
+class AwsServiceSupportAtRuntime(StrEnum):
+    AVAILABLE = "AVAILABLE"
+    AVAILABLE_WITH_LICENSE_UPGRADE = "AVAILABLE_WITH_LICENSE_UPGRADE"
+    NOT_IMPLEMENTED = "NOT_IMPLEMENTED"
+
+
+class AwsServicesSupportInLatest(StrEnum):
+    SUPPORTED = "SUPPORTED"
+    SUPPORTED_WITH_LICENSE_UPGRADE = "SUPPORTED_WITH_LICENSE_UPGRADE"
+    NOT_SUPPORTED = "NOT_SUPPORTED"
+    NON_DEFAULT_PROVIDER = "NON_DEFAULT_PROVIDER"
+
+
+class AwsServiceOperationsSupportInLatest(StrEnum):
+    SUPPORTED = "SUPPORTED"
+    SUPPORTED_WITH_LICENSE_UPGRADE = "SUPPORTED_WITH_LICENSE_UPGRADE"
+    NOT_SUPPORTED = "NOT_SUPPORTED"
+
+
+class CloudFormationResourcesSupportInLatest(StrEnum):
+    SUPPORTED = "SUPPORTED"
+    NOT_SUPPORTED = "NOT_SUPPORTED"
+
+
+class CloudFormationResourcesSupportAtRuntime(StrEnum):
+    AVAILABLE = "AVAILABLE"

--- a/localstack-core/localstack/utils/catalog/plugins.py
+++ b/localstack-core/localstack/utils/catalog/plugins.py
@@ -21,4 +21,8 @@ def get_aws_catalog() -> CatalogPlugin:
             "Failed to load catalog plugin with the latest LocalStack services support data, falling back to catalog without remote state: %s",
             e,
         )
-        return plugin_manager.load("aws-catalog-runtime-only")
+        # Try to load runtime catalog from pro version first
+        fallback_plugin_name = "aws-catalog-runtime-only-with-license"
+        if not plugin_manager.exists(fallback_plugin_name):
+            fallback_plugin_name = "aws-catalog-runtime-only"
+        return plugin_manager.load(fallback_plugin_name)

--- a/localstack-core/localstack/utils/catalog/plugins.py
+++ b/localstack-core/localstack/utils/catalog/plugins.py
@@ -1,0 +1,24 @@
+import logging
+
+from plux import PluginManager
+
+from localstack.utils.catalog.catalog import CatalogPlugin
+from localstack.utils.objects import singleton_factory
+
+LOG = logging.getLogger(__name__)
+
+
+@singleton_factory
+def get_aws_catalog() -> CatalogPlugin:
+    plugin_manager = PluginManager(CatalogPlugin.namespace)
+    try:
+        plugin_name = "aws-catalog-remote-state-with-license"
+        if not plugin_manager.exists(plugin_name):
+            plugin_name = "aws-catalog-remote-state"
+        return plugin_manager.load(plugin_name)
+    except Exception as e:
+        LOG.debug(
+            "Failed to load catalog plugin with the latest LocalStack services support data, falling back to catalog without remote state: %s",
+            e,
+        )
+        return plugin_manager.load("aws-catalog-runtime-only")

--- a/tests/unit/utils/test_catalog.py
+++ b/tests/unit/utils/test_catalog.py
@@ -1,0 +1,131 @@
+import pytest
+
+from localstack.utils.catalog.catalog import AwsCatalogRemoteStatePlugin
+from localstack.utils.catalog.catalog_loader import RemoteCatalogLoader
+from localstack.utils.catalog.common import (
+    AwsRemoteCatalog,
+    AwsServiceOperationsSupportInLatest,
+    AwsServicesSupportInLatest,
+    CloudFormationResourcesSupportAtRuntime,
+    CloudFormationResourcesSupportInLatest,
+    LocalStackMetadata,
+)
+
+
+class FakeCatalogLoader(RemoteCatalogLoader):
+    def __init__(self, catalog: AwsRemoteCatalog):
+        self.catalog = catalog
+
+    def get_remote_catalog(self) -> AwsRemoteCatalog:
+        return self.catalog
+
+
+CATALOG = AwsRemoteCatalog(
+    schema_version="1.0",
+    localstack=LocalStackMetadata(version="4.7"),
+    services={
+        "athena": {
+            "pro": {
+                "provider": "athena:pro",
+                "operations": ["StartQueryExecution", "GetQueryExecution"],
+                "plans": ["ultimate", "enterprise"],
+            }
+        },
+        "s3": {
+            "community": {
+                "provider": "s3:default",
+                "operations": ["CreateBucket"],
+                "plans": ["free", "base", "ultimate", "enterprise"],
+            },
+            "pro": {
+                "provider": "s3:pro",
+                "operations": ["SelectObjectContent"],
+                "plans": ["base", "ultimate", "enterprise"],
+            },
+        },
+        "kms": {
+            "community": {
+                "provider": "kms:default",
+                "operations": ["ListKeys"],
+                "plans": ["free", "base", "ultimate", "enterprise"],
+            }
+        },
+    },
+    cloudformation_resources={
+        "community": {"AWS::S3::Bucket": {"methods": ["Create", "Delete"]}},
+        "pro": {"AWS::Athena::CapacitiesReservation": {"methods": ["Create", "Update", "Delete"]}},
+    },
+)
+
+
+@pytest.fixture(scope="class", autouse=True)
+def aws_catalog():
+    return AwsCatalogRemoteStatePlugin(FakeCatalogLoader(CATALOG))
+
+
+class TestAwsCatalog:
+    @pytest.mark.parametrize(
+        "service_name,expected_status",
+        [
+            ("s3", AwsServicesSupportInLatest.SUPPORTED),
+            ("athena", AwsServicesSupportInLatest.SUPPORTED_WITH_LICENSE_UPGRADE),
+            ("nonexistent", AwsServicesSupportInLatest.NOT_SUPPORTED),
+        ],
+    )
+    def test_get_service_status(self, aws_catalog, service_name, expected_status):
+        result = aws_catalog.get_aws_service_status(service_name)
+        assert result == expected_status
+
+    @pytest.mark.parametrize(
+        "service_name,operation_name,expected_status",
+        [
+            ("kms", "ListKeys", AwsServiceOperationsSupportInLatest.SUPPORTED),
+            (
+                "s3",
+                "SelectObjectContent",
+                AwsServiceOperationsSupportInLatest.SUPPORTED_WITH_LICENSE_UPGRADE,
+            ),
+            ("s3", "UnsupportedOp", AwsServiceOperationsSupportInLatest.NOT_SUPPORTED),
+        ],
+    )
+    def test_get_service_status_with_operation(
+        self, aws_catalog, service_name, operation_name, expected_status
+    ):
+        result = aws_catalog.get_aws_service_status(service_name, operation_name)
+        assert result == expected_status
+
+    def test_get_service_status_with_only_one_emulator_type(self, aws_catalog):
+        result = aws_catalog.get_aws_service_status("athena")
+        assert result == AwsServicesSupportInLatest.SUPPORTED_WITH_LICENSE_UPGRADE
+
+    def test_get_service_status_with_empty_operation(self, aws_catalog):
+        assert (
+            aws_catalog.get_aws_service_status("s3", None) == AwsServicesSupportInLatest.SUPPORTED
+        )
+        assert (
+            aws_catalog.get_aws_service_status("s3", "")
+            == AwsServiceOperationsSupportInLatest.SUPPORTED
+        )
+
+    @pytest.mark.parametrize(
+        "resource_name,service_name,expected_status",
+        [
+            ("AWS::S3::Bucket", "s3", CloudFormationResourcesSupportAtRuntime.AVAILABLE),
+            ("AWS::S3::NonExistent", "s3", CloudFormationResourcesSupportInLatest.NOT_SUPPORTED),
+            (
+                "AWS::Athena::CapacitiesReservation",
+                "athena",
+                AwsServicesSupportInLatest.SUPPORTED_WITH_LICENSE_UPGRADE,
+            ),
+            (
+                "AWS::NonExistentService::NonExistent",
+                "nonexistentservice",
+                AwsServicesSupportInLatest.NOT_SUPPORTED,
+            ),
+        ],
+    )
+    def test_get_cfn_resource_status(
+        self, aws_catalog, resource_name, service_name, expected_status
+    ):
+        result = aws_catalog.get_cloudformation_resource_status(resource_name, service_name)
+        assert result == expected_status


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR introduces a plugin AWS license catalog which will be used to customize error messages for unimplemented AWS services or operations.

Downloading and loading of the license catalog is not implemented in this PR and will be completed in the next PR.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Add new license catalog plugin

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
