### PR TITLE
APIGW: internalize DeleteIntegrationResponse

### DIFF
--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -725,6 +725,17 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
         return response
 
+    def delete_integration_response(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        resource_id: String,
+        http_method: String,
+        status_code: StatusCode,
+        **kwargs,
+    ) -> None:
+        pass
+
     def update_resource(
         self,
         context: RequestContext,

--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -665,77 +665,6 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         parent_id = moto_resource.parent_id
         api_resources[parent_id].remove(resource_id)
 
-    def update_integration_response(
-        self,
-        context: RequestContext,
-        rest_api_id: String,
-        resource_id: String,
-        http_method: String,
-        status_code: StatusCode,
-        patch_operations: ListOfPatchOperation = None,
-        **kwargs,
-    ) -> IntegrationResponse:
-        # XXX: THIS IS NOT A COMPLETE IMPLEMENTATION, just the minimum required to get tests going
-        # TODO: validate patch operations
-
-        moto_rest_api = get_moto_rest_api(context, rest_api_id)
-        moto_resource = moto_rest_api.resources.get(resource_id)
-        if not moto_resource:
-            raise NotFoundException("Invalid Resource identifier specified")
-
-        moto_method = moto_resource.resource_methods.get(http_method)
-        if not moto_method:
-            raise NotFoundException("Invalid Method identifier specified")
-
-        integration_response = moto_method.method_integration.integration_responses.get(status_code)
-        if not integration_response:
-            raise NotFoundException("Invalid Integration Response identifier specified")
-
-        for patch_operation in patch_operations:
-            op = patch_operation.get("op")
-            path = patch_operation.get("path")
-
-            # for path "/responseTemplates/application~1json"
-            if "/responseTemplates" in path:
-                integration_response.response_templates = (
-                    integration_response.response_templates or {}
-                )
-                value = patch_operation.get("value")
-                if not isinstance(value, str):
-                    raise BadRequestException(
-                        f"Invalid patch value  '{value}' specified for op '{op}'. Must be a string"
-                    )
-                param = path.removeprefix("/responseTemplates/")
-                param = param.replace("~1", "/")
-                if op == "remove":
-                    integration_response.response_templates.pop(param)
-                elif op in ("add", "replace"):
-                    integration_response.response_templates[param] = value
-
-            elif "/contentHandling" in path and op == "replace":
-                integration_response.content_handling = patch_operation.get("value")
-
-            elif "/selectionPattern" in path and op == "replace":
-                integration_response.selection_pattern = patch_operation.get("value")
-
-        response: IntegrationResponse = integration_response.to_json()
-        # in case it's empty, we still want to pass it on as ""
-        # TODO: add a test case for this
-        response["selectionPattern"] = integration_response.selection_pattern
-
-        return response
-
-    def delete_integration_response(
-        self,
-        context: RequestContext,
-        rest_api_id: String,
-        resource_id: String,
-        http_method: String,
-        status_code: StatusCode,
-        **kwargs,
-    ) -> None:
-        pass
-
     def update_resource(
         self,
         context: RequestContext,
@@ -2317,6 +2246,93 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             response["selectionPattern"] = selection_pattern
 
         return response
+
+    def update_integration_response(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        resource_id: String,
+        http_method: String,
+        status_code: StatusCode,
+        patch_operations: ListOfPatchOperation = None,
+        **kwargs,
+    ) -> IntegrationResponse:
+        # XXX: THIS IS NOT A COMPLETE IMPLEMENTATION, just the minimum required to get tests going
+        # TODO: validate patch operations
+
+        moto_rest_api = get_moto_rest_api(context, rest_api_id)
+        moto_resource = moto_rest_api.resources.get(resource_id)
+        if not moto_resource:
+            raise NotFoundException("Invalid Resource identifier specified")
+
+        moto_method = moto_resource.resource_methods.get(http_method)
+        if not moto_method:
+            raise NotFoundException("Invalid Method identifier specified")
+
+        integration_response = moto_method.method_integration.integration_responses.get(status_code)
+        if not integration_response:
+            raise NotFoundException("Invalid Integration Response identifier specified")
+
+        for patch_operation in patch_operations:
+            op = patch_operation.get("op")
+            path = patch_operation.get("path")
+
+            # for path "/responseTemplates/application~1json"
+            if "/responseTemplates" in path:
+                integration_response.response_templates = (
+                    integration_response.response_templates or {}
+                )
+                value = patch_operation.get("value")
+                if not isinstance(value, str):
+                    raise BadRequestException(
+                        f"Invalid patch value  '{value}' specified for op '{op}'. Must be a string"
+                    )
+                param = path.removeprefix("/responseTemplates/")
+                param = param.replace("~1", "/")
+                if op == "remove":
+                    integration_response.response_templates.pop(param)
+                elif op in ("add", "replace"):
+                    integration_response.response_templates[param] = value
+
+            elif "/contentHandling" in path and op == "replace":
+                integration_response.content_handling = patch_operation.get("value")
+
+            elif "/selectionPattern" in path and op == "replace":
+                integration_response.selection_pattern = patch_operation.get("value")
+
+        response: IntegrationResponse = integration_response.to_json()
+        # in case it's empty, we still want to pass it on as ""
+        # TODO: add a test case for this
+        response["selectionPattern"] = integration_response.selection_pattern
+
+        return response
+
+    def delete_integration_response(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        resource_id: String,
+        http_method: String,
+        status_code: StatusCode,
+        **kwargs,
+    ) -> None:
+        moto_backend = apigw_models.apigateway_backends[context.account_id][context.region]
+        moto_rest_api = moto_backend.apis.get(rest_api_id)
+        if not moto_rest_api:
+            raise NotFoundException("Invalid Resource identifier specified")
+
+        if not (moto_resource := moto_rest_api.resources.get(resource_id)):
+            raise NotFoundException("Invalid Resource identifier specified")
+
+        if not (moto_method := moto_resource.resource_methods.get(http_method)):
+            raise NotFoundException("Invalid Integration identifier specified")
+
+        if not moto_method.method_integration:
+            raise NotFoundException("Invalid Integration identifier specified")
+        if not (
+            integration_responses := moto_method.method_integration.integration_responses
+        ) or not integration_responses.pop(status_code, None):
+            raise NotFoundException("Invalid Response status code specified")
 
     def get_export(
         self,

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -4763,5 +4763,76 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_delete_integration_response_errors": {
+    "recorded-date": "21-08-2025, 17:53:19",
+    "recorded-content": {
+      "put-integration-response": {
+        "responseTemplates": {
+          "application/json": "\"created\""
+        },
+        "selectionPattern": "",
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "non-existent-resource": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "non-existent-api-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "non-existent-method": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Integration identifier specified"
+        },
+        "message": "Invalid Integration identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "non-existent-status-code": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Response status code specified"
+        },
+        "message": "Invalid Response status code specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "bad-method": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Integration identifier specified"
+        },
+        "message": "Invalid Integration identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -236,6 +236,15 @@
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_update_gateway_response": {
     "last_validated_date": "2024-04-15T20:47:11+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_delete_integration_response_errors": {
+    "last_validated_date": "2025-08-21T17:53:19+00:00",
+    "durations_in_seconds": {
+      "setup": 0.84,
+      "call": 2.14,
+      "teardown": 0.33,
+      "total": 3.31
+    }
+  },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_integration_response_invalid_integration": {
     "last_validated_date": "2025-06-26T11:21:05+00:00",
     "durations_in_seconds": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While looking at the some exception reports, I've spotted the following:
```python
exception while calling apigateway.DeleteIntegrationResponse: 'NoneType' object has no attribute 'to_json'
```

Looking at the code, it seemed there was almost no validation, and the code would do a `value.get(x, None).to_json()` which would fail.

We can internalize the `DeleteIntegrationResponse` and add a bit of validation

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add test around validation of `DeleteIntegrationResponse`
- implement `DeleteIntegrationResponse` in our provider

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
