### PR TITLE
Fix SQS tests failing due to missing snapshot update after #12957

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
@@ -376,7 +376,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_sqs_source": {
-    "recorded-date": "30-10-2024, 14:48:16",
+    "recorded-date": "27-08-2025, 09:35:51",
     "recorded-content": {
       "stack_resources": {
         "StackResources": [
@@ -548,7 +548,7 @@
           "CreatedTimestamp": "timestamp",
           "DelaySeconds": "0",
           "LastModifiedTimestamp": "timestamp",
-          "MaximumMessageSize": "262144",
+          "MaximumMessageSize": "1048576",
           "MessageRetentionPeriod": "345600",
           "QueueArn": "arn:<partition>:sqs:<region>:111111111111:<resource:2>",
           "ReceiveMessageWaitTimeSeconds": "0",

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -12,7 +12,13 @@
     "last_validated_date": "2024-04-09T07:26:03+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_sqs_source": {
-    "last_validated_date": "2024-10-30T14:48:16+00:00"
+    "last_validated_date": "2025-08-27T09:35:51+00:00",
+    "durations_in_seconds": {
+      "setup": 0.96,
+      "call": 122.08,
+      "teardown": 0.13,
+      "total": 123.17
+    }
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_lambda_dynamodb_event_filter": {
     "last_validated_date": "2024-04-09T07:31:17+00:00"

--- a/tests/aws/services/cloudformation/resources/test_sqs.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_sqs.snapshot.json
@@ -76,7 +76,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_sqs.py::test_cfn_handle_sqs_resource": {
-    "recorded-date": "03-07-2024, 20:03:51",
+    "recorded-date": "27-08-2025, 09:37:44",
     "recorded-content": {
       "queue": {
         "Attributes": {
@@ -90,7 +90,7 @@
           "FifoQueue": "true",
           "FifoThroughputLimit": "perQueue",
           "LastModifiedTimestamp": "timestamp",
-          "MaximumMessageSize": "262144",
+          "MaximumMessageSize": "1048576",
           "MessageRetentionPeriod": "345600",
           "QueueArn": "arn:<partition>:sqs:<region>:111111111111:<queue-name>.fifo",
           "ReceiveMessageWaitTimeSeconds": "0",

--- a/tests/aws/services/cloudformation/resources/test_sqs.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_sqs.validation.json
@@ -1,6 +1,12 @@
 {
   "tests/aws/services/cloudformation/resources/test_sqs.py::test_cfn_handle_sqs_resource": {
-    "last_validated_date": "2024-07-03T20:03:51+00:00"
+    "last_validated_date": "2025-08-27T09:37:44+00:00",
+    "durations_in_seconds": {
+      "setup": 0.82,
+      "call": 74.96,
+      "teardown": 0.11,
+      "total": 75.89
+    }
   },
   "tests/aws/services/cloudformation/resources/test_sqs.py::test_sqs_fifo_queue_generates_valid_name": {
     "last_validated_date": "2024-05-15T02:01:00+00:00"

--- a/tests/aws/services/cloudformation/test_template_engine.snapshot.json
+++ b/tests/aws/services/cloudformation/test_template_engine.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/test_template_engine.py::TestTypes::test_implicit_type_conversion": {
-    "recorded-date": "29-08-2023, 15:21:22",
+    "recorded-date": "27-08-2025, 09:39:00",
     "recorded-content": {
       "queue": {
         "Attributes": {
@@ -14,7 +14,7 @@
           "FifoQueue": "true",
           "FifoThroughputLimit": "perQueue",
           "LastModifiedTimestamp": "timestamp",
-          "MaximumMessageSize": "262144",
+          "MaximumMessageSize": "1048576",
           "MessageRetentionPeriod": "345600",
           "QueueArn": "arn:<partition>:sqs:<region>:111111111111:<resource:1>",
           "ReceiveMessageWaitTimeSeconds": "0",

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -126,6 +126,12 @@
     "last_validated_date": "2023-06-12T15:08:47+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestTypes::test_implicit_type_conversion": {
-    "last_validated_date": "2023-08-29T13:21:22+00:00"
+    "last_validated_date": "2025-08-27T09:39:50+00:00",
+    "durations_in_seconds": {
+      "setup": 0.91,
+      "call": 39.47,
+      "teardown": 50.06,
+      "total": 90.44
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With #12957, the SQS maximum message size was changed to 1 MiB.
However, some snapshots were missed due to the test selection not taking into account cloudformation tests, which fails our pipelines.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Update snapshots for failing SQS cloudformation tests

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
