### PR TITLE
CFNV2: Implement Fn::Length for language extensions

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack-core/localstack/services/cloudformation/engine/transformers.py
@@ -14,6 +14,7 @@ from samtranslator.translator.transform import transform as transform_sam
 
 from localstack.aws.api import CommonServiceException
 from localstack.aws.connect import connect_to
+from localstack.services.cloudformation.engine.parameters import StackParameter
 from localstack.services.cloudformation.engine.policy_loader import create_policy_loader
 from localstack.services.cloudformation.engine.template_deployer import resolve_refs_recursively
 from localstack.services.cloudformation.engine.validations import ValidationError
@@ -39,7 +40,7 @@ class ResolveRefsRecursivelyContext:
     resources: dict
     mappings: dict
     conditions: dict
-    parameters: dict
+    parameters: dict[str, StackParameter]
 
     def resolve(self, value: Any) -> Any:
         return resolve_refs_recursively(

--- a/tests/aws/services/cloudformation/api/test_transformers.py
+++ b/tests/aws/services/cloudformation/api/test_transformers.py
@@ -215,7 +215,6 @@ def transform_template(aws_client: ServiceLevelClientFactory, snapshot, cleanups
         call_safe(lambda: aws_client.cloudformation.delete_stack(StackName=stack_id))
 
 
-@skip_if_v2_provider("LanguageExtensions")
 class TestLanguageExtensionsTransform:
     """
     Manual testing of the language extensions trasnform
@@ -239,6 +238,7 @@ class TestLanguageExtensionsTransform:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..PhysicalResourceId", "$..StackId"])
+    @skip_if_v2_provider("LanguageExtensions")
     def test_transform_foreach(self, transform_template, snapshot):
         topic_names = [
             f"mytopic1{short_uid()}",
@@ -268,6 +268,7 @@ class TestLanguageExtensionsTransform:
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..StackResources..PhysicalResourceId", "$..StackResources..StackId"]
     )
+    @skip_if_v2_provider("LanguageExtensions")
     def test_transform_foreach_multiple_resources(self, transform_template, snapshot):
         snapshot.add_transformer(
             SortingTransformer("StackResources", lambda resource: resource["LogicalResourceId"])
@@ -294,6 +295,7 @@ class TestLanguageExtensionsTransform:
             "$..StackResources..StackId",
         ]
     )
+    @skip_if_v2_provider("LanguageExtensions")
     def test_transform_foreach_use_case(self, aws_client, transform_template, snapshot):
         snapshot.add_transformer(
             SortingTransformer("StackResources", lambda resource: resource["LogicalResourceId"])
@@ -334,6 +336,7 @@ class TestLanguageExtensionsTransform:
             "$..StackResources..StackId",
         ]
     )
+    @skip_if_v2_provider("LanguageExtensions")
     def test_transform_to_json_string(self, aws_client, transform_template, snapshot):
         snapshot.add_transformer(
             SortingTransformer("StackResources", lambda resource: resource["LogicalResourceId"])


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We need to support the language extensions transform to match parity with the V1 provider. We start by implementing the `Fn::Length` transform to demonstrate general integration with the v1 implementation. We will implement `Fn::ForEach` in a follow up as this is a more complex change.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Separate local and global transforms in the `ChangeSetModelTransformer.transform` method
* **TEMPORARILY** repurpose `resolve_refs_recursively` to enable the feature, with the knowledge that the requirements for transforms are much lower, and we can potentially re-purpose the `ChangeSetVisitor` or similar to re-write this usage after the new provider is released
    * This allows us to repurpose the v1 implementation of the language extensions macro which we know is in parity with AWS and has been validated by customers
* Unskip the `Fn::Length` test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->