### PR TITLE
add skip-docs label to automatically generated PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     labels:
       - "area: dependencies"
       - "semver: patch"
+      - "skip-docs"
     groups:
       docker-base-images:
         patterns:
@@ -23,6 +24,7 @@ updates:
     labels:
       - "area: dependencies"
       - "semver: patch"
+      - "skip-docs"
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -127,6 +127,6 @@ jobs:
           author: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
           committer: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
           commit-message: "update generated ASF APIs to latest version"
-          labels: "area: asf, area: dependencies, semver: patch"
+          labels: "area: asf, area: dependencies, semver: patch, skip-docs"
           token: ${{ secrets.PRO_ACCESS_TOKEN }}
           reviewers: silv-io,alexrashed

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -72,5 +72,5 @@ jobs:
             commit-message: "CI: update .test_durations to latest version"
             path: localstack
             add-paths: .test_durations
-            labels: "semver: patch, area: testing, area: ci"
+            labels: "semver: patch, area: testing, area: ci, skip-docs"
             token: ${{ secrets.PRO_ACCESS_TOKEN }}

--- a/.github/workflows/upgrade-python-dependencies.yml
+++ b/.github/workflows/upgrade-python-dependencies.yml
@@ -11,3 +11,5 @@ jobs:
     uses: localstack/meta/.github/workflows/upgrade-python-dependencies.yml@main
     secrets:
       github-token: ${{ secrets.PRO_ACCESS_TOKEN }}
+    with:
+      labels: "area: dependencies, semver: patch, skip-docs"


### PR DESCRIPTION
## Motivation
With #13035 we are now enforcing that a label has to be added to PRs which indicates if the changes of the PR should be reflected in the documentation.
This PR adds this label to automatically to PRs created by our GitHub workflows.

## Changes
- Modify our GitHub workflows such that workflows which create PRs add the `skip-docs` label:
  - [ASF Updates](https://github.com/localstack/localstack/actions/workflows/asf-updates.yml) like https://github.com/localstack/localstack/pull/13053
  - [Test Duration Updates](https://github.com/localstack/localstack/actions/workflows/update-test-durations.yml) like https://github.com/localstack/localstack/pull/13014
  - [Upgrade Python Dependencies](https://github.com/localstack/localstack/actions/workflows/upgrade-python-dependencies.yml) like https://github.com/localstack/localstack/pull/13024
  - [Dependabot](https://github.com/localstack/localstack/blob/d89864a2aefc0be6e33746e835ec1c74df4d9b41/.github/dependabot.yml) like https://github.com/localstack/localstack/pull/12995