### PR TITLE
capture k8s env var

### DIFF
--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -53,6 +53,7 @@ TRACKED_ENV_VAR = [
     "LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT",
     "LEGACY_EDGE_PROXY",  # Not functional; deprecated in 1.0.0, removed in 2.0.0
     "LS_LOG",
+    "LOCALSTACK_K8S_DEPLOYMENT_METHOD",
     "MOCK_UNIMPLEMENTED",  # Not functional; deprecated in 1.3.0, removed in 3.0.0
     "OPENSEARCH_ENDPOINT_STRATEGY",
     "PERSISTENCE",
@@ -78,6 +79,7 @@ PRESENCE_ENV_VAR = [
     "HOSTNAME_FROM_LAMBDA",
     "HOST_TMP_FOLDER",  # Not functional; deprecated in 1.0.0, removed in 2.0.0
     "INIT_SCRIPTS_PATH",  # Not functional; deprecated in 1.1.0, removed in 2.0.0
+    "KUBERNETES_SERVICE_HOST",
     "LAMBDA_DEBUG_MODE_CONFIG_PATH",
     "LEGACY_DIRECTORIES",  # Not functional; deprecated in 1.1.0, removed in 2.0.0
     "LEGACY_INIT_DIR",  # Not functional; deprecated in 1.1.0, removed in 2.0.0


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In an effort to understand how our users are deploying to k8s, we are now capturing 2 more environment. This will allow us to identify which session is running in k8s and whether the operator and the LocalStack Helm chart was used to deploy.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- capture presence of `KUBERNETES_SERVICE_HOST` as it is en environment automatically injected into pods
- capture value of `LOCALSTACK_K8S_DEPLOYMENT_METHOD` as the operator/helm chart will be adding it to the pods environment

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
