### PR TITLE
Docker: Support remove_container(volume=True)

### DIFF
--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -686,8 +686,16 @@ class ContainerClient(metaclass=ABCMeta):
         """Unpauses a container with the given name."""
 
     @abstractmethod
-    def remove_container(self, container_name: str, force=True, check_existence=False) -> None:
-        """Removes container with given name"""
+    def remove_container(
+        self, container_name: str, force=True, check_existence=False, volumes=False
+    ) -> None:
+        """Removes container
+
+        :param container_name: Name of the container
+        :param force: Force the removal of a running container (uses SIGKILL)
+        :param check_existence: Return if container doesn't exist
+        :param volumes: Remove anonymous volumes associated with the container
+        """
 
     @abstractmethod
     def remove_image(self, image: str, force: bool = True) -> None:

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -265,12 +265,16 @@ class CmdDockerClient(ContainerClient):
                 f"Docker process returned with errorcode {e.returncode}", e.stdout, e.stderr
             ) from e
 
-    def remove_container(self, container_name: str, force=True, check_existence=False) -> None:
+    def remove_container(
+        self, container_name: str, force=True, check_existence=False, volumes=False
+    ) -> None:
         if check_existence and container_name not in self.get_all_container_names():
             return
         cmd = self._docker_cmd() + ["rm"]
         if force:
             cmd.append("-f")
+        if volumes:
+            cmd.append("--volumes")
         cmd.append(container_name)
         LOG.debug("Removing container with cmd %s", cmd)
         try:

--- a/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
@@ -264,14 +264,16 @@ class SdkDockerClient(ContainerClient):
         except APIError as e:
             raise ContainerException() from e
 
-    def remove_container(self, container_name: str, force=True, check_existence=False) -> None:
-        LOG.debug("Removing container: %s", container_name)
+    def remove_container(
+        self, container_name: str, force=True, check_existence=False, volumes=False
+    ) -> None:
+        LOG.debug("Removing container: %s, with volumes: %s", container_name, volumes)
         if check_existence and container_name not in self.get_all_container_names():
             LOG.debug("Aborting removing due to check_existence check")
             return
         try:
             container = self.client().containers.get(container_name)
-            container.remove(force=force)
+            container.remove(force=force, v=volumes)
         except NotFound:
             if not force:
                 raise NoSuchContainer(container_name)


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
If an image specifies a `VOLUME ["/tmp"]` command, this results in the creation of an anonymous volume.

When you delete a container, this volume is not deleted automatically - this has be explicitly configured via `docker container rm --volumes`

This PR adds support for that argument, plus a test to verify that an anonymous volume is created and deleted after using this argument.

