### PR TITLE
Use file URI scheme for hotreload presigned URL

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
+++ b/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
@@ -258,7 +258,7 @@ class HotReloadingCode(ArchiveCode):
     code_size: int = 0
 
     def generate_presigned_url(self, endpoint_url: str | None = None) -> str:
-        return f"Code location: {self.host_path}"
+        return f"file://{self.host_path}"
 
     def get_unzipped_code_location(self) -> Path:
         path = os.path.expandvars(self.host_path)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The presigned URL field is currently used to return the host path for hotreloaded Lambda functions. We currently return an arbitrary string: `Code location: ` followed by the host path.

Example:
* Before: `Code location: /Users/joe/Downloads/my-function`
* After: `file:///Users/joe/Downloads/my-function`

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Adopt the `file://` URI scheme

* 👍 easier to parse
* 👍 returning a valid URI seems better than an arbitrary string (still no valid URL, but file URI is clickable in some terminals)
* 👎  The meta-information "code location" gets lost
