### PR TITLE
Remove jsonpickle serializer

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -1257,7 +1257,6 @@ IN_MEMORY_CLIENT = is_env_true("IN_MEMORY_CLIENT")
 LOCALSTACK_RESPONSE_HEADER_ENABLED = is_env_not_false("LOCALSTACK_RESPONSE_HEADER_ENABLED")
 
 # Serialization backend for the LocalStack internal state (`dill` is used by default`).
-# `jsonpickle` enables the new experimental backend.
 STATE_SERIALIZATION_BACKEND = os.environ.get("STATE_SERIALIZATION_BACKEND", "").strip() or "dill"
 
 # List of environment variable names used for configuration that are passed from the host into the LocalStack container.

--- a/localstack-core/localstack/state/codecs.py
+++ b/localstack-core/localstack/state/codecs.py
@@ -2,16 +2,14 @@
 
 from localstack import config
 from localstack.state import Decoder, Encoder
-from localstack.state.pickle import JsonDecoder, JsonEncoder, PickleDecoder, PickleEncoder
+from localstack.state.pickle import PickleDecoder, PickleEncoder
 
 ENCODERS = {
-    "jsonpickle": JsonEncoder,
     "dill": PickleEncoder,
 }
 """Encoders that map to the name of ``STATE_SERIALIZATION_BACKEND``."""
 
 DECODERS = {
-    "jsonpickle": JsonDecoder,
     "dill": PickleDecoder,
 }
 """Decoders that map to the name of ``STATE_SERIALIZATION_BACKEND``."""

--- a/localstack-core/localstack/state/pickle.py
+++ b/localstack-core/localstack/state/pickle.py
@@ -30,10 +30,9 @@ https://dill.readthedocs.io/en/latest/index.html?highlight=register#dill.Pickler
 
 import inspect
 from collections.abc import Callable
-from typing import IO, Any, BinaryIO, Generic, TypeVar
+from typing import Any, BinaryIO, Generic, TypeVar
 
 import dill
-import jsonpickle
 from dill._dill import MetaCatchingDict
 
 from .core import Decoder, Encoder
@@ -255,34 +254,6 @@ class PickleDecoder(Decoder):
 
     def decode(self, file: BinaryIO) -> Any:
         return self.unpickler_class(file).load()
