### PR TITLE
Raise DockerNotAvailable exception if port checking is impossible

### DIFF
--- a/localstack-core/localstack/utils/docker_utils.py
+++ b/localstack-core/localstack/utils/docker_utils.py
@@ -9,6 +9,7 @@ from localstack.constants import DEFAULT_VOLUME_DIR, DOCKER_IMAGE_NAME
 from localstack.utils.collections import ensure_list
 from localstack.utils.container_utils.container_client import (
     ContainerClient,
+    DockerNotAvailable,
     PortMappings,
     VolumeInfo,
 )
@@ -153,10 +154,14 @@ def container_ports_can_be_bound(
             ports=port_mappings,
             remove=True,
         )
+    except DockerNotAvailable as e:
+        LOG.warning("Cannot perform port check because Docker is not available.")
+        raise e
     except Exception as e:
         if "port is already allocated" not in str(e) and "address already in use" not in str(e):
             LOG.warning(
-                "Unexpected error when attempting to determine container port status", exc_info=e
+                "Unexpected error when attempting to determine container port status",
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
             )
         return False
     # TODO(srw): sometimes the command output from the docker container is "None", particularly when this function is


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The port checking utility retries upon not being able to find a bindable because we always return `False` upon exception. If Docker (or container client) is not available, retries (without backoff) won't help (unless it's a temporary issue; e.g., Docker starting).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Raise `DockerNotAvailable` exception for client code to better distinguish error cases.
⚠️ Breaking change: The current behavior is to return `False`

## Testing

Stop Docker and try feature that uses `container_ports_can_be_bound`

This change might affect the localstack-pro and K8 pipelines, which must succeed before proceeding.
Both pipelines are 🟢🟢
