### PR TITLE
APIGW: fix TestInvokeMethod path logic

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/handlers/resource_router.py
@@ -85,12 +85,11 @@ class RestAPIResourceRouter:
             rule, args = matcher.match(path, method=request.method, return_rule=True)
         except (MethodNotAllowed, NotFound) as e:
             # MethodNotAllowed (405) exception is raised if a path is matching, but the method does not.
-            # Our router might handle this as a 404, validate with AWS.
+            # AWS handles this and the regular 404 as a '403 MissingAuthTokenError'
             LOG.warning(
                 "API Gateway: No resource or method was found for: %s %s",
                 request.method,
                 path,
-                exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
             raise MissingAuthTokenError("Missing Authentication Token") from e
 

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
@@ -45,6 +45,19 @@ TEST_INVOKE_TEMPLATE = """Execution log for request {request_id}
 {formatted_date} : Method completed with status: {method_response_status}
 """
 
+TEST_INVOKE_TEMPLATE_MOCK = """Execution log for request {request_id}
+{formatted_date} : Starting execution for request: {request_id}
+{formatted_date} : HTTP Method: {request_method}, Resource Path: {resource_path}
+{formatted_date} : Method request path: {method_request_path_parameters}
+{formatted_date} : Method request query string: {method_request_query_string}
+{formatted_date} : Method request headers: {method_request_headers}
+{formatted_date} : Method request body before transformations: {method_request_body}
+{formatted_date} : Method response body after transformations: {method_response_body}
+{formatted_date} : Method response headers: {method_response_headers}
+{formatted_date} : Successfully completed execution
+{formatted_date} : Method completed with status: {method_response_status}
+"""
+
 
 def _dump_headers(headers: Headers) -> str:
     if not headers:
@@ -93,6 +106,29 @@ def log_template(invocation_context: RestApiInvocationContext, response_headers:
     )
 
 
+def log_mock_template(
+    invocation_context: RestApiInvocationContext, response_headers: Headers
+) -> str:
+    formatted_date = datetime.datetime.now(tz=datetime.UTC).strftime("%a %b %d %H:%M:%S %Z %Y")
+    request = invocation_context.invocation_request
+    context_var = invocation_context.context_variables
+    method_resp = invocation_context.invocation_response
+
+    return TEST_INVOKE_TEMPLATE_MOCK.format(
+        formatted_date=formatted_date,
+        request_id=context_var["requestId"],
+        resource_path=request["path"],
+        request_method=request["http_method"],
+        method_request_path_parameters=dict_to_string(request["path_parameters"]),
+        method_request_query_string=dict_to_string(request["query_string_parameters"]),
+        method_request_headers=_dump_headers(request.get("headers")),
+        method_request_body=to_str(request.get("body", "")),
+        method_response_status=method_resp.get("status_code"),
+        method_response_body=to_str(method_resp.get("body", "")),
+        method_response_headers=_dump_headers(response_headers),
+    )
+
+
 def create_test_chain() -> HandlerChain[RestApiInvocationContext]:
     return HandlerChain(
         request_handlers=[
@@ -114,13 +150,16 @@ def create_test_invocation_context(
 ) -> RestApiInvocationContext:
     parse_handler = handlers.parse_request
     http_method = test_request["httpMethod"]
+    resource = deployment.rest_api.resources[test_request["resourceId"]]
+    resource_path = resource["path"]
 
     # we do not need a true HTTP request for the context, as we are skipping all the parsing steps and using the
     # provider data
     invocation_context = RestApiInvocationContext(
         request=Request(method=http_method),
     )
-    path_query = test_request.get("pathWithQueryString", "/").split("?")
+    test_request_path = test_request.get("pathWithQueryString") or resource_path
+    path_query = test_request_path.split("?")
     path = path_query[0]
     multi_query_args: dict[str, list[str]] = {}
 
@@ -140,9 +179,15 @@ def create_test_invocation_context(
         # TODO: handle multiValueHeaders
         body=to_bytes(test_request.get("body") or ""),
     )
-    invocation_context.invocation_request = invocation_request
 
-    _, path_parameters = RestAPIResourceRouter(deployment).match(invocation_context)
+    invocation_context.invocation_request = invocation_request
+    try:
+        # this is AWS behavior, it will accept any value for the `pathWithQueryString`, even if it doesn't match
+        # the expected format. It will just fall back to no value if it cannot parse the path parameters out of it
+        _, path_parameters = RestAPIResourceRouter(deployment).match(invocation_context)
+    except Exception:
+        path_parameters = {}
+
     invocation_request["path_parameters"] = path_parameters
 
     invocation_context.deployment = deployment
@@ -160,7 +205,6 @@ def create_test_invocation_context(
         responseOverride=ContextVarsResponseOverride(header={}, status=0),
     )
     invocation_context.trace_id = parse_handler.populate_trace_id({})
-    resource = deployment.rest_api.resources[test_request["resourceId"]]
     resource_method = resource["resourceMethods"][http_method]
     invocation_context.resource = resource
     invocation_context.resource_method = resource_method
@@ -179,8 +223,10 @@ def run_test_invocation(
     invocation_context = create_test_invocation_context(test_request, deployment)
 
     test_chain = create_test_chain()
+    is_mock_integration = invocation_context.integration["type"] == "MOCK"
+
     # header order is important
-    if invocation_context.integration["type"] == "MOCK":
+    if is_mock_integration:
         base_headers = {"Content-Type": APPLICATION_JSON}
     else:
         # we manually add the trace-id, as it is normally added by handlers.response_enricher which adds to much data
@@ -199,7 +245,11 @@ def run_test_invocation(
     # AWS does not return the Content-Length for TestInvokeMethod
     response_headers.remove("Content-Length")
 
-    log = log_template(invocation_context, response_headers)
+    if is_mock_integration:
+        # TODO: revisit how we're building the logs
+        log = log_mock_template(invocation_context, response_headers)
+    else:
+        log = log_template(invocation_context, response_headers)
 
     headers = dict(response_headers)
     multi_value_headers = build_multi_value_headers(response_headers)

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from urllib.parse import parse_qs
 
 from rolo import Request
@@ -21,6 +22,9 @@ from .variables import (
     ContextVarsRequestOverride,
     ContextVarsResponseOverride,
 )
+
+LOG = logging.getLogger(__name__)
+
 
 # TODO: we probably need to write and populate those logs as part of the handler chain itself
 #  and store it in the InvocationContext. That way, we could also retrieve in when calling TestInvoke
@@ -185,7 +189,14 @@ def create_test_invocation_context(
         # this is AWS behavior, it will accept any value for the `pathWithQueryString`, even if it doesn't match
         # the expected format. It will just fall back to no value if it cannot parse the path parameters out of it
         _, path_parameters = RestAPIResourceRouter(deployment).match(invocation_context)
-    except Exception:
+    except Exception as e:
+        LOG.warning(
+            "Error while trying to extract path parameters from user-provided 'pathWithQueryString=%s' "
+            "for the following resource path: '%s'. Error: '%s'",
+            path,
+            resource_path,
+            e,
+        )
         path_parameters = {}
 
     invocation_request["path_parameters"] = path_parameters

--- a/tests/aws/services/apigateway/conftest.py
+++ b/tests/aws/services/apigateway/conftest.py
@@ -1,3 +1,5 @@
+from itertools import count
+
 import pytest
 from botocore.config import Config
 
@@ -238,3 +240,60 @@ def import_apigw(aws_client, aws_client_factory):
 def apigw_add_transformers(snapshot):
     snapshot.add_transformer(snapshot.transform.jsonpath("$..items..id", "id"))
     snapshot.add_transformer(snapshot.transform.key_value("deploymentId"))
+
+
+@pytest.fixture
+def apigw_test_invoke_response_formatter(snapshot):
+    snapshot.add_transformers_list(
+        [
+            snapshot.transform.key_value(
+                "latency", value_replacement="<latency>", reference_replacement=False
+            ),
+            snapshot.transform.jsonpath(
+                "$..headers.X-Amzn-Trace-Id", value_replacement="x-amz-trace-id"
+            ),
+            snapshot.transform.regex(
+                r"URI: https:\/\/.*?\/2015-03-31", "URI: https://<endpoint_url>/2015-03-31"
+            ),
+            snapshot.transform.regex(
+                r"Integration latency: \d*? ms", "Integration latency: <latency> ms"
+            ),
+            snapshot.transform.regex(
+                r"Date=[a-zA-Z]{3},\s\d{2}\s[a-zA-Z]{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\sGMT",
+                "Date=Day, dd MMM yyyy hh:mm:ss GMT",
+            ),
+            snapshot.transform.regex(
+                r"x-amzn-RequestId=[a-f0-9-]{36}", "x-amzn-RequestId=<request-id-lambda>"
+            ),
+            snapshot.transform.regex(
+                r"[a-zA-Z]{3}\s[a-zA-Z]{3}\s\d{2}\s\d{2}:\d{2}:\d{2}\sUTC\s\d{4} :",
+                "DDD MMM dd hh:mm:ss UTC yyyy :",
+            ),
+            snapshot.transform.regex(
+                r"Authorization=.*?,", "Authorization=<authorization-header>,"
+            ),
+            snapshot.transform.regex(
+                r"X-Amz-Security-Token=.*?\s\[", "X-Amz-Security-Token=<token> ["
+            ),
+            snapshot.transform.regex(r"\d{8}T\d{6}Z", "<date>"),
+        ]
+    )
+
+    def _transform_log(_log: str) -> dict[str, str]:
+        return {f"line{index:02d}": line for index, line in enumerate(_log.split("\n"))}
+
+    counter = count(start=1)
+
+    # we want to do very precise matching on the log, and splitting on new lines will help in case the snapshot
+    # fails
+    # the snapshot library does not allow to ignore an array index as the last node, so we need to put it in a dict
+
+    def transform_response(response: dict) -> dict:
+        response["log"] = _transform_log(response["log"])
+        request_id = response["log"]["line00"].split(" ")[-1]
+        snapshot.add_transformer(
+            snapshot.transform.regex(request_id, f"<request-id-{next(counter)}>"), priority=-1
+        )
+        return response
+
+    return transform_response

--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -2806,7 +2806,7 @@ class TestApigatewayTestInvoke:
             target_resource_id=resource_id,
             method="GET",
         )
-        # assert "HTTP Method: GET, Resource Path: /pets/123" in response["log"]
+        assert "HTTP Method: GET, Resource Path: /pets/{petId}" in response["log"]
         snapshot.match(
             "test-invoke-method-get-pets-id-no-path",
             apigw_test_invoke_response_formatter(response),
@@ -2821,7 +2821,7 @@ class TestApigatewayTestInvoke:
             path_with_query_string="/random/test",
             method="GET",
         )
-        # assert "HTTP Method: GET, Resource Path: /pets/123" in response["log"]
+        assert "HTTP Method: GET, Resource Path: /random/test" in response["log"]
         snapshot.match(
             "test-invoke-method-get-pets-id-bad-path",
             apigw_test_invoke_response_formatter(response),

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -2813,17 +2813,162 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayTestInvoke::test_invoke_test_method": {
-    "recorded-date": "15-04-2024, 20:48:35",
+    "recorded-date": "19-08-2025, 17:20:41",
     "recorded-content": {
-      "test-invoke-method-get": {
+      "test-invoke-method-get-pets": {
+        "body": {
+          "pets": "all the pets"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "latency": "<latency>",
+        "log": {
+          "line00": "Execution log for request <request-id-1>",
+          "line01": "DDD MMM dd hh:mm:ss UTC yyyy : Starting execution for request: <request-id-1>",
+          "line02": "DDD MMM dd hh:mm:ss UTC yyyy : HTTP Method: GET, Resource Path: /pets",
+          "line03": "DDD MMM dd hh:mm:ss UTC yyyy : Method request path: {}",
+          "line04": "DDD MMM dd hh:mm:ss UTC yyyy : Method request query string: {}",
+          "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {}",
+          "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: ",
+          "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Method response body after transformations: {\"pets\": \"all the pets\"}",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Method response headers: {Content-Type=application/json}",
+          "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Successfully completed execution",
+          "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Method completed with status: 200",
+          "line11": ""
+        },
+        "multiValueHeaders": {
+          "Content-Type": [
+            "application/json"
+          ]
+        },
+        "status": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "test-invoke-method-get-pets-bad-path": {
+        "body": {
+          "pets": "all the pets"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "latency": "<latency>",
+        "log": {
+          "line00": "Execution log for request <request-id-2>",
+          "line01": "DDD MMM dd hh:mm:ss UTC yyyy : Starting execution for request: <request-id-2>",
+          "line02": "DDD MMM dd hh:mm:ss UTC yyyy : HTTP Method: GET, Resource Path: /random/test",
+          "line03": "DDD MMM dd hh:mm:ss UTC yyyy : Method request path: {}",
+          "line04": "DDD MMM dd hh:mm:ss UTC yyyy : Method request query string: {}",
+          "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {}",
+          "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: ",
+          "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Method response body after transformations: {\"pets\": \"all the pets\"}",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Method response headers: {Content-Type=application/json}",
+          "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Successfully completed execution",
+          "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Method completed with status: 200",
+          "line11": ""
+        },
+        "multiValueHeaders": {
+          "Content-Type": [
+            "application/json"
+          ]
+        },
+        "status": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "test-invoke-method-get-pets-id": {
         "body": {
           "petId": "123"
         },
         "headers": {
           "Content-Type": "application/json"
         },
-        "latency": "latency",
-        "log": "log",
+        "latency": "<latency>",
+        "log": {
+          "line00": "Execution log for request <request-id-3>",
+          "line01": "DDD MMM dd hh:mm:ss UTC yyyy : Starting execution for request: <request-id-3>",
+          "line02": "DDD MMM dd hh:mm:ss UTC yyyy : HTTP Method: GET, Resource Path: /pets/123",
+          "line03": "DDD MMM dd hh:mm:ss UTC yyyy : Method request path: {petId=123}",
+          "line04": "DDD MMM dd hh:mm:ss UTC yyyy : Method request query string: {}",
+          "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {}",
+          "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: ",
+          "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Method response body after transformations: {\"petId\": \"123\"}",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Method response headers: {Content-Type=application/json}",
+          "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Successfully completed execution",
+          "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Method completed with status: 200",
+          "line11": ""
+        },
+        "multiValueHeaders": {
+          "Content-Type": [
+            "application/json"
+          ]
+        },
+        "status": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "test-invoke-method-get-pets-id-no-path": {
+        "body": {
+          "petId": "{petId}"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "latency": "<latency>",
+        "log": {
+          "line00": "Execution log for request <request-id-4>",
+          "line01": "DDD MMM dd hh:mm:ss UTC yyyy : Starting execution for request: <request-id-4>",
+          "line02": "DDD MMM dd hh:mm:ss UTC yyyy : HTTP Method: GET, Resource Path: /pets/{petId}",
+          "line03": "DDD MMM dd hh:mm:ss UTC yyyy : Method request path: {petId={petId}}",
+          "line04": "DDD MMM dd hh:mm:ss UTC yyyy : Method request query string: {}",
+          "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {}",
+          "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: ",
+          "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Method response body after transformations: {\"petId\": \"{petId}\"}",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Method response headers: {Content-Type=application/json}",
+          "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Successfully completed execution",
+          "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Method completed with status: 200",
+          "line11": ""
+        },
+        "multiValueHeaders": {
+          "Content-Type": [
+            "application/json"
+          ]
+        },
+        "status": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "test-invoke-method-get-pets-id-bad-path": {
+        "body": {
+          "petId": ""
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "latency": "<latency>",
+        "log": {
+          "line00": "Execution log for request <request-id-5>",
+          "line01": "DDD MMM dd hh:mm:ss UTC yyyy : Starting execution for request: <request-id-5>",
+          "line02": "DDD MMM dd hh:mm:ss UTC yyyy : HTTP Method: GET, Resource Path: /random/test",
+          "line03": "DDD MMM dd hh:mm:ss UTC yyyy : Method request path: {}",
+          "line04": "DDD MMM dd hh:mm:ss UTC yyyy : Method request query string: {}",
+          "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {}",
+          "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: ",
+          "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Method response body after transformations: {\"petId\": \"\"}",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Method response headers: {Content-Type=application/json}",
+          "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Successfully completed execution",
+          "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Method completed with status: 200",
+          "line11": ""
+        },
         "multiValueHeaders": {
           "Content-Type": [
             "application/json"
@@ -2842,8 +2987,21 @@
         "headers": {
           "Content-Type": "application/json"
         },
-        "latency": "latency",
-        "log": "log",
+        "latency": "<latency>",
+        "log": {
+          "line00": "Execution log for request <request-id-6>",
+          "line01": "DDD MMM dd hh:mm:ss UTC yyyy : Starting execution for request: <request-id-6>",
+          "line02": "DDD MMM dd hh:mm:ss UTC yyyy : HTTP Method: GET, Resource Path: /pets/123",
+          "line03": "DDD MMM dd hh:mm:ss UTC yyyy : Method request path: {petId=123}",
+          "line04": "DDD MMM dd hh:mm:ss UTC yyyy : Method request query string: {foo=bar}",
+          "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {}",
+          "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: ",
+          "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Method response body after transformations: {\"petId\": \"123\"}",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Method response headers: {Content-Type=application/json}",
+          "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Successfully completed execution",
+          "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Method completed with status: 200",
+          "line11": ""
+        },
         "multiValueHeaders": {
           "Content-Type": [
             "application/json"
@@ -2862,8 +3020,21 @@
         "headers": {
           "Content-Type": "application/json"
         },
-        "latency": "latency",
-        "log": "log",
+        "latency": "<latency>",
+        "log": {
+          "line00": "Execution log for request <request-id-7>",
+          "line01": "DDD MMM dd hh:mm:ss UTC yyyy : Starting execution for request: <request-id-7>",
+          "line02": "DDD MMM dd hh:mm:ss UTC yyyy : HTTP Method: POST, Resource Path: /pets/123",
+          "line03": "DDD MMM dd hh:mm:ss UTC yyyy : Method request path: {petId=123}",
+          "line04": "DDD MMM dd hh:mm:ss UTC yyyy : Method request query string: {}",
+          "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {}",
+          "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: {\"foo\": \"bar\"}",
+          "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Method response body after transformations: {\"petId\": \"123\"}",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Method response headers: {Content-Type=application/json}",
+          "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Successfully completed execution",
+          "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Method completed with status: 200",
+          "line11": ""
+        },
         "multiValueHeaders": {
           "Content-Type": [
             "application/json"

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -372,6 +372,12 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayTestInvoke::test_invoke_test_method": {
-    "last_validated_date": "2024-04-15T20:48:35+00:00"
+    "last_validated_date": "2025-08-19T17:20:41+00:00",
+    "durations_in_seconds": {
+      "setup": 0.83,
+      "call": 4.12,
+      "teardown": 0.67,
+      "total": 5.62
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigw_test_invoke_method_api": {
-    "recorded-date": "11-04-2025, 18:02:16",
+    "recorded-date": "19-08-2025, 17:04:50",
     "recorded-content": {
       "test_invoke_method_response": {
         "body": {

--- a/tests/aws/services/apigateway/test_apigateway_basic.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.validation.json
@@ -15,7 +15,13 @@
     "last_validated_date": "2024-07-12T20:04:15+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigw_test_invoke_method_api": {
-    "last_validated_date": "2025-04-11T18:03:13+00:00"
+    "last_validated_date": "2025-08-19T17:04:53+00:00",
+    "durations_in_seconds": {
+      "setup": 11.42,
+      "call": 10.49,
+      "teardown": 2.81,
+      "total": 24.72
+    }
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_update_rest_api_deployment": {
     "last_validated_date": "2024-04-12T21:24:49+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We got a report that the `TestInvokeMethod` would not work when the `pathWithQueryString` was not provided. After testing in AWS, it showed that this parameter was not required and this was an assumption that stayed from the previous implementation. 

This PR implements more tests around this parameter and the behavior of AWS when it is not provided. 

It also showed AWS is not sending the same `log` response when the integration is of type `MOCK`. 

I took the opportunity to refactor a bit the utilities we have around `TestInvokeMethod`, because it is quite tricky to snapshot match as it returns a big string with newlines that we would like to snapshot match more precisely. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix the behavior of `TestInvokeMethod` when `pathWithQueryString` is not provided: it will fallback to the `Resource` `path` value
- fix the behavior when it cannot extract the path parameters from the provided path: it won't fail but silently set the path parameters to an empty map
- add a new log template for `MOCK` integration, this should probably be revisited at some point
- improve the existing tests and add more cases
- refactor the test utilities
- remove overly verbose stack trace logging when debug is enabled when we don't match a route in API Gateway REST API router

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
