### PR TITLE
Update lambda init

### DIFF
--- a/localstack-core/localstack/services/lambda_/packages.py
+++ b/localstack-core/localstack/services/lambda_/packages.py
@@ -12,7 +12,7 @@ from localstack.utils.platform import get_arch
 """Customized LocalStack version of the AWS Lambda Runtime Interface Emulator (RIE).
 https://github.com/localstack/lambda-runtime-init/blob/localstack/README-LOCALSTACK.md
 """
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.34-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.35-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Updates the lambda init to the latest version.
This version is essentially a rebuild with a newer go version, to fix [CVE-2025-47907](https://nvd.nist.gov/vuln/detail/CVE-2025-47907).


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Update lambda runtime init to the latest version
* No user facing changes

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
