### PR TITLE
Add workflow to enforce docs PR labels

### DIFF
--- a/.github/workflows/pr-enforce-docs-labels.yml
+++ b/.github/workflows/pr-enforce-docs-labels.yml
@@ -1,0 +1,11 @@
+name: Enforce Docs Labels
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+
+jobs:
+  enforce-docs-labels:
+    uses: localstack/meta/.github/workflows/pr-enforce-docs-labels.yml@main
+    secrets:
+      github-token: ${{ secrets.PRO_ACCESS_TOKEN }}


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This new workflow helps maintain consistent documentation practices by automatically checking that PRs have appropriate documentation-related labels, ensuring tracking of documentation changes across the repository, one of the following tags needs to be set:

- `needs-docs` - pull request requires documentation updates
- `skip-docs` - pull request does not require documentation changes

<!-- What notable changes does this PR make? -->
## Changes
- introduces a new GHA workflow that automatically enforces documentation labeling requirements on pull requests

<!-- The following sections are optional, but can be useful!

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->
