### PR TITLE
SNS: fix 500 error for Unsubscribe with empty Sub ARN

### DIFF
--- a/localstack-core/localstack/services/sns/provider.py
+++ b/localstack-core/localstack/services/sns/provider.py
@@ -1,4 +1,5 @@
 import base64
+import contextlib
 import copy
 import functools
 import json
@@ -419,6 +420,10 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
     def unsubscribe(
         self, context: RequestContext, subscription_arn: subscriptionARN, **kwargs
     ) -> None:
+        if subscription_arn is None:
+            raise InvalidParameterException(
+                "Invalid parameter: SubscriptionArn Reason: no value for required parameter",
+            )
         count = len(subscription_arn.split(":"))
         try:
             parsed_arn = parse_arn(subscription_arn)
@@ -469,7 +474,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 subscription_arn=subscription_arn,
             )
 
-        store.topic_subscriptions[subscription["TopicArn"]].remove(subscription_arn)
+        with contextlib.suppress(ValueError):
+            store.topic_subscriptions[subscription["TopicArn"]].remove(subscription_arn)
         store.subscription_filter_policy.pop(subscription_arn, None)
         store.subscriptions.pop(subscription_arn, None)
 

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -1120,21 +1120,30 @@ class TestSNSSubscriptionCrud:
         snapshot.match("unsubscribe-2", unsubscribe_2)
 
     @markers.aws.validated
-    def test_unsubscribe_wrong_arn_format(self, snapshot, aws_client):
+    def test_unsubscribe_wrong_arn_format(self, snapshot, aws_client_factory, region_name):
+        sns_client = aws_client_factory(
+            region_name=region_name, config=Config(parameter_validation=False)
+        ).sns
+
         with pytest.raises(ClientError) as e:
-            aws_client.sns.unsubscribe(SubscriptionArn="randomstring")
+            sns_client.unsubscribe(SubscriptionArn="randomstring")
 
         snapshot.match("invalid-unsubscribe-arn-1", e.value.response)
 
         with pytest.raises(ClientError) as e:
-            aws_client.sns.unsubscribe(SubscriptionArn="arn:aws:sns:us-east-1:random")
+            sns_client.unsubscribe(SubscriptionArn="arn:aws:sns:us-east-1:random")
 
         snapshot.match("invalid-unsubscribe-arn-2", e.value.response)
 
         with pytest.raises(ClientError) as e:
-            aws_client.sns.unsubscribe(SubscriptionArn="arn:aws:sns:us-east-1:111111111111:random")
+            sns_client.unsubscribe(SubscriptionArn="arn:aws:sns:us-east-1:111111111111:random")
 
         snapshot.match("invalid-unsubscribe-arn-3", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            sns_client.unsubscribe()
+
+        snapshot.match("invalid-unsubscribe-arn-4", e.value.response)
 
     @markers.aws.validated
     def test_subscribe_with_invalid_topic(self, sns_create_topic, sns_subscription, snapshot):

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4021,7 +4021,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_unsubscribe_wrong_arn_format": {
-    "recorded-date": "20-10-2023, 12:52:36",
+    "recorded-date": "02-09-2025, 20:17:36",
     "recorded-content": {
       "invalid-unsubscribe-arn-1": {
         "Error": {
@@ -4049,6 +4049,17 @@
         "Error": {
           "Code": "InvalidParameter",
           "Message": "Invalid parameter: SubscriptionId",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-unsubscribe-arn-4": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: SubscriptionArn Reason: no value for required parameter",
           "Type": "Sender"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -90,7 +90,13 @@
     "last_validated_date": "2023-11-06T23:36:06+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_unsubscribe_wrong_arn_format": {
-    "last_validated_date": "2023-10-20T10:52:36+00:00"
+    "last_validated_date": "2025-09-02T20:17:36+00:00",
+    "durations_in_seconds": {
+      "setup": 0.45,
+      "call": 0.73,
+      "teardown": 0.0,
+      "total": 1.18
+    }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_validate_set_sub_attributes": {
     "last_validated_date": "2024-03-29T19:30:23+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Reported by the Parity and Quality Insights reports:

```python
exception while calling sns.Unsubscribe: 'NoneType' object has no attribute 'split'
exception while calling sns.Unsubscribe: list.remove(x): x not in list
```

This PR fixes the `NoneType` split exception, and introducing guarding to avoid the `list.remove` exception


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- improve exception handling for `list.remove` in `Unsubscribe` (can happen with race conditions)
- add validation for fully empty `subscriptionARN` input parameter
- add AWS validated tests


completes FLC-32

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
