### PR TITLE
Events: harden dict view iterations

### DIFF
--- a/localstack-core/localstack/services/events/provider.py
+++ b/localstack-core/localstack/services/events/provider.py
@@ -193,7 +193,7 @@ def encode_next_token(token: int) -> NextToken:
 
 def get_filtered_dict(name_prefix: str, input_dict: dict) -> dict:
     """Filter dictionary by prefix."""
-    return {name: value for name, value in input_dict.items() if name.startswith(name_prefix)}
+    return {name: value for name, value in dict(input_dict).items() if name.startswith(name_prefix)}
 
 
 def validate_event(event: PutEventsRequestEntry) -> None | PutEventsResultEntry:
@@ -768,8 +768,8 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
 
         # Find all rules that have a target with the specified ARN
         matching_rule_names = []
-        for rule_name, rule in event_bus.rules.items():
-            for target_id, target in rule.targets.items():
+        for rule_name, rule in dict(event_bus.rules).items():
+            for target_id, target in dict(rule.targets).items():
                 if target["Arn"] == target_arn:
                     matching_rule_names.append(rule_name)
                     break  # Found a match in this rule, no need to check other targets
@@ -1028,7 +1028,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             self._check_event_bus_exists(event_source_arn, store)
             archives = {
                 key: archive
-                for key, archive in store.archives.items()
+                for key, archive in dict(store.archives).items()
                 if archive.event_source_arn == event_source_arn
             }
         elif name_prefix:
@@ -1161,7 +1161,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         if event_source_arn:
             replays = {
                 key: replay
-                for key, replay in store.replays.items()
+                for key, replay in dict(store.replays).items()
                 if replay.event_source_arn == event_source_arn
             }
         elif name_prefix:
@@ -1508,7 +1508,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         """
         if isinstance(rules, Rule):
             rules = {rules.name: rules}
-        for rule in rules.values():
+        for rule in list(rules.values()):
             del self._rule_services_store[rule.arn]
 
     def _delete_target_sender(self, ids: TargetIdList, rule) -> None:
@@ -1571,7 +1571,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
     def _get_scheduled_rule_job_function(self, account_id, region, rule: Rule) -> Callable:
         def func(*args, **kwargs):
             """Create custom scheduled event and send it to all targets specified by associated rule using respective TargetSender"""
-            for target in rule.targets.values():
+            for target in list(rule.targets.values()):
                 if custom_input := target.get("Input"):
                     event = json.loads(custom_input)
                 else:
@@ -1636,7 +1636,8 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
     ) -> EventBusList:
         """Return a converted dict of EventBus model objects as a list of event buses in API type EventBus format."""
         event_bus_list = [
-            self._event_bus_to_api_type_event_bus(event_bus) for event_bus in event_buses.values()
+            self._event_bus_to_api_type_event_bus(event_bus)
+            for event_bus in list(event_buses.values())
         ]
         return event_bus_list
 
@@ -1680,7 +1681,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
 
     def _rule_dict_to_rule_response_list(self, rules: RuleDict) -> RuleResponseList:
         """Return a converted dict of Rule model objects as a list of rules in API type Rule format."""
-        rule_list = [self._rule_to_api_type_rule(rule) for rule in rules.values()]
+        rule_list = [self._rule_to_api_type_rule(rule) for rule in list(rules.values())]
         return rule_list
 
     def _rule_to_api_type_rule(self, rule: Rule) -> ApiTypeRule:
@@ -1700,7 +1701,9 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
 
     def _archive_dict_to_archive_response_list(self, archives: ArchiveDict) -> ArchiveResponseList:
         """Return a converted dict of Archive model objects as a list of archives in API type Archive format."""
-        archive_list = [self._archive_to_api_type_archive(archive) for archive in archives.values()]
+        archive_list = [
+            self._archive_to_api_type_archive(archive) for archive in list(archives.values())
+        ]
         return archive_list
 
     def _archive_to_api_type_archive(self, archive: Archive) -> ApiTypeArchive:
@@ -1734,7 +1737,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
 
     def _replay_dict_to_replay_response_list(self, replays: ReplayDict) -> ReplayList:
         """Return a converted dict of Replay model objects as a list of replays in API type Replay format."""
-        replay_list = [self._replay_to_api_type_replay(replay) for replay in replays.values()]
+        replay_list = [self._replay_to_api_type_replay(replay) for replay in list(replays.values())]
         return replay_list
 
     def _replay_to_api_type_replay(self, replay: Replay) -> ApiTypeReplay:
@@ -1789,7 +1792,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         """Return a converted dict of Connection model objects as a list of connections in API type Connection format."""
         connection_list = [
             self._connection_to_api_type_connection(connection)
-            for connection in connections.values()
+            for connection in list(connections.values())
         ]
         return connection_list
 
@@ -1816,7 +1819,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         """Return a converted dict of ApiDestination model objects as a list of connections in API type ApiDestination format."""
         api_destination_list = [
             self._api_destination_to_api_type_api_destination(api_destination)
-            for api_destination in api_destinations.values()
+            for api_destination in list(api_destinations.values())
         ]
         return api_destination_list
 
@@ -1942,7 +1945,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                 )
                 return
 
-            for target in rule.targets.values():
+            for target in list(rule.targets.values()):
                 target_id = target["Id"]
                 if is_archive_arn(target["Arn"]):
                     self._put_to_archive(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While looking at error data, I've spotted the following:

```python
exception while calling events.PutEvents: Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo/gateway/chain.py", line 166, in handle
    handler(self, self.context, response)
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/handlers/service.py", line 113, in __call__
    handler(chain, context, response)
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/handlers/service.py", line 83, in __call__
    skeleton_response = self.skeleton.invoke(context)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/skeleton.py", line 154, in invoke
    return self.dispatch_request(serializer, context, instance)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/skeleton.py", line 168, in dispatch_request
    result = handler(context, instance) or {}
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/skeleton.py", line 118, in __call__
    return self.fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/api/core.py", line 178, in operation_marker
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/events/provider.py", line 1095, in put_events
    entries, failed_entry_count = self._process_entries(context, entries)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/events/provider.py", line 1846, in _process_entries
    self._process_entry(event, processed_entries, failed_entry_count, context)
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/events/provider.py", line 1899, in _process_entry
    self._process_rules(rule, region, account_id, event_formatted, trace_header)
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/events/provider.py", line 1939, in _process_rules
    for target in rule.targets.values():
RuntimeError: dictionary changed size during iteration
```

This can be avoided by shallow copying the dict right before iteration. This was also addressed for other services following bug reports. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- create shallow copies of dict views, `dict.values()` and `dict.items()` before iterating on them when those are store attributes, as they can be changed via parallel calls to other API operations

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
