### PR TITLE
Fix typing for the tagging service

### DIFF
--- a/localstack-core/localstack/utils/tagging.py
+++ b/localstack-core/localstack/utils/tagging.py
@@ -2,17 +2,18 @@ from typing import Optional
 
 
 class TaggingService:
-    key_field: str = "Key"
-    value_field: str = "Value"
+    key_field: str
+    value_field: str
+
     tags: dict[str, dict[str, str]]
 
-    def __init__(self, key_field: str | None = None, value_field: str | None = None):
+    def __init__(self, key_field: str = "Key", value_field: str = "Value"):
         """
         :param key_field: the field name representing the tag key as used by botocore specs
         :param value_field: the field name representing the tag value as used by botocore specs
         """
-        self.key_field = key_field or self.key_field
-        self.value_field = value_field or self.value_field
+        self.key_field = key_field
+        self.value_field = value_field
 
         self.tags = {}
 

--- a/localstack-core/localstack/utils/tagging.py
+++ b/localstack-core/localstack/utils/tagging.py
@@ -2,13 +2,17 @@ from typing import Optional
 
 
 class TaggingService:
-    def __init__(self, key_field: str = None, value_field: str = None):
+    key_field: str = "Key"
+    value_field: str = "Value"
+    tags: dict[str, dict[str, str]]
+
+    def __init__(self, key_field: str | None = None, value_field: str | None = None):
         """
         :param key_field: the field name representing the tag key as used by botocore specs
         :param value_field: the field name representing the tag value as used by botocore specs
         """
-        self.key_field = key_field or "Key"
-        self.value_field = value_field or "Value"
+        self.key_field = key_field or self.key_field
+        self.value_field = value_field or self.value_field
 
         self.tags = {}
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR improves the type hints for the `TaggingService` constructor by making explicit the nullability of the arguments.

`py-avro-schema` would raise an error with the existing implementation since the arguments were not nullable (i.e., not `str | None`) and `None` would not be a good default for a string.

In cases like this, `mypy` would raise an error: `error: Incompatible default for argument "val" (default has type "None", argument has type "str")  [assignment]`).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
