### PR TITLE
Fix:  add PLATFORM validation to docker-helper.sh build command

### DIFF
--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -125,6 +125,7 @@ function _set_version_defaults() {
 function cmd-build() {
     # start build of a platform-specific image (this target will get called for multiple archs like AMD64/ARM64)
     _enforce_image_name
+    _enforce_platform
     _set_version_defaults
 
     if [ ! -f "pyproject.toml" ]; then

--- a/tests/bin/test.docker-helper.bats
+++ b/tests/bin/test.docker-helper.bats
@@ -70,6 +70,7 @@ setup_file() {
 # build
 
 @test "build creates image from custom Dockerfile" {
+  export PLATFORM="amd64"
   export IMAGE_NAME="localstack/test"
   export DOCKERFILE="tests/bin/files/Dockerfile"
   export TEST_SPECIFIC_VERSION="3.6.1.dev45"
@@ -297,6 +298,7 @@ setup_file() {
 
 
 @test "cmd-build throws error when setuptools-scm is not installed" {
+  export PLATFORM="amd64"
   export TEST_PIP_FAIL=1
   export IMAGE_NAME="localstack/test"
 
@@ -319,4 +321,21 @@ setup_file() {
   run bin/docker-helper.sh get-release-version
   [ "$status" -eq 1 ]
   [[ "$output" == "Not a release commit." ]]
+}
+
+@test "build fails without PLATFORM" {
+  export IMAGE_NAME="localstack/test"
+  export TEST_SPECIFIC_VERSION="3.6.1.dev45"
+  run bin/docker-helper.sh build
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "PLATFORM is missing" ]]
+}
+
+@test "build succeeds with PLATFORM" {
+  export IMAGE_NAME="localstack/test"
+  export PLATFORM="amd64"
+  export TEST_SPECIFIC_VERSION="3.6.1.dev45"
+  run bin/docker-helper.sh build
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "docker buildx build --platform linux/amd64" ]]
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The `docker-helper.sh build` command fails with cryptic Docker buildx errors when executed directly without the `PLATFORM` environment variable set. Users get confusing error messages like:

`ERROR: failed to build: "" is an invalid component of "linux/": platform specifier component must match "^[A-Za-z0-9_.-]+$": invalid argument`

This happens because the `cmd-build()` function doesn't validate that the required `PLATFORM` environment variable is set, unlike other commands (`save`, `load`, `push`) which already have proper validation through the `_enforce_platform()` function.

While `make docker-build` works correctly (since the Makefile sets `PLATFORM`), developers running the script directly encounter these unclear errors without understanding what went wrong.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Added `_enforce_platform` call to the `cmd-build()` function in `bin/docker-helper.sh`
- This provides consistent error handling across all commands that require the `PLATFORM` variable
- Users now get a clear error message: `"PLATFORM is missing"` instead of cryptic Docker buildx errors
- No changes to existing functionality - `make docker-build` continues to work as before

<!-- Optional section: How to test these changes? -->
## Testing

To test the fix:

1. **Before fix** - Running `IMAGE_NAME="localstack/localstack" ./bin/docker-helper.sh build` fails with cryptic Docker buildx errors
2. **After fix** - Same command now fails with clear message: `"Mandatory parameter PLATFORM is missing"`
3. **Regression test** - `make docker-build` continues to work correctly since Makefile properly sets `PLATFORM`