### PR TITLE
Ruff linter: enable rule UP028

### DIFF
--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -397,8 +397,7 @@ class QueueUpdateWorker:
 
     def iter_queues(self) -> Iterable[SqsQueue]:
         for account_id, region, store in sqs_stores.iter_stores():
-            for queue in store.queues.values():
-                yield queue
+            yield from store.queues.values()
 
     def do_update_all_queues(self):
         for queue in self.iter_queues():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,6 @@ ignore = [
     "E501", # E501 Line too long - handled by black, see https://docs.astral.sh/ruff/faq/#is-ruff-compatible-with-black
     "T201", # TODO `print` found
     "T203", # TODO `pprint` found
-    "UP028",# TODO Replace `yield` over `for` loop with `yield from`
     "UP031",# TODO Use format specifiers instead of percent format
     "UP038",# TODO Use `X | Y` in `isinstance` call instead of `(X, Y)`
 ]

--- a/tests/integration/aws/test_app.py
+++ b/tests/integration/aws/test_app.py
@@ -105,8 +105,7 @@ class TestWerkzeugIntegration:
         chunks = [bytes(f"{n:2}", "utf-8") for n in range(0, 100)]
 
         def chunk_generator():
-            for chunk in chunks:
-                yield chunk
+            yield from chunks
 
         def stream_response_handler(_request) -> Response:
             return Response(response=chunk_generator())
@@ -133,8 +132,7 @@ class TestWerkzeugIntegration:
         cleanups.append(lambda: ROUTER.remove(rule))
 
         def chunk_generator():
-            for chunk in chunks:
-                yield chunk
+            yield from chunks
 
         response = requests.post(
             config.internal_service_url() + "/_test/test_chunked_request", data=chunk_generator()

--- a/tests/unit/http_/test_asgi.py
+++ b/tests/unit/http_/test_asgi.py
@@ -175,8 +175,7 @@ def test_close_iterable_response(serve_asgi_adapter):
             self.closed = False
 
         def __iter__(self):
-            for packet in self.data:
-                yield packet
+            yield from self.data
 
         def close(self):
             # should be called through the werkzeug layers

--- a/tests/unit/http_/test_hypercorn.py
+++ b/tests/unit/http_/test_hypercorn.py
@@ -107,8 +107,7 @@ def test_proxy_server_with_chunked_request(httpserver, httpserver_echo_request_m
     proxy_server = ProxyServer(httpserver.url_for("/"), gateway_listen, use_ssl=True)
 
     def chunk_generator():
-        for chunk in chunks:
-            yield chunk
+        yield from chunks
 
     with server_context(proxy_server):
         response = requests.get(
@@ -121,8 +120,7 @@ def test_proxy_server_with_streamed_response(httpserver):
     chunks = [bytes(f"{n:2}", "utf-8") for n in range(0, 100)]
 
     def chunk_generator():
-        for chunk in chunks:
-            yield chunk
+        yield from chunks
 
     def stream_response_handler(_: WerkzeugRequest) -> Response:
         return Response(response=chunk_generator())

--- a/tests/unit/state/test_pickle.py
+++ b/tests/unit/state/test_pickle.py
@@ -26,8 +26,7 @@ class ClassWithGenerator:
         self.gen = self._count()
 
     def _count(self):
-        for i in range(self.n):
-            yield i
+        yield from range(self.n)
 
 
 class SubclassWithGenerator(ClassWithGenerator):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
https://github.com/localstack/localstack/pull/12953 introduced the `pyupgrade` rules to our `ruff` linter.
However, a few rules have been ignored. This PR enabled [UP028](https://docs.astral.sh/ruff/rules/yield-in-for-loop/) and fixes the code accordingly.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
