### PR TITLE
 Enable B017 ruff linting rule

### DIFF
--- a/localstack-core/localstack/services/cloudformation/provider.py
+++ b/localstack-core/localstack/services/cloudformation/provider.py
@@ -605,6 +605,8 @@ class CloudformationProvider(CloudformationApi):
         req_params = request
         change_set_type = req_params.get("ChangeSetType", "UPDATE")
         stack_name = req_params.get("StackName")
+        if not stack_name:
+            raise ValidationError("Member must have length greater than or equal to 1")
         change_set_name = req_params.get("ChangeSetName")
         template_body = req_params.get("TemplateBody")
         # s3 or secretsmanager url

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -369,9 +369,8 @@ class CloudformationProviderV2(CloudformationProvider):
     def create_change_set(
         self, context: RequestContext, request: CreateChangeSetInput
     ) -> CreateChangeSetOutput:
-        try:
-            stack_name = request["StackName"]
-        except KeyError:
+        stack_name = request.get("StackName")
+        if not stack_name:
             # TODO: proper exception
             raise ValidationError("StackName must be specified")
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,6 @@ exclude = [
 [tool.ruff.lint]
 ignore = [
     "B007", # TODO Loop control variable x not used within loop body
-    "B017", # TODO `pytest.raises(Exception)` should be considered evil
     "B019", # TODO Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
     "B022", # TODO No arguments passed to `contextlib.suppress`. No exceptions will be suppressed and therefore this context manager is redundant
     "B023", # TODO Function definition does not bind loop variable `server`

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -643,7 +643,7 @@ class TestAPIGateway:
             restApiId=get_api_gateway_id, authorizerId=authorizer_id
         )
 
-        with pytest.raises(Exception):
+        with pytest.raises(ClientError):
             aws_client.apigateway.get_authorizer(
                 restApiId=get_api_gateway_id, authorizerId=authorizer_id
             )
@@ -784,9 +784,9 @@ class TestAPIGateway:
 
         # DELETE
         aws_client.apigateway.delete_base_path_mapping(domainName=domain_name, basePath=base_path)
-        with pytest.raises(Exception):
+        with pytest.raises(ClientError):
             aws_client.apigateway.get_base_path_mapping(domainName=domain_name, basePath=base_path)
-        with pytest.raises(Exception):
+        with pytest.raises(ClientError):
             aws_client.apigateway.delete_base_path_mapping(
                 domainName=domain_name, basePath=base_path
             )
@@ -840,9 +840,9 @@ class TestAPIGateway:
 
         # DELETE
         client.delete_base_path_mapping(domainName=domain_name, basePath=base_path)
-        with pytest.raises(Exception):
+        with pytest.raises(ClientError):
             client.get_base_path_mapping(domainName=domain_name, basePath=base_path)
-        with pytest.raises(Exception):
+        with pytest.raises(ClientError):
             client.delete_base_path_mapping(domainName=domain_name, basePath=base_path)
 
     @markers.aws.needs_fixing

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -3,7 +3,8 @@ import json
 import os.path
 
 import pytest
-from botocore.exceptions import ClientError, ParamValidationError, WaiterError
+from botocore.config import Config
+from botocore.exceptions import ClientError, WaiterError
 from tests.aws.services.cloudformation.api.test_stacks import (
     MINIMAL_TEMPLATE,
 )
@@ -371,14 +372,17 @@ def test_create_change_set_invalid_params(aws_client):
 
 
 @markers.aws.validated
-def test_create_change_set_missing_stackname(aws_client):
+def test_create_change_set_missing_stackname(aws_client_factory):
     """in this case boto doesn't even let us send the request"""
     change_set_name = f"change-set-{short_uid()}"
     template_path = os.path.join(
         os.path.dirname(__file__), "../../../templates/sns_topic_simple.yaml"
     )
-    with pytest.raises(ParamValidationError):
-        aws_client.cloudformation.create_change_set(
+
+    # A client with parameter validation enabled would result in a client-side ParamValidationError.
+    cfn_client = aws_client_factory(config=Config(parameter_validation=False)).cloudformation
+    with pytest.raises(ClientError):
+        cfn_client.create_change_set(
             StackName="",
             ChangeSetName=change_set_name,
             TemplateBody=load_template_raw(template_path),

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -3,7 +3,7 @@ import json
 import os.path
 
 import pytest
-from botocore.exceptions import ClientError, WaiterError
+from botocore.exceptions import ClientError, ParamValidationError, WaiterError
 from tests.aws.services.cloudformation.api.test_stacks import (
     MINIMAL_TEMPLATE,
 )
@@ -377,7 +377,7 @@ def test_create_change_set_missing_stackname(aws_client):
     template_path = os.path.join(
         os.path.dirname(__file__), "../../../templates/sns_topic_simple.yaml"
     )
-    with pytest.raises(ClientError):
+    with pytest.raises(ParamValidationError):
         aws_client.cloudformation.create_change_set(
             StackName="",
             ChangeSetName=change_set_name,

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -336,7 +336,7 @@ def test_create_change_set_update_nonexisting(aws_client):
         os.path.dirname(__file__), "../../../templates/sns_topic_simple.yaml"
     )
 
-    with pytest.raises(Exception) as ex:
+    with pytest.raises(ClientError) as ex:
         response = aws_client.cloudformation.create_change_set(
             StackName=stack_name,
             ChangeSetName=change_set_name,
@@ -377,7 +377,7 @@ def test_create_change_set_missing_stackname(aws_client):
     template_path = os.path.join(
         os.path.dirname(__file__), "../../../templates/sns_topic_simple.yaml"
     )
-    with pytest.raises(Exception):
+    with pytest.raises(ClientError):
         aws_client.cloudformation.create_change_set(
             StackName="",
             ChangeSetName=change_set_name,

--- a/tests/aws/services/cloudformation/api/test_changesets.validation.json
+++ b/tests/aws/services/cloudformation/api/test_changesets.validation.json
@@ -56,6 +56,15 @@
       "total": 89.06
     }
   },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_create_change_set_missing_stackname": {
+    "last_validated_date": "2025-08-22T12:49:42+00:00",
+    "durations_in_seconds": {
+      "setup": 0.6,
+      "call": 0.51,
+      "teardown": 0.0,
+      "total": 1.11
+    }
+  },
   "tests/aws/services/cloudformation/api/test_changesets.py::test_create_change_set_update_without_parameters": {
     "last_validated_date": "2022-05-31T07:32:02+00:00"
   },

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -110,7 +110,7 @@ class TestKMS:
     def test_create_alias(self, kms_create_alias, kms_create_key, snapshot):
         alias_name = f"{short_uid()}"
         alias_key_id = kms_create_key()["KeyId"]
-        with pytest.raises(Exception) as e:
+        with pytest.raises(ClientError) as e:
             kms_create_alias(AliasName=alias_name, TargetKeyId=alias_key_id)
 
         snapshot.match("create_alias", e.value.response)

--- a/tests/aws/services/lambda_/test_lambda_developer_tools.py
+++ b/tests/aws/services/lambda_/test_lambda_developer_tools.py
@@ -3,6 +3,7 @@ import os
 import time
 
 import pytest
+from botocore.exceptions import ClientError
 
 from localstack import config
 from localstack.aws.api.lambda_ import Runtime
@@ -146,7 +147,7 @@ class TestHotReloading:
         """Tests validation of hot reloading paths"""
         function_name = f"test-hot-reloading-{short_uid()}"
         hot_reloading_bucket = config.BUCKET_MARKER_LOCAL
-        with pytest.raises(Exception):
+        with pytest.raises(ClientError):
             aws_client.lambda_.create_function(
                 FunctionName=function_name,
                 Handler="handler.handler",

--- a/tests/aws/services/route53/test_route53.py
+++ b/tests/aws/services/route53/test_route53.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlparse
 
 import pytest
-from neo4j.exceptions import ClientError
+from botocore.exceptions import ClientError
 
 from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid

--- a/tests/aws/services/route53/test_route53.py
+++ b/tests/aws/services/route53/test_route53.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 
 import pytest
+from neo4j.exceptions import ClientError
 
 from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
@@ -54,7 +55,7 @@ class TestRoute53:
         assert response["HealthCheck"]["Id"] == health_check_id
         response = aws_client.route53.delete_health_check(HealthCheckId=health_check_id)
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-        with pytest.raises(Exception) as ctx:
+        with pytest.raises(ClientError) as ctx:
             aws_client.route53.delete_health_check(HealthCheckId=health_check_id)
         assert "NoSuchHealthCheck" in str(ctx.value)
 
@@ -171,7 +172,7 @@ class TestRoute53:
         )
         assert response["ResponseMetadata"]["HTTPStatusCode"] in [200, 201]
         # subsequent call (after disassociation) should fail with 404 error
-        with pytest.raises(Exception):
+        with pytest.raises(ClientError):
             aws_client.route53.disassociate_vpc_from_hosted_zone(
                 HostedZoneId=zone_id,
                 VPC={"VPCRegion": vpc_region, "VPCId": vpc2_id},

--- a/tests/aws/services/ssm/test_ssm.py
+++ b/tests/aws/services/ssm/test_ssm.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from botocore.exceptions import ClientError
 
 from localstack import config
 from localstack.testing.config import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
@@ -55,7 +56,7 @@ class TestSSM:
 
         _assert(f"/{param_a}/b/c", f"/{param_a}/b/c", aws_client.ssm)
         pname = param_name_pattern.replace("<param>", param_a)
-        with pytest.raises(Exception) as exc:
+        with pytest.raises(ClientError) as exc:
             _assert(pname, f"/{param_a}/b/c", aws_client.ssm)
         exc.match("ValidationException")
         exc.match("sub-paths divided by slash symbol")
@@ -82,7 +83,7 @@ class TestSSM:
         assert ":secretsmanager:" in source_result["ARN"]
 
         # negative test for https://github.com/localstack/localstack/issues/6551
-        with pytest.raises(Exception):
+        with pytest.raises(ClientError):
             aws_client.ssm.get_parameter(Name=secret_name, WithDecryption=True)
 
     @markers.aws.validated

--- a/tests/unit/services/apigateway/test_handler_integration_request.py
+++ b/tests/unit/services/apigateway/test_handler_integration_request.py
@@ -10,6 +10,7 @@ from localstack.services.apigateway.next_gen.execute_api.context import (
     RestApiInvocationContext,
 )
 from localstack.services.apigateway.next_gen.execute_api.gateway_response import (
+    InternalServerError,
     UnsupportedMediaTypeError,
 )
 from localstack.services.apigateway.next_gen.execute_api.handlers import (
@@ -328,7 +329,7 @@ class TestIntegrationRequestBinaryHandling:
 
         outcome = possible_values.get(expected, input_data)
         if outcome is None:
-            with pytest.raises(Exception):
+            with pytest.raises(InternalServerError):
                 convert(context=default_context)
         else:
             converted_body = convert(context=default_context)

--- a/tests/unit/services/apigateway/test_handler_integration_response.py
+++ b/tests/unit/services/apigateway/test_handler_integration_response.py
@@ -11,6 +11,7 @@ from localstack.services.apigateway.next_gen.execute_api.context import (
 )
 from localstack.services.apigateway.next_gen.execute_api.gateway_response import (
     ApiConfigurationError,
+    InternalServerError,
 )
 from localstack.services.apigateway.next_gen.execute_api.handlers import (
     IntegrationResponseHandler,
@@ -332,7 +333,7 @@ class TestIntegrationResponseBinaryHandling:
 
         outcome = possible_values.get(expected, input_data)
         if outcome is None:
-            with pytest.raises(Exception):
+            with pytest.raises(InternalServerError):
                 convert(body=input_data, context=ctx, content_handling=content_handling)
         else:
             converted_body = convert(

--- a/tests/unit/services/kms/test_kms.py
+++ b/tests/unit/services/kms/test_kms.py
@@ -15,7 +15,7 @@ from localstack.services.kms.utils import (
 
 
 def test_alias_name_validator():
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationException):
         validate_alias_name("test-alias")
 
 

--- a/tests/unit/services/s3/test_s3.py
+++ b/tests/unit/services/s3/test_s3.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 import pytest
 
 from localstack.aws.api import RequestContext
-from localstack.aws.api.s3 import InvalidArgument
+from localstack.aws.api.s3 import AccessDenied, AuthorizationQueryParametersError, InvalidArgument
 from localstack.config import S3_VIRTUAL_HOSTNAME
 from localstack.constants import LOCALHOST
 from localstack.http import Request
@@ -454,7 +454,7 @@ class TestS3PresignedUrl:
             if not will_raise:
                 assert presigned_url.is_valid_sig_v2(query_args) == is_sig_v2
             else:
-                with pytest.raises(Exception):
+                with pytest.raises(AccessDenied):
                     presigned_url.is_valid_sig_v2(query_args)
 
     def test_is_valid_presigned_url_v4(self):
@@ -512,7 +512,7 @@ class TestS3PresignedUrl:
             if not will_raise:
                 assert presigned_url.is_valid_sig_v4(query_args) == is_sig_v4
             else:
-                with pytest.raises(Exception):
+                with pytest.raises(AuthorizationQueryParametersError):
                     presigned_url.is_valid_sig_v4(query_args)
 
 

--- a/tests/unit/utils/test_id_generator.py
+++ b/tests/unit/utils/test_id_generator.py
@@ -134,9 +134,7 @@ def test_custom_id_context_manager(default_resource_identifier):
 def test_custom_id_context_manager_exception_handling(default_resource_identifier):
     custom_id = "set_id"
 
-    with pytest.raises(Exception):
-        with localstack_id_manager.custom_id(default_resource_identifier, custom_id):
-            assert default_resource_identifier.generate() == custom_id
-            raise Exception()
+    with localstack_id_manager.custom_id(default_resource_identifier, custom_id):
+        assert default_resource_identifier.generate() == custom_id
 
     assert default_resource_identifier.generate() != custom_id

--- a/tests/unit/utils/test_id_generator.py
+++ b/tests/unit/utils/test_id_generator.py
@@ -134,7 +134,9 @@ def test_custom_id_context_manager(default_resource_identifier):
 def test_custom_id_context_manager_exception_handling(default_resource_identifier):
     custom_id = "set_id"
 
-    with localstack_id_manager.custom_id(default_resource_identifier, custom_id):
-        assert default_resource_identifier.generate() == custom_id
+    with pytest.raises(Exception):  # noqa: B017
+        with localstack_id_manager.custom_id(default_resource_identifier, custom_id):
+            assert default_resource_identifier.generate() == custom_id
+            raise Exception()
 
     assert default_resource_identifier.generate() != custom_id

--- a/tests/unit/utils/test_objects.py
+++ b/tests/unit/utils/test_objects.py
@@ -22,7 +22,7 @@ def test_subtypes_instance_manager():
     assert instance1
     assert BaseClass.get("c1") == instance1
     assert instance1.foo() == "bar"
-    with pytest.raises(Exception):
+    with pytest.raises(NotImplementedError):
         assert BaseClass.get("c2")
 
     class C2(BaseClass):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
After https://github.com/localstack/localstack/pull/12953, we started to enable all the ignored `ruff` rules.
With this PR, we re-enable [B017](https://docs.astral.sh/ruff/rules/assert-raises-exception/) and fix the code accordingly.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Enable B017;
- Format the code.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
