### PR TITLE
Fix cross-arch Docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ PYTEST_LOGLEVEL ?= warning
 
 uname_m := $(shell uname -m)
 ifeq ($(uname_m),x86_64)
-platform = amd64
+PLATFORM ?= amd64
 else
-platform = arm64
+PLATFORM ?= arm64
 endif
 
 ifeq ($(OS), Windows_NT)
@@ -143,7 +143,7 @@ init-precommit:    		  ## install te pre-commit hook into your local git reposit
 	($(VENV_RUN); pre-commit install)
 
 docker-build:
-	IMAGE_NAME=$(IMAGE_NAME) PLATFORM=$(platform) ./bin/docker-helper.sh build
+	IMAGE_NAME=$(IMAGE_NAME) PLATFORM=$(PLATFORM) ./bin/docker-helper.sh build
 
 clean:             		  ## Clean up (npm dependencies, downloaded infrastructure code, compiled Java classes)
 	rm -rf .filesystem

--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -137,7 +137,7 @@ function cmd-build() {
     # --add-host: Fix for Centos host OS
     # --build-arg BUILDKIT_INLINE_CACHE=1: Instruct buildkit to inline the caching information into the image
     # --cache-from: Use the inlined caching information when building the image
-    DOCKER_BUILDKIT=1 docker buildx build --pull --progress=plain \
+    DOCKER_BUILDKIT=1 docker buildx build --platform linux/$PLATFORM --pull --progress=plain \
       --cache-from "$IMAGE_NAME" --build-arg BUILDKIT_INLINE_CACHE=1 \
       --build-arg LOCALSTACK_PRE_RELEASE=$(_is_release_commit && echo "0" || echo "1") \
       --build-arg LOCALSTACK_BUILD_GIT_HASH=$(git rev-parse --short HEAD) \


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The `PLATFORM` argument doesn't work for cross-arch builds (e.g., on ARM macs) because without the `--platform` argument, Docker buildkit simply picks the native arguments. In the current implementation, `make PLATFORM=amd64 docker-build` results in arm64 image being built on my M1 MacBook.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Make `PLATFORM` configurable in the `Makefile`
* Use explicit `linux/$PLATFORM` flag for the Docker build

## Testing

`make PLATFORM=amd64 docker-build`