### PR TITLE
Use ServiceExceptionSerializer for all NotImplementedError handling

### DIFF
--- a/localstack-core/localstack/aws/handlers/service.py
+++ b/localstack-core/localstack/aws/handlers/service.py
@@ -11,6 +11,7 @@ from localstack import config
 from localstack.http import Response
 from localstack.utils.coverage_docs import get_coverage_link_for_service
 
+from ...utils import analytics
 from ..api import CommonServiceException, RequestContext, ServiceException
 from ..api.core import ServiceOperation
 from ..chain import CompositeResponseHandler, ExceptionHandler, Handler, HandlerChain
@@ -178,6 +179,9 @@ class ServiceExceptionSerializer(ExceptionHandler):
             message = exception_message or get_coverage_link_for_service(service_name, action_name)
             LOG.info(message)
             error = CommonServiceException("InternalFailure", message, status_code=501)
+            analytics.log.event(
+                "services_notimplemented", payload={"s": service_name, "a": action_name}
+            )
             context.service_exception = error
 
         elif not isinstance(exception, ServiceException):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We're adding custom error messages for cases where an AWS service or operation isn't implemented. While working on this we noticed that currently the `NotImplementedError` can be handled in two places: in the `Skeleton` class and in the `ServiceExceptionSerializer`. It doesn’t seem necessary to have it in both. This PR simplifies this logic by removing the error handling from `Skeleton` and using the existing logic in `ServiceExceptionSerializer` instead

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Removed the `NotImplementedError` exception handling from `Skeleton` 
- Added analytics event to `ServiceExceptionSerializer` for the `NotImplementedError` exception

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