-
-
-class JsonEncoder(Encoder):
-    """
-    An Encoder that uses ``jsonpickle`` under the hood.
-    """
-
-    def __init__(self, pickler_class: type[jsonpickle.Pickler] = None):
-        self.pickler_class = pickler_class or jsonpickle.Pickler()
-
-    def encode(self, obj: Any, file: IO[bytes]):
-        json_str = jsonpickle.encode(obj, context=self.pickler_class)
-        file.write(json_str.encode("utf-8"))
-
-
-class JsonDecoder(Decoder):
-    """
-    A Decoder that uses ``jsonpickle`` under the hood.
-    """
-
-    unpickler_class: type[jsonpickle.Unpickler]
-
-    def __init__(self, unpickler_class: type[jsonpickle.Unpickler] = None):
-        self.unpickler_class = unpickler_class or jsonpickle.Unpickler()
-
-    def decode(self, file: IO[bytes]) -> Any:
-        json_str = file.read().decode("utf-8")
-        return jsonpickle.decode(json_str, context=self.unpickler_class)
 
 
 def get_default_encoder() -> Encoder:

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -2747,9 +2747,3 @@ def clean_up(
             call_safe(_delete_log_group)
 
     yield _clean_up
-
-
-@pytest.fixture(params=["dill", "jsonpickle"])
-def patch_default_encoder(request, monkeypatch):
-    backend = request.param
-    monkeypatch.setattr(config, "STATE_SERIALIZATION_BACKEND", backend)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "cachetools>=5.0",
     "cryptography",
     "dill==0.3.6",
-    "jsonpickle==4.1.1",
     "dnslib>=0.9.10",
     "dnspython>=1.16.0",
     "plux>=1.10",

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -77,8 +77,6 @@ jmespath==1.0.1
     #   botocore
 jsonpatch==1.33
     # via localstack-core (pyproject.toml)
-jsonpickle==4.1.1
-    # via localstack-core (pyproject.toml)
 jsonpointer==3.0.0
     # via jsonpatch
 jsonschema==4.25.1
@@ -168,7 +166,7 @@ rich==14.1.0
     # via localstack-core (pyproject.toml)
 rolo==0.7.6
     # via localstack-core (pyproject.toml)
-rpds-py==0.27.0
+rpds-py==0.27.1
     # via
     #   jsonschema
     #   referencing

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -26,8 +26,6 @@ dnspython==2.7.0
     # via localstack-core (pyproject.toml)
 idna==3.10
     # via requests
-jsonpickle==4.1.1
-    # via localstack-core (pyproject.toml)
 markdown-it-py==4.0.0
     # via rich
 mdurl==0.1.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,7 +29,7 @@ aws-cdk-asset-awscli-v1==2.2.242
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
-aws-cdk-cloud-assembly-schema==48.5.0
+aws-cdk-cloud-assembly-schema==48.6.0
     # via aws-cdk-lib
 aws-cdk-lib==2.212.0
     # via localstack-core
@@ -80,7 +80,7 @@ cffi==1.17.1
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
-cfn-lint==1.39.0
+cfn-lint==1.39.1
     # via moto-ext
 charset-normalizer==3.4.3
     # via requests
@@ -191,7 +191,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joserfc==1.3.0
+joserfc==1.3.1
     # via moto-ext
 jpype1==1.6.0
     # via localstack-core
@@ -215,10 +215,6 @@ jsonpath-ng==1.7.0
     #   moto-ext
 jsonpath-rw==1.4.0
     # via localstack-core
-jsonpickle==4.1.1
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 jsonpointer==3.0.0
     # via jsonpatch
 jsonschema==4.25.1
@@ -300,7 +296,7 @@ pathable==0.4.4
     # via jsonschema-path
 pathspec==0.12.1
     # via mypy
-platformdirs==4.3.8
+platformdirs==4.4.0
     # via virtualenv
 pluggy==1.6.0
     # via
@@ -429,7 +425,7 @@ rich==14.1.0
     #   localstack-core (pyproject.toml)
 rolo==0.7.6
     # via localstack-core
-rpds-py==0.27.0
+rpds-py==0.27.1
     # via
     #   jsonschema
     #   referencing

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -62,7 +62,7 @@ certifi==2025.8.3
     #   requests
 cffi==1.17.1
     # via cryptography
-cfn-lint==1.39.0
+cfn-lint==1.39.1
     # via moto-ext
 charset-normalizer==3.4.3
     # via requests
@@ -139,7 +139,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joserfc==1.3.0
+joserfc==1.3.1
     # via moto-ext
 jpype1==1.6.0
     # via localstack-core (pyproject.toml)
@@ -155,10 +155,6 @@ jsonpath-ng==1.7.0
     #   moto-ext
 jsonpath-rw==1.4.0
     # via localstack-core (pyproject.toml)
-jsonpickle==4.1.1
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 jsonpointer==3.0.0
     # via jsonpatch
 jsonschema==4.25.1
@@ -310,7 +306,7 @@ rich==14.1.0
     #   localstack-core (pyproject.toml)
 rolo==0.7.6
     # via localstack-core
-rpds-py==0.27.0
+rpds-py==0.27.1
     # via
     #   jsonschema
     #   referencing

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -29,7 +29,7 @@ aws-cdk-asset-awscli-v1==2.2.242
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
-aws-cdk-cloud-assembly-schema==48.5.0
+aws-cdk-cloud-assembly-schema==48.6.0
     # via aws-cdk-lib
 aws-cdk-lib==2.212.0
     # via localstack-core (pyproject.toml)
@@ -78,7 +78,7 @@ certifi==2025.8.3
     #   requests
 cffi==1.17.1
     # via cryptography
-cfn-lint==1.39.0
+cfn-lint==1.39.1
     # via moto-ext
 charset-normalizer==3.4.3
     # via requests
@@ -175,7 +175,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joserfc==1.3.0
+joserfc==1.3.1
     # via moto-ext
 jpype1==1.6.0
     # via localstack-core
@@ -199,10 +199,6 @@ jsonpath-ng==1.7.0
     #   moto-ext
 jsonpath-rw==1.4.0
     # via localstack-core
-jsonpickle==4.1.1
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 jsonpointer==3.0.0
     # via jsonpatch
 jsonschema==4.25.1
@@ -389,7 +385,7 @@ rich==14.1.0
     #   localstack-core (pyproject.toml)
 rolo==0.7.6
     # via localstack-core
-rpds-py==0.27.0
+rpds-py==0.27.1
     # via
     #   jsonschema
     #   referencing

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -29,7 +29,7 @@ aws-cdk-asset-awscli-v1==2.2.242
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
-aws-cdk-cloud-assembly-schema==48.5.0
+aws-cdk-cloud-assembly-schema==48.6.0
     # via aws-cdk-lib
 aws-cdk-lib==2.212.0
     # via localstack-core
@@ -49,7 +49,7 @@ boto3==1.40.16
     #   kclpy-ext
     #   localstack-core
     #   moto-ext
-boto3-stubs==1.40.17
+boto3-stubs==1.40.18
     # via localstack-core (pyproject.toml)
 botocore==1.40.16
     # via
@@ -84,7 +84,7 @@ cffi==1.17.1
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
-cfn-lint==1.39.0
+cfn-lint==1.39.1
     # via moto-ext
 charset-normalizer==3.4.3
     # via requests
@@ -195,7 +195,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joserfc==1.3.0
+joserfc==1.3.1
     # via moto-ext
 jpype1==1.6.0
     # via localstack-core
@@ -219,10 +219,6 @@ jsonpath-ng==1.7.0
     #   moto-ext
 jsonpath-rw==1.4.0
     # via localstack-core
-jsonpickle==4.1.1
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 jsonpointer==3.0.0
     # via jsonpatch
 jsonschema==4.25.1
@@ -306,7 +302,7 @@ mypy-boto3-cloudwatch==1.40.0
     # via boto3-stubs
 mypy-boto3-codebuild==1.40.8
     # via boto3-stubs
-mypy-boto3-codecommit==1.40.0
+mypy-boto3-codecommit==1.40.18
     # via boto3-stubs
 mypy-boto3-codeconnections==1.40.2
     # via boto3-stubs
@@ -314,7 +310,7 @@ mypy-boto3-codedeploy==1.40.0
     # via boto3-stubs
 mypy-boto3-codepipeline==1.40.0
     # via boto3-stubs
-mypy-boto3-codestar-connections==1.40.0
+mypy-boto3-codestar-connections==1.40.18
     # via boto3-stubs
 mypy-boto3-cognito-identity==1.40.15
     # via boto3-stubs
@@ -328,7 +324,7 @@ mypy-boto3-dynamodb==1.40.14
     # via boto3-stubs
 mypy-boto3-dynamodbstreams==1.40.0
     # via boto3-stubs
-mypy-boto3-ec2==1.40.17
+mypy-boto3-ec2==1.40.18
     # via boto3-stubs
 mypy-boto3-ecr==1.40.0
     # via boto3-stubs
@@ -356,13 +352,13 @@ mypy-boto3-firehose==1.40.0
     # via boto3-stubs
 mypy-boto3-fis==1.40.0
     # via boto3-stubs
-mypy-boto3-glacier==1.40.0
+mypy-boto3-glacier==1.40.18
     # via boto3-stubs
 mypy-boto3-glue==1.40.15
     # via boto3-stubs
 mypy-boto3-iam==1.40.0
     # via boto3-stubs
-mypy-boto3-identitystore==1.40.0
+mypy-boto3-identitystore==1.40.18
     # via boto3-stubs
 mypy-boto3-iot==1.40.0
     # via boto3-stubs
@@ -372,7 +368,7 @@ mypy-boto3-iotanalytics==1.40.16
     # via boto3-stubs
 mypy-boto3-iotwireless==1.40.0
     # via boto3-stubs
-mypy-boto3-kafka==1.40.0
+mypy-boto3-kafka==1.40.18
     # via boto3-stubs
 mypy-boto3-kinesis==1.40.0
     # via boto3-stubs
@@ -394,7 +390,7 @@ mypy-boto3-mediaconvert==1.40.17
     # via boto3-stubs
 mypy-boto3-mediastore==1.40.17
     # via boto3-stubs
-mypy-boto3-mq==1.40.0
+mypy-boto3-mq==1.40.18
     # via boto3-stubs
 mypy-boto3-mwaa==1.40.0
     # via boto3-stubs
@@ -406,7 +402,7 @@ mypy-boto3-organizations==1.40.8
     # via boto3-stubs
 mypy-boto3-pi==1.40.0
     # via boto3-stubs
-mypy-boto3-pinpoint==1.40.0
+mypy-boto3-pinpoint==1.40.18
     # via boto3-stubs
 mypy-boto3-pipes==1.40.0
     # via boto3-stubs
@@ -510,7 +506,7 @@ pathable==0.4.4
     # via jsonschema-path
 pathspec==0.12.1
     # via mypy
-platformdirs==4.3.8
+platformdirs==4.4.0
     # via virtualenv
 pluggy==1.6.0
     # via
@@ -639,7 +635,7 @@ rich==14.1.0
     #   localstack-core (pyproject.toml)
 rolo==0.7.6
     # via localstack-core
-rpds-py==0.27.0
+rpds-py==0.27.1
     # via
     #   jsonschema
     #   referencing

--- a/tests/unit/state/test_pickle.py
+++ b/tests/unit/state/test_pickle.py
@@ -5,7 +5,7 @@ import pytest
 from localstack.state import pickle
 
 
-def test_pickle_priority_queue(patch_default_encoder):
+def test_pickle_priority_queue():
     obj = PriorityQueue()
     obj.put(2)
     obj.put(1)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up on https://github.com/localstack/localstack/pull/13063.
As we are moving on with `avro` based serialization, we are removing the `jsonpickle` encoder/decoder.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
