### PR TITLE
fix cloudwatch v1 timestamp serialization after moto upgrade

### DIFF
--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -259,6 +259,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           filters: |
             cloudwatch-v1:
+               - 'localstack-core/localstack/services/cloudwatch/**'
                - 'tests/aws/services/cloudwatch/**'
             dynamodb-v2:
                - 'tests/aws/services/dynamodb/**'
@@ -647,7 +648,7 @@ jobs:
 
   test-cloudwatch-v1:
     name: Test CloudWatch V1
-    if: ${{ !inputs.onlyAcceptanceTests && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || needs.test-preflight.outputs.cloudwatch-v1 == 'true') }}
+    if: ${{ !inputs.onlyAcceptanceTests && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || inputs.disableTestSelection || needs.test-preflight.outputs.cloudwatch-v1 == 'true') }}
     runs-on: ubuntu-latest
     needs:
       - test-preflight
@@ -697,7 +698,7 @@ jobs:
 
   test-ddb-v2:
     name: Test DynamoDB(Streams) v2
-    if: ${{ !inputs.onlyAcceptanceTests && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || needs.test-preflight.outputs.dynamodb-v2 == 'true') }}
+    if: ${{ !inputs.onlyAcceptanceTests && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || inputs.disableTestSelection || needs.test-preflight.outputs.dynamodb-v2 == 'true') }}
     runs-on: ubuntu-latest
     needs:
       - test-preflight
@@ -746,7 +747,7 @@ jobs:
 
   test-events-v1:
     name: Test EventBridge v1
-    if: ${{ !inputs.onlyAcceptanceTests && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || needs.test-preflight.outputs.events-v1 == 'true') }}
+    if: ${{ !inputs.onlyAcceptanceTests && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || inputs.disableTestSelection || needs.test-preflight.outputs.events-v1 == 'true') }}
     runs-on: ubuntu-latest
     needs:
       - test-preflight
@@ -795,7 +796,7 @@ jobs:
 
   test-cfn-v2-engine:
     name: Test CloudFormation Engine v2
-    if: ${{ !inputs.onlyAcceptanceTests && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || needs.test-preflight.outputs.cloudformation-v2 == 'true' )}}
+    if: ${{ !inputs.onlyAcceptanceTests && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || inputs.disableTestSelection || needs.test-preflight.outputs.cloudformation-v2 == 'true' )}}
     runs-on: ubuntu-latest
     needs:
       - test-preflight

--- a/localstack-core/localstack/services/cloudwatch/provider.py
+++ b/localstack-core/localstack/services/cloudwatch/provider.py
@@ -3,7 +3,6 @@ import logging
 import uuid
 from datetime import datetime
 from typing import Any
-from xml.sax.saxutils import escape
 
 from moto.cloudwatch import cloudwatch_backends
 from moto.cloudwatch.models import Alarm, CloudWatchBackend, MetricDatum
@@ -129,8 +128,6 @@ def put_metric_alarm(
     rule: str | None = None,
     tags: list[dict[str, str]] | None = None,
 ) -> Alarm:
-    if description:
-        description = escape(description)
     return target(
         self,
         name,

--- a/localstack-core/localstack/services/cloudwatch/provider.py
+++ b/localstack-core/localstack/services/cloudwatch/provider.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import uuid
+from datetime import datetime
 from typing import Any
 from xml.sax.saxutils import escape
 
@@ -189,12 +190,12 @@ def create_message_response_update_state_lambda(
             "state": {
                 "value": alarm.state_value,
                 "reason": alarm.state_reason,
-                "timestamp": alarm.state_updated_timestamp,
+                "timestamp": _to_iso_8601_datetime_with_nanoseconds(alarm.state_updated_timestamp),
             },
             "previousState": {
                 "value": old_state,
                 "reason": old_state_reason,
-                "timestamp": old_state_timestamp,
+                "timestamp": _to_iso_8601_datetime_with_nanoseconds(old_state_timestamp),
             },
             "configuration": {
                 "description": alarm.description or "",
@@ -204,7 +205,7 @@ def create_message_response_update_state_lambda(
                 ),  # TODO: add test with metric_data_queries
             },
         },
-        "time": alarm.state_updated_timestamp,
+        "time": _to_iso_8601_datetime_with_nanoseconds(alarm.state_updated_timestamp),
         "region": alarm.region_name,
         "source": "aws.cloudwatch",
     }
@@ -217,10 +218,12 @@ def create_message_response_update_state_sns(alarm, old_state):
         "OldStateValue": old_state,
         "AlarmName": alarm.name,
         "AlarmDescription": alarm.description or "",
-        "AlarmConfigurationUpdatedTimestamp": alarm.configuration_updated_timestamp,
+        "AlarmConfigurationUpdatedTimestamp": _to_iso_8601_datetime_with_nanoseconds(
+            alarm.configuration_updated_timestamp
+        ),
         "NewStateValue": alarm.state_value,
         "NewStateReason": alarm.state_reason,
-        "StateChangeTime": alarm.state_updated_timestamp,
+        "StateChangeTime": _to_iso_8601_datetime_with_nanoseconds(alarm.state_updated_timestamp),
         # the long-name for 'region' should be used - as we don't have it, we use the short name
         # which needs to be slightly changed to make snapshot tests work
         "Region": alarm.region_name.replace("-", " ").capitalize(),
@@ -266,6 +269,11 @@ def create_message_response_update_state_sns(alarm, old_state):
 class ValidationError(CommonServiceException):
     def __init__(self, message: str):
         super().__init__("ValidationError", message, 400, True)
+
+
+def _to_iso_8601_datetime_with_nanoseconds(date: datetime | None) -> str | None:
+    if date is not None:
+        return date.strftime("%Y-%m-%dT%H:%M:%S.%f000Z")
 
 
 def _set_alarm_actions(context, alarm_names, enabled):


### PR DESCRIPTION
## Motivation
https://github.com/localstack/localstack/pull/12964 broke a cloudwatch v1 test, which is only executed if respective code is changed.
The following pipelines failed:
- https://github.com/localstack/localstack/actions/runs/17226243111/job/48871812433
- https://github.com/localstack/localstack/actions/runs/17225273361/job/48869379653

The issue was caused by a change in `moto`'s `cloudwatch` implementation, specifically the `Alarm` class, which led to serialization issues:
```
..
  File "/home/runner/work/localstack/localstack/localstack-core/localstack/services/cloudwatch/provider.py", line 263, in create_message_response_update_state_sns
    return json.dumps(response)
           ^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable
```
/cc @viren-nadkarni 

## Changes
- Properly serialize moto's `Alarm.state_updated_timestamp` for CloudWatch v1.

## Testing
- Make sure to activate the old provider when executing the test by setting `PROVIDER_OVERRIDE_CLOUDWATCH=v1`.